### PR TITLE
MGMT-16977: Mapping Alerts to AlarmEventRecords

### DIFF
--- a/data/alarms/probable_causes.json
+++ b/data/alarms/probable_causes.json
@@ -1,0 +1,32 @@
+[
+    {
+        "probableCauseId": "Watchdog",
+        "name": "An alert that should always be firing to certify that Alertmanager is working properly.",
+        "description": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n"
+    },
+    {
+        "probableCauseId": "UpdateAvailable",
+        "name": "Your upstream update recommendation service recommends you update your cluster.",
+        "description": "For more information refer to 'oc adm upgrade' or https://console-openshift-console.apps.spoke1.redhat.com/settings/cluster/."
+    },
+    {
+        "probableCauseId": "NodeClockNotSynchronising",
+        "name": "Clock not synchronising.",
+        "description": "Clock on ostest-extraworker-1 is not synchronising. Ensure NTP is configured on this host."
+    },
+    {
+        "probableCauseId": "ClusterNotUpgradeable",
+        "name": "One or more cluster operators have been blocking minor version cluster upgrades for at least an hour.",
+        "description": "In most cases, you will still be able to apply patch releases. Reason AdminAckRequired. For more information refer to 'oc adm upgrade' or https://console-openshift-console.apps.spoke1.redhat.com/settings/cluster/."
+    },
+    {
+        "probableCauseId": "AlertmanagerReceiversNotConfigured",
+        "name": "Receivers (notification integrations) are not configured on Alertmanager",
+        "description": "Alerts are not configured to be sent to a notification system, meaning that you may not be notified in a timely fashion when important failures occur. Check the OpenShift documentation to learn how to configure notifications with Alertmanager."
+    },
+    {
+        "probableCauseId": "HighOverallControlPlaneMemory",
+        "name": "Memory utilization across all control plane nodes is high, and could impact responsiveness and stability.",
+        "description": "Given three control plane nodes, the overall memory utilization may only be about 2/3 of all available capacity. This is because if a single control plane node fails, the kube-apiserver and etcd my be slow to respond. To fix this, increase memory of the control plane nodes."
+    }
+]

--- a/docs/dev/env_devscripts.md
+++ b/docs/dev/env_devscripts.md
@@ -57,14 +57,15 @@ export REDFISH_EMULATOR_IGNORE_BOOT_DEVICE=True
 
 ### Installation
 
-#### Run
+#### Deploy env
 ```bash
 cd dev-scripts
 make
 ```
 
-#### Clean
+#### Destroy env
 ```bash
+cd dev-scripts
 make clean
 ```
 
@@ -93,7 +94,7 @@ sudo dnf install xinetd
 ```bash
 cat /etc/NetworkManager/dnsmasq.d/openshift-ostest.conf
 ```
-E.g. address=/api.ostest.test.metalkube.org/11.0.0.5
+E.g. address=/.apps.ostest.test.metalkube.org/11.0.0.4
 
 ##### Add config file
 */etc/xinetd.d/openshift*
@@ -108,9 +109,11 @@ service openshift-ingress-ssl
     protocol        = tcp
     user            = root
     wait            = no
-    redirect        = 10.0.0.5 443
+    redirect        = 10.0.0.4 443
     port            = 443
     only_from       = 0.0.0.0/0
+    cps             = 1000 0
+    instances       = 1000
     per_source      = UNLIMITED
 }
 ```
@@ -202,7 +205,7 @@ sudo systemctl start agent
 
 ### Import a spoke cluster
 Navigate to web console:
-* All Clusters > Infrastructure > Clusters > Cluster list > spoke0 > Import cluster
+* All Clusters > Infrastructure > Clusters > Cluster list > spoke0 > Actions > Import cluster
 
 ### Access a spoke cluster
 ```bash

