### PR TITLE
Add missing oauth fqdn on local hosts file for console access

### DIFF
--- a/docs/dev/env_devscripts.md
+++ b/docs/dev/env_devscripts.md
@@ -80,7 +80,7 @@ export KUBECONFIG=/home/$USER/dev-scripts/ocp/ostest/auth/kubeconfig
 
 #### Configure the local /etc/hosts
 ```bash
-<host_ip> console-openshift-console.apps.ostest.test.metalkube.org grafana-open-cluster-management-observability.apps.ostest.test.metalkube.org observatorium-api-open-cluster-management-observability.apps.ostest.test.metalkube.org alertmanager-open-cluster-management-observability.apps.ostest.test.metalkube.org
+<host_ip> console-openshift-console.apps.ostest.test.metalkube.org oauth-openshift.apps.ostest.test.metalkube.org grafana-open-cluster-management-observability.apps.ostest.test.metalkube.org observatorium-api-open-cluster-management-observability.apps.ostest.test.metalkube.org alertmanager-open-cluster-management-observability.apps.ostest.test.metalkube.org
 ```
 
 #### Install and configure xinetd


### PR DESCRIPTION
Without which login to console causes a redirect failure:

This site can’t be reached
Check if there is a typo in oauth-openshift.apps.ostest.test.metalkube.org. DNS_PROBE_FINISHED_NXDOMAIN

Adding the missing oauth fqdn, enables successful console login.