### PR TITLE
Add development reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.log
 /__debug*
 /oran-o2ims

--- a/proxy.sh
+++ b/proxy.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This script starts the servers and the reverse proxy in the local machine. It is intended for
+# use in the development environment, where it is convenient to run the servers locally in order
+# to debug them. Stop it with Ctr+C, and it will kill the servers.
+
+# Stop the servers when finished:
+function clean {
+  kill -9 ${pids}
+}
+trap clean EXIT
+
+# Start the metadata server:
+./oran-o2ims start metadata-server \
+--log-file="servers.log" \
+--log-level="debug" \
+--log-field="server=metadata" \
+--log-field="pid=%p" \
+--api-listener-address="127.0.0.1:8000" \
+--cloud-id="123" \
+&
+pids="${pids} $!"
+
+# Start the deployment manager server:
+./oran-o2ims start deployment-manager-server \
+--log-file="servers.log" \
+--log-level="debug" \
+--log-field="server=deployment-manager" \
+--log-field="pid=%p" \
+--api-listener-address="127.0.0.1:8001" \
+--cloud-id="123" \
+--backend-url="${BACKEND_URL}" \
+--backend-token="${BACKEND_TOKEN}" \
+&
+pids="${pids} $!"
+
+# Start the reverse proxy:
+podman run \
+--rm \
+--network="host" \
+--volume="${PWD}/proxy.yaml:/etc/proxy.yaml:z" \
+--entrypoint="/usr/local/bin/envoy" \
+docker.io/envoyproxy/envoy:v1.28.0 \
+--config-path "/etc/proxy.yaml"

--- a/proxy.yaml
+++ b/proxy.yaml
@@ -1,0 +1,103 @@
+#
+# Copyright (c) 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This is an example Envoy configuration that redirects requests to the servers, so that they
+# appear to be a single server. It is intended for use in development environments, together
+# with the 'proxy.sh' script.
+
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9001
+
+static_resources:
+
+  clusters:
+
+  - name: metadata-server
+    connect_timeout: 1s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: metadata-server
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8000
+
+  - name: deployment-manager-server
+    connect_timeout: 1s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: deployment-manager-server
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8001
+
+  listeners:
+
+  - name: ingress
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 9000
+    filter_chains:
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: /dev/stdout
+          stat_prefix: ingress
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          route_config:
+            name: ingress
+            virtual_hosts:
+            - name: all
+              domains:
+              - "*"
+              routes:
+
+              # Requests for the deployment manager server:
+              - name: deployment-manager
+                match:
+                  prefix: /O2ims_infrastructureInventory/v1/deploymentManagers
+                route:
+                  cluster: deployment-manager-server
+                  timeout: 300s
+
+              # Everything else goes to the metadata server, which will respond with 404 to most
+              # requests:
+              - name: metadata
+                match:
+                  prefix: /
+                route:
+                  cluster: metadata-server
+                  timeout: 300s


### PR DESCRIPTION
This patch adds a `proxy.sh` script that starts the servers and the reverse proxy in the local machine. The reverse proxy is Envoy, and the configuration is in the `proxy.yaml` file.

To use it run the `run.sh` script. It will start the metadata server listening in port 8000, the deployment manager server listening in port 80001 and the reverse proxy listening in port 9000. Then, for example, go to port 9000 to get the list API versions served by the metadata server:

  http://localhost:9000/O2ims_infrastructureInventory/api_versions

Or to get the the list of deployment managers server by the deployment manager server:

  http://localhost:9000/O2ims_infrastructureInventory/v1/deploymentManagers

To finish, type Ctrl+C and the proxy and the servers will be killed.

The administration port of the proxy is 9001. There you can see Envoy cofguration details and metrics.

This reverse proxy configuration is intended for development environments only, but will be the seed for the production configuration.

Related: https://issues.redhat.com/browse/MGMT-16113