### PR TITLE
MGMT-16351: Add support for configured extensions

### DIFF
--- a/internal/cmd/server/flags.go
+++ b/internal/cmd/server/flags.go
@@ -16,5 +16,6 @@ package server
 
 // Names of command line flags:
 const (
-	cloudIDFlagName = "cloud-id"
+	cloudIDFlagName    = "cloud-id"
+	extensionsFlagName = "extensions"
 )

--- a/internal/cmd/server/start_deployment_manager_server.go
+++ b/internal/cmd/server/start_deployment_manager_server.go
@@ -58,6 +58,11 @@ func DeploymentManagerServer() *cobra.Command {
 		"",
 		"Token for authenticating to the backend server.",
 	)
+	_ = flags.StringArray(
+		extensionsFlagName,
+		[]string{},
+		"Extension to add to deployment managers.",
+	)
 	return result
 }
 
@@ -138,10 +143,20 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		)
 		return exit.Error(1)
 	}
+	extensions, err := flags.GetStringArray(extensionsFlagName)
+	if err != nil {
+		logger.Error(
+			"Failed to extension flag",
+			"flag", extensionsFlagName,
+			"error", err.Error(),
+		)
+		return exit.Error(1)
+	}
 	logger.Info(
 		"Backend details",
-		"url", backendURL,
-		"!token", backendToken,
+		slog.String("url", backendURL),
+		slog.String("!token", backendToken),
+		slog.Any("extensions", extensions),
 	)
 
 	// Create the logging wrapper:
@@ -196,6 +211,7 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetLogger(logger).
 		SetLoggingWrapper(loggingWrapper).
 		SetCloudID(cloudID).
+		SetExtensions(extensions...).
 		SetBackendURL(backendURL).
 		SetBackendToken(backendToken).
 		SetEnableHack(true).

--- a/internal/jq/tool.go
+++ b/internal/jq/tool.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"reflect"
 	"slices"
 	"sort"
 	"strings"
