### PR TITLE
Use logging context where possible

### DIFF
--- a/internal/authorization/handler_wrapper.go
+++ b/internal/authorization/handler_wrapper.go
@@ -212,7 +212,8 @@ func (h *handlerWrapper) serve(handler http.Handler, w http.ResponseWriter, r *h
 	// Get the subject and check the ACL and send an error response if there is no match:
 	subject := authentication.SubjectFromContext(ctx)
 	if !h.checkACL(subject.Claims) {
-		h.logger.Info(
+		h.logger.InfoContext(
+			ctx,
 			"Access denied",
 			slog.String("subject", subject.Name),
 			slog.Any("claims", subject.Claims),

--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -154,7 +154,8 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		// LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Unable to start manager",
 			slog.String("error", err.Error()),
 		)
@@ -166,7 +167,8 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		Logger: slog.With("controller", "ORAN-O2IMS"),
 		Image:  c.image,
 	}).SetupWithManager(mgr); err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Unable to create controller",
 			slog.String("controller", "ORANO2IMS"),
 			slog.String("error", err.Error()),
@@ -175,26 +177,30 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Unable to set up health check",
 			slog.String("error", err.Error()),
 		)
 		return exit.Error(1)
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Unable to set up ready check",
 			slog.String("error", err.Error()),
 		)
 		return exit.Error(1)
 	}
 
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"Starting manager",
 		slog.String("image", c.image),
 	)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Problem running manager",
 			slog.String("error", err.Error()),
 		)

--- a/internal/cmd/server/start_alarm_subscription_server.go
+++ b/internal/cmd/server/start_alarm_subscription_server.go
@@ -83,7 +83,8 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 	// Get the cloud identifier:
 	cloudID, err := flags.GetString(cloudIDFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to get cloud identifier flag",
 			"flag", cloudIDFlagName,
 			"error", err.Error(),
@@ -91,13 +92,15 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 		return exit.Error(1)
 	}
 	if cloudID == "" {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Cloud identifier is empty",
 			"flag", cloudIDFlagName,
 		)
 		return exit.Error(1)
 	}
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"Cloud identifier",
 		"value", cloudID,
 	)
@@ -105,14 +108,16 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 	// Get the extensions details:
 	extensions, err := flags.GetStringArray(extensionsFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to extension flag",
 			"flag", extensionsFlagName,
 			"error", err.Error(),
 		)
 		return exit.Error(1)
 	}
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"alarm subscription extensions details",
 		slog.Any("extensions", extensions),
 	)
@@ -123,7 +128,8 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetFlags(flags).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create transport wrapper",
 			"error", err.Error(),
 		)
@@ -136,7 +142,8 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetFlags(flags).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create authentication wrapper",
 			slog.String("error", err.Error()),
 		)
@@ -147,7 +154,8 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetFlags(flags).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create authorization wrapper",
 			slog.String("error", err.Error()),
 		)
@@ -171,7 +179,8 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetExtensions(extensions...).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create handler",
 			"error", err,
 		)
@@ -185,7 +194,8 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetHandler(handler).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create adapter",
 			"error", err,
 		)
@@ -207,13 +217,15 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetFlags(flags, network.APIListener).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to to create API listener",
 			slog.String("error", err.Error()),
 		)
 		return exit.Error(1)
 	}
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"API listening",
 		slog.String("address", apiListener.Addr().String()),
 	)
@@ -223,7 +235,8 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 	}
 	err = apiServer.Serve(apiListener)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"API server finished with error",
 			slog.String("error", err.Error()),
 		)

--- a/internal/cmd/server/start_deployment_manager_server.go
+++ b/internal/cmd/server/start_deployment_manager_server.go
@@ -113,7 +113,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 	// Get the cloud identifier:
 	cloudID, err := flags.GetString(cloudIDFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to get cloud identifier flag",
 			"flag", cloudIDFlagName,
 			"error", err.Error(),
@@ -121,13 +122,15 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		return exit.Error(1)
 	}
 	if cloudID == "" {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Cloud identifier is empty",
 			"flag", cloudIDFlagName,
 		)
 		return exit.Error(1)
 	}
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"Cloud identifier",
 		"value", cloudID,
 	)
@@ -135,7 +138,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 	// Get the backend details:
 	backendTypeText, err := flags.GetString(backendTypeFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to get backend type flag",
 			"flag", backendTypeFlagName,
 			"error", err.Error(),
@@ -147,7 +151,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 	case service.DeploymentManagerBackendTypeGlobalHub:
 	case service.DeploymentManagerBackendTypeRegularHub:
 	default:
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Unknown backend type",
 			slog.String("type", backendTypeText),
 		)
