### PR TITLE
Fix projection with multiple fields

### DIFF
--- a/internal/search/projector_evaluator.go
+++ b/internal/search/projector_evaluator.go
@@ -166,7 +166,6 @@ func (e *ProjectorEvaluator) setPath(path []string, object map[string]any, value
 	if ok {
 		switch next := next.(type) {
 		case map[string]any:
-			next[head] = value
 			return e.setPath(tail, next, value)
 		default:
 			empty := map[string]any{}

--- a/internal/search/projector_evaluator_test.go
+++ b/internal/search/projector_evaluator_test.go
@@ -126,5 +126,27 @@ var _ = Describe("Projector evaluator", func() {
 				},
 			},
 		),
+		Entry(
+			"Multiple subfields",
+			"extensions/country,extensions/version,extensions/hub",
+			func() any {
+				return map[string]any{
+					"extensions": map[string]any{
+						"cert":    "my-cert",
+						"key":     "my-key",
+						"country": "ES",
+						"version": "1.2.3",
+						"hub":     "hub0",
+					},
+				}
+			},
+			map[string]any{
+				"extensions": map[string]any{
+					"country": "ES",
+					"version": "1.2.3",
+					"hub":     "hub0",
+				},
+			},
+		),
 	)
 })

--- a/internal/search/selector_evaluator.go
+++ b/internal/search/selector_evaluator.go
@@ -214,6 +214,9 @@ func (e *SelectorEvaluator) evaluateEq(value any, args []any) (result bool,
 		)
 		return
 	}
+	if value == nil {
+		return
+	}
 	args, err = e.convertArgs(value, args)
 	if err != nil {
 		return


### PR DESCRIPTION
Currently when a projector contains multiple nested fields an extra field will be added with the name of the container. For example, if the projector contains `a/b,a/c` the result will be:

```
{
  "a" : {
    "b": "B"
    "c": "C",
    "a": "C"
  }
}
```

Note the extra `a.a` field, with value `C`. That shouldn't be there, it is an artifact of the projector evaluator. This patch fixes that issue.