### PR TITLE
Add DELETE support

### DIFF
--- a/internal/service/adapter_test.go
+++ b/internal/service/adapter_test.go
@@ -1083,6 +1083,41 @@ var _ = Describe("Adapter", func() {
 		})
 	})
 
+	Describe("Object deletion", func() {
+		It("Deletes an object", func() {
+			// Prepare the handler:
+			body := func(ctx context.Context,
+				request *DeleteRequest) (response *DeleteResponse, err error) {
+				response = &DeleteResponse{}
+				return
+			}
+			handler := NewMockDeleteHandler(ctrl)
+			handler.EXPECT().Delete(gomock.Any(), gomock.Any()).DoAndReturn(body)
+
+			// Create the adapter:
+			adapter, err := NewAdapter().
+				SetLogger(logger).
+				SetPathVariables("id").
+				SetHandler(handler).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			router := mux.NewRouter()
+			router.Handle("/mycollection/{id}", adapter)
+
+			// Send the request:
+			request := httptest.NewRequest(
+				http.MethodDelete,
+				"/mycollection/123",
+				nil,
+			)
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, request)
+
+			// Verify the response:
+			Expect(recorder.Code).To(Equal(http.StatusNoContent))
+		})
+	})
+
 	DescribeTable(
 		"JSON generation",
 		func(items data.Stream, expected string) {

--- a/internal/service/handlers.go
+++ b/internal/service/handlers.go
@@ -120,10 +120,37 @@ type AddHandler interface {
 	Add(ctx context.Context, request *AddRequest) (response *AddResponse, err error)
 }
 
+// DeleteRequest represents a request to delete an object from a collection.
+type DeleteRequest struct {
+	// Variables contains the values of the path variables. For example, if the request path is
+	// like this:
+	//
+	//	/o2ims-infrastructureInventory/v1/resourcePools/123/resources/456
+	//
+	// Then it will contain '456' and '123'.
+	//
+	// These path variables are ordered from more specific to less specific, the opposite of
+	// what appears in the request path. This is intended to simplify things because most
+	// handlers will only be interested in the most specific identifier and therefore they
+	// can just use index zero.
+	Variables []string
+}
+
+// DeleteResponse represents the response to the request to delete an object from a collection.
+type DeleteResponse struct {
+}
+
+// DeleteHandler is the interface implemented by objects that know how delete items from a
+// collection of objects.
+type DeleteHandler interface {
+	Delete(ctx context.Context, request *DeleteRequest) (response *DeleteResponse, err error)
+}
+
 // Handler aggregates all the other specific handlers. This is intended for unit/ tests, where it
 // is convenient to have a single mock that implements all the operations.
 type Handler interface {
 	ListHandler
 	GetHandler
 	AddHandler
+	DeleteHandler
 }

--- a/internal/service/handlers_mock.go
+++ b/internal/service/handlers_mock.go
@@ -129,6 +129,44 @@ func (mr *MockAddHandlerMockRecorder) Add(ctx, request any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockAddHandler)(nil).Add), ctx, request)
 }
 
+// MockDeleteHandler is a mock of DeleteHandler interface.
+type MockDeleteHandler struct {
+	ctrl     *gomock.Controller
+	recorder *MockDeleteHandlerMockRecorder
+}
+
+// MockDeleteHandlerMockRecorder is the mock recorder for MockDeleteHandler.
+type MockDeleteHandlerMockRecorder struct {
+	mock *MockDeleteHandler
+}
+
+// NewMockDeleteHandler creates a new mock instance.
+func NewMockDeleteHandler(ctrl *gomock.Controller) *MockDeleteHandler {
+	mock := &MockDeleteHandler{ctrl: ctrl}
+	mock.recorder = &MockDeleteHandlerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDeleteHandler) EXPECT() *MockDeleteHandlerMockRecorder {
+	return m.recorder
+}
+
+// Delete mocks base method.
+func (m *MockDeleteHandler) Delete(ctx context.Context, request *DeleteRequest) (*DeleteResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, request)
+	ret0, _ := ret[0].(*DeleteResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockDeleteHandlerMockRecorder) Delete(ctx, request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDeleteHandler)(nil).Delete), ctx, request)
+}
+
 // MockHandler is a mock of Handler interface.
 type MockHandler struct {
 	ctrl     *gomock.Controller
@@ -165,6 +203,21 @@ func (m *MockHandler) Add(ctx context.Context, request *AddRequest) (*AddRespons
 func (mr *MockHandlerMockRecorder) Add(ctx, request any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockHandler)(nil).Add), ctx, request)
+}
+
+// Delete mocks base method.
+func (m *MockHandler) Delete(ctx context.Context, request *DeleteRequest) (*DeleteResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, request)
+	ret0, _ := ret[0].(*DeleteResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockHandlerMockRecorder) Delete(ctx, request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockHandler)(nil).Delete), ctx, request)
 }
 
 // Get mocks base method.


### PR DESCRIPTION
Add DELETE support

This patch adds support for the `DELETE` HTTP method. The adapter will now accept the `DELETE` method and call the `Delete` method defined in the `DeleteHandler` interface. For example, a simple implementation that stores the object in a map in memory could look like this:

```go
func (h *MyHandler) Delete(ctx context.Context, request *AddRequest) (respone *AddResponse, err error) {
        h.storeLock.Lock()
        defer h.storeLock.Unlock()
        delete(h.storeMap, request.Variables[0])
        return
}
``` 