@@ -155,7 +160,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 	}
 	backendURL, err := flags.GetString(backendURLFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to get backend URL flag",
 			"flag", backendURLFlagName,
 			"error", err.Error(),
@@ -163,7 +169,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		return exit.Error(1)
 	}
 	if backendURL == "" {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Backend URL is empty",
 			"flag", backendURLFlagName,
 		)
@@ -171,7 +178,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 	}
 	backendToken, err := flags.GetString(backendTokenFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to get backend token flag",
 			"flag", backendTokenFlagName,
 			"error", err.Error(),
@@ -180,7 +188,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 	}
 	backendTokenFile, err := flags.GetString(backendTokenFileFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to get backend token file flag",
 			slog.String("flag", backendTokenFileFlagName),
 			slog.String("error", err.Error()),
@@ -189,7 +198,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 	}
 	extensions, err := flags.GetStringArray(extensionsFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to extension flag",
 			"flag", extensionsFlagName,
 			"error", err.Error(),
@@ -199,7 +209,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 
 	// Check that the backend token and token file haven't been simultaneously provided:
 	if backendToken != "" && backendTokenFile != "" {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Backend token and token file have both been provided, but they are incompatible",
 			slog.Any(
 				"flags",
@@ -218,7 +229,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 	if backendToken == "" && backendTokenFile != "" {
 		backendTokenData, err := os.ReadFile(backendTokenFile)
 		if err != nil {
-			logger.Error(
+			logger.ErrorContext(
+				ctx,
 				"Failed to read backend token file",
 				slog.String("file", backendTokenFile),
 				slog.String("error", err.Error()),
@@ -226,7 +238,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 			return exit.Error(1)
 		}
 		backendToken = strings.TrimSpace(string(backendTokenData))
-		logger.Info(
+		logger.InfoContext(
+			ctx,
 			"Loaded backend token from file",
 			slog.String("file", backendTokenFile),
 			slog.String("!token", backendToken),
@@ -235,12 +248,13 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 
 	// Check that we have a token:
 	if backendToken == "" {
-		logger.Error("Backend token or token file must be provided")
+		logger.ErrorContext(ctx, "Backend token or token file must be provided")
 		return exit.Error(1)
 	}
 
 	// Write the backend details to the log:
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"Backend details",
 		slog.String("type", string(backendType)),
 		slog.String("url", backendURL),
@@ -252,14 +266,16 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 	// Get the external address:
 	externalAddress, err := flags.GetString(externalAddressFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to get external address flag",
 			slog.String("flag", externalAddressFlagName),
 			slog.String("error", err.Error()),
 		)
 		return exit.Error(1)
 	}
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"External address",
 		slog.String("value", externalAddress),
 	)
@@ -270,7 +286,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetFlags(flags).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create transport wrapper",
 			"error", err.Error(),
 		)
@@ -283,7 +300,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetFlags(flags).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create authentication wrapper",
 			slog.String("error", err.Error()),
 		)
@@ -294,7 +312,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetFlags(flags).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create authorization wrapper",
 			slog.String("error", err.Error()),
 		)
@@ -323,7 +342,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetEnableHack(true).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create handler",
 			"error", err,
 		)
@@ -337,7 +357,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetHandler(handler).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create adapter",
 			"error", err,
 		)
@@ -358,13 +379,15 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		SetFlags(flags, network.APIListener).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to to create API listener",
 			slog.String("error", err.Error()),
 		)
 		return exit.Error(1)
 	}
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"API listening",
 		slog.String("address", apiListener.Addr().String()),
 	)
@@ -374,7 +397,8 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 	}
 	err = apiServer.Serve(apiListener)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"API server finished with error",
 			slog.String("error", err.Error()),
 		)

--- a/internal/cmd/server/start_metadata_server.go
+++ b/internal/cmd/server/start_metadata_server.go
@@ -77,7 +77,8 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 	// Get the cloud identifier:
 	cloudID, err := flags.GetString(cloudIDFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to get cloud identifier flag",
 			"flag", cloudIDFlagName,
 			"error", err.Error(),
@@ -85,13 +86,15 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 		return exit.Error(1)
 	}
 	if cloudID == "" {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Cloud identifier is empty",
 			"flag", cloudIDFlagName,
 		)
 		return exit.Error(1)
 	}
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"Cloud identifier",
 		"value", cloudID,
 	)
