### PR TITLE
MGMT-18232: Avoid `controller-gen` crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.2.1
-CONTROLLER_TOOLS_VERSION ?= v0.13.0
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.

--- a/config/crd/bases/hardwaremanagement.oran.openshift.io_nodeallocationrequests.yaml
+++ b/config/crd/bases/hardwaremanagement.oran.openshift.io_nodeallocationrequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: nodeallocationrequests.hardwaremanagement.oran.openshift.io
 spec:
   group: hardwaremanagement.oran.openshift.io
@@ -22,43 +22,51 @@ spec:
         description: NodeAllocationRequest is the schema for a node allocation request.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: NodeAllocationRequestSpec describes a request to allocate
-              and prepare a node that will eventually be part of a deployment manager.
+            description: |-
+              NodeAllocationRequestSpec describes a request to allocate and prepare a node that will
+              eventually be part of a deployment manager.
             properties:
               cloudID:
-                description: CloudID is the identifier of the O-Cloud that generated
-                  this request. The hardware manager may want to use this to tag the
-                  nodes in its database, and to generate statistics.
+                description: |-
+                  CloudID is the identifier of the O-Cloud that generated this request. The hardware
+                  manager may want to use this to tag the nodes in its database, and to generate
+                  statistics.
                 type: string
               extensions:
                 additionalProperties:
                   type: string
                 description: "Extensions contains additional information that is associated
-                  to the request. \n This will be populated from the extensions that
-                  are defined in the top level of the deployment manager template,
-                  in the node profile, and in the node set. For example, if the deployment
-                  manager template contains this: \n extensions: \"oran.openshift.io/release\":
-                  \"4.16.1\" \"oran.acme.com/cores\": \"16\" nodeProfiles: - name:
-                  high-performance extensions: \"oran.acme.com/cores\": \"32\" \"oran.acme.com/memory\":
-                  \"128GiB\" nodeSets: - name: control-plane size: 3 profile: high-performance
-                  extensions: \"oran.acme.com/memory\": \"256GiB\" \n Then three node
-                  orders will be generated, and each will contain the following: \n
-                  extensions: \"oran.acme.com/cores\": \"32\" \"oran.acme.com/memory\":
-                  \"256GiB\" \n Note how the extensions not related to the hardware
-                  like `oran.openshift.io/release` aren't copied to the request, and
-                  how the `oran.acme.com/memory` extension in the node set overrides
+                  to the request.\n\n\nThis will be populated from the extensions
+                  that are defined in the top level of the\ndeployment manager template,
+                  in the node profile, and in the node set. For example,\nif the deployment
+                  manager template contains this:\n\n\n\textensions:\n\t  \"oran.openshift.io/release\":
+                  \"4.16.1\"\n\t  \"oran.acme.com/cores\": \"16\"\n\tnodeProfiles:\n\t-
+                  name: high-performance\n\t  extensions:\n\t    \"oran.acme.com/cores\":
+                  \"32\"\n\t    \"oran.acme.com/memory\": \"128GiB\"\n\tnodeSets:\n\t-
+                  name: control-plane\n       size: 3\n       profile: high-performance\n\t
+                  \ extensions:\n\t    \"oran.acme.com/memory\": \"256GiB\"\n\n\nThen
+                  three node orders will be generated, and each will contain the following:\n\n\n\textensions:\n\t
+                  \ \"oran.acme.com/cores\": \"32\"\n\t  \"oran.acme.com/memory\":
+                  \"256GiB\"\n\n\nNote how the extensions not related to the hardware
+                  like `oran.openshift.io/release`\naren't copied to the request,
+                  and how the `oran.acme.com/memory` extension in the node\nset overrides
                   the same extesions from the node profile."
                 type: object
               location:
@@ -70,73 +78,74 @@ spec:
             - location
             type: object
           status:
-            description: NodeAllocationRequestStatus describes the observed state
-              of a request to allocate and prepare a node that will eventually be
-              part of a deployment manager.
+            description: |-
+              NodeAllocationRequestStatus describes the observed state of a request to allocate and prepare
+              a node that will eventually be part of a deployment manager.
             properties:
               bmc:
