### PR TITLE
Add TLS support to listeners

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/net v0.18.0 // indirect
+	golang.org/x/net v0.18.0
 	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect

--- a/internal/network/flags.go
+++ b/internal/network/flags.go
@@ -31,17 +31,31 @@ import (
 // unchanged as a prefix for the help text. The above example will result in the following flags:
 //
 //	--api-listener-address string API listen address. (default "localhost:8000")
+//	--api-listener-tls-crt string API TLS certificate in PEM format.
+//	--api-listener-tls-key string API TLS key in PEM format.
 func AddListenerFlags(set *pflag.FlagSet, name, addr string) {
 	_ = set.String(
 		listenerFlagName(name, listenerAddrFlagSuffix),
 		addr,
 		fmt.Sprintf("%s listen address.", name),
 	)
+	_ = set.String(
+		listenerFlagName(name, listenerTLSCrtFlagSuffix),
+		"",
+		fmt.Sprintf("%s TLS certificate in PEM format.", name),
+	)
+	_ = set.String(
+		listenerFlagName(name, listenerTLSKeyFlagSuffix),
+		"",
+		fmt.Sprintf("%s TLS key in PEM format.", name),
+	)
 }
 
 // Names of the flags:
 const (
-	listenerAddrFlagSuffix = "listener-address"
+	listenerAddrFlagSuffix   = "listener-address"
+	listenerTLSCrtFlagSuffix = "listener-tls-crt"
+	listenerTLSKeyFlagSuffix = "listener-tls-key"
 )
 
 // listenerFlagName calculates a complete flag name from a listener name and a flag name suffix.

--- a/internal/network/listener_test.go
+++ b/internal/network/listener_test.go
@@ -15,22 +15,31 @@ License.
 package network
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
+	"golang.org/x/net/http2"
+
+	"github.com/openshift-kni/oran-o2ims/internal/testing"
 )
 
 var _ = Describe("Listener", func() {
 	var tmp string
 
 	BeforeEach(func() {
-		// In order to avoid TCP port conflicts these tests will use only Unix sockets
-		// created in this temporary directory:
 		var err error
-		tmp, err = os.MkdirTemp("", "*.sockets")
+		tmp, err = os.MkdirTemp("", "*.test")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -40,10 +49,8 @@ var _ = Describe("Listener", func() {
 	})
 
 	It("Can't be created without a logger", func() {
-		address := filepath.Join(tmp, "my.socket")
 		listener, err := NewListener().
-			SetNetwork("unix").
-			SetAddress(address).
+			SetAddress("127.0.0.1:0").
 			Build()
 		Expect(err).To(HaveOccurred())
 		Expect(listener).To(BeNil())
@@ -55,7 +62,6 @@ var _ = Describe("Listener", func() {
 	It("Can't be created without an address", func() {
 		listener, err := NewListener().
 			SetLogger(logger).
-			SetNetwork("unix").
 			Build()
 		Expect(err).To(HaveOccurred())
 		Expect(listener).To(BeNil())
@@ -130,5 +136,302 @@ var _ = Describe("Listener", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(listener).ToNot(BeNil())
 		Expect(listener.Addr().String()).To(Equal(myAddress))
+	})
+
+	Context("TLS enabled", func() {
+		var (
+			crtRaw, keyRaw   []byte
+			crtPEM, keyPEM   []byte
+			crtFile, keyFile string
+		)
+
+		BeforeEach(func() {
+			// Generate the key pair and the self signed certificate:
+			crt := testing.LocalhostCertificate()
+			crtRaw = crt.Certificate[0]
+
+			// Write the certificate file:
+			crtPEM = pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: crtRaw,
+			})
+			crtFile = filepath.Join(tmp, "tls.crt")
+			err := os.WriteFile(crtFile, crtPEM, 0600)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Write the key bytes:
+			keyRaw, err = x509.MarshalPKCS8PrivateKey(crt.PrivateKey)
+			Expect(err).ToNot(HaveOccurred())
+			keyPEM = pem.EncodeToMemory(&pem.Block{
+				Type:  "PRIVATE KEY",
+				Bytes: keyRaw,
+			})
+			keyFile = filepath.Join(tmp, "tls.key")
+			err = os.WriteFile(keyFile, keyPEM, 0600)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		// serve waits for a connection, closes it and returns. Note that in order to
+		// complete the TLS handshake we need to _try_ to read something, even if the client
+		// isn't going to send anything inside of the TLS envelope.
+		serve := func(listener net.Listener) {
+			conn, err := listener.Accept()
+			Expect(err).ToNot(HaveOccurred())
+			defer conn.Close()
+			_, err = conn.Read([]byte{})
+			Expect(err).To(Or(Not(HaveOccurred()), Equal(io.EOF)))
+		}
+
+		// check opens a connection to the given listener and verifies that it uses the
+		// given certificate.
+		check := func(listener net.Listener, crt []byte) {
+			cas := x509.NewCertPool()
+			ok := cas.AppendCertsFromPEM(crtPEM)
+			Expect(ok).To(BeTrue())
+			dialer := tls.Dialer{
+				Config: &tls.Config{
+					RootCAs: cas,
+				},
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			addr := listener.Addr()
+			conn, err := dialer.DialContext(ctx, addr.Network(), addr.String())
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				err := conn.Close()
+				Expect(err).ToNot(HaveOccurred())
+			}()
+			tlsConn := conn.(*tls.Conn)
+			err = tlsConn.Handshake()
+			Expect(err).ToNot(HaveOccurred())
+			crts := tlsConn.ConnectionState().PeerCertificates
+			Expect(crts[0].Raw).To(Equal(crtRaw))
+		}
+
+		It("Supports TLS", func() {
+			// Create the listener:
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetAddress("127.0.0.1:0").
+				SetTLSCrt(crtFile).
+				SetTLSKey(keyFile).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				err := listener.Close()
+				Expect(err).ToNot(HaveOccurred())
+			}()
+
+			// Start listening and serve only the first connection request, as that is
+			// all we need to perform the verification.
+			go func() {
+				defer GinkgoRecover()
+				serve(listener)
+			}()
+
+			// Check the certificate:
+			check(listener, crtRaw)
+		})
+
+		It("Supports TLS flags", func() {
+			// Prepare the flags:
+			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+			AddListenerFlags(flags, "my", "localhost:80")
+			err := flags.Parse([]string{
+				"--my-listener-address", "127.0.0.1:0",
+				"--my-listener-tls-crt", crtFile,
+				"--my-listener-tls-key", keyFile,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the listener:
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetFlags(flags, "my").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			defer listener.Close()
+
+			// Check the server certificate:
+			go func() {
+				defer GinkgoRecover()
+				serve(listener)
+			}()
+			check(listener, crtRaw)
+		})
+
+		It("Can't be created if TLS certificate is set but key isn't", func() {
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetAddress("127.0.0.1:0").
+				SetTLSCrt(crtFile).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(listener).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("key"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+		})
+
+		It("Can't be created if TLS key is set but certificate isn't", func() {
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetAddress("127.0.0.1:0").
+				SetTLSKey(keyFile).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(listener).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("certificate"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+		})
+
+		It("Can't be created if TLS certificate file doesn't exist", func() {
+			missingFile := filepath.Join(tmp, "missing.crt")
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetAddress("127.0.0.1:0").
+				SetTLSCrt(missingFile).
+				SetTLSKey(keyFile).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(listener).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("missing.crt"))
+			Expect(msg).To(ContainSubstring("no such file"))
+		})
+
+		It("Can't be created if TLS key file doesn't exist", func() {
+			missingFile := filepath.Join(tmp, "missing.key")
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetAddress("127.0.0.1:0").
+				SetTLSCrt(crtFile).
+				SetTLSKey(missingFile).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(listener).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("missing.key"))
+			Expect(msg).To(ContainSubstring("no such file"))
+		})
+
+		It("Can't be created if TLS certificate file contains junk", func() {
+			junkFile := filepath.Join(tmp, "junk.pem")
+			err := os.WriteFile(junkFile, []byte("junk\n"), 0600)
+			Expect(err).ToNot(HaveOccurred())
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetAddress("127.0.0.1:0").
+				SetTLSCrt(junkFile).
+				SetTLSKey(keyFile).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(listener).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("failed to find any PEM data in certificate"))
+		})
+
+		It("Can't be created if TLS key file contains junk", func() {
+			junkFile := filepath.Join(tmp, "junk.pem")
+			err := os.WriteFile(junkFile, []byte("junk\n"), 0600)
+			Expect(err).ToNot(HaveOccurred())
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetAddress("127.0.0.1:0").
+				SetTLSCrt(crtFile).
+				SetTLSKey(junkFile).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(listener).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("failed to find any PEM data in key"))
+		})
+
+		It("Can be used to create an HTTP1 server", func() {
+			// Create the listener:
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetAddress("127.0.0.1:0").
+				SetTLSCrt(crtFile).
+				SetTLSKey(keyFile).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			defer listener.Close()
+
+			// Create the server:
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			server := http.Server{
+				Handler: handler,
+			}
+			go func() {
+				defer GinkgoRecover()
+				_ = server.Serve(listener)
+			}()
+			defer func() {
+				_ = server.Shutdown(context.Background())
+			}()
+
+			// Send a request to verify that it supports HTTP1:
+			cas := x509.NewCertPool()
+			ok := cas.AppendCertsFromPEM(crtPEM)
+			Expect(ok).To(BeTrue())
+			client := http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						RootCAs: cas,
+					},
+				},
+			}
+			response, err := client.Get("https://" + listener.Addr().String())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.Proto).To(Equal("HTTP/1.1"))
+		})
+
+		It("Can be used to create an HTTP2 server", func() {
+			// Create the listener:
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetAddress("127.0.0.1:0").
+				SetTLSCrt(crtFile).
+				SetTLSKey(keyFile).
+				AddTLSProtocol("h2").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			defer listener.Close()
+
+			// Create the server:
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			server := http.Server{
+				Handler: handler,
+			}
+			go func() {
+				defer GinkgoRecover()
+				_ = server.Serve(listener)
+			}()
+			defer func() {
+				_ = server.Shutdown(context.Background())
+			}()
+
+			// Send a request to verify that it supports HTTP2:
+			cas := x509.NewCertPool()
+			ok := cas.AppendCertsFromPEM(crtPEM)
+			Expect(ok).To(BeTrue())
+			client := http.Client{
+				Transport: &http2.Transport{
+					TLSClientConfig: &tls.Config{
+						RootCAs: cas,
+					},
+				},
+			}
+			response, err := client.Get("https://" + listener.Addr().String())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.Proto).To(Equal("HTTP/2.0"))
+		})
 	})
 })


### PR DESCRIPTION
This patch adds support for TLS to all the listeners. For example, to enable TLS in the API listener of the metadata server:

```bash
$ ./oran-o2ims start metadata-server \
--cloud-id=123 \
--api-listener-tls-crt=tls.crt \
--api-listener-rls-key=tls.key
```

For development use a self-signed certificate can be created with a command like this:

```bash
openssl req \
-x509 \
-newkey rsa:4096 \
-nodes \
-keyout tls.key \
-out tls.crt \
-subj '/CN=localhost' \
-addext 'subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1' \
-days 3650
```