--- a/internal/openapi/handler_test.go
+++ b/internal/openapi/handler_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Handler", func() {
 		})
 
 		It("All paths start with the expected prefix", func() {
-			Expect(spec).To(MatchJQ(`[.paths | keys[] | select(startswith("/o2ims-infrastructureInventory/") | not)] | length`, 0))
+			Expect(spec).To(MatchJQ(`[.paths | keys[] | select(startswith("/o2ims-infrastructure") | not)] | length`, 0))
 		})
 
 		It("Contains the expected schemas", func() {

--- a/internal/openapi/spec.yaml
+++ b/internal/openapi/spec.yaml
@@ -42,6 +42,9 @@ tags:
 - name: resources
   description: |
     Information about resources.
+- name: alarms
+  description: |
+    Information about alarms.
 
 paths:
 
@@ -284,6 +287,50 @@ paths:
               schema:
                 $ref: "#/components/schemas/Resource"
 
+  /o2ims-infrastructureMonitoring/{version}/alarms:
+    get:
+      operationId: getAlarms
+      summary: Get alarms
+      description: |
+        Returns the list of AlarmEventRecords.
+      parameters:
+      - $ref: "#/components/parameters/excludeFields"
+      - $ref: "#/components/parameters/fields"
+      - $ref: "#/components/parameters/filter"
+      - $ref: "#/components/parameters/version"
+      tags:
+      - alrams
+      responses:
+        '200':
+          description: |
+            Successfully obtained the list of alarms.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Alarms"
+
+  /o2ims-infrastructureMonitoring/{version}/alarms/{alarmEventRecordId}:
+    get:
+      operationId: getAlarm
+      summary: Get an alarm
+      description: |
+        Returns the details of an AlarmEventRecord.
+      parameters:
+      - $ref: "#/components/parameters/alarmEventRecordId"
+      - $ref: "#/components/parameters/excludeFields"
+      - $ref: "#/components/parameters/fields"
+      - $ref: "#/components/parameters/version"
+      tags:
+      - alarms
+      responses:
+        '200':
+          description: |
+            Successfully obtained the details of the alarm.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Alarm"
+
 components:
 
   parameters:
@@ -337,6 +384,16 @@ components:
       schema:
         type: string
       example: node_8_cores_amd64
+
+    alarmEventRecordId:
+      name: alarmEventRecordId
+      description: |
+        Unique identifier of an AlarmEventRecord.
+      in: path
+      required: true
+      schema:
+        type: string
+      example: ClusterNotUpgradeable_spoke1
 
     fields:
       name: fields
@@ -593,3 +650,44 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/Resources"
+
+    Alarm:
+      description: |
+        Information about an AlarmEventRecord.
+      type: object
+      properties:
+        alarmEventRecordId:
+          type: string
+          example: "ClusterNotUpgradeable_spoke1"
+        resourceID:
+          type: string
+          example: "my-node"
+        resourceTypeID:
+          type: string
+          example: "node_8_cores_amd64"
+        alarmRaisedTime:
+          type: string
+          example: "2024-03-10T13:21:33.613Z"
+        alarmChangedTime:
+          type: string
+          example: "2024-03-14T12:18:35.487Z"
+        alarmDefinitionID:
+          type: string
+          example: "ClusterNotUpgradeable"
+        probableCauseID:
+          type: string
+          example: "ClusterNotUpgradeable"
+        perceivedSeverity:
+          type: string
+          example: "info"
+        extensions:
+          type: object
+          example:
+            cluster: "spoke0"
+
+    Alarms:
+      description: |
+        List of alarms.
+      type: array
+      items:
+        $ref: "#/components/schemas/Alarms"

--- a/internal/service/alarm_handler.go
+++ b/internal/service/alarm_handler.go
@@ -116,7 +116,7 @@ func (b *AlarmHandlerBuilder) SetResourceServerURL(
 	return b
 }
 
-// SetBackendToken sets the authentication token that will be used to authenticate
+// SetResourceServerToken sets the authentication token that will be used to authenticate
 // with to the resource server. This is mandatory.
 func (b *AlarmHandlerBuilder) SetResourceServerToken(
 	value string) *AlarmHandlerBuilder {
@@ -239,6 +239,8 @@ func (h *AlarmHandler) Get(ctx context.Context,
 		SetCloudID(h.cloudID).
 		SetBackendURL(h.backendURL).
 		SetBackendToken(h.backendToken).
+		SetResourceServerURL(h.resourceServerURL).
+		SetResourceServerToken(h.resourceServerToken).
 		SetExtensions(h.extensions...).
 		Build()
 	if err != nil {
@@ -267,6 +269,8 @@ func (h *AlarmHandler) fetchItems(
 		SetCloudID(h.cloudID).
 		SetBackendURL(h.backendURL).
 		SetBackendToken(h.backendToken).
+		SetResourceServerURL(h.resourceServerURL).
+		SetResourceServerToken(h.resourceServerToken).
 		SetExtensions(h.extensions...).
 		Build()
 	if err != nil {
@@ -282,6 +286,15 @@ func (h *AlarmHandler) fetchItem(ctx context.Context,
 	if err != nil {
 		return
 	}
+
+	// Filter by ID
+	alarms = data.Select(
+		alarms,
+		func(ctx context.Context, item data.Object) (result bool, err error) {
+			result = item["alarmEventRecordId"] == id
+			return
+		},
+	)
 
 	// Get first result
 	alarm, err = alarms.Next(ctx)

--- a/internal/service/alarm_handler_test.go
+++ b/internal/service/alarm_handler_test.go
@@ -1,0 +1,467 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package service
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	. "github.com/onsi/gomega/ghttp"
+
+	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/search"
+	. "github.com/openshift-kni/oran-o2ims/internal/testing"
+)
+
+var _ = Describe("Alarm handler", func() {
+	Describe("Creation", func() {
+		It("Can't be created without a logger", func() {
+			handler, err := NewAlarmHandler().
+				SetCloudID("123").
+				SetBackendURL("https://my-backend:6443").
+				SetBackendToken("my-token").
+				SetResourceServerURL("https://resource-server:8003").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(handler).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("logger"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+		})
+
+		It("Can't be created without a cloud identifier", func() {
+			handler, err := NewAlarmHandler().
+				SetLogger(logger).
+				SetBackendURL("https://my-backend:6443").
+				SetBackendToken("my-token").
+				SetResourceServerURL("https://resource-server:8003").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(handler).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("cloud identifier"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+		})
+
+		It("Can't be created without a backend URL", func() {
+			handler, err := NewAlarmHandler().
+				SetLogger(logger).
+				SetCloudID("123").
+				SetBackendToken("my-token").
+				SetResourceServerURL("https://resource-server:8003").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(handler).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("backend URL"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+		})
+
+		It("Can't be created without a backend token", func() {
+			handler, err := NewAlarmHandler().
+				SetLogger(logger).
+				SetCloudID("123").
+				SetBackendURL("https://my-backend:6443").
+				SetResourceServerURL("https://resource-server:8003").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(handler).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("backend token"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+		})
+
+		It("Can't be created without a resource server URL", func() {
+			handler, err := NewAlarmHandler().
+				SetLogger(logger).
+				SetCloudID("123").
+				SetBackendToken("my-token").
+				SetBackendURL("https://my-backend:6443").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(handler).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("resource server URL"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var (
+			ctx            context.Context
+			backend        *Server
+			resourceServer *Server
+			handler        *AlarmHandler
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			// Create a context:
+			ctx = context.Background()
+
+			// Create the backend server:
+			backend = MakeTCPServer()
+
+			// Create the resource server:
+			resourceServer = MakeTCPServer()
+
+			// Create the handler:
+			handler, err = NewAlarmHandler().
+				SetLogger(logger).
+				SetCloudID("123").
+				SetBackendURL(backend.URL()).
+				SetBackendToken("my-token").
+				SetResourceServerURL(resourceServer.URL()).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handler).ToNot(BeNil())
+		})
+
+		AfterEach(func() {
+			backend.Close()
+			resourceServer.Close()
+		})
+
+		// RespondWithItems creates a handler that responds with the given search results.
+		var RespondWithItems = func(items ...data.Object) http.HandlerFunc {
+			return RespondWithObject(data.Object{
+				"data": data.Object{
+					"searchResult": data.Array{
+						data.Object{
+							"items": items,
+						},
+					},
+				},
+			})
+		}
+
+		// RespondWithList creates a handler that responds with the given search results.
+		var RespondWithList = func(items ...data.Object) http.HandlerFunc {
+			return ghttp.RespondWithJSONEncoded(http.StatusOK, items)
+		}
+
+		Describe("List", func() {
+			It("Uses the configured token", func() {
+				// Prepare a backend:
+				backend.AppendHandlers(
+					CombineHandlers(
+						VerifyHeaderKV("Authorization", "Bearer my-token"),
+						RespondWithItems(),
+					),
+				)
+
+				// Send the request. Note that we ignore the error here because
+				// all we care about in this test is that it sends the token, no
+				// matter what is the result.
+				_, _ = handler.List(ctx, &ListRequest{})
+			})
+
+			It("Translates empty list of results", func() {
+				// Prepare the backend:
+				backend.AppendHandlers(
+					RespondWithItems(),
+				)
+
+				// Send the request and verify the result:
+				response, err := handler.List(ctx, &ListRequest{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				items, err := data.Collect(ctx, response.Items)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(items).To(BeEmpty())
+			})
+
+			It("Translates non empty list of results", func() {
+				// Prepare the backend:
+				backend.AppendHandlers(
+					RespondWithItems(
+						data.Object{
+							"labels": data.Object{
+								"alertname":       "alert1",
+								"severity":        "warning",
+								"managed_cluster": "spoke0",
+							},
+							"annotations": data.Object{
+								"summary":     "alert1_summary",
+								"description": "alert1_description",
+							},
+							"startsAt":  "00:00",
+							"updatedAt": "01:00",
+						},
+						data.Object{
+							"labels": data.Object{
+								"alertname":       "alert2",
+								"severity":        "info",
+								"managed_cluster": "spoke0",
+								"instance":        "host0",
+							},
+							"annotations": data.Object{
+								"summary":     "alert2_summary",
+								"description": "alert2_description",
+							},
+							"startsAt":  "00:00",
+							"updatedAt": "01:00",
+						},
+					),
+				)
+
+				// Prepare the resource server:
+				resourceServer.RouteToHandler(http.MethodGet, "/resourcePools",
+					RespondWithList(
+						data.Object{
+							"name":           "spoke0",
+							"resourcePoolID": "spoke0",
+						},
+					),
+				)
+				resourceServer.RouteToHandler(http.MethodGet, "/resourcePools/spoke0/resources",
+					RespondWithList(
+						data.Object{
+							"resourceID":     "host0",
+							"resourceTypeID": "type0",
+						},
+					),
+				)
+
+				// Send the request:
+				response, err := handler.List(ctx, &ListRequest{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				items, err := data.Collect(ctx, response.Items)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(items).To(HaveLen(2))
+
+				// Verify first result:
+				Expect(items[0]).To(MatchJQ(`.alarmEventRecordId`, "alert1_spoke0"))
+				Expect(items[0]).To(MatchJQ(`.resourceID`, "spoke0"))
+				Expect(items[0]).To(MatchJQ(`.resourceTypeID`, ""))
+				Expect(items[0]).To(MatchJQ(`.alarmRaisedTime`, "00:00"))
+				Expect(items[0]).To(MatchJQ(`.alarmChangedTime`, "01:00"))
+				Expect(items[0]).To(MatchJQ(`.alarmDefinitionID`, "alert1"))
+				Expect(items[0]).To(MatchJQ(`.probableCauseID`, "alert1"))
+				Expect(items[0]).To(MatchJQ(`.perceivedSeverity`, "WARNING"))
+				Expect(items[0]).To(MatchJQ(`.extensions.summary`, "alert1_summary"))
+				Expect(items[0]).To(MatchJQ(`.extensions.description`, "alert1_description"))
+
+				// Verify seconds result:
+				Expect(items[1]).To(MatchJQ(`.alarmEventRecordId`, "alert2_spoke0_host0"))
+				Expect(items[1]).To(MatchJQ(`.resourceID`, "host0"))
+				Expect(items[1]).To(MatchJQ(`.resourceTypeID`, "type0"))
+				Expect(items[1]).To(MatchJQ(`.alarmRaisedTime`, "00:00"))
+				Expect(items[1]).To(MatchJQ(`.alarmChangedTime`, "01:00"))
+				Expect(items[1]).To(MatchJQ(`.alarmDefinitionID`, "alert2"))
+				Expect(items[1]).To(MatchJQ(`.probableCauseID`, "alert2"))
+				Expect(items[1]).To(MatchJQ(`.perceivedSeverity`, "MINOR"))
+				Expect(items[1]).To(MatchJQ(`.extensions.summary`, "alert2_summary"))
+				Expect(items[1]).To(MatchJQ(`.extensions.description`, "alert2_description"))
+			})
+
+			It("Accepts a filter", func() {
+				// Prepare the backend:
+				backend.AppendHandlers(
+					RespondWithItems(),
+				)
+
+				// Send the request:
+				response, err := handler.List(ctx, &ListRequest{
+					Selector: &search.Selector{
+						Terms: []*search.Term{{
+							Operator: search.Eq,
+							Path: []string{
+								"alarmEventRecordId",
+							},
+							Values: []any{
+								"alert_spoke0",
+							},
+						}},
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+			})
+
+			It("Accepts multiple filters", func() {
+				// Prepare the backend:
+				backend.AppendHandlers(
+					RespondWithItems(),
+				)
+
+				// Send the request:
+				response, err := handler.List(ctx, &ListRequest{
+					Selector: &search.Selector{
+						Terms: []*search.Term{
+							{
+								Operator: search.Eq,
+								Path: []string{
+									"alarmEventRecordId",
+								},
+								Values: []any{
+									"alert_spoke0",
+								},
+							},
+							{
+								Operator: search.Neq,
+								Path: []string{
+									"perceivedSeverity",
+								},
+								Values: []any{
+									"CRITICAL",
+								},
+							},
+						},
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+			})
+
+			It("Adds configurable extensions", func() {
+				// Prepare a backend:
+				backend.AppendHandlers(
+					CombineHandlers(
+						RespondWithItems(
+							data.Object{
+								"labels": data.Object{
+									"alertname":       "alert",
+									"severity":        "warning",
+									"managed_cluster": "spoke0",
+								},
+								"annotations": data.Object{
+									"summary":     "alert_summary",
+									"description": "alert_description",
+								},
+								"startsAt":  "00:00",
+								"updatedAt": "01:00",
+							},
+						),
+					),
+				)
+
+				// Prepare the resource server:
+				resourceServer.AppendHandlers(
+					CombineHandlers(
+						RespondWithList(
+							data.Object{
+								"name":           "spoke0",
+								"resourcePoolID": "spoke0",
+							},
+						),
+					),
+				)
+
+				// Create the handler:
+				handler, err := NewAlarmHandler().
+					SetLogger(logger).
+					SetCloudID("123").
+					SetBackendURL(backend.URL()).
+					SetBackendToken("my-token").
+					SetResourceServerURL(resourceServer.URL()).
+					SetExtensions(
+						`{
+							"cluster": .labels.managed_cluster,
+						}`,
+						`{
+							"fixed": 123
+						}`).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Send the request and verify the result:
+				response, err := handler.Get(ctx, &GetRequest{
+					Variables: []string{"alert_spoke0"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.Object).To(MatchJQ(`.extensions.cluster`, "spoke0"))
+				Expect(response.Object).To(MatchJQ(`.extensions.fixed`, 123))
+			})
+		})
+
+		Describe("Get", func() {
+			It("Uses the configured token", func() {
+				// Prepare a backend:
+				backend.AppendHandlers(
+					CombineHandlers(
+						VerifyHeaderKV("Authorization", "Bearer my-token"),
+						RespondWithItems(),
+					),
+				)
+
+				// Send the request. Note that we ignore the error here because
+				// all we care about in this test is that it sends the token, no
+				// matter what is the response.
+				_, _ = handler.Get(ctx, &GetRequest{
+					Variables: []string{"alert_spoke0"},
+				})
+			})
+
+			It("Translates result", func() {
+				// Prepare a backend:
+				backend.AppendHandlers(
+					CombineHandlers(
+						RespondWithItems(
+							data.Object{
+								"labels": data.Object{
+									"alertname":       "alert",
+									"severity":        "warning",
+									"managed_cluster": "spoke0",
+								},
+								"annotations": data.Object{
+									"summary":     "alert_summary",
+									"description": "alert_description",
+								},
+								"startsAt":  "00:00",
+								"updatedAt": "01:00",
+							},
+						),
+					),
+				)
+
+				// Prepare the resource server:
+				resourceServer.AppendHandlers(
+					CombineHandlers(
+						RespondWithList(
+							data.Object{
+								"name":           "spoke0",
+								"resourcePoolID": "spoke0",
+							},
+						),
+					),
+				)
+
+				// Send the request:
+				response, err := handler.Get(ctx, &GetRequest{
+					Variables: []string{"alert_spoke0"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+
+				// Verify the result:
+				Expect(response.Object).To(MatchJQ(`.alarmEventRecordId`, "alert_spoke0"))
+				Expect(response.Object).To(MatchJQ(`.resourceID`, "spoke0"))
+				Expect(response.Object).To(MatchJQ(`.resourceTypeID`, ""))
+				Expect(response.Object).To(MatchJQ(`.alarmRaisedTime`, "00:00"))
+				Expect(response.Object).To(MatchJQ(`.alarmChangedTime`, "01:00"))
+				Expect(response.Object).To(MatchJQ(`.alarmDefinitionID`, "alert"))
+				Expect(response.Object).To(MatchJQ(`.probableCauseID`, "alert"))
+				Expect(response.Object).To(MatchJQ(`.perceivedSeverity`, "WARNING"))
+			})
+		})
+	})
+})

--- a/internal/service/alarm_probable_cause_handler.go
+++ b/internal/service/alarm_probable_cause_handler.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/k8s"
+)
+
+// AlarmProbableCauseHandlerBuilder contains the data and logic needed to create a new alarm
+// collection handler. Don't create instances of this type directly, use the NewAlarmProbableCauseHandler
+// function instead.
+type AlarmProbableCauseHandlerBuilder struct {
+	logger *slog.Logger
+}
+
+// AlarmProbableCauseHandler knows how to respond to requests to list alarms. Don't create
+// instances of this type directly, use the NewAlarmProbableCauseHandler function instead.
+type AlarmProbableCauseHandler struct {
+	logger  *slog.Logger
+	jsonAPI jsoniter.API
+}
+
+// NewAlarmProbableCauseHandler creates a builder that can then be used to configure and create a
+// handler for the collection of alarms.
+func NewAlarmProbableCauseHandler() *AlarmProbableCauseHandlerBuilder {
+	return &AlarmProbableCauseHandlerBuilder{}
+}
+
+// SetLogger sets the logger that the handler will use to write to the log. This is mandatory.
+func (b *AlarmProbableCauseHandlerBuilder) SetLogger(
+	value *slog.Logger) *AlarmProbableCauseHandlerBuilder {
+	b.logger = value
+	return b
+}
+
+// Build uses the data stored in the builder to create and configure a new handler.
+func (b *AlarmProbableCauseHandlerBuilder) Build() (
+	result *AlarmProbableCauseHandler, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+
+	// Prepare the JSON iterator API:
+	jsonConfig := jsoniter.Config{
+		IndentionStep: 2,
+	}
+	jsonAPI := jsonConfig.Froze()
+
+	// Create and populate the object:
+	result = &AlarmProbableCauseHandler{
+		logger:  b.logger,
+		jsonAPI: jsonAPI,
+	}
+	return
+}
+
+// List is part of the implementation of the collection handler interface.
+func (h *AlarmProbableCauseHandler) List(ctx context.Context,
+	request *ListRequest) (response *ListResponse, err error) {
+
+	// Transform the items into what we need:
+	probableCauses, err := h.fetchItems()
+	if err != nil {
+		return
+	}
+
+	// Return the result:
+	response = &ListResponse{
+		Items: probableCauses,
+	}
+	return
+}
+
+// Get is part of the implementation of the object handler interface.
+func (h *AlarmProbableCauseHandler) Get(ctx context.Context,
+	request *GetRequest) (response *GetResponse, err error) {
+
+	// Fetch the object:
+	probableCause, err := h.fetchItem(ctx, request.Variables[0])
+	if err != nil {
+		return
+	}
+
+	// Return the result:
+	response = &GetResponse{
+		Object: probableCause,
+	}
+
+	return
+}
+
+func (h *AlarmProbableCauseHandler) fetchItems() (result data.Stream, err error) {
+	jsonFile, err := os.ReadFile("./data/alarms/probable_causes.json")
+	if err != nil {
+		return nil, err
+	}
+	reader := bytes.NewReader(jsonFile)
+
+	result, err = k8s.NewStream().
+		SetLogger(h.logger).
+		SetReader(reader).
+		Build()
+
+	return
+}
+
+func (h *AlarmProbableCauseHandler) fetchItem(ctx context.Context,
+	id string) (probableCause data.Object, err error) {
+
+	probableCauses, err := h.fetchItems()
+	if err != nil {
+		return
+	}
+
+	// Filter by ID
+	probableCauses = data.Select(
+		probableCauses,
+		func(ctx context.Context, item data.Object) (result bool, err error) {
+			result = item["probableCauseId"] == id
+			return
+		},
+	)
+
+	// Get first result
+	probableCause, err = probableCauses.Next(ctx)
+
+	return
+}


### PR DESCRIPTION
Added mapping logic to the AlarmFetcher:
* For each Alert retrieved from the AlertManager, map to an AlarmEventRecord object.
* Use the resource server url for fetching info about resources and pools (needed for resourceID/resourceTypeID properties).

Also added an API for fetching alarm probable causes:
* This API is not defined by O2ims spec, but we can use it for exposing a custom list of probable causes.
* This list is available in data folder (data/alarms/probable_causes.json), and can be customized and maintained by server admins as required.

Note: this PR does not include AlarmDictionary support (will be handled separately).