### PR TITLE
Grant deployment manager server account permissions to read managed clusters and secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # openshift.io/oran-o2ims-bundle:$VERSION and openshift.io/oran-o2ims-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/imihai/oran-o2ims-operator
+IMAGE_TAG_BASE ?= quay.io/openshift-kni/oran-o2ims-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-02-12T21:18:41Z"
+    createdAt: "2024-04-09T18:38:21Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: oran-o2ims.v4.16.0

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-04-09T18:38:21Z"
+    createdAt: "2024-04-09T18:40:03Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: oran-o2ims.v4.16.0
@@ -61,6 +61,14 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - ""
@@ -97,6 +105,14 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclusters
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - networking.k8s.io
@@ -136,6 +152,30 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - authentication.k8s.io
           resources:
@@ -202,7 +242,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/imihai/oran-o2ims-operator:4.16.0
+                image: quay.io/openshift-kni/oran-o2ims-operator:4.16.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/manifests/oran.openshift.io_orano2imses.yaml
+++ b/bundle/manifests/oran.openshift.io_orano2imses.yaml
@@ -34,6 +34,8 @@ spec:
           spec:
             description: ORANO2IMSSpec defines the desired state of ORANO2IMS
             properties:
+              alarmSubscriptionServer:
+                type: boolean
               backendToken:
                 type: string
               backendType:
@@ -49,15 +51,27 @@ spec:
               deploymentManagerServer:
                 default: false
                 type: boolean
+              extensions:
+                description: This field allows the addition of extra O-Cloud information
+                items:
+                  type: string
+                type: array
               ingressHost:
                 type: string
               metadataServer:
                 default: false
                 type: boolean
+              resourceServer:
+                default: false
+                type: boolean
+              searchAPIBackendURL:
+                type: string
             required:
+            - alarmSubscriptionServer
             - cloudId
             - deploymentManagerServer
             - metadataServer
+            - resourceServer
             type: object
           status:
             description: ORANO2IMSStatus defines the observed state of ORANO2IMS
@@ -141,6 +155,8 @@ spec:
                   deploymentServerStatus:
                     type: string
                   metadataServerStatus:
+                    type: string
+                  resourceServerStatus:
                     type: string
                 type: object
             type: object

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,5 +9,5 @@ generatorOptions:
 
 images:
 - name: controller
-  newName: quay.io/jhernand/o2ims-operator
-  newTag: "2"
+  newName: quay.io/imihai/oran-o2ims-operator
+  newTag: 4.16.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,5 +9,5 @@ generatorOptions:
 
 images:
 - name: controller
-  newName: quay.io/imihai/oran-o2ims-operator
+  newName: quay.io/openshift-kni/oran-o2ims-operator
   newTag: 4.16.0

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -8,7 +8,22 @@ metadata:
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ORANO2IMS is the Schema for the orano2ims API
+      displayName: ORANO2 IMS
+      kind: ORANO2IMS
+      name: orano2ims.oran.openshift.io
+      statusDescriptors:
+      - displayName: Conditions
+        path: deploymentStatus.conditions
+      - displayName: Deployment Server Status
+        path: deploymentStatus.deploymentServerStatus
+      - displayName: Metadata Server Status
+        path: deploymentStatus.metadataServerStatus
+      - displayName: Resource Server Status
+        path: deploymentStatus.resourceServerStatus
+      version: v1alpha1
   description: Deploys the ORAN O2IMS services
   displayName: ORAN O2IMS Operator
   icon:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create
@@ -51,6 +59,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - networking.k8s.io
@@ -90,3 +106,27 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
The service account that is used to run the deployment manager server needs permissions to read `ManagedCluster` objects and assisted installer admin kubeconfig secrets. This patch changes the operator so that it creates the corresponding cluster roles and cluster role bindings. In order to do so the operator needs to also have those permissions, as Kubernetes forbids granting more permissions than the service account granting them already has. So this patch also adds those permissions to the service account that is used to run the operator.