### PR TITLE
Add `--api-listener-...` flags to resource server

### DIFF
--- a/proxy.sh
+++ b/proxy.sh
@@ -47,6 +47,19 @@ pids="${pids} $!"
 &
 pids="${pids} $!"
 
+# Start the resource server:
+./oran-o2ims start resource-server \
+--log-file="servers.log" \
+--log-level="debug" \
+--log-field="server=resource" \
+--log-field="pid=%p" \
+--api-listener-address="127.0.0.1:8002" \
+--cloud-id="123" \
+--backend-url="${BACKEND_URL}" \
+--backend-token="${BACKEND_TOKEN}" \
+&
+pids="${pids} $!"
+
 # Start the reverse proxy:
 podman run \
 --rm \

--- a/proxy.yaml
+++ b/proxy.yaml
@@ -55,6 +55,20 @@ static_resources:
                 address: 127.0.0.1
                 port_value: 8001
 
+  - name: resource-server
+    connect_timeout: 1s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: resource-server
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8002
+
   listeners:
 
   - name: ingress
@@ -91,6 +105,14 @@ static_resources:
                   prefix: /O2ims_infrastructureInventory/v1/deploymentManagers
                 route:
                   cluster: deployment-manager-server
+                  timeout: 300s
+
+              # Requests for the resource server:
+              - name: resource-manager
+                match:
+                  prefix: /O2ims_infrastructureInventory/v1/resourcePools
+                route:
+                  cluster: resource-server
                   timeout: 300s
 
               # Everything else goes to the metadata server, which will respond with 404 to most


### PR DESCRIPTION
This patch adds the `--api-listener-...` flags to the resource server:

```
$ ./oran-o2ims start resource-server \
--api-listener-address=localhost:8002 \
```

This is intended for use in the reverse proxy configuration started with `proxy.sh`, as it requires different ports for different services.

Note that a side effect of this is that the default port is now `8000` instead of `8080`.

Related: https://issues.redhat.com/browse/MGMT-16113