### PR TITLE
Add metrics for inbound HTTP requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ vet: ## Run go vet against code.
 lint:
 	@echo "Run lint"
 	golangci-lint --version
-	golangci-lint run --verbose --print-resources-usage --modules-download-mode=vendor --timeout=5m0s
+	golangci-lint run --verbose --print-resources-usage --timeout=5m0s
 
 .PHONY: deps-update
 deps-update:

--- a/internal/cmd/server/start_alarm_server.go
+++ b/internal/cmd/server/start_alarm_server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -23,11 +24,13 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-kni/oran-o2ims/internal"
 	"github.com/openshift-kni/oran-o2ims/internal/exit"
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
+	"github.com/openshift-kni/oran-o2ims/internal/metrics"
 	"github.com/openshift-kni/oran-o2ims/internal/network"
 	"github.com/openshift-kni/oran-o2ims/internal/service"
 )
@@ -49,6 +52,7 @@ func AlarmServer() *cobra.Command {
 	}
 	flags := result.Flags()
 	network.AddListenerFlags(flags, network.APIListener, network.APIAddress)
+	network.AddListenerFlags(flags, network.MetricsListener, network.MetricsAddress)
 	_ = flags.String(
 		cloudIDFlagName,
 		"",
@@ -104,6 +108,19 @@ func (c *AlarmServerCommand) run(cmd *cobra.Command, argv []string) error {
 
 	// Get the flags:
 	flags := cmd.Flags()
+
+	// Create the exit handler:
+	exitHandler, err := exit.NewHandler().
+		SetLogger(c.logger).
+		Build()
+	if err != nil {
+		c.logger.ErrorContext(
+			ctx,
+			"Failed to create exit handler",
+			slog.String("error", err.Error()),
+		)
+		return exit.Error(1)
+	}
 
 	// Get the cloud identifier:
 	cloudID, err := flags.GetString(cloudIDFlagName)
@@ -228,6 +245,23 @@ func (c *AlarmServerCommand) run(cmd *cobra.Command, argv []string) error {
 		)
 	}
 
+	// Create the metrics wrapper:
+	metricsWrapper, err := metrics.NewHandlerWrapper().
+		AddPaths(
+			"/o2ims-infrastructureMonitoring/-/alarms/-",
+			"/o2ims-infrastructureMonitoring/-/alarmProbableCauses/-",
+		).
+		SetSubsystem("inbound").
+		Build()
+	if err != nil {
+		c.logger.ErrorContext(
+			ctx,
+			"Failed to create metrics wrapper",
+			slog.String("error", err.Error()),
+		)
+		return exit.Error(1)
+	}
+
 	// Create the router:
 	router := mux.NewRouter()
 	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -236,6 +270,7 @@ func (c *AlarmServerCommand) run(cmd *cobra.Command, argv []string) error {
 	router.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		service.SendError(w, http.StatusMethodNotAllowed, "Method not allowed")
 	})
+	router.Use(metricsWrapper)
 
 	// Generate the search API URL according the backend URL
 	backendURL, err = c.generateAlarmmanagerApiUrl(backendURL)
@@ -275,24 +310,62 @@ func (c *AlarmServerCommand) run(cmd *cobra.Command, argv []string) error {
 	}
 	c.logger.InfoContext(
 		ctx,
-		"API listening",
+		"API server listening",
 		slog.String("address", apiListener.Addr().String()),
 	)
