### PR TITLE
Make image configurable

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -58,6 +58,14 @@ RUN \
 
 FROM registry.access.redhat.com/ubi9-minimal:9.2 AS runtime
 
+# Install the binary:
 COPY \
   --from=builder \
  /home/builder/project/oran-o2ims /usr/bin/oran-o2ims
+
+# We need to explictly run the servers a a non-root user, otherwise if the container is in a pod
+# with `runAsNonRoot: true` in the security context it will fail to start. In addition the user
+# needs to be specified numerically, not with a user name like `nobody`, because otherwise the
+# cluster can't verify if it is root or not.
+USER \
+  65534:65534

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/oran-o2ims .
+COPY --from=builder /workspace/oran-o2ims /usr/bin
 USER 65532:65532
 
-ENTRYPOINT ["/oran-o2ims"]
+ENTRYPOINT ["/usr/bin/oran-o2ims"]

--- a/api/v1alpha1/orano2ims_types.go
+++ b/api/v1alpha1/orano2ims_types.go
@@ -28,6 +28,13 @@ type ORANO2IMSSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// Image is the full reference of the container image that contains the binary. This is
+	// optional and the default will be the value passed to the `--image` command line flag of
+	// the controller manager.
+	//
+	//+optional
+	Image string `json:"image"`
+
 	CloudId string `json:"cloudId"`
 	//+kubebuilder:default=false
 	MetadataServer bool `json:"metadataServer"`

--- a/config/crd/bases/oran.openshift.io_orano2imses.yaml
+++ b/config/crd/bases/oran.openshift.io_orano2imses.yaml
@@ -56,6 +56,12 @@ spec:
                 items:
                   type: string
                 type: array
+              image:
+                description: Image is the full reference of the container image that
+                  contains the binary. This is optional and the default will be the
+                  value passed to the `--image` command line flag of the controller
+                  manager.
+                type: string
               ingressHost:
                 type: string
               metadataServer:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,3 +11,20 @@ images:
 - name: controller
   newName: quay.io/openshift-kni/oran-o2ims-operator
   newTag: 4.16.0
+
+replacements:
+
+# This replacment copies the controller image into the `IMAGE` environment variable of the pod,
+# which is in turn passed to the `--image` command line flag of the `start controller-manager`
+# command. The net result is that the operator knows what is its image and can use it as the
+# default for the servers.
+- source:
+    fieldPath: spec.template.spec.containers.[name=manager].image
+    kind: Deployment
+    name: controller-manager
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=manager].env.[name=IMAGE].value
+    select:
+      kind: Deployment
+      name: controller-manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -66,13 +66,28 @@ spec:
         # seccompProfile:
         #   type: RuntimeDefault
       containers:
-      - command:
-        - /oran-o2ims
-        - start
-        - controller-manager
-        - --leader-elect
+      - name: manager
         image: controller:latest
-        name: manager
+        env:
+        # Note that we have a kustomization replacement that copies the above `image` into this
+        # environment variable.
+        - name: IMAGE
+          value: controller:latest
+        command:
+        # We use a shell script here in order to be able to pass the value of the `IMAGE`
+        # environment variable in the `--image` flag. We don't wan to read environment variables
+        # directly from the binary because all the other command use flags as their main
+        # configuration mechanism, and we don't want to deviate from that.
+        #
+        # Please keep the `exec` before the command, it removes the shell from the picture once
+        # the controller manager starts.
+        - /usr/bin/bash
+        - -c
+        - |
+          exec \
+          /usr/bin/oran-o2ims start controller-manager \
+          --leader-elect \
+          --image="${IMAGE}"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -1,10 +1,5 @@
 package utils
 
-// Default image
-const (
-	ORANImage = "quay.io/openshift-kni/oran-o2ims:latest"
-)
-
 // Default namespace
 const (
 	ORANO2IMSNamespace = "oran-o2ims"


### PR DESCRIPTION
Currently the container image used by the servers is hardcoded in the Go source code. This complicates development because when the operator is deployed it isn't possible to use a custom image. To simplify that this patch adds a new `--image` command line flag to the `start controller-manager` command. The default will be
`quay.io/openshift-kni/oran-o2ims:latest`, but it will be possible to change it in the the development environment, in two different ways:

1. Changing the `IMG` make variable, for example:

  ```
  $ make IMG=quay.io/myuser/myimage:123 build deploy
  ```

2. Using the `spec.image` field of the custom resource.

The patch also changes The kustomization files used to generate tha operator manifests so that the selected image is automatically passed to the `--image` command line flag.