### PR TITLE
Remove scheme parameter of `CreateK8sCR` and `ORANO2IMSReconciler`

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -105,7 +105,6 @@ func main() {
 	if err = (&controllers.ORANO2IMSReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controller").WithName("ORAN-O2IMS"),
-		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ORANO2IMS")
 		os.Exit(1)

--- a/internal/controllers/orano2ims_controller.go
+++ b/internal/controllers/orano2ims_controller.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/retry"
@@ -49,8 +48,7 @@ import (
 // ORANO2IMSReconciler reconciles a ORANO2IMS object
 type ORANO2IMSReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log logr.Logger
 }
 
 //+kubebuilder:rbac:groups=oran.openshift.io,resources=orano2imses,verbs=get;list;watch;create;update;patch;delete
@@ -274,7 +272,7 @@ func (r *ORANO2IMSReconciler) createDeploymentManagerClusterRole(ctx context.Con
 			},
 		},
 	}
-	return utils.CreateK8sCR(ctx, r.Client, role, orano2ims, r.Scheme, utils.UPDATE)
+	return utils.CreateK8sCR(ctx, r.Client, role, orano2ims, utils.UPDATE)
 }
 
 func (r *ORANO2IMSReconciler) createDeploymentManagerClusterRoleBinding(ctx context.Context,
@@ -302,7 +300,7 @@ func (r *ORANO2IMSReconciler) createDeploymentManagerClusterRoleBinding(ctx cont
 			},
 		},
 	}
-	return utils.CreateK8sCR(ctx, r.Client, binding, orano2ims, r.Scheme, utils.UPDATE)
+	return utils.CreateK8sCR(ctx, r.Client, binding, orano2ims, utils.UPDATE)
 }
 
 func (r *ORANO2IMSReconciler) deployServer(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS, serverName string) error {
@@ -372,7 +370,7 @@ func (r *ORANO2IMSReconciler) deployServer(ctx context.Context, orano2ims *oranv
 	}
 
 	r.Log.Info("[deployManagerServer] Create/Update/Patch Server", "Name", serverName)
-	return utils.CreateK8sCR(ctx, r.Client, newDeployment, orano2ims, r.Scheme, utils.UPDATE)
+	return utils.CreateK8sCR(ctx, r.Client, newDeployment, orano2ims, utils.UPDATE)
 }
 
 func (r *ORANO2IMSReconciler) createConfigMap(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS, resourceName string) error {
@@ -390,7 +388,7 @@ func (r *ORANO2IMSReconciler) createConfigMap(ctx context.Context, orano2ims *or
 	}
 
 	r.Log.Info("[createService] Create/Update/Patch Service: ", "name", resourceName)
-	return utils.CreateK8sCR(ctx, r.Client, configMap, orano2ims, r.Scheme, utils.UPDATE)
+	return utils.CreateK8sCR(ctx, r.Client, configMap, orano2ims, utils.UPDATE)
 }
 
 func (r *ORANO2IMSReconciler) createServiceAccount(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS, resourceName string) error {
@@ -412,7 +410,7 @@ func (r *ORANO2IMSReconciler) createServiceAccount(ctx context.Context, orano2im
 	}
 
 	r.Log.Info("[createServiceAccount] Create/Update/Patch ServiceAccount: ", "name", resourceName)
-	return utils.CreateK8sCR(ctx, r.Client, newServiceAccount, orano2ims, r.Scheme, utils.UPDATE)
+	return utils.CreateK8sCR(ctx, r.Client, newServiceAccount, orano2ims, utils.UPDATE)
 }
 
 func (r *ORANO2IMSReconciler) createService(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS, resourceName string) error {
@@ -448,7 +446,7 @@ func (r *ORANO2IMSReconciler) createService(ctx context.Context, orano2ims *oran
 	}
 
 	r.Log.Info("[createService] Create/Update/Patch Service: ", "name", resourceName)
-	return utils.CreateK8sCR(ctx, r.Client, newService, orano2ims, r.Scheme, utils.PATCH)
+	return utils.CreateK8sCR(ctx, r.Client, newService, orano2ims, utils.PATCH)
 }
 
 func (r *ORANO2IMSReconciler) createIngress(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS) error {
@@ -557,7 +555,7 @@ func (r *ORANO2IMSReconciler) createIngress(ctx context.Context, orano2ims *oran
 	}
 
 	r.Log.Info("[createIngress] Create/Update/Patch Ingress: ", "name", utils.ORANO2IMSIngressName)
-	return utils.CreateK8sCR(ctx, r.Client, newIngress, orano2ims, r.Scheme, utils.UPDATE)
+	return utils.CreateK8sCR(ctx, r.Client, newIngress, orano2ims, utils.UPDATE)
 }
 
 func (r *ORANO2IMSReconciler) updateORANO2ISMStatusConditions(ctx context.Context, orano2ims *oranv1alpha1.ORANO2IMS, deploymentName string) {

--- a/internal/controllers/orano2ims_controller_test.go
+++ b/internal/controllers/orano2ims_controller_test.go
@@ -96,7 +96,6 @@ var _ = DescribeTable(
 		r := &ORANO2IMSReconciler{
 			Client: fakeClient,
 			Log:    logr.Discard(),
-			Scheme: fakeClient.Scheme(),
 		}
 
 		// Reconcile.

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -11,7 +11,6 @@ import (
 	oranv1alpha1 "github.com/openshift-kni/oran-o2ims/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -21,7 +20,7 @@ var oranUtilsLog = ctrl.Log.WithName("oranUtilsLog")
 
 func CreateK8sCR(ctx context.Context, c client.Client,
 	newObject client.Object, ownerObject client.Object,
-	runtimeScheme *runtime.Scheme, operation string) (err error) {
+	operation string) (err error) {
 
 	// Get the name and namespace of the object:
 	key := client.ObjectKeyFromObject(newObject)
@@ -32,7 +31,7 @@ func CreateK8sCR(ctx context.Context, c client.Client,
 	// roles or cluster role bindings; those have empty namespaces so the equals comparison
 	// should also work.
 	if ownerObject.GetNamespace() == key.Namespace {
-		err = controllerutil.SetControllerReference(ownerObject, newObject, runtimeScheme)
+		err = controllerutil.SetControllerReference(ownerObject, newObject, c.Scheme())
 		if err != nil {
 			return err
 		}

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -163,7 +163,7 @@ var _ = Describe("DoesK8SResourceExist", func() {
 
 		// Create the deployment.
 		err = CreateK8sCR(context.TODO(), fakeClient,
-			deployment, orano2ims, suitescheme, UPDATE)
+			deployment, orano2ims, UPDATE)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check that the deployment has been created.
@@ -211,7 +211,7 @@ var _ = Describe("DoesK8SResourceExist", func() {
 
 		// Create the deployment.
 		err = CreateK8sCR(context.TODO(), fakeClient,
-			deployment, orano2ims, suitescheme, UPDATE)
+			deployment, orano2ims, UPDATE)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check that the deployment has been created.
@@ -227,7 +227,7 @@ var _ = Describe("DoesK8SResourceExist", func() {
 		// Update the SA Name.
 		newDeployment.Spec.Template.Spec.ServiceAccountName = "new-sa-name"
 		err = CreateK8sCR(context.TODO(), fakeClient,
-			newDeployment, orano2ims, suitescheme, UPDATE)
+			newDeployment, orano2ims, UPDATE)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Get the deployment and check that the SA Name has been updated.


### PR DESCRIPTION
It isn't necessary to explicitly pass the scheme paratemer to the `CreateK8sCR` function because it can obtain it calling the `Scheme()` function of the client.