-                description: BMC contains the details to connect to the baseboard
-                  managment controller of the node.
+                description: |-
+                  BMC contains the details to connect to the baseboard managment controller
+                  of the node.
                 properties:
                   address:
                     description: Address contains the URL for accessing the BMC over
                       the network.
                     type: string
                   credentialsName:
-                    description: CredentiasName is a reference to a secret containing
-                      the credentials. That secret should contain the keys `username`
-                      and `password`.
+                    description: |-
+                      CredentiasName is a reference to a secret containing the credentials. That secret
+                      should contain the keys `username` and `password`.
                     type: string
                   disableCertificateVerification:
-                    description: DisableCertificateVerification disables verification
-                      of server certificates when using HTTPS to connect to the BMC.
-                      This is required when the server certificate is self-signed,
-                      but is insecure because it allows a man-in-the-middle to intercept
-                      the connection.
+                    description: |-
+                      DisableCertificateVerification disables verification of server certificates when using
+                      HTTPS to connect to the BMC. This is required when the server certificate is
+                      self-signed, but is insecure because it allows a man-in-the-middle to intercept the
+                      connection.
                     type: boolean
                 type: object
               conditions:
-                description: Conditions represents the observations of the current
-                  state of the template. Possible values of the condition type are
-                  `Fulfilled` and `Failed`.
+                description: |-
+                  Conditions represents the observations of the current state of the template. Possible
+                  values of the condition type are `Fulfilled` and `Failed`.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -150,11 +159,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -167,9 +177,10 @@ spec:
                   type: object
                 type: array
               nodeID:
-                description: NodeID is the identifier of the node used by the hardware
-                  manager. This will be used by the IMS implementation to reference
-                  the node later when it needs to be updated or decomissioned.
+                description: |-
+                  NodeID is the identifier of the node used by the hardware manager. This will be used
+                  by the IMS implementation to reference the node later when it needs to be updated or
+                  decomissioned.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/hardwaremanagement.oran.openshift.io_nodereleaserequests.yaml
+++ b/config/crd/bases/hardwaremanagement.oran.openshift.io_nodereleaserequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: nodereleaserequests.hardwaremanagement.oran.openshift.io
 spec:
   group: hardwaremanagement.oran.openshift.io
@@ -23,25 +23,31 @@ spec:
           node.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: NodeReleaseRequestSpec specifies how to release a node that
-              has been previously allocated to be part of a deployment manager.
+            description: |-
+              NodeReleaseRequestSpec specifies how to release a node that has been previously allocated to be
+              part of a deployment manager.
             properties:
               cloudID:
-                description: CloudID is the identifier of the O-Cloud that generated
-                  this request. The hardware manager may want to use this to tag the
-                  nodes in its database, and to generate statistics.
+                description: |-
+                  CloudID is the identifier of the O-Cloud that generated this request. The hardware
+                  manager may want to use this to tag the nodes in its database, and to generate statistics.
                 type: string
               extensions:
                 additionalProperties:
@@ -50,8 +56,9 @@ spec:
                   to the request.
                 type: object
               nodeID:
-                description: NodeID is the identifier of the node that was provided
-                  by the hardware manager when the node was previosly allocated.
+                description: |-
+                  NodeID is the identifier of the node that was provided by the hardware manager when the
+                  node was previosly allocated.
                 type: string
             required:
             - cloudID
@@ -62,47 +69,47 @@ spec:
               request.
             properties:
               conditions:
-                description: Conditions represents the observations of the current
-                  state of the request. Possible values of the condition type are
-                  `Fulfilled` and `Failed`.
+                description: |-
+                  Conditions represents the observations of the current state of the request. Possible
+                  values of the condition type are `Fulfilled` and `Failed`.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -116,11 +123,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/oran.openshift.io_deploymentmanagerorders.yaml
+++ b/config/crd/bases/oran.openshift.io_deploymentmanagerorders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: deploymentmanagerorders.oran.openshift.io
 spec:
   group: oran.openshift.io
