### PR TITLE
Exclude vendor directory from gofmt input parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ CONTAINER_TOOL ?= docker
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+
+# Source directories
+SOURCE_DIRS := $(shell find . -maxdepth 1 -type d ! -name "vendor" ! -name "." ! -name ".*")
+
 .PHONY: all
 all: build
 
@@ -311,7 +315,7 @@ test tests:
 .PHONY: fmt
 fmt:
 	@echo "Run fmt"
-	gofmt -s -l -w .
+	gofmt -s -l -w main.go $(SOURCE_DIRS)
 
 .PHONY: vet
 vet: ## Run go vet against code.


### PR DESCRIPTION
Now that the `vendor` directory is no longer excluded from git we need to adjust the `gofmt` input parameters to exclude it since it currently looks at any and all *.go files within the entire repo.  This causes it to run on files within the vendor directory which, as it turns out, contains some *.go files that do not conform to the go formatting guidelines.

Alternatively we could have explicitly listed the required source directories, but figured that this dynamic approach would be more "future-proof" and require less code maintenance.