### PR TITLE
Adjust Makefile and Container file for new home

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -57,7 +57,7 @@ FROM registry.access.redhat.com/ubi9-minimal:9.2 AS runtime
 
 COPY \
   --from=builder \
- /home/builder/o2ims /usr/bin/o2ims
+ /home/builder/oran-o2ims /usr/bin/oran-o2ims
 
 ENTRYPOINT \
-  ["/usr/bin/o2ims"]
+  ["/usr/bin/oran-o2ims"]

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #
 
 # Details of the image:
-image_repo:=quay.io/jhernand/o2ims
+image_repo:=quay.io/openshift-kni/oran-o2ims
 image_tag:=latest
 
 # Additional flags to pass to the `ginkgo` command.
@@ -49,6 +49,7 @@ lint:
 	golangci-lint run
 
 .PHONY: clean
-clean: rm -rf \
-	o2ims \
+clean:
+	rm -rf \
+	oran-o2ims \
 	$(NULL)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export BACKEND_TOKEN=<backend_token>
 
 #### Using CLI
 ```bash
-./o2ims start deployment-manager-server --cloud-id $CLOUD_ID --backend-url $BACKEND_URL --backend-token $BACKEND_TOKEN
+./oran-o2ims start deployment-manager-server --cloud-id $CLOUD_ID --backend-url $BACKEND_URL --backend-token $BACKEND_TOKEN
 ```
 
 #### Using VS Code


### PR DESCRIPTION
Now that the project has been moved to the `openshift-kni/oran-o2ims` GitHub repository the _Makefile_ and _Containerfile_ need to be updated to use the new `oran-o2ims` binary generated by default.

Related: https://issues.redhat.com/browse/MGMT-16110