@@ -23,14 +23,19 @@ spec:
           or more deployment managers.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -53,8 +58,9 @@ spec:
                   deployment manager.
                 type: string
               template:
-                description: Template is the name of the deployment manager template
-                  that will be used to create the deployment manager.
+                description: |-
+                  Template is the name of the deployment manager template that will be used to create the
+                  deployment manager.
                 type: string
             required:
             - id
@@ -66,47 +72,47 @@ spec:
               of a deployment manager order.
             properties:
               conditions:
-                description: Conditions represents the observations of the current
-                  state of the template. Possible values of the condition type are
-                  `Fulfilled` and `Failed`.
+                description: |-
+                  Conditions represents the observations of the current state of the template. Possible
+                  values of the condition type are `Fulfilled` and `Failed`.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -120,11 +126,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/oran.openshift.io_deploymentmanagers.yaml
+++ b/config/crd/bases/oran.openshift.io_deploymentmanagers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: deploymentmanagers.oran.openshift.io
 spec:
   group: oran.openshift.io
@@ -22,14 +22,19 @@ spec:
         description: DeploymentManager is the schema a deployment manager.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/config/crd/bases/oran.openshift.io_deploymentmanagertemplates.yaml
+++ b/config/crd/bases/oran.openshift.io_deploymentmanagertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: deploymentmanagertemplates.oran.openshift.io
 spec:
   group: oran.openshift.io
@@ -19,13 +19,16 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: DeploymentManagerTemplate is the schema for a template that defines
-          how to create a deployment manager.
+        description: |-
+          DeploymentManagerTemplate is the schema for a template that defines how to create a deployment
+          manager.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           extensions:
             additionalProperties:
@@ -34,9 +37,12 @@ spec:
               to the template.
             type: object
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -50,8 +56,9 @@ spec:
                 extensions:
                   additionalProperties:
                     type: string
-                  description: Extensions contains additional information associated
-                    with the profile that can't be expressed in the other fields.
+                  description: |-
+                    Extensions contains additional information associated with the profile that can't
+                    be expressed in the other fields.
                   type: object
                 name:
                   description: Name is the name of the profile.
@@ -65,24 +72,26 @@ spec:
             description: NodeSets is a collection of named sets of nodes that will
               be used in the template.
             items:
-              description: DeploymentManagerTemplateNodeSet associates a name with
-                the configuration of a set of nodes. For example, it is common to
-                have a set of control plane nodes and a set of worker nodes where
-                all the control plane nodes share the same hardware settings, but
-                the worker nodes have different settings.
+              description: |-
+                DeploymentManagerTemplateNodeSet associates a name with the configuration of a set of nodes. For
+                example, it is common to have a set of control plane nodes and a set of worker nodes where all
+                the control plane nodes share the same hardware settings, but the worker nodes have different
+                settings.
               properties:
                 extensions:
                   additionalProperties:
                     type: string
-                  description: Extensions contains additional information associated
-                    with the node set that can't be expressed in the other fields.
+                  description: |-
+                    Extensions contains additional information associated with the node set that can't
+                    be expressed in the other fields.
                   type: object
                 name:
                   description: Name is the name of the node set.
                   type: string
                 profile:
-                  description: Profile is the name of the profile that defines the
-                    settings that will be used by nodes in this set.
+                  description: |-
+                    Profile is the name of the profile that defines the settings that will be used by
+                    nodes in this set.
                   type: string
               required:
               - name

--- a/config/crd/bases/oran.openshift.io_orano2imses.yaml
+++ b/config/crd/bases/oran.openshift.io_orano2imses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: orano2imses.oran.openshift.io
 spec:
   group: oran.openshift.io
@@ -20,14 +20,19 @@ spec:
         description: ORANO2IMS is the Schema for the orano2ims API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -79,10 +84,10 @@ spec:
                 - enabled
                 type: object
               image:
