### PR TITLE
Make deployment manager server `--backend-token` optional

### DIFF
--- a/internal/cmd/server/start_deployment_manager_server.go
+++ b/internal/cmd/server/start_deployment_manager_server.go
@@ -173,13 +173,6 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		)
 		return exit.Error(1)
 	}
-	if backendToken == "" {
-		logger.Error(
-			"Backend token is empty",
-			"flag", backendTokenFlagName,
-		)
-		return exit.Error(1)
-	}
 	backendTokenFile, err := flags.GetString(backendTokenFileFlagName)
 	if err != nil {
 		logger.Error(


### PR DESCRIPTION
When the `--backend-token-file` was introduced the `--backend-token` should have been made optional, but it wasn't. This patch fixes that.