### PR TITLE
Remove tool binaries from the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /__debug*
 /oran-o2ims
 /vendor
+/bin/*


### PR DESCRIPTION
The `controller-gen` and `manager` binaries were accidentally added to the repository. This patch removes them.