### PR TITLE
NO-ISSUE: Move selector logic from handlers to adapter

### DIFF
--- a/internal/service/resource_handler.go
+++ b/internal/service/resource_handler.go
@@ -49,19 +49,18 @@ type ResourceHandlerBuilder struct {
 // ResourceHandler knows how to respond to requests to list resources. Don't create
 // instances of this type directly, use the NewResourceHandler function instead.
 type ResourceHandler struct {
-	logger            *slog.Logger
-	transportWrapper  func(http.RoundTripper) http.RoundTripper
-	cloudID           string
-	extensions        []string
-	backendURL        string
-	backendToken      string
-	backendClient     *http.Client
-	jsonAPI           jsoniter.API
-	selectorEvaluator *search.SelectorEvaluator
-	graphqlQuery      string
-	graphqlVars       *model.SearchInput
-	resourceFetcher   *ResourceFetcher
-	jqTool            *jq.Tool
+	logger           *slog.Logger
+	transportWrapper func(http.RoundTripper) http.RoundTripper
+	cloudID          string
+	extensions       []string
+	backendURL       string
+	backendToken     string
+	backendClient    *http.Client
+	jsonAPI          jsoniter.API
+	graphqlQuery     string
+	graphqlVars      *model.SearchInput
+	resourceFetcher  *ResourceFetcher
+	jqTool           *jq.Tool
 }
 
 // NewResourceHandler creates a builder that can then be used to configure and create a
@@ -168,21 +167,6 @@ func (b *ResourceHandlerBuilder) Build() (
 	}
 	jsonAPI := jsonConfig.Froze()
 
-	// Create the filter expression evaluator:
-	pathEvaluator, err := search.NewPathEvaluator().
-		SetLogger(b.logger).
-		Build()
-	if err != nil {
-		return
-	}
-	selectorEvaluator, err := search.NewSelectorEvaluator().
-		SetLogger(b.logger).
-		SetPathEvaluator(pathEvaluator.Evaluate).
-		Build()
-	if err != nil {
-		return
-	}
-
 	// Create a jq compiler function for parsing labels
 	compilerFunc := gojq.WithFunction("parse_labels", 0, 1, func(x any, _ []any) any {
 		if labels, ok := x.(string); ok {
@@ -210,18 +194,17 @@ func (b *ResourceHandlerBuilder) Build() (
 
 	// Create and populate the object:
 	result = &ResourceHandler{
-		logger:            b.logger,
-		transportWrapper:  b.transportWrapper,
-		cloudID:           b.cloudID,
-		extensions:        slices.Clone(b.extensions),
-		backendURL:        b.backendURL,
-		backendToken:      b.backendToken,
-		backendClient:     backendClient,
-		selectorEvaluator: selectorEvaluator,
-		jsonAPI:           jsonAPI,
-		graphqlQuery:      b.graphqlQuery,
-		graphqlVars:       b.graphqlVars,
-		jqTool:            jqTool,
+		logger:           b.logger,
+		transportWrapper: b.transportWrapper,
+		cloudID:          b.cloudID,
+		extensions:       slices.Clone(b.extensions),
+		backendURL:       b.backendURL,
+		backendToken:     b.backendToken,
+		backendClient:    backendClient,
+		jsonAPI:          jsonAPI,
+		graphqlQuery:     b.graphqlQuery,
+		graphqlVars:      b.graphqlVars,
+		jqTool:           jqTool,
 	}
 	return
 }
@@ -233,17 +216,6 @@ func (h *ResourceHandler) List(ctx context.Context,
 	resources, err := h.fetchItems(ctx, request.Variables[0], request.Selector)
 	if err != nil {
 		return
-	}
-
-	// Select only the items that satisfy the filter:
-	if request.Selector != nil {
-		resources = data.Select(
-			resources,
-			func(ctx context.Context, item data.Object) (result bool, err error) {
-				result, err = h.selectorEvaluator.Evaluate(ctx, request.Selector, item)
-				return
-			},
-		)
 	}
 
 	// Return the result:

--- a/internal/service/resource_pool_handler.go
+++ b/internal/service/resource_pool_handler.go
@@ -55,7 +55,6 @@ type ResourcePoolHandler struct {
 	backendToken        string
 	backendClient       *http.Client
 	jsonAPI             jsoniter.API
-	selectorEvaluator   *search.SelectorEvaluator
 	graphqlQuery        string
 	graphqlVars         *model.SearchInput
 	resourcePoolFetcher *ResourcePoolFetcher
@@ -165,34 +164,18 @@ func (b *ResourcePoolHandlerBuilder) Build() (
 	}
 	jsonAPI := jsonConfig.Froze()
 
-	// Create the filter expression evaluator:
-	pathEvaluator, err := search.NewPathEvaluator().
-		SetLogger(b.logger).
-		Build()
-	if err != nil {
-		return
-	}
-	selectorEvaluator, err := search.NewSelectorEvaluator().
-		SetLogger(b.logger).
-		SetPathEvaluator(pathEvaluator.Evaluate).
-		Build()
-	if err != nil {
-		return
-	}
-
 	// Create and populate the object:
 	result = &ResourcePoolHandler{
-		logger:            b.logger,
-		transportWrapper:  b.transportWrapper,
-		cloudID:           b.cloudID,
-		extensions:        slices.Clone(b.extensions),
-		backendURL:        b.backendURL,
-		backendToken:      b.backendToken,
-		backendClient:     backendClient,
-		selectorEvaluator: selectorEvaluator,
-		jsonAPI:           jsonAPI,
-		graphqlQuery:      b.graphqlQuery,
-		graphqlVars:       b.graphqlVars,
+		logger:           b.logger,
+		transportWrapper: b.transportWrapper,
+		cloudID:          b.cloudID,
+		extensions:       slices.Clone(b.extensions),
+		backendURL:       b.backendURL,
+		backendToken:     b.backendToken,
+		backendClient:    backendClient,
+		jsonAPI:          jsonAPI,
+		graphqlQuery:     b.graphqlQuery,
+		graphqlVars:      b.graphqlVars,
 	}
 	return
 }
@@ -205,17 +188,6 @@ func (h *ResourcePoolHandler) List(ctx context.Context,
 	resourcePools, err := h.fetchItems(ctx, request.Selector)
 	if err != nil {
 		return
-	}
-
-	// Select only the items that satisfy the filter:
-	if request.Selector != nil {
-		resourcePools = data.Select(
-			resourcePools,
-			func(ctx context.Context, item data.Object) (result bool, err error) {
-				result, err = h.selectorEvaluator.Evaluate(ctx, request.Selector, item)
-				return
-			},
-		)
 	}
 
 	// Return the result:


### PR DESCRIPTION
Currently we apply the selector (the `filter` query parameter) in all the handlers. This patch moves the logic to the adapter, which is where it belongs.