### PR TITLE
MGMT-16391: Add support for `exclude_fields`

### DIFF
--- a/internal/search/path.go
+++ b/internal/search/path.go
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package search
+
+import (
+	"slices"
+)
+
+// Path represents the path of an attribute inside a complex data type. Each value of the slice is
+// an attribute name, starting with the outermost field name.
+type Path []string
+
+// Clone creates a deep copy of the path.
+func (p Path) Clone() Path {
+	return slices.Clone(p)
+}

--- a/internal/search/path_evaluator.go
+++ b/internal/search/path_evaluator.go
@@ -63,7 +63,7 @@ func (b *PathEvaluatorBuilder) Build() (result *PathEvaluator, err error) {
 }
 
 // Evaluate receives the attribute path and the object and returns the value of that attribute.
-func (r *PathEvaluator) Evaluate(ctx context.Context, path []string, object any) (result any,
+func (r *PathEvaluator) Evaluate(ctx context.Context, path Path, object any) (result any,
 	err error) {
 	value, err := r.evaluate(ctx, path, reflect.ValueOf(object))
 	if err != nil {

--- a/internal/search/paths_lexer.go
+++ b/internal/search/paths_lexer.go
@@ -23,86 +23,86 @@ import (
 	"unicode"
 )
 
-// projectorLexerBuilder contains the data and logic needed to create a new lexical scanner for
-// field selection expressions. Don't create instances of this directly, use the newProjectorLexer
+// pathsLexerBuilder contains the data and logic needed to create a new lexical scanner for field
+// paths. Don't create instances of this directly, use the newPthsLexer
 // function instead.
-type projectorLexerBuilder struct {
+type pathsLexerBuilder struct {
 	logger *slog.Logger
 	source string
 }
 
-// projectorLexer is a lexical scanner for the field selector expression language. Don't create
-// instances of this type directly, use the newProjectorLexer function instead.
-type projectorLexer struct {
+// pathsLexer is a lexical scanner for the fields paths. Don't create instances of this type
+// directly, use the newPthsLexer function instead.
+type pathsLexer struct {
 	logger *slog.Logger
 	buffer *bytes.Buffer
 }
 
-// projectorSymbol represents the terminal symbols of the field selection language.
-type projectorSymbol int
+// pathsSymbol represents the terminal symbols of the field selection language.
+type pathsSymbol int
 
 const (
-	projectorSymbolEnd projectorSymbol = iota
-	projectorSymbolIdentifier
-	projectorSymbolComma
-	projectorSymbolSlash
+	pathsSymbolEnd pathsSymbol = iota
+	pathsSymbolIdentifier
+	pathsSymbolComma
+	pathsSymbolSlash
 )
 
 // String generates a string representation of the terminal symbol.
-func (s projectorSymbol) String() string {
+func (s pathsSymbol) String() string {
 	switch s {
-	case projectorSymbolEnd:
+	case pathsSymbolEnd:
 		return "End"
-	case projectorSymbolIdentifier:
+	case pathsSymbolIdentifier:
 		return "Identifier"
-	case projectorSymbolComma:
+	case pathsSymbolComma:
 		return "Comma"
-	case projectorSymbolSlash:
+	case pathsSymbolSlash:
 		return "Slash"
 	default:
 		return fmt.Sprintf("Unknown:%d", s)
 	}
 }
 
-// projectorToken represents the tokens returned by the lexical scanner. Each token contains the
+// pathsToken represents the tokens returned by the lexical scanner. Each token contains the
 // terminal symbol and its text.
-type projectorToken struct {
-	Symbol projectorSymbol
+type pathsToken struct {
+	Symbol pathsSymbol
 	Text   string
 }
 
 // String geneates a string representation of the token.
-func (t *projectorToken) String() string {
+func (t *pathsToken) String() string {
 	if t == nil {
 		return "Nil"
 	}
 	switch t.Symbol {
-	case projectorSymbolIdentifier:
+	case pathsSymbolIdentifier:
 		return fmt.Sprintf("%s:%s", t.Symbol, t.Text)
 	default:
 		return t.Symbol.String()
 	}
 }
 
-// newProjectorLexer creates a builder that can then be used to configure and create lexers.
-func newProjectorLexer() *projectorLexerBuilder {
-	return &projectorLexerBuilder{}
+// newPathsLexer creates a builder that can then be used to configure and create lexers.
+func newPathsLexer() *pathsLexerBuilder {
+	return &pathsLexerBuilder{}
 }
 
 // SetLogger sets the logger that the lexer will use to write log messesages. This is mandatory.
-func (b *projectorLexerBuilder) SetLogger(value *slog.Logger) *projectorLexerBuilder {
+func (b *pathsLexerBuilder) SetLogger(value *slog.Logger) *pathsLexerBuilder {
 	b.logger = value
 	return b
 }
 
 // SetSource sets the source string to parse. This is mandatory.
-func (b *projectorLexerBuilder) SetSource(value string) *projectorLexerBuilder {
+func (b *pathsLexerBuilder) SetSource(value string) *pathsLexerBuilder {
 	b.source = value
 	return b
 }
 
 // Build uses the data stored in the builder to create a new lexer.
-func (b *projectorLexerBuilder) Build() (result *projectorLexer, err error) {
+func (b *pathsLexerBuilder) Build() (result *pathsLexer, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -114,7 +114,7 @@ func (b *projectorLexerBuilder) Build() (result *projectorLexer, err error) {
 	}
 
 	// Create and populate the object:
-	result = &projectorLexer{
+	result = &pathsLexer{
 		logger: b.logger,
 		buffer: bytes.NewBufferString(b.source),
 	}
@@ -122,7 +122,7 @@ func (b *projectorLexerBuilder) Build() (result *projectorLexer, err error) {
 }
 
 // FetchToken fetches the next token from the source.
-func (l *projectorLexer) FetchToken() (token *projectorToken, err error) {
+func (l *pathsLexer) FetchToken() (token *pathsToken, err error) {
 	type State int
 	const (
 		S0 State = iota
@@ -142,22 +142,22 @@ func (l *projectorLexer) FetchToken() (token *projectorToken, err error) {
 				lexeme.WriteRune(r)
 				state = S1
 			case r == ',':
-				token = &projectorToken{
-					Symbol: projectorSymbolComma,
+				token = &pathsToken{
+					Symbol: pathsSymbolComma,
 					Text:   ",",
 				}
 				return
 			case r == '/':
-				token = &projectorToken{
-					Symbol: projectorSymbolSlash,
+				token = &pathsToken{
+					Symbol: pathsSymbolSlash,
 					Text:   "/",
 				}
 				return
 			case r == '~':
 				state = S2
 			case r == 0:
-				token = &projectorToken{
-					Symbol: projectorSymbolEnd,
+				token = &pathsToken{
+					Symbol: pathsSymbolEnd,
 				}
 				return
 			default:
@@ -177,8 +177,8 @@ func (l *projectorLexer) FetchToken() (token *projectorToken, err error) {
 				state = S2
 			default:
 				l.unreadRune()
-				token = &projectorToken{
-					Symbol: projectorSymbolIdentifier,
+				token = &pathsToken{
+					Symbol: pathsSymbolIdentifier,
 					Text:   lexeme.String(),
 				}
 				return
@@ -209,7 +209,7 @@ func (l *projectorLexer) FetchToken() (token *projectorToken, err error) {
 	}
 }
 
-func (l *projectorLexer) readRune() rune {
+func (l *pathsLexer) readRune() rune {
 	r, _, err := l.buffer.ReadRune()
 	if errors.Is(err, io.EOF) {
 		return 0
@@ -224,7 +224,7 @@ func (l *projectorLexer) readRune() rune {
 	return r
 }
 
-func (l *projectorLexer) unreadRune() {
+func (l *pathsLexer) unreadRune() {
 	err := l.buffer.UnreadRune()
 	if err != nil {
 		l.logger.Error(

--- a/internal/search/paths_parser.go
+++ b/internal/search/paths_parser.go
@@ -1,0 +1,203 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package search
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+)
+
+// PathsParserBuilder contains the logic and data needed to create field paths parsers.
+// Don't create instances of this type directly, use the NewPathsParser function instead.
+type PathsParserBuilder struct {
+	logger *slog.Logger
+}
+
+// PathsParser knows how to parse field paths. Don't create instances of this type directly, use
+// the NewPathsParser function instead.
+type PathsParser struct {
+	logger *slog.Logger
+}
+
+// pathsParserTask contains the data needed to perform the parsing of field paths. A new one will
+// be created each time that the Parse method is called.
+type pathsParserTask struct {
+	logger *slog.Logger
+	lexer  *pathsLexer
+	token  *pathsToken
+}
+
+// NewPathsParser creates a builder that can then be used to configure and create path parsers.
+func NewPathsParser() *PathsParserBuilder {
+	return &PathsParserBuilder{}
+}
+
+// SetLogger sets the logger that the parser will use to write log messages. This is mandatory.
+func (b *PathsParserBuilder) SetLogger(value *slog.Logger) *PathsParserBuilder {
+	b.logger = value
+	return b
+}
+
+// Build uses the configuration stored in the builder to create a new parser.
+func (b *PathsParserBuilder) Build() (result *PathsParser, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+
+	// Create and populate the object:
+	result = &PathsParser{
+		logger: b.logger,
+	}
+	return
+}
+
+// Parse parses the given field paths.
+func (p *PathsParser) Parse(paths ...string) (result []Path, err error) {
+	// In order to simplify the rest of the parsing code we will panic when an error is
+	// detected. This recovers from those panics and converts them into regular errors.
+	defer func() {
+		fault := recover()
+		if fault != nil {
+			p.logger.Error(
+				"Failed to parse",
+				"text", paths,
+				"error", err,
+			)
+			err = fault.(error)
+		}
+	}()
+
+	// Parse the paths:
+	for _, path := range paths {
+		lexer, err := newPathsLexer().
+			SetLogger(p.logger).
+			SetSource(path).
+			Build()
+		if err != nil {
+			panic(err)
+		}
+		task := &pathsParserTask{
+			logger: p.logger,
+			lexer:  lexer,
+		}
+		result = append(result, task.parsePaths()...)
+	}
+	return
+}
+
+func (t *pathsParserTask) parsePaths() []Path {
+	var paths []Path
+	for {
+		path := t.parsePath()
+		paths = append(paths, path)
+		if t.checkToken(pathsSymbolComma) {
+			t.fetchToken()
+			continue
+		}
+		if t.checkToken(pathsSymbolEnd) {
+			break
+		}
+		panic(fmt.Errorf(
+			"unexpected token '%s' while expecting comma or right parenthesis",
+			t.currentToken().Text,
+		))
+	}
+	return paths
+}
+
+func (t *pathsParserTask) parsePath() Path {
+	var segments Path
+	for {
+		segment := t.parseIdentifier()
+		segments = append(segments, segment)
+		if t.checkToken(pathsSymbolSlash) {
+			t.fetchToken()
+			continue
+		}
+		if t.checkToken(pathsSymbolComma) {
+			break
+		}
+		if t.checkToken(pathsSymbolEnd) {
+			break
+		}
+		panic(fmt.Errorf(
+			"unexpected token '%s' while expecting slash or comma",
+			t.currentToken().Text,
+		))
+	}
+	return segments
+}
+
+func (t *pathsParserTask) parseIdentifier() string {
+	token := t.currentToken()
+	t.consumeToken(pathsSymbolIdentifier)
+	return token.Text
+}
+
+// currentToken resturns the current token, fetching it from the lexer if needed.
+func (t *pathsParserTask) currentToken() *pathsToken {
+	t.ensureToken()
+	return t.token
+}
+
+// fetchToken discard the current token and fetches a new one from the lexer.
+func (t *pathsParserTask) fetchToken() {
+	token, err := t.lexer.FetchToken()
+	if err != nil {
+		panic(err)
+	}
+	t.token = token
+}
+
+// checkToken returns true if the current token has the given symbol.
+func (t *pathsParserTask) checkToken(symbol pathsSymbol) bool {
+	t.ensureToken()
+	return t.token.Symbol == symbol
+}
+
+// consumeToken checks that the symbol of the current token and then discards it, so that the next
+// time that a token is needed a new one will be fetched from the lexer. If the symbol is not the
+// given one then it panics.
+func (t *pathsParserTask) consumeToken(symbol pathsSymbol) {
+	t.ensureToken()
+	if t.token.Symbol != symbol {
+		var expected string
+		switch symbol {
+		case pathsSymbolEnd:
+			expected = "end of input"
+		case pathsSymbolIdentifier:
+			expected = "identifier"
+		case pathsSymbolComma:
+			expected = "comma"
+		case pathsSymbolSlash:
+			expected = "slash"
+		}
+		panic(fmt.Errorf(
+			"unexpected token '%s' while expecting %s",
+			t.token.Text, expected,
+		))
+	}
+	t.token = nil
+}
+
+// ensureToken makes sure the current token is populated, fetching it from the lexer if needed.
+func (t *pathsParserTask) ensureToken() {
+	if t.token == nil {
+		t.fetchToken()
+	}
+}

--- a/internal/search/paths_parser_test.go
+++ b/internal/search/paths_parser_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package search
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Paths parser", func() {
+	DescribeTable(
+		"Parses correctly",
+		func(text string, expected []Path) {
+			parser, err := NewPathsParser().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			actual, err := parser.Parse(text)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		},
+		Entry(
+			"One segment",
+			"myattr",
+			[]Path{
+				{"myattr"},
+			},
+		),
+		Entry(
+			"Two segments",
+			"myattr/yourattr",
+			[]Path{
+				{"myattr", "yourattr"},
+			},
+		),
+		Entry(
+			"Quoted ~ in path",
+			"my~0attr",
+			[]Path{
+				{"my~attr"},
+			},
+		),
+		Entry(
+			"Quoted slash in path",
+			"my~1attr",
+			[]Path{
+				{"my/attr"},
+			},
+		),
+		Entry(
+			"Quoted comma in path",
+			"my~aattr",
+			[]Path{
+				{"my,attr"},
+			},
+		),
+		Entry(
+			"Multiple paths",
+			"myattr,yourattr",
+			[]Path{
+				{"myattr"},
+				{"yourattr"},
+			},
+		),
+		Entry(
+			"Multiple paths with multiple segments",
+			"myattr/yourattr,myfield/yourfield",
+			[]Path{
+				{"myattr", "yourattr"},
+				{"myfield", "yourfield"},
+			},
+		),
+	)
+
+	It("Aggreates multiple paths", func() {
+		parser, err := NewPathsParser().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		paths, err := parser.Parse("myfield", "yourfield")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(paths).To(Equal([]Path{
+			{"myfield"},
+			{"yourfield"},
+		}))
+	})
+})

--- a/internal/search/projector.go
+++ b/internal/search/projector.go
@@ -1,0 +1,54 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package search
+
+import "slices"
+
+// Projector defines how to remove fields from an object.
+type Projector struct {
+	// Include is the list of paths that will be included in the result when the projector
+	// is evaluated. An empty list means that all paths will be included.
+	Include []Path
+
+	// Exclude is the list of paths that will be excluded from the result when the projector
+	// is evaluated. An empty list means that no path will be excluded.
+	Exclude []Path
+}
+
+// Empty returns true iif the projector has no include or exclude paths.
+func (p *Projector) Empty() bool {
+	return p == nil || (len(p.Include) == 0 && len(p.Exclude) == 0)
+}
+
+// Clone creates a deep copy of the projector.
+func (p *Projector) Clone() *Projector {
+	if p == nil {
+		return nil
+	}
+	clone := &Projector{}
+	if p.Include != nil {
+		clone.Include = make([]Path, len(p.Include))
+		for i, path := range p.Include {
+			clone.Include[i] = slices.Clone(path)
+		}
+	}
+	if p.Exclude != nil {
+		clone.Exclude = make([]Path, len(p.Exclude))
+		for i, path := range p.Exclude {
+			clone.Exclude[i] = slices.Clone(path)
+		}
+	}
+	return clone
+}

--- a/internal/search/projector_evaluator_test.go
+++ b/internal/search/projector_evaluator_test.go
@@ -24,7 +24,7 @@ import (
 
 var _ = Describe("Projector evaluator", func() {
 	// nop is a simple path evaluator that always return nil.
-	var nop = func(context.Context, []string, any) (any, error) {
+	var nop = func(context.Context, Path, any) (any, error) {
 		return nil, nil
 	}
 
@@ -64,13 +64,13 @@ var _ = Describe("Projector evaluator", func() {
 
 	DescribeTable(
 		"Evaluates correctly",
-		func(src string, producer func() any, expected map[string]any) {
+		func(include, exclude string, producer func() any, expected map[string]any) {
 			// Parse the projector:
 			parser, err := NewProjectorParser().
 				SetLogger(logger).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			projector, err := parser.Parse(src)
+			projector, err := parser.Parse(include, exclude)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Evaluate the projector:
@@ -90,8 +90,28 @@ var _ = Describe("Projector evaluator", func() {
 			Expect(actual).To(Equal(expected))
 		},
 		Entry(
-			"Top level string",
+			"Include everything by default",
+			"",
+			"",
+			func() any {
+				type MyObject struct {
+					MyField   string
+					YourField string
+				}
+				return MyObject{
+					MyField:   "myvalue",
+					YourField: "yourvalue",
+				}
+			},
+			map[string]any{
+				"MyField":   "myvalue",
+				"YourField": "yourvalue",
+			},
+		),
+		Entry(
+			"Include top level string",
 			"MyField",
+			"",
 			func() any {
 				type MyObject struct {
 					MyField string
@@ -105,8 +125,9 @@ var _ = Describe("Projector evaluator", func() {
 			},
 		),
 		Entry(
-			"Nested string",
+			"Include nested string",
 			"MyField/YourField",
+			"",
 			func() any {
 				type YourObject struct {
 					YourField string
@@ -127,8 +148,9 @@ var _ = Describe("Projector evaluator", func() {
 			},
 		),
 		Entry(
-			"Multiple subfields",
+			"Include multiple subfields",
 			"extensions/country,extensions/version,extensions/hub",
+			"",
 			func() any {
 				return map[string]any{
 					"extensions": map[string]any{
@@ -146,6 +168,79 @@ var _ = Describe("Projector evaluator", func() {
 					"version": "1.2.3",
 					"hub":     "hub0",
 				},
+			},
+		),
+		Entry(
+			"Exclude top level string",
+			"",
+			"YourField",
+			func() any {
+				type MyObject struct {
+					MyField   string
+					YourField string
+				}
+				return MyObject{
+					MyField:   "myvalue",
+					YourField: "yourvalue",
+				}
+			},
+			map[string]any{
+				"MyField": "myvalue",
+			},
+		),
+		Entry(
+			"Exclude nested string",
+			"",
+			"MyField/YourField",
+			func() any {
+				type YourObject struct {
+					YourField  string
+					TheirField string
+				}
+				type MyObject struct {
+					MyField YourObject
+				}
+				return MyObject{
+					MyField: YourObject{
+						YourField:  "yourvalue",
+						TheirField: "theirvalue",
+					},
+				}
+			},
+			map[string]any{
+				"MyField": map[string]any{
+					"TheirField": "theirvalue",
+				},
+			},
+		),
+		Entry(
+			"Include and then exclude",
+			"MyField",
+			"MyField",
+			func() any {
+				type MyObject struct {
+					MyField string
+				}
+				return MyObject{
+					MyField: "myvalue",
+				}
+			},
+			map[string]any{},
+		),
+		Entry(
+			"Exclude non existing field",
+			"MyField",
+			"YourField",
+			func() any {
+				type MyObject struct {
+					MyField string
+				}
+				return MyObject{
+					MyField: "myvalue",
+				}
+			},
+			map[string]any{
+				"MyField": "myvalue",
 			},
 		),
 	)

--- a/internal/search/projector_parser.go
+++ b/internal/search/projector_parser.go
@@ -16,7 +16,6 @@ package search
 
 import (
 	"errors"
-	"fmt"
 	"log/slog"
 )
 
@@ -29,15 +28,8 @@ type ProjectorParserBuilder struct {
 // ProjectorParser knows how to parse field selectors. Don't create instances of this type
 // directly, use the NewProjectorParser function instead.
 type ProjectorParser struct {
-	logger *slog.Logger
-}
-
-// projectorParserTask contains the data needed to perform the parsing of one field selection
-// specification. A new one will be created each time that the Parse method is called.
-type projectorParserTask struct {
-	logger *slog.Logger
-	lexer  *projectorLexer
-	token  *projectorToken
+	logger      *slog.Logger
+	pathsParser *PathsParser
 }
 
 // NewProjectorParser creates a builder that can then be used to configure and create field
@@ -60,146 +52,44 @@ func (b *ProjectorParserBuilder) Build() (result *ProjectorParser, err error) {
 		return
 	}
 
+	// Create the paths parser:
+	pathsParser, err := NewPathsParser().
+		SetLogger(b.logger).
+		Build()
+	if err != nil {
+		return
+	}
+
 	// Create and populate the object:
 	result = &ProjectorParser{
-		logger: b.logger,
+		logger:      b.logger,
+		pathsParser: pathsParser,
 	}
 	return
 }
 
 // Parse parses the give field selector. If it succeeds it returns the object selector. If it fails
 // it returns an error.
-func (p *ProjectorParser) Parse(text string) (result [][]string, err error) {
-	// In order to simplify the rest of the parsing code we will panic when an error is
-	// detected. This recovers from those panics and converts them into regular errors.
-	defer func() {
-		fault := recover()
-		if fault != nil {
-			p.logger.Error(
-				"Failed to parse",
-				"text", text,
-				"error", err,
-			)
-			err = fault.(error)
+func (p *ProjectorParser) Parse(include, exclude string) (result *Projector, err error) {
+	// Parse the paths:
+	var includePaths, excludePaths []Path
+	if include != "" {
+		includePaths, err = p.pathsParser.Parse(include)
+		if err != nil {
+			return
 		}
-	}()
-
-	// Create the lexer:
-	lexer, err := newProjectorLexer().
-		SetLogger(p.logger).
-		SetSource(text).
-		Build()
-	if err != nil {
-		return
+	}
+	if exclude != "" {
+		excludePaths, err = p.pathsParser.Parse(exclude)
+		if err != nil {
+			return
+		}
 	}
 
-	// Create and run the parse task:
-	task := &projectorParserTask{
-		logger: p.logger,
-		lexer:  lexer,
+	// Create the result:
+	result = &Projector{
+		Include: includePaths,
+		Exclude: excludePaths,
 	}
-	result = task.parseProjector()
 	return
-}
-
-func (t *projectorParserTask) parseProjector() [][]string {
-	var paths [][]string
-	for {
-		path := t.parsePath()
-		paths = append(paths, path)
-		if t.checkToken(projectorSymbolComma) {
-			t.fetchToken()
-			continue
-		}
-		if t.checkToken(projectorSymbolEnd) {
-			break
-		}
-		panic(fmt.Errorf(
-			"unexpected token '%s' while expecting comma or right parenthesis",
-			t.currentToken().Text,
-		))
-	}
-	return paths
-}
-
-func (t *projectorParserTask) parsePath() []string {
-	var segments []string
-	for {
-		segment := t.parseIdentifier()
-		segments = append(segments, segment)
-		if t.checkToken(projectorSymbolSlash) {
-			t.fetchToken()
-			continue
-		}
-		if t.checkToken(projectorSymbolComma) {
-			break
-		}
-		if t.checkToken(projectorSymbolEnd) {
-			break
-		}
-		panic(fmt.Errorf(
-			"unexpected token '%s' while expecting slash or comma",
-			t.currentToken().Text,
-		))
-	}
-	return segments
-}
-
-func (t *projectorParserTask) parseIdentifier() string {
-	token := t.currentToken()
-	t.consumeToken(projectorSymbolIdentifier)
-	return token.Text
-}
-
-// currentToken resturns the current token, fetching it from the lexer if needed.
-func (t *projectorParserTask) currentToken() *projectorToken {
-	t.ensureToken()
-	return t.token
-}
-
-// fetchToken discard the current token and fetches a new one from the lexer.
-func (t *projectorParserTask) fetchToken() {
-	token, err := t.lexer.FetchToken()
-	if err != nil {
-		panic(err)
-	}
-	t.token = token
-}
-
-// checkToken returns true if the current token has the given symbol.
-func (t *projectorParserTask) checkToken(symbol projectorSymbol) bool {
-	t.ensureToken()
-	return t.token.Symbol == symbol
-}
-
-// consumeToken checks that the symbol of the current token and then discards it, so that the next
-// time that a token is needed a new one will be fetched from the lexer. If the symbol is not the
-// given one then it panics.
-func (t *projectorParserTask) consumeToken(symbol projectorSymbol) {
-	t.ensureToken()
-	if t.token.Symbol != symbol {
-		var expected string
-		switch symbol {
-		case projectorSymbolEnd:
-			expected = "end of input"
-		case projectorSymbolIdentifier:
-			expected = "identifier"
-		case projectorSymbolComma:
-			expected = "comma"
-		case projectorSymbolSlash:
-			expected = "slash"
-		}
-		panic(fmt.Errorf(
-			"unexpected token '%s' while expecting %s",
-			t.token.Text, expected,
-		))
-	}
-	t.token = nil
-}
-
-// ensureToken makes sure the current token is populated, fetching it from the lexer if needed.
-func (t *projectorParserTask) ensureToken() {
-	if t.token == nil {
-		t.fetchToken()
-	}
 }

--- a/internal/search/projector_parser_test.go
+++ b/internal/search/projector_parser_test.go
@@ -23,64 +23,127 @@ import (
 var _ = Describe("Projector parser", func() {
 	DescribeTable(
 		"Parses correctly",
-		func(text string, expected [][]string) {
+		func(include, exclude string, expected *Projector) {
 			parser, err := NewProjectorParser().
 				SetLogger(logger).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			actual, err := parser.Parse(text)
+			actual, err := parser.Parse(include, exclude)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(Equal(expected))
 		},
 		Entry(
-			"One segment",
+			"Include one segment",
 			"myattr",
-			[][]string{
-				{"myattr"},
+			"",
+			&Projector{
+				Include: []Path{
+					{"myattr"},
+				},
+				Exclude: nil,
 			},
 		),
 		Entry(
-			"Two segments",
+			"Include two segments",
 			"myattr/yourattr",
-			[][]string{
-				{"myattr", "yourattr"},
+			"",
+			&Projector{
+				Include: []Path{
+					{"myattr", "yourattr"},
+				},
+				Exclude: nil,
 			},
 		),
 		Entry(
-			"Quoted ~ in path",
+			"Include quoted ~ in path",
 			"my~0attr",
-			[][]string{
-				{"my~attr"},
+			"",
+			&Projector{
+				Include: []Path{
+					{"my~attr"},
+				},
+				Exclude: nil,
 			},
 		),
 		Entry(
-			"Quoted slash in path",
+			"Include quoted slash in path",
 			"my~1attr",
-			[][]string{
-				{"my/attr"},
+			"",
+			&Projector{
+				Include: []Path{
+					{"my/attr"},
+				},
+				Exclude: nil,
 			},
 		),
 		Entry(
-			"Quoted comma in path",
+			"Include quoted comma in path",
 			"my~aattr",
-			[][]string{
-				{"my,attr"},
+			"",
+			&Projector{
+				Include: []Path{
+					{"my,attr"},
+				},
+				Exclude: nil,
 			},
 		),
 		Entry(
-			"Multiple paths",
+			"Include multiple paths",
 			"myattr,yourattr",
-			[][]string{
-				{"myattr"},
-				{"yourattr"},
+			"",
+			&Projector{
+				Include: []Path{
+					{"myattr"},
+					{"yourattr"},
+				},
+				Exclude: nil,
 			},
 		),
 		Entry(
-			"Multiple paths with multiple segments",
+			"Include multiple paths with multiple segments",
 			"myattr/yourattr,myfield/yourfield",
-			[][]string{
-				{"myattr", "yourattr"},
-				{"myfield", "yourfield"},
+			"",
+			&Projector{
+				Include: []Path{
+					{"myattr", "yourattr"},
+					{"myfield", "yourfield"},
+				},
+				Exclude: nil,
+			},
+		),
+		Entry(
+			"Exclude one segment",
+			"",
+			"myattr",
+			&Projector{
+				Include: nil,
+				Exclude: []Path{
+					{"myattr"},
+				},
+			},
+		),
+		Entry(
+			"Exclude two segments",
+			"",
+			"myattr/yourattr",
+			&Projector{
+				Include: nil,
+				Exclude: []Path{
+					{"myattr", "yourattr"},
+				},
+			},
+		),
+		Entry(
+			"Include one field and exclude another",
+			"myattr",
+			"yourattr",
+			&Projector{
+				Include: []Path{
+					{"myattr"},
+				},
+				Exclude: []Path{
+					{"yourattr"},
+				},
 			},
 		),
 	)

--- a/internal/search/projector_test.go
+++ b/internal/search/projector_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package search
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Projector", func() {
+	DescribeTable(
+		"Check empty",
+		func(projector *Projector, expected bool) {
+			Expect(projector.Empty()).To(Equal(expected))
+		},
+		Entry(
+			"Nil",
+			nil,
+			true,
+		),
+		Entry(
+			"Nil include and exclude",
+			&Projector{
+				Include: nil,
+				Exclude: nil,
+			},
+			true,
+		),
+		Entry(
+			"Empty include and exclude",
+			&Projector{
+				Include: []Path{},
+				Exclude: []Path{},
+			},
+			true,
+		),
+		Entry(
+			"Non empty include",
+			&Projector{
+				Include: []Path{
+					{"myattr"},
+				},
+				Exclude: nil,
+			},
+			false,
+		),
+		Entry(
+			"Non empty exclude",
+			&Projector{
+				Include: nil,
+				Exclude: []Path{
+					{"myattr"},
+				},
+			},
+			false,
+		),
+		Entry(
+			"Non empty include and exclude",
+			&Projector{
+				Include: []Path{
+					{"myattr"},
+				},
+				Exclude: []Path{
+					{"myattr"},
+				},
+			},
+			false,
+		),
+	)
+})

--- a/internal/search/selector_evaluator.go
+++ b/internal/search/selector_evaluator.go
@@ -29,14 +29,14 @@ import (
 // instead.
 type SelectorEvaluatorBuilder struct {
 	logger        *slog.Logger
-	pathEvaluator func(context.Context, []string, any) (any, error)
+	pathEvaluator func(context.Context, Path, any) (any, error)
 }
 
 // SelectorEvaluator knows how to evaluate filter expressions. Don't create instances of this type
 // directly, use the NewSelectorEvaluator function instead.
 type SelectorEvaluator struct {
 	logger        *slog.Logger
-	pathEvaluator func(context.Context, []string, any) (any, error)
+	pathEvaluator func(context.Context, Path, any) (any, error)
 }
 
 // NewSelectorEvaluator creates a builder that can then be used to configure and create expression
@@ -94,7 +94,7 @@ func (b *SelectorEvaluatorBuilder) SetLogger(value *slog.Logger) *SelectorEvalua
 // The path evaluator function should return nil if the path corresponds to a valid optional
 // attribute that hasn't a value.
 func (b *SelectorEvaluatorBuilder) SetPathEvaluator(
-	value func(context.Context, []string, any) (any, error)) *SelectorEvaluatorBuilder {
+	value func(context.Context, Path, any) (any, error)) *SelectorEvaluatorBuilder {
 	b.pathEvaluator = value
 	return b
 }

--- a/internal/search/selector_evaluator_test.go
+++ b/internal/search/selector_evaluator_test.go
@@ -24,7 +24,7 @@ import (
 
 var _ = Describe("Selector evaluator", func() {
 	// nop is a simple path evaluator that always return nil.
-	var nop = func(context.Context, []string, any) (any, error) {
+	var nop = func(context.Context, Path, any) (any, error) {
 		return nil, nil
 	}
 

--- a/internal/service/collection_handler.go
+++ b/internal/service/collection_handler.go
@@ -27,7 +27,7 @@ type ListRequest struct {
 	Selector *search.Selector
 
 	// Projector is the list of field paths to return.
-	Projector [][]string
+	Projector *search.Projector
 
 	// ParentID is the identifier of the parent collection.
 	ParentID string

--- a/internal/service/object_handler.go
+++ b/internal/service/object_handler.go
@@ -18,12 +18,13 @@ import (
 	"context"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/search"
 )
 
 // ObjectHandler represents a request for an individual object.
 type GetRequest struct {
 	// Projector is the  list of field paths to return.
-	Projector [][]string
+	Projector *search.Projector
 
 	// ID is the identifier of the object.
 	ID string


### PR DESCRIPTION
This patch adds support for the `exclude_fields` query parameter as defined in section 5.3.2 of the ETSI GS NFV-SOL 013 document. For, example, to exclude the _name_ field from the list of deployment managers:

```
GET /o2ims-infrastructureInventory/v1/deploymentManagers?exclude_fields=name
```

This requires a large refactoring of the search package, as well as changes in the adapters. The logic handlers aren't affected.

Related: https://issues.redhat.com/browse/MGMT-16391
Related: https://www.etsi.org/deliver/etsi_gs/NFV-SOL/001_099/013/03.03.01_60/gs_NFV-SOL013v030301p.pdf