### PR TITLE
Update Containerfile.tools

### DIFF
--- a/Containerfile.tools
+++ b/Containerfile.tools
@@ -29,9 +29,6 @@ RUN \
   tar -C /usr/local -xf tarball && \
   rm tarball
 
-WORKDIR /go/src/github.com/openshift-kni/oran-o2ims
-COPY . .
-
 # Update GOPATH and PATH.
 ENV \
   GOPATH=/go


### PR DESCRIPTION
No need to copy the content of the repo over as the ci-operator is automatically doing this.