### PR TITLE
Add `--external-address` to metadata server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,8 @@
                                 "start",
                                 "metadata-server",
                                 "--log-level=debug",
-                                "--cloud-id=6575154c-72fc-4ed8-9a87-a81885ab38bb"
+                                "--cloud-id=6575154c-72fc-4ed8-9a87-a81885ab38bb",
+                                "--external-address=https://o2ims.example.com"
                         ]
                 },
                 {

--- a/internal/cmd/server/flags.go
+++ b/internal/cmd/server/flags.go
@@ -16,6 +16,7 @@ package server
 
 // Names of command line flags:
 const (
-	cloudIDFlagName    = "cloud-id"
-	extensionsFlagName = "extensions"
+	cloudIDFlagName         = "cloud-id"
+	extensionsFlagName      = "extensions"
+	externalAddressFlagName = "external-address"
 )

--- a/internal/cmd/server/start_metadata_server.go
+++ b/internal/cmd/server/start_metadata_server.go
@@ -44,6 +44,11 @@ func MetadataServer() *cobra.Command {
 		"",
 		"O-Cloud identifier.",
 	)
+	_ = flags.String(
+		externalAddressFlagName,
+		"",
+		"External address.",
+	)
 	return result
 }
 
@@ -89,6 +94,21 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 	logger.Info(
 		"Cloud identifier",
 		"value", cloudID,
+	)
+
+	// Get the external address:
+	externalAddress, err := flags.GetString(externalAddressFlagName)
+	if err != nil {
+		logger.Error(
+			"Failed to get external address flag",
+			slog.String("flag", externalAddressFlagName),
+			slog.String("error", err.Error()),
+		)
+		return exit.Error(1)
+	}
+	logger.Info(
+		"External address",
+		slog.String("value", externalAddress),
 	)
 
 	// Create the router:
@@ -151,6 +171,7 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 	cloudInfoHandler, err := service.NewCloudInfoHandler().
 		SetLogger(logger).
 		SetCloudID(cloudID).
+		SetExternalAddress(externalAddress).
 		Build()
 	if err != nil {
 		logger.Error(

--- a/internal/controllers/orano2ims_controller.go
+++ b/internal/controllers/orano2ims_controller.go
@@ -218,7 +218,7 @@ func (r *ORANO2IMSReconciler) deployMetadataServer(ctx context.Context, orano2im
 							"--api-listener-tls-crt=/secrets/tls/tls.crt",
 							"--api-listener-tls-key=/secrets/tls/tls.key",
 							fmt.Sprintf("--cloud-id=%s", orano2ims.Spec.CloudId),
-							//fmt.Sprintf("--external-address=https://%s", orano2ims.Spec.IngressHost),
+							fmt.Sprintf("--external-address=https://%s", orano2ims.Spec.IngressHost),
 						},
 						Ports: []corev1.ContainerPort{
 							{

--- a/internal/service/cloud_info_handler.go
+++ b/internal/service/cloud_info_handler.go
@@ -25,15 +25,17 @@ import (
 // CloudInfoHandlerBuilder contains the data and logic needed to create a new handler for the application
 // root. Don't create instances of this type directly, use the NewCloudInfoHandler function instead.
 type CloudInfoHandlerBuilder struct {
-	logger  *slog.Logger
-	cloudID string
+	logger          *slog.Logger
+	cloudID         string
+	externalAddress string
 }
 
 // RootHander knows how to respond to requests for the application root. Don't create instances of
 // this type directly, use the NewCloudInfoHandler function instead.
 type CloudInfoHandler struct {
-	logger  *slog.Logger
-	cloudID string
+	logger          *slog.Logger
+	cloudID         string
+	externalAddress string
 }
 
 // NewCloudInfoHandler creates a builder that can then be used to configure and create a handler for the
@@ -54,6 +56,12 @@ func (b *CloudInfoHandlerBuilder) SetCloudID(value string) *CloudInfoHandlerBuil
 	return b
 }
 
+// SetExternalAddress set the URL of the service as seen by external users.
+func (b *CloudInfoHandlerBuilder) SetExternalAddress(value string) *CloudInfoHandlerBuilder {
+	b.externalAddress = value
+	return b
+}
+
 // Build uses the data stored in the builder to create and configure a new handler.
 func (b *CloudInfoHandlerBuilder) Build() (result *CloudInfoHandler, err error) {
 	// Check parameters:
@@ -68,8 +76,9 @@ func (b *CloudInfoHandlerBuilder) Build() (result *CloudInfoHandler, err error) 
 
 	// Create and populate the object:
 	result = &CloudInfoHandler{
-		logger:  b.logger,
-		cloudID: b.cloudID,
+		logger:          b.logger,
+		cloudID:         b.cloudID,
+		externalAddress: b.externalAddress,
 	}
 	return
 }
@@ -83,7 +92,7 @@ func (h *CloudInfoHandler) Get(ctx context.Context, request *GetRequest) (respon
 			"globalCloudId": h.cloudID,
 			"name":          "OpenShift O-Cloud",
 			"description":   "OpenShift O-Cloud",
-			"serviceUri":    "https://localhost:8080",
+			"serviceUri":    h.externalAddress,
 			"extensions":    data.Object{},
 		},
 	}


### PR DESCRIPTION
This patch adds a new `--externa-address` option to the metadata server. It is used to populate the `serviceUri` field returned by the `/o2ims-infrastructureInventory/v1` endpoint. The operator calculates this using the host name of the ingress.