@@ -99,14 +102,16 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 	// Get the external address:
 	externalAddress, err := flags.GetString(externalAddressFlagName)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to get external address flag",
 			slog.String("flag", externalAddressFlagName),
 			slog.String("error", err.Error()),
 		)
 		return exit.Error(1)
 	}
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"External address",
 		slog.String("value", externalAddress),
 	)
@@ -125,7 +130,8 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 		SetLogger(logger).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create OpenAPI handler",
 			slog.String("error", err.Error()),
 		)
@@ -140,7 +146,8 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 		SetLogger(logger).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create versions handler",
 			slog.String("error", err.Error()),
 		)
@@ -152,7 +159,8 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 		SetHandler(versionsHandler).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create versions adapter",
 			slog.String("error", err.Error()),
 		)
@@ -174,7 +182,8 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 		SetExternalAddress(externalAddress).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create cloud info handler",
 			slog.String("error", err.Error()),
 		)
@@ -185,7 +194,8 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 		SetHandler(cloudInfoHandler).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to create cloud info adapter",
 			slog.String("error", err.Error()),
 		)
@@ -202,13 +212,15 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 		SetFlags(flags, network.APIListener).
 		Build()
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"Failed to to create API listener",
 			slog.String("error", err.Error()),
 		)
 		return exit.Error(1)
 	}
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"API listening",
 		slog.String("address", apiListener.Addr().String()),
 	)
