### PR TITLE
Remove `oldObject` parameter from `CreateK8sCR`

### DIFF
--- a/internal/controllers/orano2ims_controller.go
+++ b/internal/controllers/orano2ims_controller.go
@@ -292,7 +292,7 @@ func (r *ORANO2IMSReconciler) deployServer(ctx context.Context, orano2ims *oranv
 
 	r.Log.Info("[deployManagerServer] Create/Update/Patch Server", "Name", serverName)
 	return utils.CreateK8sCR(ctx, r.Client, newDeployment,
-		orano2ims, &appsv1.Deployment{}, r.Scheme, utils.UPDATE)
+		orano2ims, r.Scheme, utils.UPDATE)
 }
 
 func (r *ORANO2IMSReconciler) createConfigMap(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS, resourceName string) error {
@@ -311,7 +311,7 @@ func (r *ORANO2IMSReconciler) createConfigMap(ctx context.Context, orano2ims *or
 
 	r.Log.Info("[createService] Create/Update/Patch Service: ", "name", resourceName)
 	return utils.CreateK8sCR(ctx, r.Client,
-		configMap, orano2ims, &corev1.ConfigMap{}, r.Scheme, utils.UPDATE)
+		configMap, orano2ims, r.Scheme, utils.UPDATE)
 }
 
 func (r *ORANO2IMSReconciler) createServiceAccount(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS, resourceName string) error {
@@ -334,7 +334,7 @@ func (r *ORANO2IMSReconciler) createServiceAccount(ctx context.Context, orano2im
 
 	r.Log.Info("[createServiceAccount] Create/Update/Patch ServiceAccount: ", "name", resourceName)
 	return utils.CreateK8sCR(ctx, r.Client,
-		newServiceAccount, orano2ims, &corev1.ServiceAccount{}, r.Scheme, utils.UPDATE)
+		newServiceAccount, orano2ims, r.Scheme, utils.UPDATE)
 }
 
 func (r *ORANO2IMSReconciler) createService(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS, resourceName string) error {
@@ -371,7 +371,7 @@ func (r *ORANO2IMSReconciler) createService(ctx context.Context, orano2ims *oran
 
 	r.Log.Info("[createService] Create/Update/Patch Service: ", "name", resourceName)
 	return utils.CreateK8sCR(ctx, r.Client,
-		newService, orano2ims, &corev1.Service{}, r.Scheme, utils.PATCH)
+		newService, orano2ims, r.Scheme, utils.PATCH)
 }
 
 func (r *ORANO2IMSReconciler) createIngress(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS) error {
@@ -481,7 +481,7 @@ func (r *ORANO2IMSReconciler) createIngress(ctx context.Context, orano2ims *oran
 
 	r.Log.Info("[createIngress] Create/Update/Patch Ingress: ", "name", utils.ORANO2IMSIngressName)
 	return utils.CreateK8sCR(ctx, r.Client,
-		newIngress, orano2ims, &networkingv1.Ingress{}, r.Scheme, utils.UPDATE)
+		newIngress, orano2ims, r.Scheme, utils.UPDATE)
 }
 
 func (r *ORANO2IMSReconciler) updateORANO2ISMStatusConditions(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS, deploymentName string) {

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -20,7 +20,7 @@ import (
 var oranUtilsLog = ctrl.Log.WithName("oranUtilsLog")
 
 func CreateK8sCR(ctx context.Context, c client.Client,
-	newObject client.Object, ownerObject client.Object, oldObject client.Object,
+	newObject client.Object, ownerObject client.Object,
 	runtimeScheme *runtime.Scheme, operation string) (err error) {
 
 	// Get the name and namespace of the object:
@@ -31,7 +31,11 @@ func CreateK8sCR(ctx context.Context, c client.Client,
 		return err
 	}
 
-	// Check if the CR already exists.
+	// Create an empty object of the same type of the new object. We will use it to fetch the
+	// current state.
+	objectType := reflect.TypeOf(newObject).Elem()
+	oldObject := reflect.New(objectType).Interface().(client.Object)
+
 	err = c.Get(ctx, key, oldObject)
 
 	// If there was an error obtaining the CR and the error was "Not found", create the object.

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -163,7 +163,7 @@ var _ = Describe("DoesK8SResourceExist", func() {
 
 		// Create the deployment.
 		err = CreateK8sCR(context.TODO(), fakeClient,
-			deployment, orano2ims, &appsv1.Deployment{}, suitescheme, UPDATE)
+			deployment, orano2ims, suitescheme, UPDATE)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check that the deployment has been created.
@@ -211,7 +211,7 @@ var _ = Describe("DoesK8SResourceExist", func() {
 
 		// Create the deployment.
 		err = CreateK8sCR(context.TODO(), fakeClient,
-			deployment, orano2ims, &appsv1.Deployment{}, suitescheme, UPDATE)
+			deployment, orano2ims, suitescheme, UPDATE)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check that the deployment has been created.
@@ -227,7 +227,7 @@ var _ = Describe("DoesK8SResourceExist", func() {
 		// Update the SA Name.
 		newDeployment.Spec.Template.Spec.ServiceAccountName = "new-sa-name"
 		err = CreateK8sCR(context.TODO(), fakeClient,
-			newDeployment, orano2ims, &appsv1.Deployment{}, suitescheme, UPDATE)
+			newDeployment, orano2ims, suitescheme, UPDATE)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Get the deployment and check that the SA Name has been updated.


### PR DESCRIPTION
Currently the `CreateK8sCR` function receives an `oldObject` parameter that is needed because the function doesn't know how to create an empty object of the same type of the object that is going to be created. But that can be solved using reflection, something like this:

```go
// Create an empty object of the same type of the new object. We will use it to
// fetch the current state.
objectType := reflect.TypeOf(newObject).Elem()
oldObject := reflect.New(objectType).Interface().(client.Object)
```

This patch does that and removes the `oldObject` parameter, which simplifies the code that calls the `CreateK8sCR` function.