### PR TITLE
Supports for alarm notification server:

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,7 @@
 {
         "version": "0.2.0",
         "configurations": [
+
                 {
                         "name": "version",
                         "type": "go",
@@ -66,7 +67,33 @@
                                 "alarm-subscription-server",
                                 "--log-level=debug",
                                 "--log-field=server=alarm-subscription",
-                                "--cloud-id=6575154c-72fc-4ed8-9a87-a81885ab38bb"
+                                "--cloud-id=6575154c-72fc-4ed8-9a87-a81885ab38bb",
+                                "--api-listener-address=127.0.0.1:8010",
+                                "--metrics-listener-address=127.0.0.1:8095",
+                                "--configmap-name=oran-o2ims-alarm-subscriptions",
+                        ]
+                },
+                {
+                        "name": "start alarm-notification-server",
+                        "type": "go",
+                        "request": "launch",
+                        "mode": "auto",
+                        "env": {
+                            "KUBECONFIG": "/home/username/.kube/kubeconfig",
+                        }
+                        "program": "${workspaceFolder}",
+                        "args": [
+                                "start",
+                                "alarm-notification-server",
+                                "--log-level=debug",
+                                "--log-field=server=alarm-notification",
+                                "--cloud-id=6575154c-72fc-4ed8-9a87-a81885ab38bb",
+                                "--namespace=orantest",
+                                "--api-listener-address=127.0.0.1:8035",
+                                "--metrics-listener-address=127.0.0.1:8075",
+                                "--resource-server-url=${env:RESOURCE_SERVER_URL}",
+                                "--resource-server-token=${env:RESOURCE_SERVER_TOKEN}",
+}"
                         ]
                 },
                 {

--- a/README.md
+++ b/README.md
@@ -185,8 +185,12 @@ $ ./oran-o2ims start infrastructure-inventory-subscription-server \
 --log-field="server=resource-subscriptions" \
 --api-listener-address=localhost:8004 \
 --metrics-listener-address=localhost:8008 \
+--namespace="test" \
+--configmap-name="testInventorySubscriptionConfigmap" \
 --cloud-id=123
 ```
+
+Note: By default, the namespace of "orantest" and "oran-infra-inventory-sub" are used currently.
 
 For more information about other command line flags use the `--help` command:
 
@@ -332,6 +336,8 @@ $./oran-o2ims start alarm-subscription-server \
 --log-field="pid=%p" \
 --api-listener-address="127.0.0.1:8006" \
 --metrics-listener-address="127.0.0.1:8008" \
+--namespace="test" \
+--configmap-name="testConfigmap" \
 --cloud-id="123" 
 ```
 
@@ -340,6 +346,8 @@ be conflicts if you try to run multiple servers in the same machine. The
 `--api-listener-address` and `--metrics-listener-address` options are used to select a port number that isn't in use.
 
 The `cloud-id` is any string that you want to use as identifier of the O-Cloud instance.
+
+By default, the namespace of "orantest" and configmap-name of "oran-o2ims-alarm-subscriptions" are used.
 
 For more information about other command line flags use the `--help` command:
 
@@ -354,5 +362,57 @@ $ curl -s http://localhost:8001/o2ims-infrastructureMonitoring/v1/alarmSubscript
 ```
 Above example will get a list of existing alarm subscriptions
 
+```
+$ curl -s -X POST --header "Content-Type: application/json" -d @subscription.json http://localhost:8000/o2ims-infrastructureMonitoring/v1/alarmSubscriptions
+```
+Above example will post an alarm subscription defined in subscription.json file 
+
 Inside _VS Code_ use the _Run and Debug_ option with the `start
 alarm-subscription-server` [configuration](.vscode/launch.json).
+
+#### Alarm Notification server
+
+The alarm-notification-server should use together with alarm subscription server. The alarm subscription sever accept and manages the alarm subscriptions. The alarm notificaton servers synch the alarm subscriptions via perisist storage. To use the configmap to persist the subscriptions, the namespace "orantest" should be created at hub cluster for now (will use official oranims namespace in future). Alarm subscripton server and corresonding alarm notification server should have same namespace and configmap-name. The alarm notification server accept the alerts, match the subscription filter, build and send out the alarm notification based on url in the subscription.
+
+The required Resource server URL and token can be obtained as follows:
+
+```
+$ export RESOURCE_SERVER_URL=http://localhost:8002/o2ims-infrastructureInventory/v1/
+$ export RESOURCE_SERVER_TOKEN=$(
+  oc whoami --show-token
+)
+```
+
+Start the alarm notification server with a command like this:
+
+```
+$./oran-o2ims start alarm-notification-server \
+--log-file="servers.log" \
+--log-level="debug" \
+--log-field="server=alarm-notification" \
+--log-field="pid=%p" \
+--api-listener-address="127.0.0.1:8010" \
+--metrics-listener-address="127.0.0.1:8011" \
+--cloud-id="123" \
+--namespace="test" \
+--configmap-name="testConfigmap" \
+--resource-server-url="${RESOURCE_SERVER_URL}"
+--resource-server-token="${RESOURCE_SERVER_TOKEN}" \
+```
+
+Note that by default all the servers listen on `localhost:8000`, so there will
+be conflicts if you try to run multiple servers in the same machine. The
+`--api-listener-address` and `--metrics-listener-address` options are used to select a port number that isn't in use.
+
+The `cloud-id` is any string that you want to use as identifier of the O-Cloud instance.
+
+By default, the namespace of "orantest" and configmap-name of "oran-o2ims-alarm-subscriptions" are used.
+
+For more information about other command line flags use the `--help` command:
+
+```
+$ ./oran-o2ims start alarm-notification-server --help
+```
+
+Inside _VS Code_ use the _Run and Debug_ option with the `start
+alarm-notification-server` [configuration](.vscode/launch.json).

--- a/internal/cmd/server/flags.go
+++ b/internal/cmd/server/flags.go
@@ -133,11 +133,15 @@ func GetTokenFlag(
 
 // Names of command line flags:
 const (
-	backendTypeFlagName      = "backend-type"
-	backendTokenFlagName     = "backend-token"
-	backendTokenFileFlagName = "backend-token-file"
-	backendURLFlagName       = "backend-url"
-	cloudIDFlagName          = "cloud-id"
-	extensionsFlagName       = "extensions"
-	externalAddressFlagName  = "external-address"
+	backendTypeFlagName               = "backend-type"
+	backendTokenFlagName              = "backend-token"
+	backendTokenFileFlagName          = "backend-token-file"
+	backendURLFlagName                = "backend-url"
+	cloudIDFlagName                   = "cloud-id"
+	extensionsFlagName                = "extensions"
+	externalAddressFlagName           = "external-address"
+	namespaceFlagName                 = "namespace"
+	subscriptionConfigmapNameFlagName = "configmap-name"
+	resourceServerURLFlagName         = "resource-server-url"
+	resourceServerTokenFlagName       = "resource-server-token"
 )

--- a/internal/cmd/server/start_alarm_server.go
+++ b/internal/cmd/server/start_alarm_server.go
@@ -36,9 +36,7 @@ import (
 )
 
 const (
-	alertmanagerApiUrlPrefix    = "alertmanager-open-cluster-management-observability"
-	resourceServerURLFlagName   = "resource-server-url"
-	resourceServerTokenFlagName = "resource-server-token"
+	alertmanagerApiUrlPrefix = "alertmanager-open-cluster-management-observability"
 )
 
 // Server creates and returns the `start alarm-server` command.

--- a/internal/cmd/start_cmd.go
+++ b/internal/cmd/start_cmd.go
@@ -35,5 +35,6 @@ func Start() *cobra.Command {
 	result.AddCommand(server.AlarmSubscriptionServer())
 	result.AddCommand(server.InfrastructureInventorySubscriptionServer())
 	result.AddCommand(operator.ControllerManager())
+	result.AddCommand(server.AlarmNotificationServer())
 	return result
 }

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -11,6 +11,7 @@ const (
 	ORANO2IMSDeploymentManager = "deployment-manager"
 	ORANO2IMSResource          = "resource"
 	ORANO2IMSAlarmSubscription = "alarm-subscription"
+	ORANO2IMSAlarmNotification = "alarm-notification"
 )
 
 // Deployment names
@@ -19,6 +20,7 @@ const (
 	ORANO2IMSDeploymentManagerServerName = ORANO2IMSDeploymentManager + "-server"
 	ORANO2IMSResourceServerName          = ORANO2IMSResource + "-server"
 	ORANO2IMSAlarmSubscriptionServerName = ORANO2IMSAlarmSubscription + "-server"
+	ORANO2IMSAlarmNotificationServerName = ORANO2IMSAlarmNotification + "-server"
 )
 
 // CR default names

--- a/internal/persiststorage/persiststorage.go
+++ b/internal/persiststorage/persiststorage.go
@@ -10,6 +10,9 @@ import (
 
 var ErrNotFound = errors.New("not found")
 
+// process change function
+type ProcessFunc func(dataMap *map[string]data.Object)
+
 // interface for persistent storage
 type Storage interface {
 	//notification from db to application about db entry changes
@@ -19,6 +22,7 @@ type Storage interface {
 	DeleteEntry(ctx context.Context, key string) (err error)
 	ReadAllEntries(ctx context.Context) (result map[string]data.Object, err error)
 	ProcessChanges(ctx context.Context, dataMap **map[string]data.Object, lock *sync.Mutex) (err error)
+	ProcessChangesWithFunction(ctx context.Context, function ProcessFunc) (err error)
 }
 
 func Add(so Storage, ctx context.Context, key string, value string) (err error) {
@@ -35,4 +39,8 @@ func Delete(so Storage, ctx context.Context, key string) (err error) {
 }
 func ProcessChanges(so Storage, ctx context.Context, dataMap **map[string]data.Object, lock *sync.Mutex) (err error) {
 	return so.ProcessChanges(ctx, dataMap, lock)
+}
+
+func ProcessChangesWithFunction(so Storage, ctx context.Context, function ProcessFunc) (err error) {
+	return so.ProcessChangesWithFunction(ctx, function)
 }

--- a/internal/service/alarm_fetcher.go
+++ b/internal/service/alarm_fetcher.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	neturl "net/url"
 
-	"github.com/imdario/mergo"
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/jq"
 	"github.com/openshift-kni/oran-o2ims/internal/k8s"
@@ -42,6 +41,7 @@ type AlarmFetcher struct {
 	extensions          []string
 	filters             []string
 	jqTool              *jq.Tool
+	alarmMapper         *AlarmMapper
 }
 
 // AlarmFetcherBuilder contains the data and logic needed to create a new AlarmFetcher.
@@ -58,7 +58,7 @@ type AlarmFetcherBuilder struct {
 }
 
 // NewAlarmFetcher creates a builder that can then be used to configure
-// and create a handler for the AlarmFetcher.
+// and create a alarm fetcher object for the AlarmFetcher.
 func NewAlarmFetcher() *AlarmFetcherBuilder {
 	return &AlarmFetcherBuilder{}
 }
@@ -189,6 +189,16 @@ func (b *AlarmFetcherBuilder) Build() (
 		}
 	}
 
+	alarmMapper, err := NewAlarmMapper().
+		SetLogger(b.logger).
+		SetBackendClient(backendClient).
+		SetResourceServerURL(b.resourceServerURL).
+		SetResourceServerToken(b.resourceServerToken).
+		SetExtensions(b.extensions...).
+		Build()
+	if err != nil {
+		return
+	}
 	// Create and populate the object:
 	result = &AlarmFetcher{
 		logger:              b.logger,
@@ -201,6 +211,7 @@ func (b *AlarmFetcherBuilder) Build() (
 		extensions:          b.extensions,
 		filters:             b.filters,
 		jqTool:              jqTool,
+		alarmMapper:         alarmMapper,
 	}
 	return
 }
@@ -226,7 +237,7 @@ func (r *AlarmFetcher) FetchItems(
 	}
 
 	// Transform Alerts to Alarms
-	alarms = data.Map(alerts, r.mapAlertItem)
+	alarms = data.Map(alerts, r.alarmMapper.MapItem)
 
 	return
 }
@@ -267,163 +278,4 @@ func (r *AlarmFetcher) doGet(ctx context.Context, url, token string,
 		return
 	}
 	return
-}
-
-// Map Alert to an O2 Alarm object.
-func (r *AlarmFetcher) mapAlertItem(ctx context.Context,
-	from data.Object) (to data.Object, err error) {
-
-	alertName, err := data.GetString(from, "labels.alertname")
-	if err != nil {
-		return
-	}
-
-	alarmRaisedTime, err := data.GetString(from, "startsAt")
-	if err != nil {
-		return
-	}
-
-	alarmChangedTime, err := data.GetString(from, "updatedAt")
-	if err != nil {
-		return
-	}
-
-	severity, err := data.GetString(from, "labels.severity")
-	if err != nil {
-		return
-	}
-
-	clusterId, err := data.GetString(from, "labels.managed_cluster")
-	if err != nil {
-		return
-	}
-
-	resourcePool, err := r.fetchResourcePool(ctx, clusterId)
-	if err != nil {
-		return
-	}
-	resourcePoolName, err := data.GetString(resourcePool, "name")
-	if err != nil {
-		return
-	}
-
-	var alarmEventRecordId, resourceID, resourceTypeID string
-	alertInstance, err := data.GetString(from, "labels.instance")
-	if err != nil {
-		// Instance is not available for cluster global alerts
-		alarmEventRecordId = fmt.Sprintf("%s_%s", alertName, resourcePoolName)
-		resourceID = resourcePool["resourcePoolID"].(string)
-	} else {
-		alarmEventRecordId = fmt.Sprintf("%s_%s_%s", alertName, resourcePoolName, alertInstance)
-		resource, err := r.fetchResource(ctx, resourcePoolName, alertInstance)
-		if err == nil {
-			resourceID = resource["resourceID"].(string)
-			resourceTypeID = resource["resourceTypeID"].(string)
-		}
-	}
-
-	// Add the extensions:
-	extensionsMap, err := data.GetExtensions(from, r.extensions, r.jqTool)
-	if err != nil {
-		return
-	}
-	if len(extensionsMap) == 0 {
-		// Fallback to all labels and annotations
-		var labels, annotations data.Object
-		labels, err = data.GetObj(from, "labels")
-		if err != nil {
-			return
-		}
-		annotations, err = data.GetObj(from, "annotations")
-		if err != nil {
-			return
-		}
-		err = mergo.Map(&extensionsMap, labels, mergo.WithOverride)
-		if err != nil {
-			return
-		}
-		err = mergo.Map(&extensionsMap, annotations, mergo.WithOverride)
-		if err != nil {
-			return
-		}
-	}
-
-	to = data.Object{
-		"alarmEventRecordId": alarmEventRecordId,
-		"resourceID":         resourceID,
-		"resourceTypeID":     resourceTypeID,
-		"alarmRaisedTime":    alarmRaisedTime,
-		"alarmChangedTime":   alarmChangedTime,
-		"alarmDefinitionID":  alertName,
-		"probableCauseID":    alertName,
-		"perceivedSeverity":  AlarmSeverity(severity).mapProperty(),
-		"extensions":         extensionsMap,
-	}
-
-	return
-}
-
-func (r *AlarmFetcher) fetchResourcePool(ctx context.Context, clusterId string) (resourcePool data.Object, err error) {
-	query := neturl.Values{}
-	query.Add("filter", fmt.Sprintf("(eq,description,%s)", clusterId))
-	url := r.resourceServerURL + "/resourcePools"
-	response, err := r.doGet(ctx, url, r.resourceServerToken, query, nil)
-	if err != nil {
-		return
-	}
-
-	// Create a reader for Resource pools
-	resourcePools, err := k8s.NewStream().
-		SetLogger(r.logger).
-		SetReader(response.Body).
-		Build()
-	if err != nil {
-		return
-	}
-
-	resourcePool, err = resourcePools.Next(ctx)
-
-	return
-}
-
-func (r *AlarmFetcher) fetchResource(ctx context.Context, clusterName, resourceName string) (resource data.Object, err error) {
-	query := neturl.Values{}
-	query.Add("filter", fmt.Sprintf("(eq,description,%s)", resourceName))
-	path := fmt.Sprintf("/resourcePools/%s/resources", clusterName)
-	url := r.resourceServerURL + path
-	response, err := r.doGet(ctx, url, r.resourceServerToken, query, nil)
-	if err != nil {
-		return
-	}
-
-	// Create a reader for Resources
-	resources, err := k8s.NewStream().
-		SetLogger(r.logger).
-		SetReader(response.Body).
-		Build()
-	if err != nil {
-		return
-	}
-
-	resource, err = resources.Next(ctx)
-
-	return
-}
-
-type AlarmSeverity string
-
-func (p AlarmSeverity) mapProperty() string {
-	switch p {
-	case "critical":
-		return "CRITICAL"
-	case "info":
-		return "MINOR"
-	case "warning":
-		return "WARNING"
-	case "none":
-		return "INDETERMINATE"
-	default:
-		// unknown property
-		return "CLEARED"
-	}
 }

--- a/internal/service/alarm_mapper.go
+++ b/internal/service/alarm_mapper.go
@@ -1,0 +1,332 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	neturl "net/url"
+
+	"github.com/imdario/mergo"
+	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/jq"
+	"github.com/openshift-kni/oran-o2ims/internal/k8s"
+
+	"github.com/itchyny/gojq"
+)
+
+type AlarmMapper struct {
+	logger              *slog.Logger
+	backendClient       *http.Client
+	resourceServerURL   string
+	resourceServerToken string
+	extensions          []string
+	jqTool              *jq.Tool
+}
+
+// AlarmMapperBuilder contains the data and logic needed to create a new AlarmMapper.
+type AlarmMapperBuilder struct {
+	logger        *slog.Logger
+	backendClient *http.Client
+	//transportWrapper    func(http.RoundTripper) http.RoundTripper
+	resourceServerURL   string
+	resourceServerToken string
+	extensions          []string
+}
+
+// AlarmMapper creates a builder that can then be used to configure
+// and create a handler for the AlarmMapper.
+func NewAlarmMapper() *AlarmMapperBuilder {
+	return &AlarmMapperBuilder{}
+}
+
+// SetLogger sets the logger that the handler will use to write to the log. This is mandatory.
+func (b *AlarmMapperBuilder) SetLogger(
+	value *slog.Logger) *AlarmMapperBuilder {
+	b.logger = value
+	return b
+}
+
+// SetBackendClient sets the backend client used to connect to other servers. This is mandatory.
+func (b *AlarmMapperBuilder) SetBackendClient(value *http.Client) *AlarmMapperBuilder {
+	b.backendClient = value
+	return b
+}
+
+// SetResourceServerURL sets the URL of the resource server. This is mandatory.
+// The resource server is used for mapping Alarms to Resources.
+func (b *AlarmMapperBuilder) SetResourceServerURL(
+	value string) *AlarmMapperBuilder {
+	b.resourceServerURL = value
+	return b
+}
+
+// SetResourceServerToken sets the authentication token that will be used to authenticate
+// with to the resource server. This is mandatory.
+func (b *AlarmMapperBuilder) SetResourceServerToken(
+	value string) *AlarmMapperBuilder {
+	b.resourceServerToken = value
+	return b
+}
+
+// SetExtensions sets the fields that will be added to the extensions. This is optional.
+func (b *AlarmMapperBuilder) SetExtensions(values ...string) *AlarmMapperBuilder {
+	b.extensions = values
+	return b
+}
+
+// Build uses the data stored in the builder to create and configure a new handler.
+func (b *AlarmMapperBuilder) Build() (
+	result *AlarmMapper, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.backendClient == nil {
+		err = errors.New("backend client is mandatory")
+		return
+	}
+
+	// Create a jq compiler function for parsing labels
+	compilerFunc := gojq.WithFunction("parse_labels", 0, 1, func(x any, _ []any) any {
+		if labels, ok := x.(string); ok {
+			return data.GetLabelsMap(labels)
+		}
+		return nil
+	})
+
+	// Create the jq tool:
+	jqTool, err := jq.NewTool().
+		SetLogger(b.logger).
+		SetCompilerOption(&compilerFunc).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Check that extensions are at least syntactically valid:
+	for _, extension := range b.extensions {
+		_, err = jqTool.Compile(extension)
+		if err != nil {
+			return
+		}
+	}
+
+	// Create and populate the object:
+	result = &AlarmMapper{
+		logger:              b.logger,
+		backendClient:       b.backendClient,
+		resourceServerURL:   b.resourceServerURL,
+		resourceServerToken: b.resourceServerToken,
+		extensions:          b.extensions,
+		jqTool:              jqTool,
+	}
+	return
+}
+
+// Map an Alert to an O2 Alarm object.
+func (r *AlarmMapper) MapItem(ctx context.Context,
+	from data.Object) (to data.Object, err error) {
+
+	alertName, err := data.GetString(from, "labels.alertname")
+	if err != nil {
+		return
+	}
+
+	alarmRaisedTime, err := data.GetString(from, "startsAt")
+	if err != nil {
+		return
+	}
+
+	alarmChangedTime, err := data.GetString(from, "updatedAt")
+	if err != nil {
+		return
+	}
+
+	severity, err := data.GetString(from, "labels.severity")
+	if err != nil {
+		return
+	}
+
+	clusterId, err := data.GetString(from, "labels.managed_cluster")
+	if err != nil {
+		return
+	}
+
+	resourcePool, err := r.fetchResourcePool(ctx, clusterId)
+	if err != nil {
+		return
+	}
+	resourcePoolName, err := data.GetString(resourcePool, "name")
+	if err != nil {
+		return
+	}
+
+	var alarmEventRecordId, resourceID, resourceTypeID string
+	alertInstance, err := data.GetString(from, "labels.instance")
+	if err != nil {
+		// Instance is not available for cluster global alerts
+		alarmEventRecordId = fmt.Sprintf("%s_%s", alertName, resourcePoolName)
+		resourceID = resourcePool["resourcePoolID"].(string)
+	} else {
+		alarmEventRecordId = fmt.Sprintf("%s_%s_%s", alertName, resourcePoolName, alertInstance)
+		resource, err := r.fetchResource(ctx, resourcePoolName, alertInstance)
+		if err == nil {
+			resourceID = resource["resourceID"].(string)
+			resourceTypeID = resource["resourceTypeID"].(string)
+		}
+	}
+
+	// Add the extensions:
+	extensionsMap, err := data.GetExtensions(from, r.extensions, r.jqTool)
+	if err != nil {
+		return
+	}
+	if len(extensionsMap) == 0 {
+		// Fallback to all labels and annotations
+		var labels, annotations data.Object
+		labels, err = data.GetObj(from, "labels")
+		if err != nil {
+			return
+		}
+		annotations, err = data.GetObj(from, "annotations")
+		if err != nil {
+			return
+		}
+		err = mergo.Map(&extensionsMap, labels, mergo.WithOverride)
+		if err != nil {
+			return
+		}
+		err = mergo.Map(&extensionsMap, annotations, mergo.WithOverride)
+		if err != nil {
+			return
+		}
+	}
+
+	to = data.Object{
+		"alarmEventRecordId": alarmEventRecordId,
+		"resourceID":         resourceID,
+		"resourceTypeID":     resourceTypeID,
+		"alarmRaisedTime":    alarmRaisedTime,
+		"alarmChangedTime":   alarmChangedTime,
+		"alarmDefinitionID":  alertName,
+		"probableCauseID":    alertName,
+		"perceivedSeverity":  AlarmSeverity(severity).mapProperty(),
+		"extensions":         extensionsMap,
+	}
+
+	return
+}
+
+func (r *AlarmMapper) doGet(ctx context.Context, url, token string,
+	query neturl.Values) (response *http.Response, err error) {
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return
+	}
+	if query != nil {
+		request.URL.RawQuery = query.Encode()
+	}
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	request.Header.Set("Accept", "application/json")
+
+	response, err = r.backendClient.Do(request)
+	if err != nil {
+		return
+	}
+	if response.StatusCode != http.StatusOK {
+		r.logger.ErrorContext(
+			ctx,
+			"Received unexpected status code",
+			"code", response.StatusCode,
+			"url", request.URL,
+		)
+		err = fmt.Errorf(
+			"received unexpected status code %d from '%s'",
+			response.StatusCode, request.URL,
+		)
+		return
+	}
+	return
+}
+
+func (r *AlarmMapper) fetchResourcePool(ctx context.Context, clusterId string) (resourcePool data.Object, err error) {
+	query := neturl.Values{}
+	query.Add("filter", fmt.Sprintf("(eq,description,%s)", clusterId))
+	url := r.resourceServerURL + "/resourcePools"
+	response, err := r.doGet(ctx, url, r.resourceServerToken, query)
+	if err != nil {
+		return
+	}
+
+	// Create a reader for Resource pools
+	resourcePools, err := k8s.NewStream().
+		SetLogger(r.logger).
+		SetReader(response.Body).
+		Build()
+	if err != nil {
+		return
+	}
+
+	resourcePool, err = resourcePools.Next(ctx)
+
+	return
+}
+
+func (r *AlarmMapper) fetchResource(ctx context.Context, clusterName, resourceName string) (resource data.Object, err error) {
+	query := neturl.Values{}
+	query.Add("filter", fmt.Sprintf("(eq,description,%s)", resourceName))
+	path := fmt.Sprintf("/resourcePools/%s/resources", clusterName)
+	url := r.resourceServerURL + path
+	response, err := r.doGet(ctx, url, r.resourceServerToken, query)
+	if err != nil {
+		return
+	}
+
+	// Create a reader for Resources
+	resources, err := k8s.NewStream().
+		SetLogger(r.logger).
+		SetReader(response.Body).
+		Build()
+	if err != nil {
+		return
+	}
+
+	resource, err = resources.Next(ctx)
+
+	return
+}
+
+type AlarmSeverity string
+
+func (p AlarmSeverity) mapProperty() string {
+	switch p {
+	case "critical":
+		return "CRITICAL"
+	case "info":
+		return "MINOR"
+	case "warning":
+		return "WARNING"
+	case "none":
+		return "INDETERMINATE"
+	default:
+		// unknown property
+		return "CLEARED"
+	}
+}

--- a/internal/service/alarm_notification_dispatcher.go
+++ b/internal/service/alarm_notification_dispatcher.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"mime"
+	"net/http"
+	"strings"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/jq"
+)
+
+// Add is the implementation of the object handler ADD interface.
+// receive obsability alarm post and trigger the alarms
+
+func (h *AlarmNotificationHandler) add(ctx context.Context,
+	request *AddRequest) (response *AddResponse, err error) {
+
+	h.logger.Debug(
+		"AlarmNotificationHandler Add",
+	)
+
+	// Following needs to be test alert
+	// Map iterm
+
+	// map/translate alert to alarm
+
+	alarmEventRecord, err := h.alarmMapper.MapItem(ctx, request.Object)
+	if err != nil {
+		h.logger.Debug(
+			"AlarmNotificationHandler failed to map the item",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	debug, err := h.jsonAPI.MarshalIndent(&alarmEventRecord, "", " ")
+	if err == nil {
+		h.logger.Debug(
+			"AlarmNotificationHandler alarmEventRecord",
+			slog.String("packet", string(debug)),
+		)
+	}
+
+	subIdSet := h.getSubscriptionIdsFromAlarm(ctx, alarmEventRecord)
+
+	//now look up subscriptions id_set matched and send http packets to URIs
+	for key := range subIdSet {
+		subInfo, ok := h.getSubscriptionInfo(ctx, key)
+
+		if !ok {
+			h.logger.Debug(
+				"AlarmNotificationHandler failed to get subinfo key",
+				slog.String(": ", key),
+			)
+
+			continue
+		}
+
+		var obj data.Object
+		// TODO:
+		// determin if alarmNotificationType needs to be added
+
+		err = h.jqTool.Evaluate(
+			`{
+				"alarmSubscriptionId": $subId,
+				"consumerSubscriptionId": $alarmConsumerSubId,
+				"objectRef": $objRef,
+				"alarmEventRecord": $alarmEvent
+			}`,
+			alarmEventRecord, &obj,
+			jq.String("$alarmConsumerSubId", subInfo.consumerSubscriptionId),
+			jq.String("$objRef", alarmEventRecord["alarmEventRecordId"].(string)),
+			jq.String("$subId", key),
+			jq.Any("$alarmEvent", alarmEventRecord),
+		)
+
+		//following function will send out the notification packet based on subscription
+		//and alert received in a go route thread that will not hold the AddRequest ctx.
+		go func(pkt data.Object) {
+			content, err := h.jsonAPI.MarshalIndent(&pkt, "", " ")
+			if err != nil {
+				h.logger.Debug(
+					"AlarmNotificationHandler failed to get content of new packet",
+					slog.String("error", err.Error()),
+				)
+			}
+
+			//following new buffer usage may need optimization
+			resp, err := h.httpClient.Post(subInfo.uris, "application/json", bytes.NewBuffer(content))
+			if err != nil {
+				h.logger.Debug("AlarmNotificationHandler failed to post packet",
+					slog.String("error", err.Error()),
+				)
+				return
+			}
+
+			defer resp.Body.Close()
+		}(obj)
+
+	}
+
+	response = &AddResponse{}
+	return
+}
+
+func (h *AlarmNotificationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Check that the content type is acceptable:
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		h.logger.ErrorContext(
+			ctx,
+			"Received empty content type header",
+		)
+		SendError(
+			w, http.StatusBadRequest,
+			"Content type is mandatory, use 'application/json'",
+		)
+		return
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		h.logger.ErrorContext(
+			ctx,
+			"Failed to parse content type",
+			slog.String("header", contentType),
+			slog.String("error", err.Error()),
+		)
+		SendError(w, http.StatusBadRequest, "Failed to parse content type '%s'", contentType)
+	}
+	if !strings.EqualFold(mediaType, "application/json") {
+		h.logger.ErrorContext(
+			ctx,
+			"Unsupported content type",
+			slog.String("header", contentType),
+			slog.String("media", mediaType),
+		)
+		SendError(
+			w, http.StatusBadRequest,
+			"Content type '%s' isn't supported, use 'application/json'",
+			mediaType,
+		)
+		return
+	}
+	// Parse the request body:
+	decoder := h.jsonAPI.NewDecoder(r.Body)
+	var object data.Object
+	err = decoder.Decode(&object)
+	if err != nil {
+		h.logger.ErrorContext(
+			ctx,
+			"Failed to decode input",
+			slog.String("error", err.Error()),
+		)
+		SendError(w, http.StatusBadRequest, "Failed to decode input")
+		return
+	}
+
+	request := &AddRequest{
+		Object: object,
+	}
+
+	response, err := h.add(ctx, request)
+	if err != nil {
+		h.logger.ErrorContext(
+			ctx,
+			"Failed to add item",
+			"error", err,
+		)
+		SendError(
+			w,
+			http.StatusInternalServerError,
+			"Failed to add item",
+		)
+		return
+	}
+
+	//send response back
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	writer := jsoniter.NewStream(h.jsonAPI, w, 0)
+	writer.WriteVal(response.Object)
+	if writer.Error != nil {
+		h.logger.ErrorContext(
+			ctx,
+			"Failed to send object",
+			"error", writer.Error.Error(),
+		)
+	}
+	writer.Flush()
+	if writer.Error != nil {
+		h.logger.ErrorContext(
+			ctx,
+			"Failed to flush stream",
+			"error", writer.Error.Error(),
+		)
+	}
+}

--- a/internal/service/alarm_notification_handler.go
+++ b/internal/service/alarm_notification_handler.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/jq"
+	"github.com/openshift-kni/oran-o2ims/internal/k8s"
+	"github.com/openshift-kni/oran-o2ims/internal/persiststorage"
+	"github.com/openshift-kni/oran-o2ims/internal/search"
+)
+
+// AlarmNotificationManagerHandlerBuilder contains the data and logic needed to construct
+// alarm notification handler. Don't create instances of this type directly, use the
+// NewAlarmNotificationHandler function instead.
+type AlarmNotificationHandlerBuilder struct {
+	logger                     *slog.Logger
+	loggingWrapper             func(http.RoundTripper) http.RoundTripper
+	cloudID                    string
+	kubeClient                 *k8s.Client
+	o2imsNamespace             string
+	subscriptionsConfigmapName string
+	resourceServerURL          string
+	resourceServerToken        string
+}
+
+// key string is uuid
+type alarmSubIdSet map[string]struct{}
+
+// AlarmNotificationHander will receive the alarts from openshift alert manager,
+// match alarm subscription filter rules with the alerts/alarm, and send out matched alarm notifications
+// Don't create instances of this type directly, use the NewAlarmNotificationHandler function
+// instead.
+type AlarmNotificationHandler struct {
+	logger            *slog.Logger
+	loggingWrapper    func(http.RoundTripper) http.RoundTripper
+	cloudID           string
+	jsonAPI           jsoniter.API
+	selectorEvaluator *search.SelectorEvaluator
+	jqTool            *jq.Tool
+	alarmMapper       *AlarmMapper
+
+	//structures for notification
+	subscriptionMapMemoryLock *sync.RWMutex
+	subscriptionMap           *map[string]data.Object
+	persistStore              *persiststorage.KubeConfigMapStore
+	subscriptionSearcher      *alarmSubscriptionSearcher
+	httpClient                http.Client
+}
+
+// NewAlarmNotificationHandler creates a builder that can then be used to configure and create a
+// handler for AlarmNotificationHandler.
+func NewAlarmNotificationHandler() *AlarmNotificationHandlerBuilder {
+	return &AlarmNotificationHandlerBuilder{}
+}
+
+// SetLogger sets the logger that the handler will use to write to the log. This is mandatory.
+func (b *AlarmNotificationHandlerBuilder) SetLogger(
+	value *slog.Logger) *AlarmNotificationHandlerBuilder {
+	b.logger = value
+	return b
+}
+
+// SetLoggingWrapper sets the wrapper that will be used to configure logging for the HTTP clients
+// used to connect to other servers, including the backend server. This is optional.
+func (b *AlarmNotificationHandlerBuilder) SetLoggingWrapper(
+	value func(http.RoundTripper) http.RoundTripper) *AlarmNotificationHandlerBuilder {
+	b.loggingWrapper = value
+	return b
+}
+
+// SetCloudID sets the identifier of the O-Cloud of this handler. This is mandatory.
+func (b *AlarmNotificationHandlerBuilder) SetCloudID(
+	value string) *AlarmNotificationHandlerBuilder {
+	b.cloudID = value
+	return b
+}
+
+// SetKubeClient sets the kubeClient.
+func (b *AlarmNotificationHandlerBuilder) SetKubeClient(
+	kubeClient *k8s.Client) *AlarmNotificationHandlerBuilder {
+	b.kubeClient = kubeClient
+	return b
+}
+
+// SetNamespace sets the namespace.
+func (b *AlarmNotificationHandlerBuilder) SetNamespace(
+	value string) *AlarmNotificationHandlerBuilder {
+	b.o2imsNamespace = value
+	return b
+}
+
+// SetNamespace sets the namespace.
+func (b *AlarmNotificationHandlerBuilder) SetConfigmapName(
+	value string) *AlarmNotificationHandlerBuilder {
+	b.subscriptionsConfigmapName = value
+	return b
+}
+
+// SetResourceServerURL sets the URL of the resource server. This is mandatory.
+// The resource server is used for mapping Alarms to Resources.
+func (b *AlarmNotificationHandlerBuilder) SetResourceServerURL(
+	value string) *AlarmNotificationHandlerBuilder {
+	b.resourceServerURL = value
+	return b
+}
+
+// SetResourceServerToken sets the authentication token that will be used to authenticate
+// with to the resource server. This is mandatory.
+func (b *AlarmNotificationHandlerBuilder) SetResourceServerToken(
+	value string) *AlarmNotificationHandlerBuilder {
+	b.resourceServerToken = value
+	return b
+}
+
+// Build uses the data stored in the builder to create anad configure a new handler.
+func (b *AlarmNotificationHandlerBuilder) Build(ctx context.Context) (
+	result *AlarmNotificationHandler, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.cloudID == "" {
+		err = errors.New("cloud identifier is mandatory")
+		return
+	}
+
+	if b.kubeClient == nil {
+		err = errors.New("kubeClient is mandatory")
+		return
+	}
+
+	if b.resourceServerURL == "" {
+		err = errors.New("resource server URL is mandatory")
+		return
+	}
+
+	if b.resourceServerToken == "" {
+		err = errors.New("resource server token is mandatory")
+		return
+	}
+
+	// Prepare the JSON iterator API:
+	jsonConfig := jsoniter.Config{
+		IndentionStep: 2,
+	}
+	jsonAPI := jsonConfig.Froze()
+
+	// Create the filter expression evaluator:
+	pathEvaluator, err := search.NewPathEvaluator().
+		SetLogger(b.logger).
+		Build()
+	if err != nil {
+		return
+	}
+	selectorEvaluator, err := search.NewSelectorEvaluator().
+		SetLogger(b.logger).
+		SetPathEvaluator(pathEvaluator.Evaluate).
+		Build()
+	if err != nil {
+		return
+	}
+	// Create the jq tool:
+	jqTool, err := jq.NewTool().
+		SetLogger(b.logger).
+		Build()
+	if err != nil {
+		return
+	}
+
+	alarmSubscriptionSearcher, err := newAlarmSubscriptionSearcherBuilder().
+		SetLogger(b.logger).
+		SetJqTool(jqTool).build()
+	if err != nil {
+		return
+	}
+
+	// create persist storeage option
+	persistStore, err := persiststorage.NewKubeConfigMapStoreBuilder().
+		SetNamespace(b.o2imsNamespace).
+		SetName(b.subscriptionsConfigmapName).
+		SetFieldOwner(FieldOwner).
+		SetJsonAPI(jsonAPI).
+		SetClient(b.kubeClient).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// http client to send out notification
+	// use 2 sec first
+	httpClient := http.Client{Timeout: 2 * time.Second}
+
+	alarmMapper, err := NewAlarmMapper().
+		SetLogger(b.logger).
+		SetBackendClient(&httpClient).
+		SetResourceServerURL(b.resourceServerURL).
+		SetResourceServerToken(b.resourceServerToken).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Create and populate the object:
+	handler := &AlarmNotificationHandler{
+		logger:                    b.logger,
+		loggingWrapper:            b.loggingWrapper,
+		cloudID:                   b.cloudID,
+		selectorEvaluator:         selectorEvaluator,
+		jsonAPI:                   jsonAPI,
+		jqTool:                    jqTool,
+		subscriptionMapMemoryLock: &sync.RWMutex{},
+		subscriptionMap:           &map[string]data.Object{},
+		persistStore:              persistStore,
+		subscriptionSearcher:      alarmSubscriptionSearcher,
+		httpClient:                httpClient,
+		alarmMapper:               alarmMapper,
+	}
+
+	b.logger.Debug(
+		"AlarmNotificationHandler build:",
+		"CloudID", b.cloudID,
+	)
+
+	b.logger.Debug(
+		"alarmSubscriptionHandler build:",
+		"persistStorage namespace", b.o2imsNamespace,
+	)
+
+	b.logger.Debug(
+		"alarmSubscriptionHandler build:",
+		"persistStorage configmap name", b.subscriptionsConfigmapName,
+	)
+
+	err = handler.recoveryFromPersistStore(ctx)
+	if err != nil {
+		b.logger.Error(
+			"AlarmNotificationHandler failed to recovery from persistStore ",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	err = handler.watchPersistStore(ctx)
+	if err != nil {
+		b.logger.Error(
+			"AlarmNotificationHandler failed to watch persist store changes ",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	result = handler
+	return
+}
+
+func (h *AlarmNotificationHandler) recoveryFromPersistStore(ctx context.Context) (err error) {
+	newMap, err := persiststorage.GetAll(h.persistStore, ctx)
+	if err != nil {
+		return
+	}
+	err = h.assignSubscriptionMap(&newMap)
+	if err != nil {
+		h.logger.Error(
+			"AlarmNotificationHandler failed building the indexes ",
+			slog.String("error", err.Error()),
+		)
+
+	}
+	return
+}
+
+func (h *AlarmNotificationHandler) watchPersistStore(ctx context.Context) (err error) {
+	err = persiststorage.ProcessChangesWithFunction(h.persistStore, ctx, h.processStorageChanges)
+
+	if err != nil {
+		h.logger.Error(
+			"AlarmNotificationHandler watchPersistStore failed ",
+			slog.String("error", err.Error()),
+		)
+	}
+	return
+}
+
+// Following function is called during daemon start to update alarm subscription as well as
+// alarm subscription got updated. The write lock is need to update subscription kept in memory
+func (h *AlarmNotificationHandler) assignSubscriptionMap(newMap *map[string]data.Object) (err error) {
+	h.subscriptionMapMemoryLock.Lock()
+	defer h.subscriptionMapMemoryLock.Unlock()
+	h.subscriptionMap = newMap
+
+	//clear existing search index and build new one for now
+	h.subscriptionSearcher.subscriptionInfoMap = map[string]subscriptionInfo{}
+
+	err = h.subscriptionSearcher.pocessSubscriptionMapForSearcher(h.subscriptionMap, h.jqTool)
+
+	if err != nil {
+		h.logger.Error(
+			"pocessSubscriptionMapForSearcher ",
+			slog.String("error", err.Error()),
+		)
+	}
+	return
+}
+
+func (h *AlarmNotificationHandler) processStorageChanges(newMap *map[string]data.Object) {
+
+	err := h.assignSubscriptionMap(newMap)
+
+	if err != nil {
+		h.logger.Error(
+			"AlarmNotificationHandler failed to watch persist store changes ",
+			slog.String("error", err.Error()),
+		)
+	}
+
+}

--- a/internal/service/alarm_notification_handler_test.go
+++ b/internal/service/alarm_notification_handler_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package service
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/k8s"
+)
+
+var _ = Describe("alarm Notification handler", func() {
+	Describe("Creation", func() {
+
+		var (
+			ctx        context.Context
+			fakeClient *k8s.Client
+		)
+
+		BeforeEach(func() {
+			// Create a context:
+			ctx = context.TODO()
+			fakeClient = k8s.NewFakeClient()
+		})
+
+		It("Can't be created without a logger", func() {
+			handler, err := NewAlarmNotificationHandler().
+				SetCloudID("123").
+				SetKubeClient(fakeClient).
+				SetConfigmapName(DefaultAlarmConfigmapName).
+				SetNamespace(DefaultNamespace).
+				Build(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(handler).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("logger"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+		})
+
+		It("Can't be created without a cloud identifier", func() {
+			handler, err := NewAlarmNotificationHandler().
+				SetLogger(logger).
+				SetKubeClient(fakeClient).
+				SetConfigmapName(DefaultAlarmConfigmapName).
+				SetNamespace(DefaultNamespace).
+				Build(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(handler).To(BeNil())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("cloud identifier"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var (
+			ctx        context.Context
+			fakeClient *k8s.Client
+		)
+
+		BeforeEach(func() {
+			// Create a context:
+			ctx = context.TODO()
+			fakeClient = k8s.NewFakeClient()
+		})
+
+		Describe("Synch from persistent storage and test filter ", func() {
+			It("Build alarm notification server searcher and verify subId set size", func() {
+				// Create the handler:
+				handler, err := NewAlarmNotificationHandler().
+					SetLogger(logger).
+					SetKubeClient(fakeClient).
+					SetConfigmapName(DefaultAlarmConfigmapName).
+					SetNamespace(DefaultNamespace).
+					SetCloudID("123").
+					SetResourceServerToken("testToken").
+					SetResourceServerURL("testURL").
+					Build(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				obj1 := data.Object{
+					"consumerSubscriptionId": "ef74487e-81ea-40ce-8b48-899b6310c3a7",
+					"filter":                 "(eq,resourceID,my-host)",
+					"callback":               "https://my-smo.example.com/host-alarms",
+				}
+				obj2 := data.Object{
+					"consumerSubscriptionId": "69253c4b-8398-4602-855d-783865f5f25c",
+					"filter":                 "(eq,extensions/country,US);(in,perceivedSeverity,CRITICAL,MAJOR)",
+					"callback":               "https://my-smo.example.com/country-alarms",
+				}
+
+				newMap := map[string]data.Object{
+					"subId-1": obj1,
+					"subId-2": obj2,
+				}
+
+				//validate the prebuild indexes go through
+				Expect(handler.assignSubscriptionMap(&newMap)).ToNot(HaveOccurred())
+
+				requestObj := data.Object{
+					"alarmEventRecordId": "a267bbd0-57aa-4ea1-b030-a300d420ef19",
+					"resourceTypeID":     "c1fe0c43-28e3-4b61-aac5-84bea67551ea",
+					"resourceID":         "my-host",
+					"alarmDefinitionID":  "4db97698-e612-430a-9520-c00e214c39e1",
+					"probableCauseID":    "4a02fdab-e135-4919-b60c-96af08bd088b",
+					"alarmRaisedTime":    "2012-04-23T18:25:43.511Z",
+					"perceivedSeverity":  "CRITICAL",
+					"extensions": data.Object{
+						"country": "US",
+					},
+				}
+
+				//validate the subId set size(expected filter matched number correct)
+				subIdSet := handler.getSubscriptionIdsFromAlarm(ctx, requestObj)
+				Expect(len(subIdSet) == 2)
+
+				//validate add/post request go through
+				add_req := AddRequest{nil, requestObj}
+				_, err = handler.add(ctx, &add_req)
+				Expect(err).To(HaveOccurred())
+
+				//packet does not match any subscription filters
+				requestObj2 := data.Object{
+					"alarmRaisedTime":   "2024-06-11T11:08:56.160Z",
+					"alarmChangedTime":  "2024-06-11T11:13:26.937Z",
+					"alarmDefinitionID": "NodeClockNotSynchronising",
+					"perceivedSeverity": "CRITICAL",
+					"extensions": data.Object{
+						"namespace":                 "openshift-monitoring",
+						"pod":                       "node-exporter-r7vfl",
+						"container":                 "kube-rbac-proxy",
+						"instance":                  "ostest-extraworker-1",
+						"summary":                   "Clock not synchronising.",
+						"runbook_url":               "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeClockNotSynchronising.md",
+						"service":                   "node-exporter",
+						"severity":                  "critical",
+						"alertname":                 "NodeClockNotSynchronising",
+						"openshift_io_alert_source": "platform",
+						"prometheus":                "openshift-monitoring/k8s",
+						"managed_cluster":           "e98f27b4-b09b-47e1-8d4a-d2b3630a0b37",
+						"description":               "Clock at ostest-extraworker-1 is not synchronising. Ensure NTP is configured on this host.",
+						"job":                       "node-exporter",
+						"endpoint":                  "https",
+					},
+					"resourceID":         "1cf16c13-f5cb-497a-97d5-e909cba396a3",
+					"resourceTypeID":     "node_8_cores_amd64",
+					"alarmEventRecordId": "NodeClockNotSynchronising_spoke1_ostest-extraworker-1",
+					"probableCauseID":    "NodeClockNotSynchronising",
+				}
+
+				//validate the subId set size(expected filter matched number correct)
+				subIdSet2 := handler.getSubscriptionIdsFromAlarm(ctx, requestObj)
+				Expect(len(subIdSet2) == 0)
+
+				//validate add/post request go through
+				add_req = AddRequest{nil, requestObj2}
+				_, err = handler.add(ctx, &add_req)
+				Expect(err).To(HaveOccurred())
+			})
+
+		})
+	})
+})

--- a/internal/service/alarm_notification_searcher.go
+++ b/internal/service/alarm_notification_searcher.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package service
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/openshift-kni/oran-o2ims/internal/data"
+	"github.com/openshift-kni/oran-o2ims/internal/jq"
+	"github.com/openshift-kni/oran-o2ims/internal/search"
+)
+
+type subscriptionInfo struct {
+	filters                search.Selector
+	uris                   string
+	consumerSubscriptionId string
+}
+
+// This file contains oran alarm notification serer searcher funcality for matching subscriptions
+// at 1st step linear search
+
+type alarmSubscriptionSearcherBuilder struct {
+	logger *slog.Logger
+	jqTool *jq.Tool
+}
+
+func newAlarmSubscriptionSearcherBuilder() *alarmSubscriptionSearcherBuilder {
+	return &alarmSubscriptionSearcherBuilder{}
+}
+
+func (b *alarmSubscriptionSearcherBuilder) SetLogger(
+	value *slog.Logger) *alarmSubscriptionSearcherBuilder {
+	b.logger = value
+	return b
+}
+func (b *alarmSubscriptionSearcherBuilder) SetJqTool(
+	value *jq.Tool) *alarmSubscriptionSearcherBuilder {
+	b.jqTool = value
+	return b
+}
+
+type alarmSubscriptionSearcher struct {
+	logger *slog.Logger
+	jqTool *jq.Tool
+	//map with prebuilt selector
+	subscriptionInfoMap map[string]subscriptionInfo
+
+	//Parser used for the subscription filters
+	selectorParser *search.SelectorParser
+}
+
+func (b *alarmSubscriptionSearcherBuilder) build() (result *alarmSubscriptionSearcher, err error) {
+
+	// Create the filter expression parser:
+	selectorParser, err := search.NewSelectorParser().
+		SetLogger(b.logger).
+		Build()
+	if err != nil {
+		b.logger.Error(
+			"failed to create filter expression parser: ",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	result = &alarmSubscriptionSearcher{
+		logger:              b.logger,
+		jqTool:              b.jqTool,
+		subscriptionInfoMap: map[string]subscriptionInfo{},
+		selectorParser:      selectorParser,
+	}
+
+	return
+}
+
+// NOTE the function should be called by a function that is holding the semophone
+func (b *alarmSubscriptionSearcher) getSubFilters(filterStr string, subId string) (err error) {
+
+	result, err := b.selectorParser.Parse(filterStr)
+
+	if err != nil {
+		b.logger.Debug(
+			"getSubFilters failed to parse the filter string ",
+			slog.String("filter string", filterStr),
+		)
+		return
+	}
+
+	subInfo := b.subscriptionInfoMap[subId]
+	subInfo.filters = *result
+	b.subscriptionInfoMap[subId] = subInfo
+
+	return
+}
+
+// NOTE the function should be called by a function that is holding the semophone
+func (b *alarmSubscriptionSearcher) pocessSubscriptionMapForSearcher(subscriptionMap *map[string]data.Object,
+	jqTool *jq.Tool) (err error) {
+
+	for key, value := range *subscriptionMap {
+
+		b.subscriptionInfoMap[key] = subscriptionInfo{}
+
+		subInfo := b.subscriptionInfoMap[key]
+		//get uris
+		var uris string
+		err = jqTool.Evaluate(`.callback`, value, &uris)
+		if err != nil {
+			b.logger.Error(
+				"Subscription  ", key,
+				" does not have callback included",
+			)
+			continue
+		}
+		subInfo.uris = uris
+
+		var consumerId string
+		err = jqTool.Evaluate(`.consumerSubscriptionId`, value, &consumerId)
+		if err == nil {
+			subInfo.consumerSubscriptionId = consumerId
+		}
+
+		b.subscriptionInfoMap[key] = subInfo
+
+		//get filter from data object
+		var filter string
+		err = jqTool.Evaluate(`.filter`, value, &filter)
+		if err != nil {
+			b.logger.Debug(
+				"Subscription  ", key,
+				" does not have filter included",
+			)
+		}
+
+		err = b.getSubFilters(filter, key)
+		if err != nil {
+			b.logger.Debug(
+				"pocessSubscriptionMapForSearcher ",
+				"subscription: ", key,
+				" error", err.Error(),
+			)
+		}
+	}
+	return
+}
+
+// following function is on the path trigger by alerts originated from alert manager
+// and query the subscription data structure to get matched the subscription
+// The read lock is needed here to protect the read access to the data
+func (h *AlarmNotificationHandler) getSubscriptionIdsFromAlarm(ctx context.Context, alarm data.Object) (result alarmSubIdSet) {
+
+	h.subscriptionMapMemoryLock.RLock()
+	defer h.subscriptionMapMemoryLock.RUnlock()
+	result = alarmSubIdSet{}
+
+	for subId, subInfo := range h.subscriptionSearcher.subscriptionInfoMap {
+
+		match, err := h.selectorEvaluator.Evaluate(ctx, &subInfo.filters, alarm)
+		if err != nil {
+			h.logger.Debug(
+				"pocessSubscriptionMapForSearcher ",
+				"subscription: ", subId,
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		if match {
+			h.logger.Debug(
+				"pocessSubscriptionMapForSearcher MATCH ",
+				"subscription: ", subId,
+			)
+			result[subId] = struct{}{}
+		}
+	}
+	return
+}
+
+func (h *AlarmNotificationHandler) getSubscriptionInfo(ctx context.Context, subId string) (result subscriptionInfo, ok bool) {
+	h.subscriptionMapMemoryLock.RLock()
+	defer h.subscriptionMapMemoryLock.RUnlock()
+	result, ok = h.subscriptionSearcher.subscriptionInfoMap[subId]
+	return
+}

--- a/internal/service/constants.go
+++ b/internal/service/constants.go
@@ -1,13 +1,14 @@
 package service
 
 const (
-	TestNamespace               = "orantest"
-	AlarmConfigMapName          = "oran-alarms-sub"
-	InfraInventoryConfigMapName = "oran-infra-inventory-sub"
-	FieldOwner                  = "oran-o2ims"
+	//default namespace should be changed to official namespace when it is available
+	DefaultNamespace                   = "orantest"
+	DefaultAlarmConfigmapName          = "oran-o2ims-alarm-subscriptions"
+	DefaultInfraInventoryConfigmapName = "oran-infra-inventory-sub"
+	FieldOwner                         = "oran-o2ims"
 )
 
 const (
-	SubscriptionTypeAlarm                   = "ALARM"
-	SubscriptionTypeInfrastructureInventory = "INFRA-INV"
+	SubscriptionIdAlarm                   = "alarmSubscriptionId"
+	SubscriptionIdInfrastructureInventory = "subscriptionId"
 )

--- a/internal/service/subscription_handler_test.go
+++ b/internal/service/subscription_handler_test.go
@@ -46,6 +46,8 @@ var _ = Describe("Subscription handler", func() {
 				SetLogger(logger).
 				SetCloudID("123").
 				SetKubeClient(fakeClient).
+				SetConfigmapName(DefaultInfraInventoryConfigmapName).
+				SetNamespace(DefaultNamespace).
 				Build(ctx)
 			Expect(err).To(HaveOccurred())
 			Expect(handler).To(BeNil())
@@ -53,8 +55,8 @@ var _ = Describe("Subscription handler", func() {
 			Expect(msg).To(
 				ContainSubstring(
 					fmt.Sprintf("subscription type can only be %s or %s",
-						SubscriptionTypeAlarm,
-						SubscriptionTypeInfrastructureInventory),
+						SubscriptionIdAlarm,
+						SubscriptionIdInfrastructureInventory),
 				),
 			)
 		})
@@ -63,7 +65,7 @@ var _ = Describe("Subscription handler", func() {
 			handler, err := NewSubscriptionHandler().
 				SetCloudID("123").
 				SetKubeClient(fakeClient).
-				SetSubscriptionType(SubscriptionTypeInfrastructureInventory).
+				SetSubscriptionIdString(SubscriptionIdInfrastructureInventory).
 				Build(ctx)
 			Expect(err).To(HaveOccurred())
 			Expect(handler).To(BeNil())
@@ -76,7 +78,9 @@ var _ = Describe("Subscription handler", func() {
 			handler, err := NewSubscriptionHandler().
 				SetLogger(logger).
 				SetKubeClient(fakeClient).
-				SetSubscriptionType(SubscriptionTypeInfrastructureInventory).
+				SetSubscriptionIdString(SubscriptionIdInfrastructureInventory).
+				SetConfigmapName(DefaultInfraInventoryConfigmapName).
+				SetNamespace(DefaultNamespace).
 				Build(ctx)
 			Expect(err).To(HaveOccurred())
 			Expect(handler).To(BeNil())
@@ -99,7 +103,7 @@ var _ = Describe("Subscription handler", func() {
 			//create fake namespace
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: TestNamespace,
+					Name: DefaultNamespace,
 				},
 			}
 			err := fakeClient.Create(ctx, namespace, &client.CreateOptions{}, client.FieldOwner(FieldOwner))
@@ -110,8 +114,8 @@ var _ = Describe("Subscription handler", func() {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: TestNamespace,
-					Name:      AlarmConfigMapName,
+					Namespace: DefaultNamespace,
+					Name:      DefaultAlarmConfigmapName,
 				},
 				Data: nil,
 			}
@@ -124,8 +128,8 @@ var _ = Describe("Subscription handler", func() {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: TestNamespace,
-					Name:      InfraInventoryConfigMapName,
+					Namespace: DefaultNamespace,
+					Name:      DefaultInfraInventoryConfigmapName,
 				},
 				Data: nil,
 			}
@@ -142,7 +146,9 @@ var _ = Describe("Subscription handler", func() {
 					SetLogger(logger).
 					SetCloudID("123").
 					SetKubeClient(fakeClient).
-					SetSubscriptionType(SubscriptionTypeAlarm).
+					SetSubscriptionIdString(SubscriptionIdAlarm).
+					SetConfigmapName(DefaultAlarmConfigmapName).
+					SetNamespace(DefaultNamespace).
 					Build(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler).ToNot(BeNil())
@@ -162,7 +168,9 @@ var _ = Describe("Subscription handler", func() {
 					SetLogger(logger).
 					SetCloudID("123").
 					SetKubeClient(fakeClient).
-					SetSubscriptionType(SubscriptionTypeInfrastructureInventory).
+					SetSubscriptionIdString(SubscriptionIdInfrastructureInventory).
+					SetConfigmapName(DefaultInfraInventoryConfigmapName).
+					SetNamespace(DefaultNamespace).
 					Build(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler).ToNot(BeNil())
@@ -226,7 +234,9 @@ var _ = Describe("Subscription handler", func() {
 					SetLogger(logger).
 					SetCloudID("123").
 					SetKubeClient(fakeClient).
-					SetSubscriptionType(SubscriptionTypeInfrastructureInventory).
+					SetSubscriptionIdString(SubscriptionIdInfrastructureInventory).
+					SetConfigmapName(DefaultInfraInventoryConfigmapName).
+					SetNamespace(DefaultNamespace).
 					Build(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -249,7 +259,9 @@ var _ = Describe("Subscription handler", func() {
 					SetLogger(logger).
 					SetCloudID("123").
 					SetKubeClient(fakeClient).
-					SetSubscriptionType(SubscriptionTypeInfrastructureInventory).
+					SetSubscriptionIdString(SubscriptionIdInfrastructureInventory).
+					SetConfigmapName(DefaultInfraInventoryConfigmapName).
+					SetNamespace(DefaultNamespace).
 					Build(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				obj_1 := data.Object{
@@ -286,7 +298,9 @@ var _ = Describe("Subscription handler", func() {
 					SetLogger(logger).
 					SetCloudID("123").
 					SetKubeClient(fakeClient).
-					SetSubscriptionType(SubscriptionTypeInfrastructureInventory).
+					SetSubscriptionIdString(SubscriptionIdInfrastructureInventory).
+					SetConfigmapName(DefaultInfraInventoryConfigmapName).
+					SetNamespace(DefaultNamespace).
 					Build(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				obj := data.Object{

--- a/proxy.sh
+++ b/proxy.sh
@@ -66,7 +66,23 @@ pids="${pids} $!"
 --log-level="debug" \
 --log-field="server=alarm-subscription" \
 --log-field="pid=%p" \
---api-listener-address="127.0.0.1:8006" \
+--api-listener-address="127.0.0.1:8010" \
+--metrics-listener-address="127.0.0.1:8095" \
+--namespace="orantest" \
+--configmap-name="oran-o2ims-alarm-subscriptions" \
+--cloud-id="123" \
+&
+pids="${pids} $!"
+#### start notificaton server deamon from cmd line
+# Start the alert notification debug server:
+./oran-o2ims start alarm-notification-server \
+--log-level="debug" \
+--log-field="server=alarm-notification" \
+--log-field="pid=%p" \
+--api-listener-address="127.0.0.1:8030" \
+--metrics-listener-address="127.0.0.1:8070" \
+--resource-server-url="${RESOURCE_SERVER_URL}" \
+--resource-server-token="${RESOURCE_SERVER_TOKEN}" \
 --cloud-id="123" \
 &
 pids="${pids} $!"


### PR DESCRIPTION
   Create the alarm notification server.
   Manage in memory alarm subscriptions base on persist storage (populated by alarm subscription server).
   Prebuilt subscription filter terms + limited optimization
   Accept the alarms, match the filters and build and send out notification packet based on matched subscription.


This PR supports basic alert packet flow. In future the filter match will have more optimization and the alert to notification the attributes may need fine tuned. 