### PR TITLE
initial commit for siteconfig template cm

### DIFF
--- a/internal/files/controllers/siteconfig-template-cm.yaml
+++ b/internal/files/controllers/siteconfig-template-cm.yaml
@@ -1,0 +1,164 @@
+kind: ConfigMap
+metadata:
+  name: default-siteconfig-template
+  namespace: default
+data:
+  sc-siteconfig-template: |
+    apiVersion: metaclusterinstall.openshift.io/v1alpha1
+    kind: SiteConfig
+    metadata:
+      name: "{{ .Cluster.clusterName }}"
+      namespace: "{{ .Cluster.clusterName }}"
+    spec:
+      # Mandatory fields at cluster-level
+      baseDomain: "{{ .Cluster.baseDomain }}"
+      clusterImageSetNameRef:
+        name: "{{ .Cluster.clusterName }}"
+      clusterName: "{{ .Cluster.clusterName }}"
+      pullSecretRef:
+        name: "{{ .Cluster.pullSecretRef.name }}"
+      templateRefs:
+      {{- range .Cluster.templateRefs }}
+        - name: "{{ .name }}"
+          namespace: "{{ .namespace }}"
+      {{- end }}
+      # Optional fields at cluster-level
+{{- if .Cluster.additionalNTPSources }}
+      additionalNTPSources:
+{{ .Cluster.additionalNTPSources | toYaml | indent 8 }}
+{{- end }}
+{{- if .Cluster.apiVIPs }}
+      apiVIPs:
+{{ .Cluster.apiVIPs | toYaml | indent 8 }}
+{{- end }}
+{{- if .Cluster.caBundleRef.name }}
+      caBundleRef:
+        name: "{{ .Cluster.caBundleRef.name }}"
+{{- end }}
+{{- if .Cluster.clusterLabels }}
+      clusterLabels:
+{{ .Cluster.clusterLabels | toYaml | indent 8 }}
+{{- end }}
+{{- if .Cluster.clusterType }}
+      clusterType: "{{ .Cluster.clusterType }}"
+{{- end }}
+{{- if .Cluster.clusterNetwork }}
+      clusterNetwork:
+      {{- range .Cluster.clusterNetwork }}
+        - cidr: "{{ .cidr }}"
+          {{- if .hostPrefix }}
+          hostPrefix: "{{ .hostPrefix }}"
+          {{- end }}
+      {{- end }}
+{{- end }}
+{{- if .Cluster.machineNetwork }}
+      machineNetwork:
+      {{- range .Cluster.machineNetwork }}
+        - cidr: "{{ .cidr }}"
+      {{- end }}
+{{- end }}
+{{- if .Cluster.networkType }}
+      networkType: "{{ .Cluster.networkType }}"
+{{- end }}
+{{- if .Cluster.cpuPartitioningMode }}
+      cpuPartitioningMode: "{{ .Cluster.cpuPartitioningMode }}"
+{{- end }}
+{{- if .Cluster.diskEncryption }}
+      diskEncryption:
+{{ .Cluster.diskEncryption | toYaml | indent 8 }}
+{{- end }}
+{{- if .Cluster.extraAnnotations }}
+      extraAnnotations:
+{{ .Cluster.extraAnnotations | toYaml | indent 8 }}
+{{- end }}
+{{- if .Cluster.extraManifestsRef }}
+      extraManifestsRef:
+      {{- range .Cluster.extraManifestsRef }}
+        - name: "{{ .name }}"
+      {{- end }}
+{{- end }}
+{{- if .Cluster.holdInstallation }}
+      holdInstallation: {{ .Cluster.holdInstallation }}
+{{- end }}
+{{- if .Cluster.ignitionConfigOverride }}
+      ignitionConfigOverride: "{{ .Cluster.ignitionConfigOverride }}"
+{{- end }}
+{{- if .Cluster.installConfigOverrides }}
+      installConfigOverrides: "{{ .Cluster.installConfigOverrides }}"
+{{- end }}
+{{- if .Cluster.ingressVIPs }}
+      ingressVIPs:
+{{ .Cluster.ingressVIPs | toYaml | indent 8 }}    
+{{- end }}
+{{- if .Cluster.proxy }}
+      proxy:
+{{ .Cluster.proxy | toYaml | indent 8 }}
+{{- end }}
+{{- if .Cluster.serviceNetwork }}
+      serviceNetwork:
+      {{- range .Cluster.serviceNetwork }}
+        - cidr: "{{ .cidr }}"
+      {{- end }}
+{{- end }}
+{{- if .Cluster.sshPublicKey }}
+      sshPublicKey: "{{ .Cluster.sshPublicKey }}"
+{{- end }}
+{{- if .Cluster.suppressedManifests }}
+      suppressedManifests:
+{{ .Cluster.suppressedManifests | toYaml | indent 8 }}
+{{- end }}
+      nodes:
+      {{- range .Cluster.nodes }}
+        # Mandatory fields at node-level
+        - bmcAddress: "{{ .bmcAddress }}"
+          bmcCredentialsName:
+            name: "{{ .bmcCredentialsName.name }}"
+          bootMACAddress: "{{ .bootMACAddress }}"
+          bootMode: "{{ .bootMode }}"
+          automatedCleaningMode: "{{ .automatedCleaningMode }}"
+          hostName: "{{ .hostName }}"
+          templateRefs:
+          {{- range .templateRefs }}
+            - name: "{{ .name }}"
+              namespace: "{{ .namespace }}"
+          {{- end }}
+          # Optional fields at node-level
+          {{- if .extraAnnotations }}
+          extraAnnotations:
+{{ .extraAnnotations | toYaml | indent 12 }}
+          {{- end }}
+          {{- if .ignitionConfigOverride }}
+          ignitionConfigOverride: "{{ .ignitionConfigOverride }}"
+          {{- end }}
+          {{- if .installerArgs }}
+          installerArgs: "{{ .installerArgs }}"
+          {{- end }}
+          {{- if .ironicInspect }}
+          ironicInspect: "{{ .ironicInspect }}"
+          {{- end }}
+          {{- if .nodeLabels }}
+          nodeLabels:
+{{ .nodeLabels | toYaml | indent 12 }}
+          {{- end }}
+          {{- if .nodeNetwork }}
+          nodeNetwork:
+            config:
+{{ .nodeNetwork.config | toYaml | indent 14 }}
+            interfaces:
+            {{- range .nodeNetwork.interfaces }}
+              - macAddress: "{{ .macAddress }}"
+                name: "{{ .name }}"
+            {{- end }}
+          {{- end }}
+          {{- if .role }}
+          role: "{{ .role }}"
+          {{- end }}
+          {{- if .rootDeviceHints }}
+          rootDeviceHints:
+{{ .rootDeviceHints | toYaml | indent 12 }}
+          {{- end }}
+          {{- if .suppressedManifests }}
+          suppressedManifests:
+{{ .suppressedManifests | toYaml | indent 12 }}
+          {{- end }}
+      {{- end }}


### PR DESCRIPTION
- follows the required/optional fields defined in the [siteconfig API](https://github.com/stolostron/siteconfig/blob/main/api/v1alpha1/siteconfig_types.go)
- toYaml is a custom template function being used to convert complex nested structures into YAML format string within the template, without the need to specify each field from a map or iteraging over each element of a list. This is helpful for an optional field without required nested fields
- indent is a srig function that adds a specified number of spaces before each line of the output. This is used with toYaml function to ensure the corrent indention of YAML string
- The default values will be provided in another configmap and be merged with the configuration provided in the ClusterRequest.ClusterTemplateInput field. The merged data will be stored into a map with key named "Cluster"

/cc @irinamihai @bartwensley 