### PR TITLE
CNF-13957: Enable goimports linter configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     #- gocritic
     - revive
     - gofmt
-    #- goimports
+    - goimports
     - govet
     - ineffassign
     #- misspell

--- a/internal/authentication/handler_wrapper.go
+++ b/internal/authentication/handler_wrapper.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"math/big"
 	"net/http"
@@ -36,6 +35,8 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	"k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/golang-jwt/jwt/v4"
 	jsoniter "github.com/json-iterator/go"

--- a/internal/service/alarm_fetcher.go
+++ b/internal/service/alarm_fetcher.go
@@ -19,10 +19,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	neturl "net/url"
+
+	"k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/jq"

--- a/internal/service/alarm_handler.go
+++ b/internal/service/alarm_handler.go
@@ -19,10 +19,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	"slices"
+
+	"k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/search"

--- a/internal/service/deployment_manager_handler.go
+++ b/internal/service/deployment_manager_handler.go
@@ -20,12 +20,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	neturl "net/url"
 	"slices"
 	"sync"
+
+	"k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/imdario/mergo"
 	jsoniter "github.com/json-iterator/go"

--- a/internal/service/resource_fetcher.go
+++ b/internal/service/resource_fetcher.go
@@ -22,9 +22,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/k8s"

--- a/internal/service/resource_handler.go
+++ b/internal/service/resource_handler.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	"slices"
+
+	"k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/itchyny/gojq"
 

--- a/internal/service/resource_pool_fetcher.go
+++ b/internal/service/resource_pool_fetcher.go
@@ -22,10 +22,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/graphql"

--- a/internal/service/resource_pool_handler.go
+++ b/internal/service/resource_pool_handler.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
 	"slices"
+
+	"k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/graphql"

--- a/internal/service/resource_type_handler.go
+++ b/internal/service/resource_type_handler.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"k8s.io/apimachinery/pkg/util/net"
 	"log/slog"
 	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/files"


### PR DESCRIPTION
This addresses import statement ordering/grouping violations reported by the golintci tool.