-	apiServer := http.Server{
+	apiServer := &http.Server{
 		Addr:    apiListener.Addr().String(),
 		Handler: router,
 	}
-	err = apiServer.Serve(apiListener)
+	exitHandler.AddServer(apiServer)
+	go func() {
+		err = apiServer.Serve(apiListener)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			c.logger.ErrorContext(
+				ctx,
+				"API server finished with error",
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+
+	// Start the metrics server:
+	metricsListener, err := network.NewListener().
+		SetLogger(c.logger).
+		SetFlags(flags, network.MetricsListener).
+		Build()
 	if err != nil {
 		c.logger.ErrorContext(
 			ctx,
-			"API server finished with error",
+			"Failed to create metrics listener",
 			slog.String("error", err.Error()),
 		)
 		return exit.Error(1)
 	}
+	c.logger.InfoContext(
+		ctx,
+		"Metrics server listening",
+		slog.String("address", metricsListener.Addr().String()),
+	)
+	metricsHandler := promhttp.Handler()
+	metricsServer := &http.Server{
+		Addr:    metricsListener.Addr().String(),
+		Handler: metricsHandler,
+	}
+	exitHandler.AddServer(metricsServer)
+	go func() {
+		err = metricsServer.Serve(metricsListener)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			c.logger.ErrorContext(
+				ctx,
+				"Metrics server finished with error",
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
 
-	return nil
+	// Wait for exit signals:
+	return exitHandler.Wait(ctx)
 }
 
 func (c *AlarmServerCommand) createAlarmHandler(

--- a/internal/exit/handler.go
+++ b/internal/exit/handler.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package exit
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"slices"
+	"syscall"
+)
+
+// HandlerBuilder contains the data and logic needed to build an exit handler.
+type HandlerBuilder struct {
+	logger  *slog.Logger
+	signals []os.Signal
+}
+
+// Handler knows how to wait for exit signals and how to execute exit actions before exiting.
+type Handler struct {
+	logger  *slog.Logger
+	signals []os.Signal
+	actions []func(ctx context.Context) error
+}
+
+// NewHandler creates a builder that can then be used to configure and create an exit handler.
+func NewHandler() *HandlerBuilder {
+	return &HandlerBuilder{
+		signals: []os.Signal{syscall.SIGINT, syscall.SIGTERM},
+	}
+}
+
+// SetLogger sets the logger that the handler will use to write to the log. This is mandatory.
+func (b *HandlerBuilder) SetLogger(logger *slog.Logger) *HandlerBuilder {
+	b.logger = logger
+	return b
+}
+
+// AddSignal adds a shutdown signal. Signals SIGINT and SIGTERM are included by default.
+func (b *HandlerBuilder) AddSignal(value os.Signal) *HandlerBuilder {
+	b.signals = append(b.signals, value)
+	return b
+}
+
+// AddSignals adds a list of exit signal. Signals SIGINT and SIGTERM are included by default.
+func (b *HandlerBuilder) AddSignals(values ...os.Signal) *HandlerBuilder {
+	b.signals = append(b.signals, values...)
+	return b
+}
+
+// SetSignal sets the exit signal, discarding any signals that have been previosly configured,
+// including the defaults.
+func (b *HandlerBuilder) SetSignal(value os.Signal) *HandlerBuilder {
+	b.signals = append(b.signals, value)
+	return b
+}
+
+// SetSignals sets a list of exit signal, discarding any signals that have been previosly
+// configured, including the defaults.
+func (b *HandlerBuilder) SetSignals(values ...os.Signal) *HandlerBuilder {
+	b.signals = append(b.signals, values...)
+	return b
+}
+
+// Build uses the data stored in the builder to create and configure a new exit handler.
+func (b *HandlerBuilder) Build() (result *Handler, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if len(b.signals) == 0 {
+		err = errors.New("at least one signal is required")
+		return
+	}
+
+	// Create and populate the object:
+	result = &Handler{
+		logger:  b.logger,
+		signals: slices.Clone(b.signals),
+	}
+	return
+}
+
+// AddAction adds an action that will be executed prior to exiting.
+func (h *Handler) AddAction(value func(ctx context.Context) error) {
+	h.actions = append(h.actions, value)
+}
+
+// AddServer adds an HTTP server that should be shutdown prior to exiting.
+func (h *Handler) AddServer(value *http.Server) {
+	h.actions = append(
+		h.actions,
+		func(ctx context.Context) error {
+			return h.shutdownServer(ctx, value)
+		},
+	)
+}
+
+// Wait waits for an exit signal. When it is received it will perform all the registered exit
+// actions and then it will exit the process.
+func (h *Handler) Wait(ctx context.Context) error {
+	// Configure the process to receive the signals:
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, h.signals...)
+
+	// Wait for the first signal and then run the exit actions:
+	names := make([]string, len(h.signals))
+	for i, s := range h.signals {
+		names[i] = s.String()
+		s.Signal()
+	}
+	h.logger.InfoContext(
+		ctx,
+		"Waiting for exit signals",
+		slog.Any("signals", names),
+	)
+	s := <-c
+	go func() {
+		h.logger.InfoContext(
+			ctx,
+			"Received exit signal",
+			slog.String("signal", s.String()),
+		)
+		for _, action := range h.actions {
+			err := action(ctx)
+			if err != nil {
+				h.logger.ErrorContext(
+					ctx,
+					"Failed to run exit action",
+					slog.String("error", err.Error()),
+				)
+			}
+		}
+		os.Exit(0)
+	}()
+
+	// If we receive a second signal then we stop inmediately, without waiting for the exit
+	// actions to complete.
+	s = <-c
+	h.logger.InfoContext(
+		ctx,
+		"Received signal while waiting for actions to complete",
+		slog.String("signal", s.String()),
+	)
+	os.Exit(1)
+
+	return nil
+}
+
+func (h *Handler) shutdownServer(ctx context.Context, server *http.Server) error {
+	h.logger.InfoContext(
+		ctx,
+		"Shutting down server",
+		slog.String("address", server.Addr),
+	)
+	err := server.Shutdown(ctx)
+	if errors.Is(err, http.ErrServerClosed) {
+		err = nil
+	}
+	return err
+}

--- a/internal/metrics/handler_wrapper.go
+++ b/internal/metrics/handler_wrapper.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+// This file contains the implementations of a handler wrapper that generates Prometheus metrics.
+
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// HandlerWrapperBuilder contains the data and logic needed to build a new metrics handler wrapper
+// that creates HTTP handlers that generate the following Prometheus metrics:
+//
+//	<subsystem>_request_count - Number of API requests sent.
+//	<subsystem>_request_duration_sum - Total time to send API requests, in seconds.
+//	<subsystem>_request_duration_count - Total number of API requests measured.
+//	<subsystem>_request_duration_bucket - Number of API requests organized in buckets.
+//
+// To set the subsystem prefix use the Subsystem method.
+//
+// The duration buckets metrics contain an `le` label that indicates the upper bound. For example if
+// the `le` label is `1` then the value will be the number of requests that were processed in less
+// than one second.
+//
+// The metrics will have the following labels:
+//
+//	method - Name of the HTTP method, for example GET or POST.
+//	path - Request path, for example /api/my/v1/resources.
+//	code - HTTP response code, for example 200 or 500.
+//
+// To calculate the average request duration during the last 10 minutes, for example, use a
+// Prometheus expression like this:
+//
+//	rate(my_request_duration_sum[10m]) / rate(my_request_duration_count[10m])
+//
+// In order to reduce the cardinality of the metrics the path label is modified to remove the
+// identifiers of the objects. For example, if the original path is .../resources/123 then it will
+// be replaced by .../resources/-, and the values will be accumulated. The line returned by the
+// metrics server will be like this:
+//
+//	<subsystem>_request_count{code="200",method="GET",path=".../resources/-"} 56
+//
+// The meaning of that is that there were a total of 56 requests to get specific resources,
+// independently of the specific identifier of the resource.
+//
+// The value of the `code` label will be zero when sending the request failed without a response
+// code, for example if it wasn't possible to open the connection, or if there was a timeout waiting
+// for the response.
+//
+// Note that setting this attribute is not enough to have metrics published, you also need to
+// create and start a metrics server, as described in the documentation of the Prometheus library.
+//
+// Don't create objects of this type directly; use the NewHandlerWrapper function instead.
+type HandlerWrapperBuilder struct {
+	paths      []string
+	subsystem  string
+	registerer prometheus.Registerer
+}
+
+// handlerWrapper contains the data and logic needed to wrap an HTTP handler with another one that
+// generates Prometheus metrics.
+type handlerWrapper struct {
+	paths           pathTree
+	requestCount    *prometheus.CounterVec
+	requestDuration *prometheus.HistogramVec
+}
+
+// handler is an HTTP handler that generates Prometheus metrics.
+type handler struct {
+	owner   *handlerWrapper
+	handler http.Handler
+}
+
+// Make sure that we implement the interface:
+var _ http.Handler = (*handler)(nil)
+
+// responseWriter is the HTTP response writer used to obtain the response code.
+type responseWriter struct {
+	code   int
+	writer http.ResponseWriter
+}
+
+// Make sure that we implement the interface:
+var _ http.ResponseWriter = (*responseWriter)(nil)
+
+// NewHandlerWrapper creates a new builder that can then be used to configure and create a new
+// metrics handler wrapper.
+func NewHandlerWrapper() *HandlerWrapperBuilder {
+	return &HandlerWrapperBuilder{
+		registerer: prometheus.DefaultRegisterer,
+	}
+}
+
+// AddPath adds a path that will be accepted as a value for the `path` label. For paths aren't
+// explicitly specified here then their metrics will be accumulated in the `/-` path.
+func (b *HandlerWrapperBuilder) AddPath(value string) *HandlerWrapperBuilder {
+	b.paths = append(b.paths, value)
+	return b
+}
+
+// AddPaths adds a list of paths that will be accepted as a value for the `path` label. For paths
+// aren't explicitly specified here then their metrics will be accumulated in the `/-` path.
+func (b *HandlerWrapperBuilder) AddPaths(values ...string) *HandlerWrapperBuilder {
+	b.paths = append(b.paths, values...)
+	return b
+}
+
+// SetSubsystem sets the name of the subsystem that will be used by to register the metrics
+// with Prometheus. For example, if the value is `my` then the following metrics will be
+// registered:
+//
+//	my_request_count - Number of API requests sent.
+//	my_inbound_request_duration_sum - Total time to send API requests, in seconds.
+//	my_inbound_request_duration_count - Total number of API requests measured.
+//	my_inbound_request_duration_bucket - Number of API requests organized in buckets.
+//
+// This is mandatory.
+func (b *HandlerWrapperBuilder) SetSubsystem(value string) *HandlerWrapperBuilder {
+	b.subsystem = value
+	return b
+}
+
+// SetRegisterer sets the Prometheus registerer that will be used to register the metrics. The
+// default is to use the default Prometheus registerer and there is usually no need to change that.
+// This is intended for unit tests, where it is convenient to have a registerer that doesn't
+// interfere with the rest of the system.
+func (b *HandlerWrapperBuilder) SetRegisterer(value prometheus.Registerer) *HandlerWrapperBuilder {
+	if value == nil {
+		value = prometheus.DefaultRegisterer
+	}
+	b.registerer = value
+	return b
+}
+
+// Build uses the information stored in the builder to create a new handler wrapper.
+func (b *HandlerWrapperBuilder) Build() (result func(http.Handler) http.Handler, err error) {
+	// Check parameters:
+	if b.subsystem == "" {
+		err = fmt.Errorf("subsystem is mandatory")
+		return
+	}
+
+	// Register the request count metric:
+	requestCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: b.subsystem,
+			Name:      "request_count",
+			Help:      "Number of requests sent.",
+		},
+		requestLabelNames,
+	)
+	err = b.registerer.Register(requestCount)
+	if err != nil {
+		registered, ok := err.(prometheus.AlreadyRegisteredError)
+		if ok {
+			requestCount = registered.ExistingCollector.(*prometheus.CounterVec)
+			err = nil // nolint
+		} else {
+			return
+		}
+	}
+
+	// Create the path tree:
+	paths := pathTree{}
+	for _, path := range b.paths {
+		paths.add(path)
+	}
+
+	// Register the request duration metric:
+	requestDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: b.subsystem,
+			Name:      "request_duration",
+			Help:      "Request duration in seconds.",
+			Buckets: []float64{
+				0.1,
+				1.0,
+				10.0,
+				30.0,
+			},
+		},
+		requestLabelNames,
+	)
+	err = b.registerer.Register(requestDuration)
+	if err != nil {
+		registered, ok := err.(prometheus.AlreadyRegisteredError)
+		if ok {
+			requestDuration = registered.ExistingCollector.(*prometheus.HistogramVec)
+			err = nil
+		} else {
+			return
+		}
+	}
+
+	// Create and populate the object:
+	wrapper := &handlerWrapper{
+		paths:           paths,
+		requestCount:    requestCount,
+		requestDuration: requestDuration,
+	}
+	result = wrapper.wrap
+
+	return
+}
+
+// wrap creates a new handler that wraps the given one and generates the Prometheus metrics.
+func (w *handlerWrapper) wrap(h http.Handler) http.Handler {
+	return &handler{
+		owner:   w,
+		handler: h,
+	}
+}
+
+// ServeHTTP is the implementation of the HTTP handler interface.
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// We need to replace the response writer with a custom one that captures the response code
+	// generated by the next handler:
+	writer := responseWriter{
+		code:   http.StatusOK,
+		writer: w,
+	}
+
+	// Measure the time that it takes to process the request and send the response:
+	start := time.Now()
+	h.handler.ServeHTTP(&writer, r)
+	elapsed := time.Since(start)
+
+	// Update the metrics:
+	path := r.URL.Path
+	method := r.Method
+	labels := prometheus.Labels{
+		methodLabelName: methodLabel(method),
+		pathLabelName:   pathLabel(h.owner.paths, path),
+		codeLabelName:   codeLabel(writer.code),
+	}
+	h.owner.requestCount.With(labels).Inc()
+	h.owner.requestDuration.With(labels).Observe(elapsed.Seconds())
+}
+
+// Header is part of the implementation of the http.ResponseWriter interface.
+func (w *responseWriter) Header() http.Header {
+	return w.writer.Header()
+}
+
+// Write is part of the implementation of the http.ResponseWriter interface.
+func (w *responseWriter) Write(b []byte) (n int, err error) {
+	n, err = w.writer.Write(b)
+	return
+}
+
+// WriteHeader is part of the implementation of the http.ResponseWriter interface.
+func (w *responseWriter) WriteHeader(code int) {
+	w.code = code
+	w.writer.WriteHeader(code)
+}
+
+// Flush is the implementation of the http.Flusher interface.
+func (w *responseWriter) Flush() {
+	flusher, ok := w.writer.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}