@@ -218,7 +230,8 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 	}
 	err = apiServer.Serve(apiListener)
 	if err != nil {
-		logger.Error(
+		logger.ErrorContext(
+			ctx,
 			"API server finished with error",
 			slog.String("error", err.Error()),
 		)

--- a/internal/cmd/version_cmd.go
+++ b/internal/cmd/version_cmd.go
@@ -68,7 +68,8 @@ func (c *VersionCommand) run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Print the values:
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"Version",
 		slog.String("commit", buildCommit),
 		slog.String("time", buildTime),

--- a/internal/controllers/orano2ims_controller.go
+++ b/internal/controllers/orano2ims_controller.go
@@ -93,7 +93,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (resul
 			err = nil
 			return ctrl.Result{RequeueAfter: 5 * time.Minute}, err
 		}
-		r.Logger.Error(
+		r.Logger.ErrorContext(
+			ctx,
 			"Unable to fetch ORANO2IMS",
 			slog.String("error", err.Error()),
 		)
@@ -118,7 +119,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 	if t.object.Spec.MetadataServer || t.object.Spec.DeploymentManagerServer || t.object.Spec.ResourceServer || t.object.Spec.AlarmSubscriptionServer {
 		err = t.createIngress(ctx)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy Ingress.",
 				slog.String("error", err.Error()),
 			)
@@ -129,7 +131,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 	// Create the client service account.
 	err = t.createServiceAccount(ctx, utils.ORANO2IMSClientSAName)
 	if err != nil {
-		t.logger.Error(
+		t.logger.ErrorContext(
+			ctx,
 			"Failed to create client service account",
 			slog.String("error", err.Error()),
 		)
@@ -141,7 +144,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the needed ServiceAccount.
 		err = t.createServiceAccount(ctx, utils.ORANO2IMSResourceServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy ServiceAccount for the Resource server.",
 				slog.String("error", err.Error()),
 			)
@@ -151,7 +155,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the Service needed for the Resource server.
 		err = t.createService(ctx, utils.ORANO2IMSResourceServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy Service for Resource server.",
 				slog.String("error", err.Error()),
 			)
@@ -161,7 +166,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the resource-server deployment.
 		err = t.deployServer(ctx, utils.ORANO2IMSResourceServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy the Resource server.",
 				slog.String("error", err.Error()),
 			)
@@ -174,7 +180,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the needed ServiceAccount.
 		err = t.createServiceAccount(ctx, utils.ORANO2IMSMetadataServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy ServiceAccount for Metadata server.",
 				slog.String("error", err.Error()),
 			)
@@ -184,7 +191,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the Service needed for the Metadata server.
 		err = t.createService(ctx, utils.ORANO2IMSMetadataServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy Service for Metadata server.",
 				slog.String("error", err.Error()),
 			)
@@ -194,7 +202,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the metadata-server deployment.
 		err = t.deployServer(ctx, utils.ORANO2IMSMetadataServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy the Metadata server.",
 				slog.String("error", err.Error()),
 			)
@@ -207,7 +216,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the service account, role and binding:
 		err = t.createServiceAccount(ctx, utils.ORANO2IMSDeploymentManagerServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to create deployment manager service account",
 				slog.String("error", err.Error()),
 			)
@@ -215,7 +225,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		}
 		err = t.createDeploymentManagerClusterRole(ctx)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to create deployment manager cluster role",
 				slog.String("error", err.Error()),
 			)
@@ -223,7 +234,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		}
 		err = t.createDeploymentManagerClusterRoleBinding(ctx)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to create deployment manager cluster role binding",
 				slog.String("error", err.Error()),
 			)
@@ -233,7 +245,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create authz ConfigMap.
 		err = t.createConfigMap(ctx, utils.ORANO2IMSConfigMapName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy ConfigMap for Deployment Manager server.",
 				slog.String("error", err.Error()),
 			)
@@ -243,7 +256,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the Service needed for the Deployment Manager server.
 		err = t.createService(ctx, utils.ORANO2IMSDeploymentManagerServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy Service for Deployment Manager server.",
 				slog.String("error", err.Error()),
 			)
@@ -253,7 +267,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the deployment-manager-server deployment.
 		err = t.deployServer(ctx, utils.ORANO2IMSDeploymentManagerServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy the Deployment Manager server.",
 				slog.String("error", err.Error()),
 			)
@@ -265,7 +280,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create authz ConfigMap.
 		err = t.createConfigMap(ctx, utils.ORANO2IMSConfigMapName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy ConfigMap for alarm subscription server.",
 				slog.String("error", err.Error()),
 			)
@@ -275,7 +291,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the needed ServiceAccount.
 		err = t.createServiceAccount(ctx, utils.ORANO2IMSAlarmSubscriptionServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy ServiceAccount for Alarm Subscription server.",
 				slog.String("error", err.Error()),
 			)
@@ -285,7 +302,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the Service needed for the alarm subscription server.
 		err = t.createService(ctx, utils.ORANO2IMSAlarmSubscriptionServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy Service for Alarm Subscription server.",
 				slog.String("error", err.Error()),
 			)
@@ -295,7 +313,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		// Create the alarm subscription-server deployment.
 		err = t.deployServer(ctx, utils.ORANO2IMSAlarmSubscriptionServerName)
 		if err != nil {
-			t.logger.Error(
+			t.logger.ErrorContext(
+				ctx,
 				"Failed to deploy the alarm subscription server.",
 				slog.String("error", err.Error()),
 			)
@@ -305,7 +324,8 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 
 	err = t.updateORANO2ISMStatus(ctx)
 	if err != nil {
-		t.logger.Error(
+		t.logger.ErrorContext(
+			ctx,
 			"Failed to update status for ORANO2IMS",
 			slog.String("name", t.object.Name),
 		)
@@ -386,7 +406,7 @@ func (t *reconcilerTask) createDeploymentManagerClusterRoleBinding(ctx context.C
 }
 
 func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) error {
-	t.logger.Info("[deploy server]", "Name", serverName)
+	t.logger.InfoContext(ctx, "[deploy server]", "Name", serverName)
 
 	// Server variables.
 	deploymentVolumes := utils.GetDeploymentVolumes(serverName)
@@ -457,12 +477,12 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) er
 		Spec:       deploymentSpec,
 	}
 
-	t.logger.Info("[deployManagerServer] Create/Update/Patch Server", "Name", serverName)
+	t.logger.InfoContext(ctx, "[deployManagerServer] Create/Update/Patch Server", "Name", serverName)
 	return utils.CreateK8sCR(ctx, t.client, newDeployment, t.object, utils.UPDATE)
 }
 
 func (t *reconcilerTask) createConfigMap(ctx context.Context, resourceName string) error {
-	t.logger.Info("[createConfigMap]")
+	t.logger.InfoContext(ctx, "[createConfigMap]")
 
 	// Build the ConfigMap object.
 	configMap := &corev1.ConfigMap{
@@ -475,12 +495,12 @@ func (t *reconcilerTask) createConfigMap(ctx context.Context, resourceName strin
 		},
 	}
 
-	t.logger.Info("[createService] Create/Update/Patch Service: ", "name", resourceName)
+	t.logger.InfoContext(ctx, "[createService] Create/Update/Patch Service: ", "name", resourceName)
 	return utils.CreateK8sCR(ctx, t.client, configMap, t.object, utils.UPDATE)
 }
 
 func (t *reconcilerTask) createServiceAccount(ctx context.Context, resourceName string) error {
-	t.logger.Info("[createServiceAccount]")
+	t.logger.InfoContext(ctx, "[createServiceAccount]")
 	// Build the ServiceAccount object.
 	serviceAccountMeta := metav1.ObjectMeta{
 		Name:      resourceName,
@@ -497,12 +517,12 @@ func (t *reconcilerTask) createServiceAccount(ctx context.Context, resourceName 
 		ObjectMeta: serviceAccountMeta,
 	}
 
-	t.logger.Info("[createServiceAccount] Create/Update/Patch ServiceAccount: ", "name", resourceName)
+	t.logger.InfoContext(ctx, "[createServiceAccount] Create/Update/Patch ServiceAccount: ", "name", resourceName)
 	return utils.CreateK8sCR(ctx, t.client, newServiceAccount, t.object, utils.UPDATE)
 }
 
 func (t *reconcilerTask) createService(ctx context.Context, resourceName string) error {
-	t.logger.Info("[createService]")
+	t.logger.InfoContext(ctx, "[createService]")
 	// Build the Service object.
 	serviceMeta := metav1.ObjectMeta{
 		Name:      resourceName,
@@ -533,12 +553,12 @@ func (t *reconcilerTask) createService(ctx context.Context, resourceName string)
 		Spec:       serviceSpec,
 	}
 
-	t.logger.Info("[createService] Create/Update/Patch Service: ", "name", resourceName)
+	t.logger.InfoContext(ctx, "[createService] Create/Update/Patch Service: ", "name", resourceName)
 	return utils.CreateK8sCR(ctx, t.client, newService, t.object, utils.PATCH)
 }
 
 func (t *reconcilerTask) createIngress(ctx context.Context) error {
-	t.logger.Info("[createIngress]")
+	t.logger.InfoContext(ctx, "[createIngress]")
 	// Build the Ingress object.
 	ingressMeta := metav1.ObjectMeta{
 		Name:      utils.ORANO2IMSIngressName,
@@ -642,7 +662,7 @@ func (t *reconcilerTask) createIngress(ctx context.Context) error {
 		Spec:       ingressSpec,
 	}
 
-	t.logger.Info("[createIngress] Create/Update/Patch Ingress: ", "name", utils.ORANO2IMSIngressName)
+	t.logger.InfoContext(ctx, "[createIngress] Create/Update/Patch Ingress: ", "name", utils.ORANO2IMSIngressName)
 	return utils.CreateK8sCR(ctx, t.client, newIngress, t.object, utils.UPDATE)
 }
 
@@ -693,7 +713,7 @@ func (t *reconcilerTask) updateORANO2ISMStatusConditions(ctx context.Context, de
 
 func (t *reconcilerTask) updateORANO2ISMStatus(ctx context.Context) error {
 
-	t.logger.Info("[updateORANO2ISMStatus]")
+	t.logger.InfoContext(ctx, "[updateORANO2ISMStatus]")
 	if t.object.Spec.MetadataServer {
 		t.updateORANO2ISMStatusConditions(ctx, utils.ORANO2IMSMetadataServerName)
 	}

--- a/internal/k8s/stream.go
+++ b/internal/k8s/stream.go
@@ -97,22 +97,23 @@ func (s *Stream) Next(ctx context.Context) (item data.Object, err error) {
 	if !s.found {
 		err = s.find(ctx)
 		if err != nil {
-			s.close()
+			s.close(ctx)
 			return
 		}
 	}
 	if s.iterator.ReadArray() {
 		item, err = s.readObject()
 		if err != nil {
-			s.close()
+			s.close(ctx)
 			return
 		}
-		s.logger.Info(
+		s.logger.InfoContext(
+			ctx,
 			"Read item",
 			"item", item,
 		)
 	} else {
-		s.close()
+		s.close(ctx)
 		err = data.ErrEnd
 	}
 	return
@@ -152,7 +153,8 @@ func (s *Stream) find(ctx context.Context) error {
 		if s.iterator.Error != nil {
 			return s.iterator.Error
 		}
-		s.logger.Debug(
+		s.logger.DebugContext(
+			ctx,
 			"Ignored field while looking for items",
 			"field", field,
 		)
@@ -160,12 +162,13 @@ func (s *Stream) find(ctx context.Context) error {
 }
 
 // close closes the input reader, if it is closeable.
-func (s *Stream) close() {
+func (s *Stream) close(ctx context.Context) {
 	closer, ok := s.reader.(io.ReadCloser)
 	if ok {
 		err := closer.Close()
 		if err != nil {
-			s.logger.Error(
+			s.logger.ErrorContext(
+				ctx,
 				"Failed to close reader",
 				"error", err,
 			)

--- a/internal/openapi/handler.go
+++ b/internal/openapi/handler.go
@@ -91,11 +91,16 @@ func (b *HandlerBuilder) loadSpec() (result []byte, err error) {
 
 // ServeHTTP is the implementation of the object HTTP handler interface.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Get the context:
+	ctx := r.Context()
+
+	// Send the response:
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write(h.spec)
 	if err != nil {
-		h.logger.Error(
+		h.logger.ErrorContext(
+			ctx,
 			"Failed to send data",
 			slog.String("error", err.Error()),
 		)

--- a/internal/search/projector_evaluator.go
+++ b/internal/search/projector_evaluator.go
@@ -124,7 +124,8 @@ func (e *ProjectorEvaluator) Evaluate(ctx context.Context, projector *Projector,
 	object any) (result map[string]any, err error) {
 	result, err = e.evaluateProjector(ctx, projector, object)
 	if e.logger.Enabled(ctx, slog.LevelDebug) {
-		e.logger.Debug(
+		e.logger.DebugContext(
+			ctx,
 			"Evaluated projector",
 			slog.String("projector", fmt.Sprintf("%v", projector)),
 			slog.Any("object", object),

--- a/internal/search/selector_evaluator.go
+++ b/internal/search/selector_evaluator.go
@@ -125,7 +125,8 @@ func (e *SelectorEvaluator) Evaluate(ctx context.Context, selector *Selector,
 	object any) (result bool, err error) {
 	result, err = e.evaluateSelector(ctx, selector, object)
 	if e.logger.Enabled(ctx, slog.LevelDebug) {
-		e.logger.Debug(
+		e.logger.DebugContext(
+			ctx,
 			"Evaluated selector",
 			"selector", selector.String(),
 			"object", object,

--- a/internal/service/alarm_definition_handler.go
+++ b/internal/service/alarm_definition_handler.go
@@ -181,13 +181,19 @@ func (h *AlarmDefinitionHandler) mapItem(ctx context.Context,
 	proposedRepairActions, err := data.GetString(from, "proposedRepairActions")
 	if err != nil {
 		// Property is optional
-		h.logger.Debug(fmt.Sprintf("'%s' is missing from alarm definition (optional)", "proposedRepairActions"))
+		h.logger.DebugContext(
+			ctx,
+			fmt.Sprintf("'%s' is missing from alarm definition (optional)", "proposedRepairActions"),
+		)
 	}
 
 	alarmAdditionalFields, err := data.GetObj(from, "alarmAdditionalFields")
 	if err != nil {
 		// Property is optional
-		h.logger.Debug(fmt.Sprintf("'%s' is missing from alarm definition (optional)", "alarmAdditionalFields"))
+		h.logger.DebugContext(
+			ctx,
+			fmt.Sprintf("'%s' is missing from alarm definition (optional)", "alarmAdditionalFields"),
+		)
 		err = nil
 	}
 

--- a/internal/service/alarm_fetcher.go
+++ b/internal/service/alarm_fetcher.go
@@ -237,7 +237,8 @@ func (r *AlarmFetcher) doGet(ctx context.Context, url, token string,
 		return
 	}
 	if response.StatusCode != http.StatusOK {
-		r.logger.Error(
+		r.logger.ErrorContext(
+			ctx,
 			"Received unexpected status code",
 			"code", response.StatusCode,
 			"url", request.URL,

--- a/internal/service/alarm_subscription_handler.go
+++ b/internal/service/alarm_subscription_handler.go
@@ -198,7 +198,8 @@ func (h *alarmSubscriptionHandler) List(ctx context.Context,
 func (h *alarmSubscriptionHandler) Get(ctx context.Context,
 	request *GetRequest) (response *GetResponse, err error) {
 
-	h.logger.Debug(
+	h.logger.DebugContext(
+		ctx,
 		"alarmSubscriptionHandler Get:",
 	)
 	item, err := h.fetchItem(ctx, request.Variables[0])
@@ -214,7 +215,8 @@ func (h *alarmSubscriptionHandler) Get(ctx context.Context,
 func (h *alarmSubscriptionHandler) Add(ctx context.Context,
 	request *AddRequest) (response *AddResponse, err error) {
 
-	h.logger.Debug(
+	h.logger.DebugContext(
+		ctx,
 		"alarmSubscriptionHandler Add:",
 	)
 	id, err := h.addItem(ctx, *request)
@@ -243,7 +245,8 @@ func (h *alarmSubscriptionHandler) Add(ctx context.Context,
 func (h *alarmSubscriptionHandler) Delete(ctx context.Context,
 	request *DeleteRequest) (response *DeleteResponse, err error) {
 
-	h.logger.Debug(
+	h.logger.DebugContext(
+		ctx,
 		"alarmSubscriptionHandler delete:",
 	)
 	err = h.deleteItem(ctx, *request)
@@ -265,12 +268,12 @@ func (h *alarmSubscriptionHandler) fetchItem(ctx context.Context,
 	return
 }
 
-func (h *alarmSubscriptionHandler) fetchItems(
-	ctx context.Context) (result data.Stream, err error) {
+func (h *alarmSubscriptionHandler) fetchItems(ctx context.Context) (result data.Stream, err error) {
 	h.subscritionMapMemoryLock.Lock()
 	defer h.subscritionMapMemoryLock.Unlock()
 	ar := maps.Values(h.subscriptionMap)
-	h.logger.Debug(
+	h.logger.DebugContext(
+		ctx,
 		"alarmSubscriptionHandler fetchItems:",
 	)
 	result = data.Pour(ar...)

--- a/internal/service/deployment_manager_handler.go
+++ b/internal/service/deployment_manager_handler.go
@@ -590,7 +590,8 @@ func (h *DeploymentManagerHandler) fetchProfile(ctx context.Context,
 		return
 	}
 	if assistedInstallerAdminKubeconfig != nil {
-		h.logger.Info(
+		h.logger.InfoContext(
+			ctx,
 			"Using assisted installer admin kubeconfig",
 			slog.String("cluster", cluster),
 		)
@@ -654,7 +655,8 @@ func (h *DeploymentManagerHandler) fetchProfile(ctx context.Context,
 	if err != nil {
 		return
 	}
-	h.logger.Info(
+	h.logger.InfoContext(
+		ctx,
 		"Using registration admin kubeconfig",
 		slog.String("cluster", cluster),
 	)
@@ -679,7 +681,8 @@ func (h *DeploymentManagerHandler) fetchAssistedInstallerAdminKubeconfig(ctx con
 	}
 	err = client.Get(ctx, key, secret)
 	if apierrors.IsNotFound(err) {
-		h.logger.Info(
+		h.logger.InfoContext(
+			ctx,
 			"Assisted installer kubeconfig secret doesn't exist",
 			slog.String("cluster", clusterName),
 			slog.String("namespace", key.Namespace),
@@ -720,7 +723,8 @@ func (h *DeploymentManagerHandler) fetchRegistrationKubeconfig(ctx context.Conte
 	}
 	err = client.Get(ctx, key, secret)
 	if apierrors.IsNotFound(err) {
-		h.logger.Info(
+		h.logger.InfoContext(
+			ctx,
 			"Cluster secret doesn't exist",
 			slog.String("cluster", clusterName),
 			slog.String("namespace", key.Namespace),

--- a/internal/service/resource_fetcher.go
+++ b/internal/service/resource_fetcher.go
@@ -245,7 +245,8 @@ func (r *ResourceFetcher) getSearchResponse(ctx context.Context) (result io.Read
 		return
 	}
 	if response.StatusCode != http.StatusOK {
-		r.logger.Error(
+		r.logger.ErrorContext(
+			ctx,
 			"Received unexpected status code",
 			"code", response.StatusCode,
 			"url", r.backendURL,

--- a/internal/service/resource_handler.go
+++ b/internal/service/resource_handler.go
@@ -362,14 +362,16 @@ func (h *ResourceHandler) getCollectionGraphqlVars(ctx context.Context, id strin
 				return graphql.PropertyNode(s).MapProperty()
 			})
 			if err != nil {
-				h.logger.Error(
+				h.logger.ErrorContext(
+					ctx,
 					"Failed to map GraphQL filter term (fallback to selector filtering).",
 					slog.String("filter", term.String()),
 					slog.String("error", err.Error()),
 				)
 				continue
 			}
-			h.logger.Debug(
+			h.logger.DebugContext(
+				ctx,
 				"Mapped filter term to GraphQL SearchFilter",
 				slog.String("term", term.String()),
 				slog.String("mapped property", searchFilter.Property),

--- a/internal/service/resource_pool_fetcher.go
+++ b/internal/service/resource_pool_fetcher.go
@@ -262,7 +262,8 @@ func (r *ResourcePoolFetcher) getSearchResponse(ctx context.Context) (result io.
 		return
 	}
 	if response.StatusCode != http.StatusOK {
-		r.logger.Error(
+		r.logger.ErrorContext(
+			ctx,
 			"Received unexpected status code",
 			"code", response.StatusCode,
 			"url", r.backendURL,

--- a/internal/service/resource_pool_handler.go
+++ b/internal/service/resource_pool_handler.go
@@ -301,14 +301,16 @@ func (h *ResourcePoolHandler) getCollectionGraphqlVars(ctx context.Context, sele
 				return graphql.PropertyCluster(s).MapProperty()
 			})
 			if err != nil {
-				h.logger.Error(
+				h.logger.ErrorContext(
+					ctx,
 					"Failed to map GraphQL filter term (fallback to selector filtering).",
 					slog.String("term", term.String()),
 					slog.String("error", err.Error()),
 				)
 				continue
 			}
-			h.logger.Debug(
+			h.logger.DebugContext(
+				ctx,
 				"Mapped filter term to GraphQL SearchFilter",
 				slog.String("term", term.String()),
 				slog.String("mapped property", searchFilter.Property),

--- a/internal/service/resource_type_handler.go
+++ b/internal/service/resource_type_handler.go
@@ -346,7 +346,8 @@ func (h *ResourceTypeHandler) getAlarmDictionary(ctx context.Context, resourceCl
 		SetLogger(h.logger).
 		Build()
 	if err != nil {
-		h.logger.Error(
+		h.logger.ErrorContext(
+			ctx,
 			"Failed to create handler",
 			"error", err,
 		)

--- a/internal/service/versions_handler.go
+++ b/internal/service/versions_handler.go
@@ -91,7 +91,8 @@ func (h *VersionsHandler) Get(ctx context.Context, request *GetRequest) (respons
 		for _, currentVersion := range allVersions {
 			versionValue, ok := currentVersion["version"]
 			if !ok {
-				h.logger.Error(
+				h.logger.ErrorContext(
+					ctx,
 					"Version doesn't have a version number, will ignore it",
 					slog.Any("version", currentVersion),
 				)
@@ -99,7 +100,8 @@ func (h *VersionsHandler) Get(ctx context.Context, request *GetRequest) (respons
 			}
 			versionText, ok := versionValue.(string)
 			if !ok {
-				h.logger.Error(
+				h.logger.ErrorContext(
+					ctx,
 					"Version number isn't a string, will ignore it",
 					slog.Any("version", versionValue),
 				)
@@ -107,7 +109,8 @@ func (h *VersionsHandler) Get(ctx context.Context, request *GetRequest) (respons
 			}
 			versionNumber, err := semver.NewVersion(versionText)
 			if err != nil {
-				h.logger.Error(
+				h.logger.ErrorContext(
+					ctx,
 					"Version number isn't a valid semantic version, will ignore it",
 					slog.String("version", versionText),
 					slog.String("error", err.Error()),

--- a/internal/tool.go
+++ b/internal/tool.go
@@ -168,14 +168,16 @@ func (t *Tool) Run(ctx context.Context) error {
 	}
 
 	// Execute the main command:
-	t.logger.Info(
+	t.logger.InfoContext(
+		ctx,
 		"Command",
 		"args", t.args,
 	)
 	t.cmd.SetArgs(t.args[1:])
 	err = t.cmd.ExecuteContext(ctx)
 	if err != nil {
-		t.logger.Error(
+		t.logger.ErrorContext(
+			ctx,
 			"Failed to run command",
 			"args", t.args,
 			"error", err,
@@ -202,7 +204,7 @@ func (t *Tool) run(cmd *cobra.Command, args []string) error {
 	cmd.SetContext(ctx)
 
 	// Write build information:
-	t.writeBuildInfo()
+	t.writeBuildInfo(ctx)
 
 	return nil
 }
@@ -246,11 +248,11 @@ func (t *Tool) createConfiguredLogger() (result *slog.Logger, err error) {
 	return
 }
 
-func (t *Tool) writeBuildInfo() {
+func (t *Tool) writeBuildInfo(ctx context.Context) {
 	// Retrieve the information:
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
-		t.logger.Info("Build information isn't available")
+		t.logger.InfoContext(ctx, "Build information isn't available")
 		return
 	}
 
@@ -270,7 +272,7 @@ func (t *Tool) writeBuildInfo() {
 	}
 
 	// Write the information:
-	t.logger.Info("Build", logFields...)
+	t.logger.InfoContext(ctx, "Build", logFields...)
 }
 
 // In returns the input stream of the tool.


### PR DESCRIPTION
Currently whe use the `Info`, `Error` and `Debug` methods of the `slog.Logger` package, which don't receive a context. There are `InfoContext`, `ErrorContext` and `DebugContext` that receive a context as a parameter and make it possible to later include context information in the generated log messages. This patch changes our code to use those variants, so that we will eventually be able to use that context information.