### PR TITLE
Add reconciler task

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -102,9 +102,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.ORANO2IMSReconciler{
+	if err = (&controllers.Reconciler{
 		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controller").WithName("ORAN-O2IMS"),
+		Logger: ctrl.Log.WithName("controller").WithName("ORAN-O2IMS"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ORANO2IMS")
 		os.Exit(1)

--- a/internal/controllers/orano2ims_controller_test.go
+++ b/internal/controllers/orano2ims_controller_test.go
@@ -77,7 +77,7 @@ var _ = BeforeSuite(func() {
 
 var _ = DescribeTable(
 	"Reconciler",
-	func(objs []client.Object, request reconcile.Request, validate func(result ctrl.Result, reconciler ORANO2IMSReconciler)) {
+	func(objs []client.Object, request reconcile.Request, validate func(result ctrl.Result, reconciler Reconciler)) {
 		// Declare the Namespace for the O-RAN O2IMS resource.
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -93,9 +93,9 @@ var _ = DescribeTable(
 		Expect(err).ToNot(HaveOccurred())
 
 		// Initialize the O-RAN O2IMS reconciler.
-		r := &ORANO2IMSReconciler{
+		r := &Reconciler{
 			Client: fakeClient,
-			Log:    logr.Discard(),
+			Logger: logr.Discard(),
 		}
 
 		// Reconcile.
@@ -125,7 +125,7 @@ var _ = DescribeTable(
 				Name:      "oran-o2ims-sample-1",
 			},
 		},
-		func(result ctrl.Result, reconciler ORANO2IMSReconciler) {
+		func(result ctrl.Result, reconciler Reconciler) {
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Minute}))
 
 			// Check that the metadata server deployment exists.
@@ -189,7 +189,7 @@ var _ = DescribeTable(
 				Name:      "oran-o2ims-sample-1",
 			},
 		},
-		func(result ctrl.Result, reconciler ORANO2IMSReconciler) {
+		func(result ctrl.Result, reconciler Reconciler) {
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Minute}))
 
 			// Check the metadata server deployment exists.
@@ -270,7 +270,7 @@ var _ = DescribeTable(
 				Name:      "oran-o2ims-sample-1",
 			},
 		},
-		func(result ctrl.Result, reconciler ORANO2IMSReconciler) {
+		func(result ctrl.Result, reconciler Reconciler) {
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Minute}))
 
 			// Check that the metadata deployment exists.
@@ -317,7 +317,7 @@ var _ = DescribeTable(
 				Name:      "oran-o2ims-sample-1",
 			},
 		},
-		func(result ctrl.Result, reconciler ORANO2IMSReconciler) {
+		func(result ctrl.Result, reconciler Reconciler) {
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Minute}))
 			// Check the metadata server deployment does not exist.
 			metadataDeployment := &appsv1.Deployment{}


### PR DESCRIPTION
This patch adds a new `reconcilerTask` that contains the logic and data needed to perform the reconciliation process. It contains, for example, the state of the object being reconciled. This reduces the number of parameters that need to be passed to methods, as some of them are available as fields of the receiver.