### PR TITLE
MGMT-16974: Introducing the Alarm server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,6 +56,22 @@
                         ]
                 },
                 {
+                        "name": "start alarm-server",
+                        "type": "go",
+                        "request": "launch",
+                        "mode": "auto",
+                        "program": "${workspaceFolder}",
+                        "args": [
+                                "start",
+                                "alarm-server",
+                                "--log-level=debug",
+                                "--cloud-id=6575154c-72fc-4ed8-9a87-a81885ab38bb",
+                                "--backend-url=${env:BACKEND_URL}",
+                                "--backend-token=${env:BACKEND_TOKEN}",
+                                "--resource-server-url=${env:RESOURCE_SERVER_URL}",
+                        ]
+                },
+                {
                         "name": "test",
                         "type": "go",
                         "request": "launch",

--- a/internal/cmd/server/start_alarm_server.go
+++ b/internal/cmd/server/start_alarm_server.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-kni/oran-o2ims/internal"
+	"github.com/openshift-kni/oran-o2ims/internal/exit"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
+	"github.com/openshift-kni/oran-o2ims/internal/network"
+	"github.com/openshift-kni/oran-o2ims/internal/service"
+)
+
+const (
+	alartmanagerApiUrlPrefix    = "alertmanager-open-cluster-management-observability"
+	resourceServerURLFlagName   = "resource-server-url"
+	resourceServerTokenFlagName = "resource-server-token"
+)
+
+// Server creates and returns the `start alarm-server` command.
+func AlarmServer() *cobra.Command {
+	c := NewAlarmServer()
+	result := &cobra.Command{
+		Use:   "alarm-server",
+		Short: "Starts the alarm server",
+		Args:  cobra.NoArgs,
+		RunE:  c.run,
+	}
+	flags := result.Flags()
+	network.AddListenerFlags(flags, network.APIListener, network.APIAddress)
+	_ = flags.String(
+		cloudIDFlagName,
+		"",
+		"O-Cloud identifier.",
+	)
+	_ = flags.String(
+		backendURLFlagName,
+		"",
+		"URL of the backend server.",
+	)
+	_ = flags.String(
+		backendTokenFlagName,
+		"",
+		"Token for authenticating to the backend server.",
+	)
+	_ = flags.String(
+		resourceServerURLFlagName,
+		"",
+		"URL of the resource server.",
+	)
+	_ = flags.String(
+		resourceServerTokenFlagName,
+		"",
+		"Token for authenticating to the resource server.",
+	)
+	_ = flags.StringArray(
+		extensionsFlagName,
+		[]string{},
+		"Extension to add to alarms.",
+	)
+	return result
+}
+
+// AlarmServerCommand contains the data and logic needed to run the `start
+// alarm-server` command.
+type AlarmServerCommand struct {
+	logger *slog.Logger
+}
+
+// NewAlarmServer creates a new runner that knows how to execute the `start
+// alarm-server` command.
+func NewAlarmServer() *AlarmServerCommand {
+	return &AlarmServerCommand{}
+}
+
+// run executes the `start alarm-server` command.
+func (c *AlarmServerCommand) run(cmd *cobra.Command, argv []string) error {
+	// Get the context:
+	ctx := cmd.Context()
+
+	// Get the dependencies from the context:
+	c.logger = internal.LoggerFromContext(ctx)
+
+	// Get the flags:
+	flags := cmd.Flags()
+
+	// Get the cloud identifier:
+	cloudID, err := flags.GetString(cloudIDFlagName)
+	if err != nil {
+		c.logger.Error(
+			"Failed to get cloud identifier flag",
+			"flag", cloudIDFlagName,
+			"error", err.Error(),
+		)
+		return exit.Error(1)
+	}
+	if cloudID == "" {
+		c.logger.Error(
+			"Cloud identifier is empty",
+			"flag", cloudIDFlagName,
+		)
+		return exit.Error(1)
+	}
+	c.logger.Info(
+		"Cloud identifier",
+		"value", cloudID,
+	)
+
+	// Get the backend details:
+	backendURL, err := flags.GetString(backendURLFlagName)
+	if err != nil {
+		c.logger.Error(
+			"Failed to get backend URL flag",
+			"flag", backendURLFlagName,
+			"error", err.Error(),
+		)
+		return exit.Error(1)
+	}
+	if backendURL == "" {
+		c.logger.Error(
+			"Backend URL is empty",
+			"flag", backendURLFlagName,
+		)
+		return exit.Error(1)
+	}
+	backendToken, err := flags.GetString(backendTokenFlagName)
+	if err != nil {
+		c.logger.Error(
+			"Failed to get backend token flag",
+			"flag", backendTokenFlagName,
+			"error", err.Error(),
+		)
+		return exit.Error(1)
+	}
+	if backendToken == "" {
+		c.logger.Error(
+			"Backend token is empty",
+			"flag", backendTokenFlagName,
+		)
+		return exit.Error(1)
+	}
+
+	// Get the resource server details:
+	resourceServerURL, err := flags.GetString(resourceServerURLFlagName)
+	if err != nil {
+		c.logger.Error(
+			"Failed to get resource server URL flag",
+			"flag", resourceServerURLFlagName,
+			"error", err.Error(),
+		)
+		return exit.Error(1)
+	}
+	if resourceServerURL == "" {
+		c.logger.Error(
+			"Resource server URL is empty",
+			"flag", resourceServerURLFlagName,
+		)
+		return exit.Error(1)
+	}
+	resourceServerToken, err := flags.GetString(resourceServerTokenFlagName)
+	if err != nil || resourceServerToken == "" {
+		// Fallbacks to backend token
+		c.logger.Info("Resource server token wasn't specified, using backend token instead.")
+		resourceServerToken = backendToken
+	}
+
+	extensions, err := flags.GetStringArray(extensionsFlagName)
+	if err != nil {
+		c.logger.Error(
+			"Failed to extension flag",
+			"flag", extensionsFlagName,
+			"error", err.Error(),
+		)
+		return exit.Error(1)
+	}
+	c.logger.Info(
+		"Backend details",
+		slog.String("url", backendURL),
+		slog.String("!token", backendToken),
+		slog.Any("extensions", extensions),
+	)
+
+	// Create the transport wrapper:
+	transportWrapper, err := logging.NewTransportWrapper().
+		SetLogger(c.logger).
+		SetFlags(flags).
+		Build()
+	if err != nil {
+		c.logger.Error(
+			"Failed to create transport wrapper",
+			"error", err.Error(),
+		)
+	}
+
+	// Create the router:
+	router := mux.NewRouter()
+	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		service.SendError(w, http.StatusNotFound, "Not found")
+	})
+	router.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		service.SendError(w, http.StatusMethodNotAllowed, "Method not allowed")
+	})
+
+	// Generate the search API URL according the backend URL
+	backendURL, err = c.generateAlarmmanagerApiUrl(backendURL)
+	if err != nil {
+		c.logger.Error(
+			"Failed to generate search API URL",
+			"error", err.Error(),
+		)
+	}
+
+	// Create the handler for alarms:
+	if err := c.createAlarmHandler(
+		transportWrapper, router,
+		cloudID, backendURL, backendToken, resourceServerURL, resourceServerToken, extensions); err != nil {
+		return err
+	}
+
+	// Start the API server:
+	apiListener, err := network.NewListener().
+		SetLogger(c.logger).
+		SetFlags(flags, network.APIListener).
+		Build()
+	if err != nil {
+		c.logger.Error(
+			"Failed to to create API listener",
+			slog.String("error", err.Error()),
+		)
+		return exit.Error(1)
+	}
+	c.logger.Info(
+		"API listening",
+		slog.String("address", apiListener.Addr().String()),
+	)
+	apiServer := http.Server{
+		Addr:    apiListener.Addr().String(),
+		Handler: router,
+	}
+	err = apiServer.Serve(apiListener)
+	if err != nil {
+		c.logger.Error(
+			"API server finished with error",
+			slog.String("error", err.Error()),
+		)
+		return exit.Error(1)
+	}
+
+	return nil
+}
+
+func (c *AlarmServerCommand) createAlarmHandler(
+	transportWrapper func(http.RoundTripper) http.RoundTripper,
+	router *mux.Router,
+	cloudID, backendURL, backendToken, resourceServerUrl, resourceServerToken string,
+	extensions []string) error {
+
+	// Create the handler:
+	handler, err := service.NewAlarmHandler().
+		SetLogger(c.logger).
+		SetTransportWrapper(transportWrapper).
+		SetCloudID(cloudID).
+		SetBackendURL(backendURL).
+		SetBackendToken(backendToken).
+		SetResourceServerURL(resourceServerUrl).
+		SetResourceServerToken(resourceServerToken).
+		SetExtensions(extensions...).
+		Build()
+	if err != nil {
+		c.logger.Error(
+			"Failed to create handler",
+			"error", err,
+		)
+		return exit.Error(1)
+	}
+
+	// Create the routes:
+	adapter, err := service.NewAdapter().
+		SetLogger(c.logger).
+		SetPathVariables("alarmEventRecordId").
+		SetHandler(handler).
+		Build()
+	if err != nil {
+		c.logger.Error(
+			"Failed to create adapter",
+			"error", err,
+		)
+		return exit.Error(1)
+	}
+	router.Handle(
+		"/o2ims-infrastructureMonitoring/{version}/alarms",
+		adapter,
+	).Methods(http.MethodGet)
+	router.Handle(
+		"/o2ims-infrastructureMonitoring/{version}/alarms/{alarmEventRecordId}",
+		adapter,
+	).Methods(http.MethodGet)
+
+	return nil
+}
+
+func (c *AlarmServerCommand) generateAlarmmanagerApiUrl(backendURL string) (string, error) {
+	u, err := url.Parse(backendURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Split URL address
+	hostArr := strings.Split(u.Host, ".")
+
+	// Replace with Alarmmanager API prefix
+	hostArr[0] = alartmanagerApiUrlPrefix
+
+	// Generate search API URL
+	alertmanagerUri := strings.Join(hostArr, ".")
+	return fmt.Sprintf("%s://%s/api/v2", u.Scheme, alertmanagerUri), nil
+}

--- a/internal/cmd/start_cmd.go
+++ b/internal/cmd/start_cmd.go
@@ -30,5 +30,6 @@ func Start() *cobra.Command {
 	result.AddCommand(server.DeploymentManagerServer())
 	result.AddCommand(server.MetadataServer())
 	result.AddCommand(server.ResourceServer())
+	result.AddCommand(server.AlarmServer())
 	return result
 }

--- a/internal/k8s/stream.go
+++ b/internal/k8s/stream.go
@@ -120,6 +120,11 @@ func (s *Stream) Next(ctx context.Context) (item data.Object, err error) {
 
 // find reads from the input until it finds the `items` field, ignoring everything before that.
 func (s *Stream) find(ctx context.Context) error {
+	if s.iterator.WhatIsNext() == jsoniter.ArrayValue {
+		// Found items array in root element
+		s.found = true
+		return nil
+	}
 	for {
 		field := s.iterator.ReadObject()
 		if s.iterator.Error != nil {

--- a/internal/service/alarm_fetcher.go
+++ b/internal/service/alarm_fetcher.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package service
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	neturl "net/url"
+
+	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/jq"
+	"github.com/openshift-kni/oran-o2ims/internal/k8s"
+
+	"github.com/itchyny/gojq"
+)
+
+type AlarmFetcher struct {
+	logger        *slog.Logger
+	cloudID       string
+	backendURL    string
+	backendToken  string
+	backendClient *http.Client
+	extensions    []string
+	jqTool        *jq.Tool
+}
+
+// AlarmFetcherBuilder contains the data and logic needed to create a new AlarmFetcher.
+type AlarmFetcherBuilder struct {
+	logger           *slog.Logger
+	transportWrapper func(http.RoundTripper) http.RoundTripper
+	cloudID          string
+	backendURL       string
+	backendToken     string
+	extensions       []string
+}
+
+// NewAlarmFetcher creates a builder that can then be used to configure
+// and create a handler for the AlarmFetcher.
+func NewAlarmFetcher() *AlarmFetcherBuilder {
+	return &AlarmFetcherBuilder{}
+}
+
+// SetLogger sets the logger that the handler will use to write to the log. This is mandatory.
+func (b *AlarmFetcherBuilder) SetLogger(
+	value *slog.Logger) *AlarmFetcherBuilder {
+	b.logger = value
+	return b
+}
+
+// SetTransportWrapper sets the wrapper that will be used to configure the HTTP clients used to
+// connect to other servers, including the backend server. This is optional.
+func (b *AlarmFetcherBuilder) SetTransportWrapper(
+	value func(http.RoundTripper) http.RoundTripper) *AlarmFetcherBuilder {
+	b.transportWrapper = value
+	return b
+}
+
+// SetCloudID sets the identifier of the O-Cloud of this handler. This is mandatory.
+func (b *AlarmFetcherBuilder) SetCloudID(
+	value string) *AlarmFetcherBuilder {
+	b.cloudID = value
+	return b
+}
+
+// SetBackendURL sets the URL of the backend server This is mandatory.
+func (b *AlarmFetcherBuilder) SetBackendURL(
+	value string) *AlarmFetcherBuilder {
+	b.backendURL = value
+	return b
+}
+
+// SetBackendToken sets the authentication token that will be used to authenticate to the backend
+// server. This is mandatory.
+func (b *AlarmFetcherBuilder) SetBackendToken(
+	value string) *AlarmFetcherBuilder {
+	b.backendToken = value
+	return b
+}
+
+// SetExtensions sets the fields that will be added to the extensions.
+func (b *AlarmFetcherBuilder) SetExtensions(values ...string) *AlarmFetcherBuilder {
+	b.extensions = values
+	return b
+}
+
+// Build uses the data stored in the builder to create and configure a new handler.
+func (b *AlarmFetcherBuilder) Build() (
+	result *AlarmFetcher, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.cloudID == "" {
+		err = errors.New("cloud identifier is mandatory")
+		return
+	}
+	if b.backendURL == "" {
+		err = errors.New("backend URL is mandatory")
+		return
+	}
+	if b.backendToken == "" {
+		err = errors.New("backend token is mandatory")
+		return
+	}
+
+	// Create the HTTP client that we will use to connect to the backend:
+	var backendTransport http.RoundTripper
+	backendTransport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	if b.transportWrapper != nil {
+		backendTransport = b.transportWrapper(backendTransport)
+	}
+	backendClient := &http.Client{
+		Transport: backendTransport,
+	}
+
+	// Create a jq compiler function for parsing labels
+	compilerFunc := gojq.WithFunction("parse_labels", 0, 1, func(x any, _ []any) any {
+		if labels, ok := x.(string); ok {
+			return data.GetLabelsMap(labels)
+		}
+		return nil
+	})
+
+	// Create the jq tool:
+	jqTool, err := jq.NewTool().
+		SetLogger(b.logger).
+		SetCompilerOption(&compilerFunc).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Check that extensions are at least syntactically valid:
+	for _, extension := range b.extensions {
+		_, err = jqTool.Compile(extension)
+		if err != nil {
+			return
+		}
+	}
+
+	// Create and populate the object:
+	result = &AlarmFetcher{
+		logger:        b.logger,
+		cloudID:       b.cloudID,
+		backendURL:    b.backendURL,
+		backendToken:  b.backendToken,
+		backendClient: backendClient,
+		extensions:    b.extensions,
+		jqTool:        jqTool,
+	}
+	return
+}
+
+// FetchItems returns a data stream of O2 Alarms.
+// The items are converted from Alerts fetched from the Alertmanager API.
+func (r *AlarmFetcher) FetchItems(
+	ctx context.Context) (alarms data.Stream, err error) {
+	query := neturl.Values{}
+	response, err := r.doGet(ctx, "/alerts", query)
+	if err != nil {
+		return
+	}
+
+	// Create reader for Alerts
+	alerts, err := k8s.NewStream().
+		SetLogger(r.logger).
+		SetReader(response.Body).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Transform Alerts to Alarms
+	alarms = data.Map(alerts, r.mapAlertItem)
+
+	return
+}
+
+func (h *AlarmFetcher) doGet(ctx context.Context, path string,
+	query neturl.Values) (response *http.Response, err error) {
+	url := h.backendURL + path
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return
+	}
+	if query != nil {
+		request.URL.RawQuery = query.Encode()
+	}
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", h.backendToken))
+	request.Header.Set("Accept", "application/json")
+	response, err = h.backendClient.Do(request)
+	if err != nil {
+		return
+	}
+	if response.StatusCode != http.StatusOK {
+		h.logger.Error(
+			"Received unexpected status code",
+			"code", response.StatusCode,
+			"url", request.URL,
+		)
+		err = fmt.Errorf(
+			"received unexpected status code %d from '%s'",
+			response.StatusCode, request.URL,
+		)
+		return
+	}
+	return
+}
+
+// Map Alert to an O2 Alarm object.
+func (r *AlarmFetcher) mapAlertItem(ctx context.Context,
+	from data.Object) (to data.Object, err error) {
+
+	// TODO: implement mapping
+	to = from
+
+	return
+}

--- a/internal/service/alarm_handler.go
+++ b/internal/service/alarm_handler.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package service
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"log/slog"
+	"net/http"
+	"slices"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/search"
+)
+
+// AlarmHandlerBuilder contains the data and logic needed to create a new alarm
+// collection handler. Don't create instances of this type directly, use the NewAlarmHandler
+// function instead.
+type AlarmHandlerBuilder struct {
+	logger              *slog.Logger
+	transportWrapper    func(http.RoundTripper) http.RoundTripper
+	cloudID             string
+	extensions          []string
+	backendURL          string
+	backendToken        string
+	resourceServerURL   string
+	resourceServerToken string
+}
+
+// AlarmHandler knows how to respond to requests to list alarms. Don't create
+// instances of this type directly, use the NewAlarmHandler function instead.
+type AlarmHandler struct {
+	logger              *slog.Logger
+	transportWrapper    func(http.RoundTripper) http.RoundTripper
+	cloudID             string
+	extensions          []string
+	backendURL          string
+	backendToken        string
+	backendClient       *http.Client
+	resourceServerURL   string
+	resourceServerToken string
+	jsonAPI             jsoniter.API
+	selectorEvaluator   *search.SelectorEvaluator
+	alarmFetcher        *AlarmFetcher
+}
+
+// NewAlarmHandler creates a builder that can then be used to configure and create a
+// handler for the collection of alarms.
+func NewAlarmHandler() *AlarmHandlerBuilder {
+	return &AlarmHandlerBuilder{}
+}
+
+// SetLogger sets the logger that the handler will use to write to the log. This is mandatory.
+func (b *AlarmHandlerBuilder) SetLogger(
+	value *slog.Logger) *AlarmHandlerBuilder {
+	b.logger = value
+	return b
+}
+
+// SetTransportWrapper sets the wrapper that will be used to configure the HTTP clients used to
+// connect to other servers, including the backend server. This is optional.
+func (b *AlarmHandlerBuilder) SetTransportWrapper(
+	value func(http.RoundTripper) http.RoundTripper) *AlarmHandlerBuilder {
+	b.transportWrapper = value
+	return b
+}
+
+// SetCloudID sets the identifier of the O-Cloud of this handler. This is mandatory.
+func (b *AlarmHandlerBuilder) SetCloudID(
+	value string) *AlarmHandlerBuilder {
+	b.cloudID = value
+	return b
+}
+
+// SetExtensions sets the fields that will be added to the extensions.
+func (b *AlarmHandlerBuilder) SetExtensions(values ...string) *AlarmHandlerBuilder {
+	b.extensions = values
+	return b
+}
+
+// SetBackendURL sets the URL of the backend server. This is mandatory.
+func (b *AlarmHandlerBuilder) SetBackendURL(
+	value string) *AlarmHandlerBuilder {
+	b.backendURL = value
+	return b
+}
+
+// SetBackendToken sets the authentication token that will be used to authenticate
+// with the backend server. This is mandatory.
+func (b *AlarmHandlerBuilder) SetBackendToken(
+	value string) *AlarmHandlerBuilder {
+	b.backendToken = value
+	return b
+}
+
+// SetResourceServerURL sets the URL of the resource server. This is mandatory.
+// The resource server is used for mapping Alarms to Resources.
+func (b *AlarmHandlerBuilder) SetResourceServerURL(
+	value string) *AlarmHandlerBuilder {
+	b.resourceServerURL = value
+	return b
+}
+
+// SetBackendToken sets the authentication token that will be used to authenticate
+// with to the resource server. This is mandatory.
+func (b *AlarmHandlerBuilder) SetResourceServerToken(
+	value string) *AlarmHandlerBuilder {
+	b.resourceServerToken = value
+	return b
+}
+
+// Build uses the data stored in the builder to create and configure a new handler.
+func (b *AlarmHandlerBuilder) Build() (
+	result *AlarmHandler, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.cloudID == "" {
+		err = errors.New("cloud identifier is mandatory")
+		return
+	}
+	if b.backendURL == "" {
+		err = errors.New("backend URL is mandatory")
+		return
+	}
+	if b.backendToken == "" {
+		err = errors.New("backend token is mandatory")
+		return
+	}
+	if b.resourceServerURL == "" {
+		err = errors.New("resource server URL is mandatory")
+		return
+	}
+
+	// Create the HTTP client that we will use to connect to the backend:
+	var backendTransport http.RoundTripper
+	backendTransport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	if b.transportWrapper != nil {
+		backendTransport = b.transportWrapper(backendTransport)
+	}
+	backendClient := &http.Client{
+		Transport: backendTransport,
+	}
+
+	// Prepare the JSON iterator API:
+	jsonConfig := jsoniter.Config{
+		IndentionStep: 2,
+	}
+	jsonAPI := jsonConfig.Froze()
+
+	// Create the filter expression evaluator:
+	pathEvaluator, err := search.NewPathEvaluator().
+		SetLogger(b.logger).
+		Build()
+	if err != nil {
+		return
+	}
+	selectorEvaluator, err := search.NewSelectorEvaluator().
+		SetLogger(b.logger).
+		SetPathEvaluator(pathEvaluator.Evaluate).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Create and populate the object:
+	result = &AlarmHandler{
+		logger:              b.logger,
+		transportWrapper:    b.transportWrapper,
+		cloudID:             b.cloudID,
+		extensions:          slices.Clone(b.extensions),
+		backendClient:       backendClient,
+		backendURL:          b.backendURL,
+		backendToken:        b.backendToken,
+		resourceServerURL:   b.resourceServerURL,
+		resourceServerToken: b.resourceServerToken,
+		selectorEvaluator:   selectorEvaluator,
+		jsonAPI:             jsonAPI,
+	}
+	return
+}
+
+// List is part of the implementation of the collection handler interface.
+func (h *AlarmHandler) List(ctx context.Context,
+	request *ListRequest) (response *ListResponse, err error) {
+
+	// Transform the items into what we need:
+	alarms, err := h.fetchItems(ctx, request.Selector)
+	if err != nil {
+		return
+	}
+
+	// Select only the items that satisfy the filter:
+	if request.Selector != nil {
+		alarms = data.Select(
+			alarms,
+			func(ctx context.Context, item data.Object) (result bool, err error) {
+				result, err = h.selectorEvaluator.Evaluate(ctx, request.Selector, item)
+				return
+			},
+		)
+	}
+
+	// Return the result:
+	response = &ListResponse{
+		Items: alarms,
+	}
+	return
+}
+
+// Get is part of the implementation of the object handler interface.
+func (h *AlarmHandler) Get(ctx context.Context,
+	request *GetRequest) (response *GetResponse, err error) {
+
+	h.alarmFetcher, err = NewAlarmFetcher().
+		SetLogger(h.logger).
+		SetTransportWrapper(h.transportWrapper).
+		SetCloudID(h.cloudID).
+		SetBackendURL(h.backendURL).
+		SetBackendToken(h.backendToken).
+		SetExtensions(h.extensions...).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Fetch the object:
+	alarm, err := h.fetchItem(ctx, request.Variables[0])
+	if err != nil {
+		return
+	}
+
+	// Return the result:
+	response = &GetResponse{
+		Object: alarm,
+	}
+
+	return
+}
+
+func (h *AlarmHandler) fetchItems(
+	ctx context.Context, selector *search.Selector) (result data.Stream, err error) {
+	h.alarmFetcher, err = NewAlarmFetcher().
+		SetLogger(h.logger).
+		SetTransportWrapper(h.transportWrapper).
+		SetCloudID(h.cloudID).
+		SetBackendURL(h.backendURL).
+		SetBackendToken(h.backendToken).
+		SetExtensions(h.extensions...).
+		Build()
+	if err != nil {
+		return
+	}
+	return h.alarmFetcher.FetchItems(ctx)
+}
+
+func (h *AlarmHandler) fetchItem(ctx context.Context,
+	id string) (alarm data.Object, err error) {
+	// Fetch alarms
+	alarms, err := h.alarmFetcher.FetchItems(ctx)
+	if err != nil {
+		return
+	}
+
+	// Get first result
+	alarm, err = alarms.Next(ctx)
+
+	return
+}


### PR DESCRIPTION
Added the basic components for the Alarm server:
* AlarmServer cobra command
* AlarmHandler service (handles List/Get requests)
* AlarmFetcher (invoke the requests to the Alertmanager)

This PR mainly includes the boilerplate needed for the server basic functionality.
For now, the server simply returns the list of alert objects from Alertmanager API as-as.
The consecutive PRs will include the actual mapping to O-Cloud objects.