-                description: Image is the full reference of the container image that
-                  contains the binary. This is optional and the default will be the
-                  value passed to the `--image` command line flag of the controller
-                  manager.
+                description: |-
+                  Image is the full reference of the container image that contains the binary. This is
+                  optional and the default will be the value passed to the `--image` command line flag of
+                  the controller manager.
                 type: string
               ingressHost:
                 type: string
@@ -129,52 +134,51 @@ spec:
             description: ORANO2IMSStatus defines the observed state of ORANO2IMS
             properties:
               deploymentStatus:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 properties:
                   conditions:
                     items:
                       description: "Condition contains details for one aspect of the
-                        current state of this API Resource. --- This struct is intended
+                        current state of this API Resource.\n---\nThis struct is intended
                         for direct use as an array at the field path .status.conditions.
-                        \ For example, \n type FooStatus struct{ // Represents the
-                        observations of a foo's current state. // Known .status.conditions.type
-                        are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type
-                        // +patchStrategy=merge // +listType=map // +listMapKey=type
-                        Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                        patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                        \n // other fields }"
+                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
+                        the observations of a foo's current state.\n\t    // Known
+                        .status.conditions.type are: \"Available\", \"Progressing\",
+                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
+                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                        \   // other fields\n\t}"
                       properties:
                         lastTransitionTime:
-                          description: lastTransitionTime is the last time the condition
-                            transitioned from one status to another. This should be
-                            when the underlying condition changed.  If that is not
-                            known, then using the time when the API field changed
-                            is acceptable.
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                           format: date-time
                           type: string
                         message:
-                          description: message is a human readable message indicating
-                            details about the transition. This may be an empty string.
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
                           maxLength: 32768
                           type: string
                         observedGeneration:
-                          description: observedGeneration represents the .metadata.generation
-                            that the condition was set based upon. For instance, if
-                            .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
-                            is 9, the condition is out of date with respect to the
-                            current state of the instance.
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
                           format: int64
                           minimum: 0
                           type: integer
                         reason:
-                          description: reason contains a programmatic identifier indicating
-                            the reason for the condition's last transition. Producers
-                            of specific condition types may define expected values
-                            and meanings for this field, and whether the values are
-                            considered a guaranteed API. The value should be a CamelCase
-                            string. This field may not be empty.
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
                           maxLength: 1024
                           minLength: 1
                           pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -188,11 +192,12 @@ spec:
                           - Unknown
                           type: string
                         type:
-                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            --- Many .condition.type values are consistent across
-                            resources like Available, but because arbitrary conditions
-                            can be useful (see .node.status.conditions), the ability
-                            to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          description: |-
+                            type of condition in CamelCase or in foo.example.com/CamelCase.
+                            ---
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                            useful (see .node.status.conditions), the ability to deconflict is important.
+                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                           maxLength: 316
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string


### PR DESCRIPTION
Version of `controller-gen` 0.13.0 crashes like this when we execute `make install`:

```
/home/user/repos/oran-o2ims/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa0de0f]goroutine 1 [running]:
go/types.(*Checker).handleBailout(0xc0004aa600, 0xc000e42a18)
        /usr/lib/golang/src/go/types/check.go:367 +0x88
panic({0xbc7860?, 0x12b48a0?})
        /usr/lib/golang/src/runtime/panic.go:770 +0x132
go/types.(*StdSizes).Sizeof(0x0, {0xdc35b8, 0x12bd080})
        /usr/lib/golang/src/go/types/sizes.go:228 +0x30f
go/types.(*Config).sizeof(...)
        /usr/lib/golang/src/go/types/sizes.go:333
go/types.representableConst.func1({0xdc35b8?, 0x12bd080?})
        /usr/lib/golang/src/go/types/const.go:76 +0x9e
go/types.representableConst({0xdc9990, 0x1287f80}, 0xc0004aa600, 0x12bd080, 0xc000e42188)
        /usr/lib/golang/src/go/types/const.go:92 +0x192
go/types.(*Checker).representation(0xc0004aa600, 0xc000f397c0, 0x12bd080)
        /usr/lib/golang/src/go/types/const.go:256 +0x65
go/types.(*Checker).implicitTypeAndValue(0xc0004aa600, 0xc000f397c0, {0xdc35e0, 0xc0000b2700})
        /usr/lib/golang/src/go/types/expr.go:375 +0x2d7
go/types.(*Checker).assignment(0xc0004aa600, 0xc000f397c0, {0xdc35e0, 0xc0000b2700}, {0xc9528c, 0x14})
        /usr/lib/golang/src/go/types/assignments.go:52 +0x2e5
go/types.(*Checker).initConst(0xc0004aa600, 0xc00138f1a0, 0xc000f397c0)
        /usr/lib/golang/src/go/types/assignments.go:126 +0x2c5
go/types.(*Checker).constDecl(0xc0004aa600, 0xc00138f1a0, {0xdc6200, 0xc0006f9dc0}, {0xdc6200, 0xc0006f9de0}, 0x0)
        /usr/lib/golang/src/go/types/decl.go:490 +0x311
go/types.(*Checker).objDecl(0xc0004aa600, {0xdcf120, 0xc00138f1a0}, 0x0)
        /usr/lib/golang/src/go/types/decl.go:191 +0xa49
go/types.(*Checker).packageObjects(0xc0004aa600)
        /usr/lib/golang/src/go/types/resolver.go:693 +0x4dd
go/types.(*Checker).checkFiles(0xc0004aa600, {0xc00027e870, 0x2, 0x2})
        /usr/lib/golang/src/go/types/check.go:408 +0x1a5
go/types.(*Checker).Files(...)
        /usr/lib/golang/src/go/types/check.go:372
sigs.k8s.io/controller-tools/pkg/loader.(*loader).typeCheck(0xc00023f440, 0xc000992e00)
        /home/user/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/loader.go:286 +0x36a
sigs.k8s.io/controller-tools/pkg/loader.(*Package).NeedTypesInfo(0xc000992e00)
        /home/user/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/loader.go:99 +0x39
sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check(0xc000f3b560, 0xc000992e00)
        /home/user/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:268 +0x2b7
sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).Check(...)
        /home/user/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:216
sigs.k8s.io/controller-tools/pkg/crd.(*Parser).AddPackage(0xc00108d2c0, 0xc000992e00)
        /home/user/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/crd/parser.go:224 +0xfd
sigs.k8s.io/controller-tools/pkg/crd.(*Parser).NeedPackage(0xc00108d2c0, 0xc000992e00)
        /home/user/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/crd/parser.go:242 +0xee
sigs.k8s.io/controller-tools/pkg/crd.Generator.Generate({0x0, 0x0, 0x0, {0x0, 0x0, 0x0}, 0x0, {0x0, 0x0}, {0x0, ...}}, ...)
        /home/user/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/crd/gen.go:116 +0x128
sigs.k8s.io/controller-tools/pkg/genall.(*Runtime).Run(0xc000468ab0)
        /home/user/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/genall/genall.go:273 +0x23d
main.main.func1(0xc00050c300?, {0xc0002346e0?, 0x4?, 0xc8af70?})
        /home/user/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/cmd/controller-gen/main.go:176 +0x6a
github.com/spf13/cobra.(*Command).execute(0xc000202c08, {0xc0000361f0, 0x5, 0x5})
        /home/user/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x882
github.com/spf13/cobra.(*Command).ExecuteC(0xc000202c08)
        /home/user/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
        /home/user/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
main.main()
        /home/user/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/cmd/controller-gen/main.go:200 +0x2f6
make: *** [Makefile:113: manifests] Error 2
```

I didn't find a bug report for this, but the latest version (0.15.0) works correctly. This patch updates the project to use that version. Note that that has some minor effects in the generated custom resource definitions: the newer version uses `description: |-` instead of just `description: ...`. That is also included in the patch.

Related: https://issues.redhat.com/browse/MGMT-18232