### PR TITLE
graphql: handle unknown property in MapFilter

### DIFF
--- a/internal/graphql/graphql.go
+++ b/internal/graphql/graphql.go
@@ -15,6 +15,7 @@ License.
 package graphql
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/openshift-kni/oran-o2ims/internal/model"
@@ -99,6 +100,9 @@ func (t FilterTerm) MapFilter(mapPropertyFunc func(string) string) (searchFilter
 
 	// Convert to GraphQL property
 	searchProperty := mapPropertyFunc(t.Path[0])
+	if searchProperty == "" {
+		return nil, errors.New("unknown GraphQL property")
+	}
 
 	// Build search filter
 	searchFilter = &model.SearchFilter{


### PR DESCRIPTION
Handling unknown GraphQL filter property in MapFilter func.
It is required to fallback into selector filtering when the specified property is not available in the search response.
E.g. ?filter=(eq,location,US) --> should filter using the selector.