@@ -98,7 +97,7 @@ func (t *Tool) lookup(source string, variables []string) (result *Query, err err
 	if !ok {
 		return
 	}
-	if !reflect.DeepEqual(variables, query.variables) {
+	if !slices.Equal(variables, query.variables) {
 		err = fmt.Errorf(
 			"query was compiled with variables %s but used with %s",
 			logging.All(query.variables), logging.All(variables),

--- a/internal/service/deployment_manager_handler_test.go
+++ b/internal/service/deployment_manager_handler_test.go
@@ -86,27 +86,14 @@ var _ = Describe("Deployment manager handler", func() {
 		var (
 			ctx     context.Context
 			backend *Server
-			handler *DeploymentManagerHandler
 		)
 
 		BeforeEach(func() {
-			var err error
-
 			// Create a context:
 			ctx = context.Background()
 
 			// Create the backend server:
 			backend = MakeTCPServer()
-
-			// Create the handler:
-			handler, err = NewDeploymentManagerHandler().
-				SetLogger(logger).
-				SetCloudID("123").
-				SetBackendURL(backend.URL()).
-				SetBackendToken("my-token").
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(handler).ToNot(BeNil())
 		})
 
 		AfterEach(func() {
@@ -132,6 +119,16 @@ var _ = Describe("Deployment manager handler", func() {
 					),
 				)
 
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handler).ToNot(BeNil())
+
 				// Send the request. Note that we ignore the error here because
 				// all we care about in this test is that it sends the token, no
 				// matter what is the result.
@@ -147,6 +144,16 @@ var _ = Describe("Deployment manager handler", func() {
 					),
 				)
 
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handler).ToNot(BeNil())
+
 				// Send the request. Note that we ignore the error here because
 				// all we care about here in this test is that it uses the right
 				// URL path, no matter what is the result.
@@ -158,6 +165,16 @@ var _ = Describe("Deployment manager handler", func() {
 				backend.AppendHandlers(
 					RespondWithList(),
 				)
+
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handler).ToNot(BeNil())
 
 				// Send the request and verify the result:
 				response, err := handler.List(ctx, &ListRequest{})
@@ -207,6 +224,16 @@ var _ = Describe("Deployment manager handler", func() {
 					),
 				)
 
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handler).ToNot(BeNil())
+
 				// Send the request and verify the result:
 				response, err := handler.List(ctx, &ListRequest{})
 				Expect(err).ToNot(HaveOccurred())
@@ -229,6 +256,60 @@ var _ = Describe("Deployment manager handler", func() {
 					"serviceUri":          "https://your-cluster:6443",
 				}))
 			})
+
+			It("Adds configurable extensions", func() {
+				// Prepare a backend:
+				backend.AppendHandlers(
+					CombineHandlers(
+						RespondWithList(data.Object{
+							"metadata": data.Object{
+								"name": "my-cluster",
+								"labels": data.Object{
+									"clusterID": "123",
+									"country":   "ES",
+								},
+								"annotations": data.Object{
+									"region": "Madrid",
+								},
+							},
+							"spec": data.Object{
+								"managedClusterClientConfigs": data.Array{
+									data.Object{
+										"url": "https://my-cluster:6443",
+									},
+								},
+							},
+						}),
+					),
+				)
+
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					SetExtensions(
+						`{
+							"country": .metadata.labels["country"],
+							"region": .metadata.annotations["region"]
+						}`,
+						`{
+							"fixed": 123
+						}`).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Send the request and verify the result:
+				response, err := handler.List(ctx, &ListRequest{})
+				Expect(err).ToNot(HaveOccurred())
+				items, err := data.Collect(ctx, response.Items)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(items).To(HaveLen(1))
+				Expect(items[0]).To(MatchJQ(`.extensions.country`, "ES"))
+				Expect(items[0]).To(MatchJQ(`.extensions.region`, "Madrid"))
+				Expect(items[0]).To(MatchJQ(`.extensions.fixed`, 123))
+			})
 		})
 
 		Describe("Get", func() {
@@ -240,6 +321,15 @@ var _ = Describe("Deployment manager handler", func() {
 						RespondWithObject(data.Object{}),
 					),
 				)
+
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					Build()
+				Expect(err).ToNot(HaveOccurred())
 
 				// Send the request. Note that we ignore the error here because
 				// all we care about in this test is that it sends the token, no
@@ -258,6 +348,15 @@ var _ = Describe("Deployment manager handler", func() {
 					),
 				)
 
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
 				// Send the request. Note that we ignore the error here because
 				// all we care about in this test is that it uses the right URL
 				// path, no matter what is the response.
@@ -275,6 +374,15 @@ var _ = Describe("Deployment manager handler", func() {
 					),
 				)
 
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
 				// Send the request. Note that we ignore the error here because
 				// all we care about in this test is that it uses the right URL
 				// path, no matter what is the response.
@@ -291,6 +399,15 @@ var _ = Describe("Deployment manager handler", func() {
 						RespondWithObject(data.Object{}),
 					),
 				)
+
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					Build()
+				Expect(err).ToNot(HaveOccurred())
 
 				// Send the request. Note that we ignore the error here because
 				// all we care about in this test is that it uses the right URL
@@ -322,6 +439,15 @@ var _ = Describe("Deployment manager handler", func() {
 					),
 				)
 
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
 				// Send the request and verify the result:
 				response, err := handler.Get(ctx, &GetRequest{
 					ID: "123",
@@ -335,6 +461,60 @@ var _ = Describe("Deployment manager handler", func() {
 					"oCloudId":            "123",
 					"serviceUri":          "https://my-cluster:6443",
 				}))
+			})
+
+			It("Adds configurable extensions", func() {
+				// Prepare a backend:
+				backend.AppendHandlers(
+					CombineHandlers(
+						RespondWithList(data.Object{
+							"metadata": data.Object{
+								"name": "my-cluster",
+								"labels": data.Object{
+									"clusterID": "123",
+									"country":   "ES",
+								},
+								"annotations": data.Object{
+									"region": "Madrid",
+								},
+							},
+							"spec": data.Object{
+								"managedClusterClientConfigs": data.Array{
+									data.Object{
+										"url": "https://my-cluster:6443",
+									},
+								},
+							},
+						}),
+					),
+				)
+
+				// Create the handler:
+				handler, err := NewDeploymentManagerHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					SetExtensions(
+						`{
+							"country": .metadata.labels["country"],
+							"region": .metadata.annotations["region"]
+						}`,
+						`{
+							"fixed": 123
+						}`).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Send the request and verify the result:
+				response, err := handler.Get(ctx, &GetRequest{
+					ID: "123",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.Object).To(MatchJQ(`.extensions.country`, "ES"))
+				Expect(response.Object).To(MatchJQ(`.extensions.region`, "Madrid"))
+				Expect(response.Object).To(MatchJQ(`.extensions.fixed`, 123))
 			})
 		})
 	})


### PR DESCRIPTION
Currently the population of the _extensions_ field is completely hardcoded. This patch adds support for populating it in a configurable way. A new `--extensions` command line option is added to the deployment manager server. The value will be a jq script that calculates extension fields. For example, if the managed cluster has a `country` label the following command line option will configure the server to add a corresponding `country` extension:

```
--extensions={
  "country": .metadata.labels["country"]
}
```

For a cluster where the value of the `contry` label is `ES` that will result in the following extensions:

```json
{
  "country": "ES"
}
```

Related: https://issues.redhat.com/browse/MGMT-16351