### PR TITLE
Reduce numer of parameters of `CreateK8sCR`

### DIFF
--- a/internal/controllers/orano2ims_controller.go
+++ b/internal/controllers/orano2ims_controller.go
@@ -291,7 +291,7 @@ func (r *ORANO2IMSReconciler) deployServer(ctx context.Context, orano2ims *oranv
 	}
 
 	r.Log.Info("[deployManagerServer] Create/Update/Patch Server", "Name", serverName)
-	return utils.CreateK8sCR(ctx, r.Client, serverName, orano2ims.Namespace, newDeployment,
+	return utils.CreateK8sCR(ctx, r.Client, newDeployment,
 		orano2ims, &appsv1.Deployment{}, r.Scheme, utils.UPDATE)
 }
 
@@ -310,7 +310,7 @@ func (r *ORANO2IMSReconciler) createConfigMap(ctx context.Context, orano2ims *or
 	}
 
 	r.Log.Info("[createService] Create/Update/Patch Service: ", "name", resourceName)
-	return utils.CreateK8sCR(ctx, r.Client, resourceName, orano2ims.Namespace,
+	return utils.CreateK8sCR(ctx, r.Client,
 		configMap, orano2ims, &corev1.ConfigMap{}, r.Scheme, utils.UPDATE)
 }
 
@@ -333,7 +333,7 @@ func (r *ORANO2IMSReconciler) createServiceAccount(ctx context.Context, orano2im
 	}
 
 	r.Log.Info("[createServiceAccount] Create/Update/Patch ServiceAccount: ", "name", resourceName)
-	return utils.CreateK8sCR(ctx, r.Client, resourceName, orano2ims.Namespace,
+	return utils.CreateK8sCR(ctx, r.Client,
 		newServiceAccount, orano2ims, &corev1.ServiceAccount{}, r.Scheme, utils.UPDATE)
 }
 
@@ -370,7 +370,7 @@ func (r *ORANO2IMSReconciler) createService(ctx context.Context, orano2ims *oran
 	}
 
 	r.Log.Info("[createService] Create/Update/Patch Service: ", "name", resourceName)
-	return utils.CreateK8sCR(ctx, r.Client, resourceName, orano2ims.Namespace,
+	return utils.CreateK8sCR(ctx, r.Client,
 		newService, orano2ims, &corev1.Service{}, r.Scheme, utils.PATCH)
 }
 
@@ -480,7 +480,7 @@ func (r *ORANO2IMSReconciler) createIngress(ctx context.Context, orano2ims *oran
 	}
 
 	r.Log.Info("[createIngress] Create/Update/Patch Ingress: ", "name", utils.ORANO2IMSIngressName)
-	return utils.CreateK8sCR(ctx, r.Client, utils.ORANO2IMSIngressName, orano2ims.Namespace,
+	return utils.CreateK8sCR(ctx, r.Client,
 		newIngress, orano2ims, &networkingv1.Ingress{}, r.Scheme, utils.UPDATE)
 }
 

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -19,18 +19,20 @@ import (
 
 var oranUtilsLog = ctrl.Log.WithName("oranUtilsLog")
 
-func CreateK8sCR(ctx context.Context, c client.Client, Name string, Namespace string,
+func CreateK8sCR(ctx context.Context, c client.Client,
 	newObject client.Object, ownerObject client.Object, oldObject client.Object,
 	runtimeScheme *runtime.Scheme, operation string) (err error) {
 
-	oranUtilsLog.Info("[CreateK8sCR] Resource", "name", Name)
+	// Get the name and namespace of the object:
+	key := client.ObjectKeyFromObject(newObject)
+	oranUtilsLog.Info("[CreateK8sCR] Resource", "name", key.Name)
 	// Set owner reference.
 	if err = controllerutil.SetControllerReference(ownerObject, newObject, runtimeScheme); err != nil {
 		return err
 	}
 
 	// Check if the CR already exists.
-	err = c.Get(ctx, types.NamespacedName{Name: Name, Namespace: Namespace}, oldObject)
+	err = c.Get(ctx, key, oldObject)
 
 	// If there was an error obtaining the CR and the error was "Not found", create the object.
 	// If any other other occurred, return the error.

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -162,8 +162,8 @@ var _ = Describe("DoesK8SResourceExist", func() {
 		Expect(k8sResourceExists).To(Equal(false))
 
 		// Create the deployment.
-		err = CreateK8sCR(context.TODO(), fakeClient, deployment.Name,
-			deployment.Namespace, deployment, orano2ims, &appsv1.Deployment{}, suitescheme, UPDATE)
+		err = CreateK8sCR(context.TODO(), fakeClient,
+			deployment, orano2ims, &appsv1.Deployment{}, suitescheme, UPDATE)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check that the deployment has been created.
@@ -210,8 +210,8 @@ var _ = Describe("DoesK8SResourceExist", func() {
 		Expect(err).To(MatchError("deployments.apps \"deployment-server-2\" not found"))
 
 		// Create the deployment.
-		err = CreateK8sCR(context.TODO(), fakeClient, deployment.Name,
-			deployment.Namespace, deployment, orano2ims, &appsv1.Deployment{}, suitescheme, UPDATE)
+		err = CreateK8sCR(context.TODO(), fakeClient,
+			deployment, orano2ims, &appsv1.Deployment{}, suitescheme, UPDATE)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check that the deployment has been created.
@@ -226,8 +226,8 @@ var _ = Describe("DoesK8SResourceExist", func() {
 
 		// Update the SA Name.
 		newDeployment.Spec.Template.Spec.ServiceAccountName = "new-sa-name"
-		err = CreateK8sCR(context.TODO(), fakeClient, newDeployment.Name,
-			newDeployment.Namespace, newDeployment, orano2ims, &appsv1.Deployment{}, suitescheme, UPDATE)
+		err = CreateK8sCR(context.TODO(), fakeClient,
+			newDeployment, orano2ims, &appsv1.Deployment{}, suitescheme, UPDATE)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Get the deployment and check that the SA Name has been updated.


### PR DESCRIPTION
Currently this function has nine parameters. Two of them are the name and namespace of the object, but the object itself is also passed. Assuming that the `Name` and `Namespace` fields of the object will be populated it is not necessary to have additional parameters for that. This patch removes those parameters.