### PR TITLE
Fix binay name in help output

### DIFF
--- a/internal/tool.go
+++ b/internal/tool.go
@@ -212,7 +212,7 @@ func (t *Tool) run(cmd *cobra.Command, args []string) error {
 func (t *Tool) createCommand() error {
 	// Create the main command:
 	t.cmd = &cobra.Command{
-		Use:               "o2ims",
+		Use:               "oran-o2ims",
 		Long:              "O2 IMS",
 		PersistentPreRunE: t.run,
 		SilenceErrors:     true,


### PR DESCRIPTION
Currently the name of the binary is `oran-o2ims` but the output of the `--help` option says `o2ims`. This patch fixes that.

Related: https://github.com/openshift-kni/oran-o2ims/issues/104