### PR TITLE
Set transport defaults when creating HTTP backend transport

### DIFF
--- a/internal/authentication/handler_wrapper.go
+++ b/internal/authentication/handler_wrapper.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"math/big"
 	"net/http"
@@ -343,12 +344,12 @@ func (b *HandlerWrapperBuilder) Build() (result func(http.Handler) http.Handler,
 
 	// Create the HTTP client that will be used to load the keys:
 	keysClient := &http.Client{
-		Transport: &http.Transport{
+		Transport: net.SetTransportDefaults(&http.Transport{
 			TLSClientConfig: &tls.Config{
 				RootCAs:            keysCA,
 				InsecureSkipVerify: b.keysInsecure,
 			},
-		},
+		}),
 	}
 
 	// Try to compile the regular expressions that define the parts of the URL space that are

--- a/internal/service/alarm_fetcher.go
+++ b/internal/service/alarm_fetcher.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	neturl "net/url"
@@ -151,12 +152,11 @@ func (b *AlarmFetcherBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper
-	backendTransport = &http.Transport{
+	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/alarm_handler.go
+++ b/internal/service/alarm_handler.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	"slices"
@@ -147,12 +148,11 @@ func (b *AlarmHandlerBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper
-	backendTransport = &http.Transport{
+	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/deployment_manager_handler.go
+++ b/internal/service/deployment_manager_handler.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	neturl "net/url"
@@ -174,12 +175,11 @@ func (b *DeploymentManagerHandlerBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper
-	backendTransport = &http.Transport{
+	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 	if b.loggingWrapper != nil {
 		backendTransport = b.loggingWrapper(backendTransport)
 	}

--- a/internal/service/resource_fetcher.go
+++ b/internal/service/resource_fetcher.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 
@@ -134,12 +135,11 @@ func (b *ResourceFetcherBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper
-	backendTransport = &http.Transport{
+	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/resource_handler.go
+++ b/internal/service/resource_handler.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	"slices"
@@ -146,12 +147,11 @@ func (b *ResourceHandlerBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper
-	backendTransport = &http.Transport{
+	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/resource_pool_fetcher.go
+++ b/internal/service/resource_pool_fetcher.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -145,12 +146,11 @@ func (b *ResourcePoolFetcherBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper
-	backendTransport = &http.Transport{
+	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/resource_pool_handler.go
+++ b/internal/service/resource_pool_handler.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	"slices"
@@ -142,12 +143,11 @@ func (b *ResourcePoolHandlerBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper
-	backendTransport = &http.Transport{
+	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/resource_type_handler.go
+++ b/internal/service/resource_type_handler.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 
@@ -143,12 +144,11 @@ func (b *ResourceTypeHandlerBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper
-	backendTransport = &http.Transport{
+	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}


### PR DESCRIPTION
The zero value of HttpTransport doesn't include any default attribute values for setting up the HTTP transport.  This prevents using the HTTPS_PROXY environment variable (and other related proxy variables) to redirect HTTP requests to a proxy.

We could set this explicitly on our own, but that wouldn't pick up any future changes to the defaults made upstream in the library.

This is useful when testing as a standalone binary and connecting to a system that is behind a proxy.