### PR TITLE
Add defaults for deployment manager backend URL and token

### DIFF
--- a/api/v1alpha1/orano2ims_types.go
+++ b/api/v1alpha1/orano2ims_types.go
@@ -34,7 +34,7 @@ type ORANO2IMSSpec struct {
 	//+kubebuilder:default=false
 	DeploymentManagerServer bool `json:"deploymentManagerServer"`
 	//+kubebuilder:default=false
-	ResourceServer bool `json:"resourceServer"`
+	ResourceServer          bool `json:"resourceServer"`
 	AlarmSubscriptionServer bool `json:"alarmSubscriptionServer"`
 	//+optional
 	IngressHost string `json:"ingressHost,omitempty"`

--- a/config/crd/bases/oran.openshift.io_orano2imses.yaml
+++ b/config/crd/bases/oran.openshift.io_orano2imses.yaml
@@ -34,6 +34,8 @@ spec:
           spec:
             description: ORANO2IMSSpec defines the desired state of ORANO2IMS
             properties:
+              alarmSubscriptionServer:
+                type: boolean
               backendToken:
                 type: string
               backendType:
@@ -54,9 +56,6 @@ spec:
                 items:
                   type: string
                 type: array
-              alarmSubscriptionServer:
-                default: false
-                type: boolean
               ingressHost:
                 type: string
               metadataServer:
@@ -68,9 +67,9 @@ spec:
               searchAPIBackendURL:
                 type: string
             required:
+            - alarmSubscriptionServer
             - cloudId
             - deploymentManagerServer
-            - AlarmSubscriptionServer
             - metadataServer
             - resourceServer
             type: object

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,5 +9,5 @@ generatorOptions:
 
 images:
 - name: controller
-  newName: quay.io/imihai/oran-o2ims-operator
-  newTag: 4.16.0
+  newName: quay.io/jhernand/o2ims-operator
+  newTag: "2"

--- a/internal/controllers/orano2ims_controller.go
+++ b/internal/controllers/orano2ims_controller.go
@@ -241,7 +241,10 @@ func (r *ORANO2IMSReconciler) deployServer(ctx context.Context, orano2ims *oranv
 		},
 	}
 
-	deploymentContainerArgs := utils.BuildServerContainerArgs(orano2ims, serverName)
+	deploymentContainerArgs, err := utils.BuildServerContainerArgs(orano2ims, serverName)
+	if err != nil {
+		return err
+	}
 
 	// Build the deployment's spec.
 	deploymentSpec := appsv1.DeploymentSpec{

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -73,3 +73,9 @@ var (
 		"--api-listener-tls-key=/secrets/tls/tls.key",
 	}
 )
+
+// Default values for backend URL and token:
+const (
+	defaultBackendURL       = "https://kubernetes.default.svc"
+	defaultBackendTokenFile = "/run/secrets/kubernetes.io/serviceaccount/token"
+)

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -74,13 +74,13 @@ var _ = Describe("ExtensionUtils", func() {
 				},
 			},
 		}
-		actualArgs := BuildServerContainerArgs(orano2ims, ORANO2IMSDeploymentManagerServerName)
+		actualArgs, err := BuildServerContainerArgs(orano2ims, ORANO2IMSDeploymentManagerServerName)
+		Expect(err).ToNot(HaveOccurred())
 		expectedArgs := DeploymentManagerServerArgs
 		expectedArgs = append(expectedArgs,
 			fmt.Sprintf("--cloud-id=%s", orano2ims.Spec.CloudId),
-			fmt.Sprintf("--backend-url=%s", orano2ims.Spec.BackendURL),
-			fmt.Sprintf("--backend-token=%s", orano2ims.Spec.BackendToken),
-			fmt.Sprintf("--backend-type=%s", orano2ims.Spec.BackendType),
+			fmt.Sprintf("--backend-url=%s", defaultBackendURL),
+			fmt.Sprintf("--backend-token-file=%s", defaultBackendTokenFile),
 		)
 		expectedArgs = append(expectedArgs,
 			"--extensions=.metadata.labels[\"name\"] as $name |\n{\n  name: $name,\n  alias: $name\n}\n",
@@ -100,13 +100,13 @@ var _ = Describe("ExtensionUtils", func() {
 			},
 		}
 
-		actualArgs := BuildServerContainerArgs(orano2ims, ORANO2IMSDeploymentManagerServerName)
+		actualArgs, err := BuildServerContainerArgs(orano2ims, ORANO2IMSDeploymentManagerServerName)
+		Expect(err).ToNot(HaveOccurred())
 		expectedArgs := DeploymentManagerServerArgs
 		expectedArgs = append(expectedArgs,
 			fmt.Sprintf("--cloud-id=%s", orano2ims.Spec.CloudId),
-			fmt.Sprintf("--backend-url=%s", orano2ims.Spec.BackendURL),
-			fmt.Sprintf("--backend-token=%s", orano2ims.Spec.BackendToken),
-			fmt.Sprintf("--backend-type=%s", orano2ims.Spec.BackendType),
+			fmt.Sprintf("--backend-url=%s", defaultBackendURL),
+			fmt.Sprintf("--backend-token-file=%s", defaultBackendTokenFile),
 		)
 		Expect(actualArgs).To(Equal(expectedArgs))
 	})


### PR DESCRIPTION
Currently the backend URL and token don't have defaults. That means that the user has to explicitly set them in the custom resource that represents the O2 IMS deployment. That is reasonable for the URL, but not for the token, because it is the token of a service account that is created by the operator. That means that the user would have to create the service account in advance, wait for the token to be created and then read it and update the custom resource. That isn't practical. To avoid that this patch changes the operator so that the token is the default URL of the Kubernetes API server and the token is taken from the `/run/secrets/kubernetes.io/serviceaccount/token` file.