### PR TITLE
MGMT-16112: Run 'spectral' checks in unit tests

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -48,6 +48,13 @@ jobs:
         go install github.com/onsi/ginkgo/v2/ginkgo@$(go list -f '{{.Version}}' -m github.com/onsi/ginkgo/v2)
         go install go.uber.org/mock/mockgen@v0.3.0
 
+    - name: Install spectral
+      run: |
+        curl -Lo spectral https://github.com/stoplightio/spectral/releases/download/v6.11.0/spectral-linux-x64
+        echo 0e151d3dc5729750805428f79a152fa01dd4c203f1d9685ef19f4fd4696fcd5f spectral | sha256sum -c
+        chmod +x spectral
+        sudo mv spectral /usr/bin
+
     - name: Run the tests
       run: make tests
 

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,6 @@ lint:
 	golangci-lint --version
 	golangci-lint run --verbose --print-resources-usage --modules-download-mode=vendor --timeout=5m0s
 
-.PHONY: lint-openapi
-lint-openapi:
-	@echo "Run lint OpenAPI"
-	spectral lint --ruleset internal/openapi/lint.yaml internal/openapi/spec.yaml
-
 .PHONY: deps-update
 deps-update:
 	@echo "Update dependencies"


### PR DESCRIPTION
Currently there is a `lint-openapi` tarket in the Makefile that runs the 'spectral' tool to check the OpenAPI specification. This patch moves that to the unit tests, so that there will be no need to run a separate command.

Related: https://issues.redhat.com/browse/MGMT-16112