### PR TITLE
CNF-13961: Enable unconvert linter configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
     #- misspell
     - staticcheck
     - typecheck
-    #- unconvert
+    - unconvert
     #- unparam
     #- gocyclo
     - unused

--- a/internal/jq/query.go
+++ b/internal/jq/query.go
@@ -168,7 +168,7 @@ func (q *Query) convert(input any, output any) error {
 				q.logger.Warn(
 					"Conversion from float to 64 bits integer loses precision",
 					slog.Float64("input", input),
-					slog.Int64("output", int64(*output)),
+					slog.Int64("output", *output),
 				)
 			}
 		case *float64:


### PR DESCRIPTION
This addresses issues with unnecessary type conversions reported by the golintci tool.