### PR TITLE
MGMT-16307: Optimize GraphQL search using filters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.29.0
+	github.com/thoas/go-funk v0.9.3
 	go.uber.org/mock v0.3.0
 	k8s.io/api v0.28.4
 	k8s.io/apimachinery v0.28.4
@@ -39,7 +40,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/thoas/go-funk v0.9.3 // indirect
 	golang.org/x/exp v0.0.0-20230118134722-a68e582fa157 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/term v0.14.0 // indirect

--- a/internal/graphql/graphql.go
+++ b/internal/graphql/graphql.go
@@ -1,0 +1,110 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package graphql
+
+import (
+	"fmt"
+
+	"github.com/openshift-kni/oran-o2ims/internal/model"
+	"github.com/openshift-kni/oran-o2ims/internal/search"
+)
+
+type FilterOperator search.Operator
+
+// String generates a GraphQL string representation of the operator. It panics if used on an unknown
+// operator.
+func (o FilterOperator) String() (result string, err error) {
+	switch search.Operator(o) {
+	case search.Eq:
+		result = "="
+	case search.Neq:
+		result = "!="
+	case search.Gt:
+		result = ">"
+	case search.Gte:
+		result = ">="
+	case search.Lt:
+		result = "<"
+	case search.Lte:
+		result = "<="
+	default:
+		err = fmt.Errorf("unknown operator %d", o)
+	}
+	return
+}
+
+type PropertyCluster string
+
+// MapProperty maps a specified O2 property name to the search API property name
+func (p PropertyCluster) MapProperty() string {
+	switch p {
+	case "name":
+		return "name"
+	case "resourcePoolID":
+		return "cluster"
+	default:
+		// unknown property
+		return ""
+	}
+}
+
+type PropertyNode string
+
+// MapProperty maps a specified O2 property name to the search API property name
+func (p PropertyNode) MapProperty() string {
+	switch p {
+	case "description":
+		return "name"
+	case "resourcePoolID":
+		return "cluster"
+	case "globalAssetID":
+		return "_uid"
+	case "resourceID":
+		return "_systemUUID"
+	default:
+		// unknown property
+		return ""
+	}
+}
+
+type FilterTerm search.Term
+
+// Map a filter term to a GraphQL SearchFilter
+func (t FilterTerm) MapFilter(mapPropertyFunc func(string) string) (searchFilter *model.SearchFilter, err error) {
+	// Get filter operator
+	var operator string
+	operator, err = FilterOperator(t.Operator).String()
+	if err != nil {
+		return
+	}
+
+	// Generate values
+	values := []*string{}
+	for _, v := range t.Values {
+		value := fmt.Sprintf("%s%s", operator, v.(string))
+		values = append(values, &value)
+	}
+
+	// Convert to GraphQL property
+	searchProperty := mapPropertyFunc(t.Path[0])
+	
+	// Build search filter
+	searchFilter = &model.SearchFilter{
+		Property: searchProperty,
+		Values:   values,
+	}
+
+	return
+}

--- a/internal/graphql/graphql_test.go
+++ b/internal/graphql/graphql_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package graphql
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/oran-o2ims/internal/model"
+	"github.com/openshift-kni/oran-o2ims/internal/search"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("GraphQL filters", func() {
+	DescribeTable(
+		"Map a filter term to a SearchFilter",
+		func(term search.Term, expected *model.SearchFilter, mapPropertyFunc func(string) string) {
+			actual, err := FilterTerm(term).MapFilter(mapPropertyFunc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		},
+		Entry(
+			"Filter term for Cluster",
+			search.Term{
+				Operator: search.Eq,
+				Path: []string{
+					"resourcePoolID",
+				},
+				Values: []any{
+					"spoke0",
+				},
+			},
+			&model.SearchFilter{
+				Property: "cluster",
+				Values:   []*string{ptr.To("=spoke0")},
+			},
+			func(s string) string {
+				return PropertyCluster(s).MapProperty()
+			},
+		),
+		Entry(
+			"Filter term for Node",
+			search.Term{
+				Operator: search.Eq,
+				Path: []string{
+					"resourcePoolID",
+				},
+				Values: []any{
+					"spoke0",
+				},
+			},
+			&model.SearchFilter{
+				Property: "cluster",
+				Values:   []*string{ptr.To("=spoke0")},
+			},
+			func(s string) string {
+				return PropertyNode(s).MapProperty()
+			},
+		),
+	)
+})

--- a/internal/graphql/suite_test.go
+++ b/internal/graphql/suite_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package graphql
+
+import (
+	"log/slog"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestSearch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Search")
+}
+
+var logger *slog.Logger
+
+var _ = BeforeSuite(func() {
+	// Create a logger that writes to the Ginkgo writer, so that the log messages will be
+	// attached to the output of the right test:
+	options := &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}
+	handler := slog.NewJSONHandler(GinkgoWriter, options)
+	logger = slog.New(handler)
+})

--- a/internal/service/resource_fetcher.go
+++ b/internal/service/resource_fetcher.go
@@ -217,7 +217,6 @@ func (r *ResourceFetcher) getSearchResponse(ctx context.Context) (result io.Read
 	if err != nil {
 		return
 	}
-	r.logger.Error(fmt.Sprintf("%v", graphqlVars))
 
 	// Build GraphQL request body
 	var requestBody bytes.Buffer

--- a/internal/service/resource_pool_fetcher.go
+++ b/internal/service/resource_pool_fetcher.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/graphql"
 	"github.com/openshift-kni/oran-o2ims/internal/k8s"
 	"github.com/openshift-kni/oran-o2ims/internal/model"
 	"github.com/thoas/go-funk"
@@ -242,12 +243,14 @@ func (r *ResourcePoolFetcher) getSearchResponse(ctx context.Context) (result io.
 // Map Cluster to an O2 ResourcePool object.
 func (r *ResourcePoolFetcher) mapClusterItem(ctx context.Context,
 	from data.Object) (to data.Object, err error) {
-	resourcePoolID, err := data.GetString(from, "cluster")
+	resourcePoolID, err := data.GetString(from,
+		graphql.PropertyCluster("resourcePoolID").MapProperty())
 	if err != nil {
 		return
 	}
 
-	name, err := data.GetString(from, "name")
+	name, err := data.GetString(from,
+		graphql.PropertyCluster("name").MapProperty())
 	if err != nil {
 		return
 	}

--- a/internal/service/resource_type_handler.go
+++ b/internal/service/resource_type_handler.go
@@ -340,7 +340,7 @@ func (h *ResourceTypeHandler) getGraphqlVars(ctx context.Context) (graphqlVars *
 	return
 }
 
-// Map an item to and O2 Resource object.
+// Map an item to an O2 Resource object.
 func (h *ResourceTypeHandler) mapItem(ctx context.Context,
 	from data.Object) (to data.Object, err error) {
 	kind, err := data.GetString(from, "kind")


### PR DESCRIPTION
Optimized the filtering of search results in the resource server. I.e. instead of filtering the items after fetching a response, used the filter functionality of [GraphQL](https://github.com/stolostron/search-v2-operator/wiki/Search-Query-API#sample-queries) search query API. This change includes the required mapping from 'filter' query param (as defined in the NFV spec) into SearchFilter as used in GraphQL.
Note: for any unsupported search operator by GraphQL, we fallback to the regular selector filtering.