### PR TITLE
Use slog in controllers

### DIFF
--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -153,7 +153,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 
 	if err = (&controllers.Reconciler{
 		Client: mgr.GetClient(),
-		Logger: ctrl.Log.WithName("controller").WithName("ORAN-O2IMS"),
+		Logger: slog.With("controller", "ORAN-O2IMS"),
 	}).SetupWithManager(mgr); err != nil {
 		logger.Error(
 			"Unable to create controller",

--- a/internal/controllers/orano2ims_controller_test.go
+++ b/internal/controllers/orano2ims_controller_test.go
@@ -19,10 +19,8 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -31,12 +29,9 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	oranv1alpha1 "github.com/openshift-kni/oran-o2ims/api/v1alpha1"
@@ -47,33 +42,9 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var suitescheme = scheme.Scheme
-
 func getFakeClientFromObjects(objs ...client.Object) (client.WithWatch, error) {
-	return fake.NewClientBuilder().WithScheme(suitescheme).WithObjects(objs...).WithStatusSubresource(&oranv1alpha1.ORANO2IMS{}).Build(), nil
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).WithStatusSubresource(&oranv1alpha1.ORANO2IMS{}).Build(), nil
 }
-
-func TestORANO2IMSReconciler(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controller Suite")
-}
-
-var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	By("Bootstrapping test environment")
-
-	suitescheme.AddKnownTypes(oranv1alpha1.GroupVersion, &oranv1alpha1.ORANO2IMS{})
-	suitescheme.AddKnownTypes(oranv1alpha1.GroupVersion, &oranv1alpha1.ORANO2IMSList{})
-	suitescheme.AddKnownTypes(networkingv1.SchemeGroupVersion, &networkingv1.Ingress{})
-	suitescheme.AddKnownTypes(networkingv1.SchemeGroupVersion, &networkingv1.IngressList{})
-	suitescheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceAccount{})
-	suitescheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceAccountList{})
-	suitescheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Service{})
-	suitescheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceList{})
-	suitescheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.Deployment{})
-	suitescheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DeploymentList{})
-})
 
 var _ = DescribeTable(
 	"Reconciler",
@@ -95,7 +66,7 @@ var _ = DescribeTable(
 		// Initialize the O-RAN O2IMS reconciler.
 		r := &Reconciler{
 			Client: fakeClient,
-			Logger: logr.Discard(),
+			Logger: logger,
 		}
 
 		// Reconcile.

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package controllers
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	oranv1alpha1 "github.com/openshift-kni/oran-o2ims/api/v1alpha1"
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controllers")
+}
+
+// Logger used for tests:
+var logger *slog.Logger
+
+// Scheme used for the tests:
+var scheme = clientgoscheme.Scheme
+
+var _ = BeforeSuite(func() {
+	// Create a logger that writes to the Ginkgo writer, so that the log messages will be
+	// attached to the output of the right test:
+	options := &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}
+	handler := slog.NewJSONHandler(GinkgoWriter, options)
+	logger = slog.New(handler)
+
+	// Configure the controller runtime library to use our logger:
+	adapter := logr.FromSlogHandler(logger.Handler())
+	ctrl.SetLogger(adapter)
+	klog.SetLogger(adapter)
+
+	// Add all the required types to the scheme used by the tests:
+	scheme.AddKnownTypes(oranv1alpha1.GroupVersion, &oranv1alpha1.ORANO2IMS{})
+	scheme.AddKnownTypes(oranv1alpha1.GroupVersion, &oranv1alpha1.ORANO2IMSList{})
+	scheme.AddKnownTypes(networkingv1.SchemeGroupVersion, &networkingv1.Ingress{})
+	scheme.AddKnownTypes(networkingv1.SchemeGroupVersion, &networkingv1.IngressList{})
+	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceAccount{})
+	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceAccountList{})
+	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Service{})
+	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceList{})
+	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.Deployment{})
+	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DeploymentList{})
+})


### PR DESCRIPTION
Currently we use the `slog` logging library in the servers and the `logr` library in the controllers. To make things a bit more consistent this patch changes the controllers to use `slog`.