--- a/internal/metrics/handler_wrapper_test.go
+++ b/internal/metrics/handler_wrapper_test.go
@@ -1,0 +1,490 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+// This file contains tests for the metrics transport wrapper.
+
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+
+	. "github.com/openshift-kni/oran-o2ims/internal/testing"
+)
+
+var _ = Describe("Create", func() {
+	It("Can't be created without a subsystem", func() {
+		wrapper, err := NewHandlerWrapper().
+			Build()
+		Expect(err).To(HaveOccurred())
+		Expect(wrapper).To(BeNil())
+		message := err.Error()
+		Expect(message).To(ContainSubstring("subsystem"))
+		Expect(message).To(ContainSubstring("mandatory"))
+	})
+})
+
+var _ = Describe("Metrics", func() {
+	var (
+		server  *MetricsServer
+		wrapper func(http.Handler) http.Handler
+		handler http.Handler
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Start the metrics server:
+		server = NewMetricsServer()
+
+		// Create the wrapper:
+		wrapper, err = NewHandlerWrapper().
+			AddPaths(
+				"/my",
+				"/my/v1/resources",
+				"/my/v1/resources/-",
+				"/my/v1/resources/-/action",
+				"/my/v1/resources/-/groups",
+				"/my/v1/resources/-/groups",
+				"/my/v1/resources/-/groups/-",
+			).
+			SetSubsystem("my").
+			SetRegisterer(server.Registry()).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		// Stop the metrics server:
+		server.Close()
+	})
+
+	// Get sends a GET request to the API server.
+	var Send = func(method, path string) {
+		request := httptest.NewRequest(method, "http://localhost"+path, nil)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+	}
+
+	It("Calls wrapped handler", func() {
+		// Prepare the handler:
+		called := false
+		handler = wrapper(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}))
+
+		// Send the request:
+		Send(http.MethodGet, "/")
+
+		// Check that the wrapped handler was called:
+		Expect(called).To(BeTrue())
+	})
+
+	Describe("Request count", func() {
+		It("Honours subsystem", func() {
+			// Prepare the handler:
+			handler = wrapper(RespondWith(http.StatusOK, nil))
+
+			// Send the request:
+			Send(http.MethodGet, "/")
+
+			// Verify the metrics:
+			metrics := server.Metrics()
+			Expect(metrics).To(MatchLine(`^my_request_count\{.*\} .*$`))
+		})
+
+		DescribeTable(
+			"Counts correctly",
+			func(count int) {
+				// Prepare the handler:
+				handler = wrapper(RespondWith(http.StatusOK, nil))
+
+				// Send the requests:
+				for i := 0; i < count; i++ {
+					Send(http.MethodGet, "/")
+				}
+
+				// Verify the metrics:
+				metrics := server.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_count\{.*\} %d$`, count))
+			},
+			Entry("One", 1),
+			Entry("Two", 2),
+			Entry("Trhee", 3),
+		)
+
+		DescribeTable(
+			"Includes method label",
+			func(method string) {
+				// Prepare the handler:
+				handler = wrapper(RespondWith(http.StatusOK, nil))
+
+				// Send the requests:
+				Send(method, "/")
+
+				// Verify the metrics:
+				metrics := server.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_count\{.*method="%s".*\} .*$`, method))
+			},
+			Entry("GET", http.MethodGet),
+			Entry("POST", http.MethodPost),
+			Entry("PATCH", http.MethodPatch),
+			Entry("DELETE", http.MethodDelete),
+		)
+
+		DescribeTable(
+			"Includes path label",
+			func(path, label string) {
+				// Prepare the handler:
+				handler = wrapper(RespondWith(http.StatusOK, nil))
+
+				// Send the requests:
+				Send(http.MethodGet, path)
+
+				// Verify the metrics:
+				metrics := server.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_count\{.*path="%s".*\} .*$`, label))
+			},
+			Entry(
+				"Empty",
+				"",
+				"/",
+			),
+			Entry(
+				"One slash",
+				"/",
+				"/",
+			),
+			Entry(
+				"Two slashes",
+				"//",
+				"/",
+			),
+			Entry(
+				"Tree slashes",
+				"///",
+				"/",
+			),
+			Entry(
+				"Unknown root",
+				"/junk/",
+				"/-",
+			),
+			Entry(
+				"Service root",
+				"/my",
+				"/my",
+			),
+			Entry(
+				"Unknown service root",
+				"/junk",
+				"/-",
+			),
+			Entry(
+				"Version root",
+				"/my/v1",
+				"/my/v1",
+			),
+			Entry(
+				"Unknown version root",
+				"/junk/v1",
+				"/-",
+			),
+			Entry(
+				"Collection",
+				"/my/v1/resources",
+				"/my/v1/resources",
+			),
+			Entry(
+				"Unknown collection",
+				"/my/v1/junk",
+				"/-",
+			),
+			Entry(
+				"Collection item",
+				"/my/v1/resources/123",
+				"/my/v1/resources/-",
+			),
+			Entry(
+				"Collection item action",
+				"/my/v1/resources/123/action",
+				"/my/v1/resources/-/action",
+			),
+			Entry(
+				"Unknown collection item action",
+				"/my/v1/resources/123/junk",
+				"/-",
+			),
+			Entry(
+				"Subcollection",
+				"/my/v1/resources/123/groups",
+				"/my/v1/resources/-/groups",
+			),
+			Entry(
+				"Unknown subcollection",
+				"/my/v1/resources/123/junks",
+				"/-",
+			),
+			Entry(
+				"Subcollection item",
+				"/my/v1/resources/123/groups/456",
+				"/my/v1/resources/-/groups/-",
+			),
+			Entry(
+				"Too long",
+				"/my/v1/resources/123/groups/456/junk",
+				"/-",
+			),
+			Entry(
+				"Unknown path",
+				"/your/path",
+				"/-",
+			),
+		)
+
+		DescribeTable(
+			"Includes code label",
+			func(code int) {
+				// Prepare the handler:
+				handler = wrapper(RespondWith(code, nil))
+
+				// Send the requests:
+				Send(http.MethodGet, "/")
+
+				// Verify the metrics:
+				metrics := server.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_count\{.*code="%d".*\} .*$`, code))
+			},
+			Entry("200", http.StatusOK),
+			Entry("201", http.StatusCreated),
+			Entry("202", http.StatusAccepted),
+			Entry("401", http.StatusUnauthorized),
+			Entry("404", http.StatusNotFound),
+			Entry("500", http.StatusInternalServerError),
+		)
+	})
+
+	Describe("Request duration", func() {
+		It("Honours subsystem", func() {
+			// Prepare the handler:
+			handler = wrapper(RespondWith(http.StatusOK, nil))
+
+			// Send the request:
+			Send(http.MethodGet, "/")
+
+			// Verify the metrics:
+			metrics := server.Metrics()
+			Expect(metrics).To(MatchLine(`^my_request_duration_bucket\{.*\} .*$`))
+			Expect(metrics).To(MatchLine(`^my_request_duration_sum\{.*\} .*$`))
+			Expect(metrics).To(MatchLine(`^my_request_duration_count\{.*\} .*$`))
+		})
+
+		It("Honours buckets", func() {
+			// Prepare the handler:
+			handler = wrapper(RespondWith(http.StatusOK, nil))
+
+			// Send the request:
+			Send(http.MethodGet, "/")
+
+			// Verify the metrics:
+			metrics := server.Metrics()
+			Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*,le="0.1"\} .*$`))
+			Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*,le="1"\} .*$`))
+			Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*,le="10"\} .*$`))
+			Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*,le="30"\} .*$`))
+			Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*,le="\+Inf"\} .*$`))
+		})
+
+		DescribeTable(
+			"Counts correctly",
+			func(count int) {
+				// Prepare the handler:
+				handler = wrapper(RespondWith(http.StatusOK, nil))
+
+				// Send the requests:
+				for i := 0; i < count; i++ {
+					Send(http.MethodGet, "/")
+				}
+
+				// Verify the metrics:
+				metrics := server.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_count\{.*\} %d$`, count))
+			},
+			Entry("One", 1),
+			Entry("Two", 2),
+			Entry("Trhee", 3),
+		)
+
+		DescribeTable(
+			"Includes method label",
+			func(method string) {
+				// Prepare the handler:
+				handler = wrapper(RespondWith(http.StatusOK, nil))
+
+				// Send the requests:
+				Send(method, "/")
+
+				// Verify the metrics:
+				metrics := server.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*method="%s".*\} .*$`, method))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_sum\{.*method="%s".*\} .*$`, method))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_count\{.*method="%s".*\} .*$`, method))
+			},
+			Entry("GET", http.MethodGet),
+			Entry("POST", http.MethodPost),
+			Entry("PATCH", http.MethodPatch),
+			Entry("DELETE", http.MethodDelete),
+		)
+
+		DescribeTable(
+			"Includes path label",
+			func(path, label string) {
+				// Prepare the handler:
+				handler = wrapper(RespondWith(http.StatusOK, nil))
+
+				// Send the requests:
+				Send(http.MethodGet, path)
+
+				// Verify the metrics:
+				metrics := server.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*path="%s".*\} .*$`, label))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_sum\{.*path="%s".*\} .*$`, label))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_count\{.*path="%s".*\} .*$`, label))
+			},
+			Entry(
+				"Empty",
+				"",
+				"/",
+			),
+			Entry(
+				"One slash",
+				"/",
+				"/",
+			),
+			Entry(
+				"Two slashes",
+				"//",
+				"/",
+			),
+			Entry(
+				"Tree slashes",
+				"///",
+				"/",
+			),
+			Entry(
+				"Unknown root",
+				"/junk/",
+				"/-",
+			),
+			Entry(
+				"Service root",
+				"/my",
+				"/my",
+			),
+			Entry(
+				"Unknown service root",
+				"/junk",
+				"/-",
+			),
+			Entry(
+				"Version root",
+				"/my/v1",
+				"/my/v1",
+			),
+			Entry(
+				"Unknown version root",
+				"/junk/v1",
+				"/-",
+			),
+			Entry(
+				"Collection",
+				"/my/v1/resources",
+				"/my/v1/resources",
+			),
+			Entry(
+				"Unknown collection",
+				"/my/v1/junk",
+				"/-",
+			),
+			Entry(
+				"Collection item",
+				"/my/v1/resources/123",
+				"/my/v1/resources/-",
+			),
+			Entry(
+				"Collection item action",
+				"/my/v1/resources/123/action",
+				"/my/v1/resources/-/action",
+			),
+			Entry(
+				"Unknown collection item action",
+				"/my/v1/resources/123/junk",
+				"/-",
+			),
+			Entry(
+				"Subcollection",
+				"/my/v1/resources/123/groups",
+				"/my/v1/resources/-/groups",
+			),
+			Entry(
+				"Unknown subcollection",
+				"/my/v1/resources/123/junks",
+				"/-",
+			),
+			Entry(
+				"Subcollection item",
+				"/my/v1/resources/123/groups/456",
+				"/my/v1/resources/-/groups/-",
+			),
+			Entry(
+				"Too long",
+				"/my/v1/resources/123/groups/456/junk",
+				"/-",
+			),
+			Entry(
+				"Unknown path",
+				"/your/path",
+				"/-",
+			),
+		)
+
+		DescribeTable(
+			"Includes code label",
+			func(code int) {
+				// Prepare the handler:
+				handler = wrapper(RespondWith(code, nil))
+
+				// Send the requests:
+				Send(http.MethodGet, "/")
+
+				// Verify the metrics:
+				metrics := server.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*code="%d".*\} .*$`, code))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_sum\{.*code="%d".*\} .*$`, code))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_count\{.*code="%d".*\} .*$`, code))
+			},
+			Entry("200", http.StatusOK),
+			Entry("201", http.StatusCreated),
+			Entry("202", http.StatusAccepted),
+			Entry("401", http.StatusUnauthorized),
+			Entry("404", http.StatusNotFound),
+			Entry("500", http.StatusInternalServerError),
+		)
+	})
+})

--- a/internal/metrics/labels.go
+++ b/internal/metrics/labels.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+// This file contains functions that calculate the labels included in metrics.
+
+package metrics
+
+import (
+	"strconv"
+	"strings"
+)
+
+// methodLabel calculates the `method` label from the given HTTP method.
+func methodLabel(method string) string {
+	return strings.ToUpper(method)
+}
+
+// pathLabel calculates the `path` label from the URL path.
+func pathLabel(paths pathTree, path string) string {
+	// Remove leading and trailing slashes:
+	path = strings.Trim(path, "/")
+
+	// Handle the special case of the root, which at this point will be an empty string:
+	if path == "" {
+		return "/"
+	}
+
+	// Clear segments that correspond to path variables:
+	segments := strings.Split(path, "/")
+	current := paths
+	for i, segment := range segments {
+		next, ok := current[segment]
+		if ok {
+			current = next
+			continue
+		}
+		next, ok = current["-"]
+		if ok {
+			segments[i] = "-"
+			current = next
+			continue
+		}
+		return "/-"
+	}
+
+	// Reconstruct the path joining the modified segments:
+	return "/" + strings.Join(segments, "/")
+}
+
+// codeLabel calculates the `code` label from the given HTTP response.
+func codeLabel(code int) string {
+	return strconv.Itoa(code)
+}
+
+// Names of the labels added to metrics:
+const (
+	codeLabelName   = "code"
+	methodLabelName = "method"
+	pathLabelName   = "path"
+)
+
+// Array of labels added to call metrics:
+var requestLabelNames = []string{
+	codeLabelName,
+	methodLabelName,
+	pathLabelName,
+}

--- a/internal/metrics/path_tree.go
+++ b/internal/metrics/path_tree.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+// This file contains the type that describes trees of URL paths used to translate request paths
+// into labes suitalbe for use as Prometheus labels.
+
+package metrics
+
+import (
+	"strings"
+)
+
+// pathTree defines a tree of URL paths that will be used to transform request paths into labels
+// suitable for use in Prometheus metrics. For example, a server that has these URL paths:
+//
+//	/api
+//	/api/my
+//	/api/my/v1
+//	/api/my/v1/resources
+//	/api/my/v1/resources/{resource_id}
+//	/api/my/v1/resources/{resource_id}/groups
+//	/api/my/v1/resources/{resource_id}/groups/{group_id}
+//
+// Will be described with a tree like this:
+//
+//	var pathRoot = pathTree{
+//		"api": {
+//			"my": {
+//				"v1": {
+//					"resources": {
+//						"-": {
+//							"groups": {
+//								"-": nil,
+//							},
+//						},
+//					},
+//				},
+//			},
+//		},
+//	}
+//
+// Path variables are represented with a dash.
+type pathTree map[string]pathTree
+
+// add adds the given branch to this tree.
+func (t pathTree) add(path string) {
+	path = t.clean(path)
+	if len(path) == 0 {
+		return
+	}
+	segments := strings.Split(path, "/")
+	t.addSegments(segments)
+}
+
+func (t pathTree) addSegments(segments []string) {
+	if len(segments) == 0 {
+		return
+	}
+	head := segments[0]
+	tail := segments[1:]
+	next := t[head]
+	if next == nil {
+		if len(tail) > 0 {
+			next = pathTree{}
+		}
+		t[head] = next
+	}
+	next.addSegments(tail)
+}
+
+func (t pathTree) clean(path string) string {
+	for len(path) > 0 && strings.HasPrefix(path, "/") {
+		path = path[1:]
+	}
+	for len(path) > 0 && strings.HasSuffix(path, "/") {
+		path = path[0 : len(path)-1]
+	}
+	return path
+}

--- a/internal/metrics/path_tree_test.go
+++ b/internal/metrics/path_tree_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+// This file contains tests for the URL path tree.
+
+package metrics
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeTable(
+	"Add",
+	func(original string, paths []string, expected string) {
+		var tree *pathTree
+		err := json.Unmarshal([]byte(original), &tree)
+		Expect(err).ToNot(HaveOccurred())
+		for _, path := range paths {
+			tree.add(path)
+		}
+		actual, err := json.Marshal(tree)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(MatchJSON(expected))
+	},
+	Entry(
+		"Empty path",
+		`{}`,
+		[]string{
+			``,
+		},
+		`{}`,
+	),
+	Entry(
+		"Non existing path with one segment",
+		`{}`,
+		[]string{
+			`/api`,
+		},
+		`{
+			"api": null
+		}`,
+	),
+	Entry(
+		"Non existing path with two segments",
+		`{}`,
+		[]string{
+			`/api/my`,
+		},
+		`{
+			"api": {
+				"my": null
+			}
+		}`,
+	),
+	Entry(
+		"Non existing path with three segments",
+		`{}`,
+		[]string{
+			`/api/my/v1`,
+		},
+		`{
+			"api": {
+				"my": {
+					"v1": null
+				}
+			}
+		}`,
+	),
+	Entry(
+		"Existing path with one segment",
+		`{
+			"api": null
+		}`,
+		[]string{
+			`/api`,
+		},
+		`{
+			"api": null
+		}`,
+	),
+	Entry(
+		"Existing path with two segments",
+		`{
+			"api": {
+				"my": null
+			}
+		}`,
+		[]string{
+			`/api/my`,
+		},
+		`{
+			"api": {
+				"my": null
+			}
+		}`,
+	),
+	Entry(
+		"Existing path with three segments",
+		`{
+			"api": {
+				"my": {
+					"v1": null
+				}
+			}
+		}`,
+		[]string{
+			`/api/my/v1`,
+		},
+		`{
+			"api": {
+				"my": {
+					"v1": null
+				}
+			}
+		}`,
+	),
+	Entry(
+		"Appends to partially existing path",
+		`{
+			"api": null
+		}`,
+		[]string{
+			`/api/my`,
+		},
+		`{
+			"api": {
+				"my": null
+			}
+		}`,
+	),
+	Entry(
+		"Adds default token URL",
+		`{
+			"api": {
+				"my": null
+			}
+		}`,
+		[]string{
+			`/auth/realms/redhat-external/protocol/openid-connect/token`,
+		},
+		`{
+			"api": {
+				"my": null
+			},
+			"auth": {
+				"realms": {
+					"redhat-external": {
+						"protocol": {
+							"openid-connect": {
+								"token": null
+							}
+						}
+					}
+				}
+			}
+		}`,
+	),
+	Entry(
+		"Merges prefix",
+		`{
+			"api": {
+				"my": null
+			}
+		}`,
+		[]string{
+			`/api/my`,
+			`/api/your`,
+			`/api/their`,
+		},
+		`{
+			"api": {
+				"my": null,
+				"your": null,
+				"their": null
+			}
+		}`,
+	),
+)

--- a/internal/metrics/suite_test.go
+++ b/internal/metrics/suite_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics")
+}

--- a/internal/metrics/transport_wrapper.go
+++ b/internal/metrics/transport_wrapper.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+// This file contains the implementations of a transport wrapper that generates Prometheus metrics.
+
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TransportWrapperBuilder contains the data and logic needed to build a new metrics transport
+// wrapper that creates HTTP round trippers that generate the following Prometheus metrics:
+//
+//	<subsystem>_request_count - Number of API requests sent.
+//	<subsystem>_request_duration_sum - Total time to send API requests, in seconds.
+//	<subsystem>_request_duration_count - Total number of API requests measured.
+//	<subsystem>_request_duration_bucket - Number of API requests organized in buckets.
+//
+// To set the subsystem prefix use the Subsystem method.
+//
+// The duration buckets metrics contain an `le` label that indicates the upper bound. For example if
+// the `le` label is `1` then the value will be the number of requests that were processed in less
+// than one second.
+//
+// The metrics will have the following labels:
+//
+//	method - Name of the HTTP method, for example GET or POST.
+//	path - Request path, for example /o2ims-infrastructureInventory/v1/resourcePools
+//	code - HTTP response code, for example 200 or 500.
+//
+// To calculate the average request duration during the last 10 minutes, for example, use a
+// Prometheus expression like this:
+//
+//	rate(my_request_duration_sum[10m]) / rate(my_request_duration_count[10m])
+//
+// In order to reduce the cardinality of the metrics the path label is modified to remove the
+// identifiers of the objects. For example, if the original path is ../resources/123 then it will
+// be replaced by .../resources/-, and the values will be accumulated. The line returned by the
+// metrics server will be like this:
+//
+//	<subsystem>_request_count{code="200",method="GET",path=".../resources/-"} 56
+//
+// The meaning of that is that there were a total of 56 requests to get specific resources,
+// independently of the specific identifier of the resource.
+//
+// The value of the `code` label will be zero when sending the request failed without a response
+// code, for example if it wasn't possible to open the connection, or if there was a timeout waiting
+// for the response.
+//
+// Note that setting this attribute is not enough to have metrics published, you also need to
+// create and start a metrics server, as described in the documentation of the Prometheus library.
+//
+// Don't create objects of this type directly; use the NewTransportWrapper function instead.
+type TransportWrapperBuilder struct {
+	paths      []string
+	subsystem  string
+	registerer prometheus.Registerer
+}
+
+// transportWrapper contains the data and logic needed to wrap an HTTP round tripper with another
+// one that generates Prometheus metrics.
+type transportWrapper struct {
+	paths           pathTree
+	requestCount    *prometheus.CounterVec
+	requestDuration *prometheus.HistogramVec
+}
+
+// roundTripper is a round tripper that generates Prometheus metrics.
+type roundTripper struct {
+	owner     *transportWrapper
+	transport http.RoundTripper
+}
+
+// Make sure that we implement the interface:
+var _ http.RoundTripper = (*roundTripper)(nil)
+
+// NewTransportWrapper creates a new builder that can then be used to configure and create a new metrics
+// round tripper.
+func NewTransportWrapper() *TransportWrapperBuilder {
+	return &TransportWrapperBuilder{
+		registerer: prometheus.DefaultRegisterer,
+	}
+}
+
+// AddPath adds a path that will be accepted as a value for the `path` label. For paths that
+// aren't explicitly specified here their metrics will be accumulated in the `/-` path.
+func (b *TransportWrapperBuilder) AddPath(value string) *TransportWrapperBuilder {
+	b.paths = append(b.paths, value)
+	return b
+}
+
+// AddPaths adds a list path that will be accepted as a value for the `path` label. For paths that
+// aren't explicitly specified here their metrics will be accumulated in the `/-` path.
+func (b *TransportWrapperBuilder) AddPaths(values ...string) *TransportWrapperBuilder {
+	b.paths = append(b.paths, values...)
+	return b
+}
+
+// SetSubsystem sets the name of the subsystem that will be used by to register the metrics with
+// Prometheus. For example, if the value is `my` then the following metrics will be registered:
+//
+//	my_request_count - Number of API requests sent.
+//	my_request_duration_sum - Total time to send API requests, in seconds.
+//	my_request_duration_count - Total number of API requests measured.
+//	my_request_duration_bucket - Number of API requests organized in buckets.
+//
+// This is mandatory.
+func (b *TransportWrapperBuilder) SetSubsystem(value string) *TransportWrapperBuilder {
+	b.subsystem = value
+	return b
+}
+
+// SetRegisterer sets the Prometheus registerer that will be used to register the metrics. The
+// default is to use the default Prometheus registerer and there is usually no need to change that.
+// This is intended for unit tests, where it is convenient to have a registerer that doesn't
+// interfere with the rest of the system.
+func (b *TransportWrapperBuilder) SetRegisterer(
+	value prometheus.Registerer) *TransportWrapperBuilder {
+	if value == nil {
+		value = prometheus.DefaultRegisterer
+	}
+	b.registerer = value
+	return b
+}
+
+// Build uses the information stored in the builder to create a new transport wrapper.
+func (b *TransportWrapperBuilder) Build() (result func(http.RoundTripper) http.RoundTripper,
+	err error) {
+	// Check parameters:
+	if b.subsystem == "" {
+		err = fmt.Errorf("subsystem is mandatory")
+		return
+	}
+
+	// Register the request count metric:
+	requestCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: b.subsystem,
+			Name:      "request_count",
+			Help:      "Number of requests sent.",
+		},
+		requestLabelNames,
+	)
+	err = b.registerer.Register(requestCount)
+	if err != nil {
+		registered, ok := err.(prometheus.AlreadyRegisteredError)
+		if ok {
+			requestCount = registered.ExistingCollector.(*prometheus.CounterVec)
+			err = nil // nolint
+		} else {
+			return
+		}
+	}
+
+	// Create the path tree:
+	paths := pathTree{}
+	for _, path := range b.paths {
+		paths.add(path)
+	}
+
+	// Register the request duration metric:
+	requestDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: b.subsystem,
+			Name:      "request_duration",
+			Help:      "Request duration in seconds.",
+			Buckets: []float64{
+				0.1,
+				1.0,
+				10.0,
+				30.0,
+			},
+		},
+		requestLabelNames,
+	)
+	err = b.registerer.Register(requestDuration)
+	if err != nil {
+		registered, ok := err.(prometheus.AlreadyRegisteredError)
+		if ok {
+			requestDuration = registered.ExistingCollector.(*prometheus.HistogramVec)
+			err = nil
+		} else {
+			return
+		}
+	}
+
+	// Create and populate the object:
+	wrapper := &transportWrapper{
+		paths:           paths,
+		requestCount:    requestCount,
+		requestDuration: requestDuration,
+	}
+	result = wrapper.wrap
+
+	return
+}
+
+// wrap creates a new round tripper that wraps the given one and generates the Prometheus metrics.
+func (w *transportWrapper) wrap(transport http.RoundTripper) http.RoundTripper {
+	return &roundTripper{
+		owner:     w,
+		transport: transport,
+	}
+}
+
+// RoundTrip is the implementation of the round tripper interface.
+func (t *roundTripper) RoundTrip(request *http.Request) (response *http.Response, err error) {
+	// Measure the time that it takes to send the request and receive the response:
+	start := time.Now()
+	response, err = t.transport.RoundTrip(request)
+	elapsed := time.Since(start)
+
+	// Update the metrics:
+	path := request.URL.Path
+	method := request.Method
+	var code int
+	if response != nil {
+		code = response.StatusCode
+	}
+	labels := prometheus.Labels{
+		methodLabelName: methodLabel(method),
+		pathLabelName:   pathLabel(t.owner.paths, path),
+		codeLabelName:   codeLabel(code),
+	}
+	t.owner.requestCount.With(labels).Inc()
+	t.owner.requestDuration.With(labels).Observe(elapsed.Seconds())
+
+	return
+}

--- a/internal/metrics/transport_wrapper_test.go
+++ b/internal/metrics/transport_wrapper_test.go
@@ -1,0 +1,517 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+// This file contains tests for the metrics transport wrapper.
+
+package metrics
+
+import (
+	"io"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+
+	. "github.com/openshift-kni/oran-o2ims/internal/testing"
+)
+
+var _ = Describe("Create", func() {
+	It("Can't be created without a subsystem", func() {
+		wrapper, err := NewTransportWrapper().
+			Build()
+		Expect(err).To(HaveOccurred())
+		Expect(wrapper).To(BeNil())
+		message := err.Error()
+		Expect(message).To(ContainSubstring("subsystem"))
+		Expect(message).To(ContainSubstring("mandatory"))
+	})
+})
+
+var _ = Describe("Metrics", func() {
+	var (
+		apiServer     *Server
+		metricsServer *MetricsServer
+		apiClient     *http.Client
+	)
+
+	BeforeEach(func() {
+		// Start the servers:
+		apiServer = NewServer()
+		metricsServer = NewMetricsServer()
+
+		// Create the API client:
+		wrapper, err := NewTransportWrapper().
+			AddPaths(
+				"/my",
+				"/my/v1/resources",
+				"/my/v1/resources/-",
+				"/my/v1/resources/-/action",
+				"/my/v1/resources/-/groups",
+				"/my/v1/resources/-/groups",
+				"/my/v1/resources/-/groups/-",
+			).
+			SetSubsystem("my").
+			SetRegisterer(metricsServer.Registry()).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		apiTransport := wrapper(http.DefaultTransport)
+		Expect(apiTransport).ToNot(BeNil())
+		apiClient = &http.Client{
+			Transport: apiTransport,
+		}
+	})
+
+	AfterEach(func() {
+		// Stop the servers:
+		metricsServer.Close()
+		apiServer.Close()
+
+		// Close connections:
+		apiClient.CloseIdleConnections()
+	})
+
+	// Send sends a GET request to the API server.
+	var Send = func(method, path string) {
+		request, err := http.NewRequest(method, apiServer.URL()+path, nil)
+		Expect(err).ToNot(HaveOccurred())
+		response, err := apiClient.Do(request)
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			err = response.Body.Close()
+			Expect(err).ToNot(HaveOccurred())
+		}()
+		_, err = io.Copy(io.Discard, response.Body)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	Describe("Request count", func() {
+		It("Honours subsystem", func() {
+			// Prepare the server:
+			apiServer.AppendHandlers(
+				RespondWith(http.StatusOK, nil),
+			)
+
+			// Send the request:
+			Send(http.MethodGet, "/")
+
+			// Verify the metrics:
+			metrics := metricsServer.Metrics()
+			Expect(metrics).To(MatchLine(`^my_request_count\{.*\} .*$`))
+		})
+
+		DescribeTable(
+			"Counts correctly",
+			func(count int) {
+				// Prepare the server:
+				for i := 0; i < count; i++ {
+					apiServer.AppendHandlers(
+						RespondWith(http.StatusOK, nil),
+					)
+				}
+
+				// Send the requests:
+				for i := 0; i < count; i++ {
+					Send(http.MethodGet, "/")
+				}
+
+				// Verify the metrics:
+				metrics := metricsServer.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_count\{.*\} %d$`, count))
+			},
+			Entry("One", 1),
+			Entry("Two", 2),
+			Entry("Trhee", 3),
+		)
+
+		DescribeTable(
+			"Includes method label",
+			func(method string) {
+				// Prepare the server:
+				apiServer.AppendHandlers(
+					RespondWith(http.StatusOK, nil),
+				)
+
+				// Send the requests:
+				Send(method, "/")
+
+				// Verify the metrics:
+				metrics := metricsServer.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_count\{.*method="%s".*\} .*$`, method))
+			},
+			Entry("GET", http.MethodGet),
+			Entry("POST", http.MethodPost),
+			Entry("PATCH", http.MethodPatch),
+			Entry("DELETE", http.MethodDelete),
+		)
+
+		DescribeTable(
+			"Includes path label",
+			func(path, label string) {
+				// Prepare the server:
+				apiServer.AppendHandlers(
+					RespondWith(http.StatusOK, nil),
+				)
+
+				// Send the requests:
+				Send(http.MethodGet, path)
+
+				// Verify the metrics:
+				metrics := metricsServer.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_count\{.*path="%s".*\} .*$`, label))
+			},
+			Entry(
+				"Empty",
+				"",
+				"/",
+			),
+			Entry(
+				"One slash",
+				"/",
+				"/",
+			),
+			Entry(
+				"Two slashes",
+				"//",
+				"/",
+			),
+			Entry(
+				"Tree slashes",
+				"///",
+				"/",
+			),
+			Entry(
+				"Unknown root",
+				"/junk/",
+				"/-",
+			),
+			Entry(
+				"Service root",
+				"/my",
+				"/my",
+			),
+			Entry(
+				"Unknown service root",
+				"/junk",
+				"/-",
+			),
+			Entry(
+				"Version root",
+				"/my/v1",
+				"/my/v1",
+			),
+			Entry(
+				"Unknown version root",
+				"/junk/v1",
+				"/-",
+			),
+			Entry(
+				"Collection",
+				"/my/v1/resources",
+				"/my/v1/resources",
+			),
+			Entry(
+				"Unknown collection",
+				"/my/v1/junk",
+				"/-",
+			),
+			Entry(
+				"Collection item",
+				"/my/v1/resources/123",
+				"/my/v1/resources/-",
+			),
+			Entry(
+				"Collection item action",
+				"/my/v1/resources/123/action",
+				"/my/v1/resources/-/action",
+			),
+			Entry(
+				"Unknown collection item action",
+				"/my/v1/resources/123/junk",
+				"/-",
+			),
+			Entry(
+				"Subcollection",
+				"/my/v1/resources/123/groups",
+				"/my/v1/resources/-/groups",
+			),
+			Entry(
+				"Unknown subcollection",
+				"/my/v1/resources/123/junks",
+				"/-",
+			),
+			Entry(
+				"Subcollection item",
+				"/my/v1/resources/123/groups/456",
+				"/my/v1/resources/-/groups/-",
+			),
+			Entry(
+				"Too long",
+				"/my/v1/resources/123/groups/456/junk",
+				"/-",
+			),
+			Entry(
+				"Unknown path",
+				"/your/path",
+				"/-",
+			),
+		)
+
+		DescribeTable(
+			"Includes code label",
+			func(code int) {
+				// Prepare the server:
+				apiServer.AppendHandlers(
+					RespondWith(code, nil),
+				)
+
+				// Send the requests:
+				Send(http.MethodGet, "/")
+
+				// Verify the metrics:
+				metrics := metricsServer.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_count\{.*code="%d".*\} .*$`, code))
+			},
+			Entry("200", http.StatusOK),
+			Entry("201", http.StatusCreated),
+			Entry("202", http.StatusAccepted),
+			Entry("401", http.StatusUnauthorized),
+			Entry("404", http.StatusNotFound),
+			Entry("500", http.StatusInternalServerError),
+		)
+	})
+
+	Describe("Request duration", func() {
+		It("Honours subsystem", func() {
+			// Prepare the server:
+			apiServer.AppendHandlers(
+				RespondWith(http.StatusOK, nil),
+			)
+
+			// Send the request:
+			Send(http.MethodGet, "/")
+
+			// Verify the metrics:
+			metrics := metricsServer.Metrics()
+			Expect(metrics).To(MatchLine(`^my_request_duration_bucket\{.*\} .*$`))
+			Expect(metrics).To(MatchLine(`^my_request_duration_sum\{.*\} .*$`))
+			Expect(metrics).To(MatchLine(`^my_request_duration_count\{.*\} .*$`))
+		})
+
+		It("Honours buckets", func() {
+			// Prepare the server:
+			apiServer.AppendHandlers(
+				RespondWith(http.StatusOK, nil),
+			)
+
+			// Send the request:
+			Send(http.MethodGet, "/")
+
+			// Verify the metrics:
+			metrics := metricsServer.Metrics()
+			Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*,le="0.1"\} .*$`))
+			Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*,le="1"\} .*$`))
+			Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*,le="10"\} .*$`))
+			Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*,le="30"\} .*$`))
+			Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*,le="\+Inf"\} .*$`))
+		})
+
+		DescribeTable(
+			"Counts correctly",
+			func(count int) {
+				// Prepare the server:
+				for i := 0; i < count; i++ {
+					apiServer.AppendHandlers(
+						RespondWith(http.StatusOK, nil),
+					)
+				}
+
+				// Send the requests:
+				for i := 0; i < count; i++ {
+					Send(http.MethodGet, "/")
+				}
+
+				// Verify the metrics:
+				metrics := metricsServer.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_count\{.*\} %d$`, count))
+			},
+			Entry("One", 1),
+			Entry("Two", 2),
+			Entry("Trhee", 3),
+		)
+
+		DescribeTable(
+			"Includes method label",
+			func(method string) {
+				// Prepare the server:
+				apiServer.AppendHandlers(
+					RespondWith(http.StatusOK, nil),
+				)
+
+				// Send the requests:
+				Send(method, "/")
+
+				// Verify the metrics:
+				metrics := metricsServer.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*method="%s".*\} .*$`, method))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_sum\{.*method="%s".*\} .*$`, method))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_count\{.*method="%s".*\} .*$`, method))
+			},
+			Entry("GET", http.MethodGet),
+			Entry("POST", http.MethodPost),
+			Entry("PATCH", http.MethodPatch),
+			Entry("DELETE", http.MethodDelete),
+		)
+
+		DescribeTable(
+			"Includes path label",
+			func(path, label string) {
+				// Prepare the server:
+				apiServer.AppendHandlers(
+					RespondWith(http.StatusOK, nil),
+				)
+
+				// Send the requests:
+				Send(http.MethodGet, path)
+
+				// Verify the metrics:
+				metrics := metricsServer.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*path="%s".*\} .*$`, label))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_sum\{.*path="%s".*\} .*$`, label))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_count\{.*path="%s".*\} .*$`, label))
+			},
+			Entry(
+				"Empty",
+				"",
+				"/",
+			),
+			Entry(
+				"One slash",
+				"/",
+				"/",
+			),
+			Entry(
+				"Two slashes",
+				"//",
+				"/",
+			),
+			Entry(
+				"Tree slashes",
+				"///",
+				"/",
+			),
+			Entry(
+				"Unknown root",
+				"/junk/",
+				"/-",
+			),
+			Entry(
+				"Service root",
+				"/my",
+				"/my",
+			),
+			Entry(
+				"Unknown service root",
+				"/junk",
+				"/-",
+			),
+			Entry(
+				"Version root",
+				"/my/v1",
+				"/my/v1",
+			),
+			Entry(
+				"Unknown version root",
+				"/junk/v1",
+				"/-",
+			),
+			Entry(
+				"Collection",
+				"/my/v1/resources",
+				"/my/v1/resources",
+			),
+			Entry(
+				"Unknown collection",
+				"/my/v1/junk",
+				"/-",
+			),
+			Entry(
+				"Collection item",
+				"/my/v1/resources/123",
+				"/my/v1/resources/-",
+			),
+			Entry(
+				"Collection item action",
+				"/my/v1/resources/123/action",
+				"/my/v1/resources/-/action",
+			),
+			Entry(
+				"Unknown collection item action",
+				"/my/v1/resources/123/junk",
+				"/-",
+			),
+			Entry(
+				"Subcollection",
+				"/my/v1/resources/123/groups",
+				"/my/v1/resources/-/groups",
+			),
+			Entry(
+				"Unknown subcollection",
+				"/my/v1/resources/123/junks",
+				"/-",
+			),
+			Entry(
+				"Subcollection item",
+				"/my/v1/resources/123/groups/456",
+				"/my/v1/resources/-/groups/-",
+			),
+			Entry(
+				"Too long",
+				"/my/v1/resources/123/groups/456/junk",
+				"/-",
+			),
+			Entry(
+				"Unknown path",
+				"/your/path",
+				"/-",
+			),
+		)
+
+		DescribeTable(
+			"Includes code label",
+			func(code int) {
+				// Prepare the server:
+				apiServer.AppendHandlers(
+					RespondWith(code, nil),
+				)
+
+				// Send the requests:
+				Send(http.MethodGet, "/")
+
+				// Verify the metrics:
+				metrics := metricsServer.Metrics()
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_bucket\{.*code="%d".*\} .*$`, code))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_sum\{.*code="%d".*\} .*$`, code))
+				Expect(metrics).To(MatchLine(`^\w+_request_duration_count\{.*code="%d".*\} .*$`, code))
+			},
+			Entry("200", http.StatusOK),
+			Entry("201", http.StatusCreated),
+			Entry("202", http.StatusAccepted),
+			Entry("401", http.StatusUnauthorized),
+			Entry("404", http.StatusNotFound),
+			Entry("500", http.StatusInternalServerError),
+		)
+	})
+})

--- a/internal/network/listener.go
+++ b/internal/network/listener.go
@@ -193,10 +193,12 @@ func (b *ListenerBuilder) Build() (result net.Listener, err error) {
 
 // Common listener names:
 const (
-	APIListener = "API"
+	APIListener     = "API"
+	MetricsListener = "Metrics"
 )
 
 // Common listener addresses:
 const (
-	APIAddress = "localhost:8000"
+	APIAddress     = "localhost:8000"
+	MetricsAddress = "localhost:8001"
 )

--- a/internal/testing/metrics.go
+++ b/internal/testing/metrics.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+// This file types and functions useful for testing Prometheus metrics.
+
+package testing
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+)
+
+// MetricsServer is an HTTP server configured to return Prometheus metrics. Don't create objects of
+// this type directly, use the MakeMetricsServer function instead.
+type MetricsServer struct {
+	server   *Server
+	registry *prometheus.Registry
+}
+
+// NewMetricsServer creates a metrics server.
+func NewMetricsServer() *MetricsServer {
+	// Create the registry:
+	registry := prometheus.NewPedanticRegistry()
+
+	// Create the server:
+	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	server := NewServer()
+	server.AppendHandlers(handler.ServeHTTP)
+
+	// Create and populate the object:
+	return &MetricsServer{
+		server:   server,
+		registry: registry,
+	}
+}
+
+// Metrics returns an array of strings containing the metrics available in this server. Each item in
+// this array is a line in the Prometheus exposition format. This is intended to be used together
+// with the MatchLine matcher.
+func (s *MetricsServer) Metrics() []string {
+	response, err := http.Get(s.server.URL() + "/metrics")
+	Expect(err).ToNot(HaveOccurred())
+	defer func() {
+		err = response.Body.Close()
+		Expect(err).ToNot(HaveOccurred())
+	}()
+	data, err := io.ReadAll(response.Body)
+	Expect(err).ToNot(HaveOccurred())
+	return strings.Split(string(data), "\n")
+}
+
+// Registry returns the registry that should be used to register metrics for this server.
+func (s *MetricsServer) Registry() prometheus.Registerer {
+	return s.registry
+}
+
+// Close stops the server and releases the resources it uses.
+func (s *MetricsServer) Close() {
+	s.server.Close()
+}
+
+// MatchLine succeeds if actual is an slice of strings that contains at least one items that matches
+// the passed regular expression.
+func MatchLine(regexp string, args ...interface{}) OmegaMatcher {
+	return ContainElement(MatchRegexp(regexp, args...))
+}


### PR DESCRIPTION
This patch adds to all the servers a metrics server that provides the default metrics generated by the Prometheus Go instrumentation library as well as metrics for the number of duration of inbound HTTP requests.

The metrics handler will listen by default in port 8001, but that can be changed with the following options:

- `--metrics-listener-address` - Metrics listen address. (default "localhost:8001")
- `--metrics-listener-tls-crt` - Metrics TLS certificate in PEM format.
- `--metrics-listener-tls-key` - Metrics TLS key in PEM format.

The metrics generated are the following:

- `inbound_request_count` - Number of API requests sent.
- `inbound_inbound_request_duration_sum` - Total time to send API requests, in seconds.
- `inbound_inbound_request_duration_count` - Total number of API requests measured.
- `inbound_inbound_request_duration_bucket` - Number of API requests organized in buckets.

With the following labels:

- `method` - Name of the HTTP method, for example GET or POST.
- `path` - Request path, for example /api/my/v1/resources.
- `code` - HTTP response code, for example 200 or 500.

In order to reduce the cardinality of the metrics the path label is modified to remove the identifiers of the objects. For example, if the original path is `.../deploymentManagers/123` then it will be replaced by `.../deploymentManagers/-`, and the values will be accumulated. The line returned by the metrics server will be like this:

```
inbound_request_count{code="200",method="GET",path=".../deploymentManagers/-"} 56
```

For example, these are some metrics generated by the deployment manager server:

```
inbound_request_count{code="500",method="GET",path="/o2ims-infrastructureInventory/-/deploymentManagers"} 4
inbound_request_duration_bucket{code="500",method="GET",path="/o2ims-infrastructureInventory/-/deploymentManagers",le="0.1"} 0
inbound_request_duration_bucket{code="500",method="GET",path="/o2ims-infrastructureInventory/-/deploymentManagers",le="1"} 0
inbound_request_duration_bucket{code="500",method="GET",path="/o2ims-infrastructureInventory/-/deploymentManagers",le="10"} 0
inbound_request_duration_bucket{code="500",method="GET",path="/o2ims-infrastructureInventory/-/deploymentManagers",le="30"} 0
inbound_request_duration_bucket{code="500",method="GET",path="/o2ims-infrastructureInventory/-/deploymentManagers",le="+Inf"} 4
inbound_request_duration_sum{code="500",method="GET",path="/o2ims-infrastructureInventory/-/deploymentManagers"} 602.541828752
inbound_request_duration_count{code="500",method="GET",path="/o2ims-infrastructureInventory/-/deploymentManagers"} 4
```