### PR TITLE
Fix resources endpoint collection

### DIFF
--- a/internal/cmd/server/start_resource_server.go
+++ b/internal/cmd/server/start_resource_server.go
@@ -323,7 +323,7 @@ func (c *ResourceServerCommand) createResourceHandler(
 	// Create the routes:
 	adapter, err := service.NewAdapter().
 		SetLogger(c.logger).
-		SetPathVariables("resourcePoolID").
+		SetPathVariables("resourcePoolID", "resourceID").
 		SetHandler(handler).
 		Build()
 	if err != nil {

--- a/internal/service/adapter.go
+++ b/internal/service/adapter.go
@@ -250,7 +250,7 @@ func (a *Adapter) serveObject(w http.ResponseWriter, r *http.Request, pathVariab
 			"Failed to get object",
 			"error", err,
 		)
-		if errors.Is(err, ErrNotFound) {
+		if errors.Is(err, ErrNotFound) || errors.Is(err, streaming.ErrEnd) {
 			SendError(
 				w,
 				http.StatusNotFound,


### PR DESCRIPTION
* Added "resourceID" to SetPathVariables in order to support '/resourcePools/{resourcePoolID}/resources' endpoint.
  * Note: the ['Unify collection and object adapters'](https://github.com/openshift-kni/oran-o2ims/pull/44) change relies on it.
* Added missing handling to a 'not found' object in serveObject func.
  * Identifying a stream end error.