### PR TITLE
CNF-13962: Enable golangci-lint unparam test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
     - staticcheck
     - typecheck
     - unconvert
-    #- unparam
+    - unparam
     #- gocyclo
     - unused
     #- errorlint

--- a/internal/authentication/handler_wrapper.go
+++ b/internal/authentication/handler_wrapper.go
@@ -577,6 +577,7 @@ func (h *handlerWrapper) loadKeys(ctx context.Context) error {
 				slog.String("file", keysFile),
 				slog.String("error", err.Error()),
 			)
+			return fmt.Errorf("unable to load keys from file: %w", err)
 		}
 	}
 
@@ -595,6 +596,7 @@ func (h *handlerWrapper) loadKeys(ctx context.Context) error {
 				slog.String("url", keysURL),
 				slog.String("error", err.Error()),
 			)
+			return fmt.Errorf("unable to load keys from URL: %w", err)
 		}
 	}
 
@@ -907,7 +909,7 @@ func (h *handlerWrapper) checkStringClaim(ctx context.Context, claims jwt.MapCla
 // checkTimeClaim checks that the given claim exists and that the value is a time. If it exists it
 // returns the value.
 func (h *handlerWrapper) checkTimeClaim(ctx context.Context, claims jwt.MapClaims,
-	name string) (result time.Time, err error) {
+	name string) (result time.Time, err error) { // nolint: unparam
 	value, err := h.checkClaim(ctx, claims, name)
 	if err != nil {
 		return
@@ -925,7 +927,7 @@ func (h *handlerWrapper) checkTimeClaim(ctx context.Context, claims jwt.MapClaim
 }
 
 // checkClaim checks that the given claim exists. If it exists it returns the value.
-func (h *handlerWrapper) checkClaim(ctx context.Context, claims jwt.MapClaims,
+func (h *handlerWrapper) checkClaim(ctx context.Context, claims jwt.MapClaims, // nolint: unparam
 	name string) (result any, err error) {
 	value, ok := claims[name]
 	if !ok {

--- a/internal/authorization/handler_wrapper.go
+++ b/internal/authorization/handler_wrapper.go
@@ -256,7 +256,7 @@ func (h *handlerWrapper) checkACL(claims map[string]any) bool {
 }
 
 // sendError sends an error response to the client with the message of the given error.
-func (h *handlerWrapper) sendError(w http.ResponseWriter, r *http.Request) {
+func (h *handlerWrapper) sendError(w http.ResponseWriter, r *http.Request) { // nolint: unparam
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(http.StatusForbidden)
 	writer := jsoniter.NewStream(h.jsonAPI, w, 512)

--- a/internal/controllers/clusterrequest_controller.go
+++ b/internal/controllers/clusterrequest_controller.go
@@ -153,7 +153,7 @@ func (r *ClusterRequestReconciler) Reconcile(
 	return
 }
 
-func (t *clusterRequestReconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, err error) {
+func (t *clusterRequestReconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, err error) { // nolint: unparam
 	// ### CLUSTERINSTANCE TEMPLATE RENDERING ###
 	renderedClusterInstance, renderErr := t.renderClusterInstanceTemplate(ctx)
 	if renderErr != nil {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -206,7 +206,7 @@ func (b *ClientBuilder) loadConfig() (result *rest.Config, err error) {
 
 // loadDefaultConfig loads the configuration from the typical default locations, the `KUBECONFIG`
 // environment variable and the ~/.kube/config` file.
-func (b *ClientBuilder) loadDefaultConfig() (result clientcmd.ClientConfig, err error) {
+func (b *ClientBuilder) loadDefaultConfig() (result clientcmd.ClientConfig, err error) { // nolint: unparam
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	overrides := &clientcmd.ConfigOverrides{}
 	result = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -298,7 +298,7 @@ func (b *LoggerBuilder) customFields() (result []any, err error) {
 	return
 }
 
-func (b *LoggerBuilder) customField(name string, value any) (result any, err error) {
+func (b *LoggerBuilder) customField(name string, value any) (result any, err error) { // nolint: unparam
 	switch value {
 	case pidLogFieldValue:
 		result = os.Getpid()

--- a/internal/search/projector_evaluator.go
+++ b/internal/search/projector_evaluator.go
@@ -200,7 +200,7 @@ func (e *ProjectorEvaluator) setPath(path Path, object map[string]any, value any
 	}
 }
 
-func (e *ProjectorEvaluator) excludePath(ctx context.Context, path Path, object any, result map[string]any) error {
+func (e *ProjectorEvaluator) excludePath(ctx context.Context, path Path, object any, result map[string]any) error { // nolint: unparam
 	return e.clearPath(path, result)
 }
 

--- a/internal/service/adapter.go
+++ b/internal/service/adapter.go
@@ -369,7 +369,7 @@ func (a *Adapter) serveGetMethod(ctx context.Context, w http.ResponseWriter, r *
 	}
 }
 
-func (a *Adapter) servePostMethod(ctx context.Context, w http.ResponseWriter, r *http.Request,
+func (a *Adapter) servePostMethod(ctx context.Context, w http.ResponseWriter, r *http.Request, // nolint: unparam
 	pathVariables []string) {
 	// Check that we have a compatible handler:
 	if a.addHandler == nil {
@@ -606,7 +606,7 @@ func (a *Adapter) serveAdd(w http.ResponseWriter, r *http.Request, pathVariables
 	a.sendObject(ctx, w, response.Object)
 }
 
-func (a *Adapter) serveDelete(ctx context.Context, w http.ResponseWriter, r *http.Request,
+func (a *Adapter) serveDelete(ctx context.Context, w http.ResponseWriter, r *http.Request, // nolint: unparam
 	pathVariables []string) {
 	// Create the request:
 	request := &DeleteRequest{

--- a/internal/service/alarm_notification_searcher.go
+++ b/internal/service/alarm_notification_searcher.go
@@ -188,7 +188,7 @@ func (h *AlarmNotificationHandler) getSubscriptionIdsFromAlarm(ctx context.Conte
 	return
 }
 
-func (h *AlarmNotificationHandler) getSubscriptionInfo(ctx context.Context, subId string) (result subscriptionInfo, ok bool) {
+func (h *AlarmNotificationHandler) getSubscriptionInfo(ctx context.Context, subId string) (result subscriptionInfo, ok bool) { // nolint: unparam
 	h.subscriptionMapMemoryLock.RLock()
 	defer h.subscriptionMapMemoryLock.RUnlock()
 	result, ok = h.subscriptionSearcher.subscriptionInfoMap[subId]

--- a/internal/service/deployment_manager_handler.go
+++ b/internal/service/deployment_manager_handler.go
@@ -377,7 +377,7 @@ func (h *DeploymentManagerHandler) fetchItemFromRegularHub(ctx context.Context,
 	return
 }
 
-func (h *DeploymentManagerHandler) doGet(ctx context.Context, path string,
+func (h *DeploymentManagerHandler) doGet(ctx context.Context, path string, // nolint: unparam
 	query neturl.Values) (response *http.Response, err error) {
 	url := h.backendURL + path
 	request, err := http.NewRequest(http.MethodGet, url, nil)

--- a/internal/service/resource_handler.go
+++ b/internal/service/resource_handler.go
@@ -273,7 +273,7 @@ func (h *ResourceHandler) fetchItems(
 }
 
 func (h *ResourceHandler) fetchItem(ctx context.Context,
-	id, parentID string) (resource data.Object, err error) {
+	id, parentID string) (resource data.Object, err error) { // nolint: unparam
 	// Fetch items
 	items, err := h.resourceFetcher.FetchItems(ctx)
 	if err != nil {
@@ -365,7 +365,7 @@ func (r *ResourceHandler) mapItem(ctx context.Context,
 }
 
 // Map a Node to an O2 Resource object.
-func (r *ResourceHandler) mapNodeItem(ctx context.Context,
+func (r *ResourceHandler) mapNodeItem(ctx context.Context, // nolint: unparam
 	from data.Object) (to data.Object, err error) {
 	description, err := data.GetString(from,
 		graphql.PropertyNode("description").MapProperty())

--- a/internal/service/resource_pool_handler.go
+++ b/internal/service/resource_pool_handler.go
@@ -239,7 +239,7 @@ func (h *ResourcePoolHandler) fetchItems(
 }
 
 func (h *ResourcePoolHandler) fetchItem(ctx context.Context,
-	id string) (resourcePool data.Object, err error) {
+	id string) (resourcePool data.Object, err error) { // nolint: unparam
 	// Fetch resource pools
 	resourcePools, err := h.resourcePoolFetcher.FetchItems(ctx)
 	if err != nil {
@@ -286,7 +286,7 @@ func (h *ResourcePoolHandler) getCollectionGraphqlVars(ctx context.Context, sele
 	return
 }
 
-func (h *ResourcePoolHandler) getObjectGraphqlVars(ctx context.Context, id string) (graphqlVars *model.SearchInput) {
+func (h *ResourcePoolHandler) getObjectGraphqlVars(ctx context.Context, id string) (graphqlVars *model.SearchInput) { // nolint: unparam
 	graphqlVars = &model.SearchInput{}
 	graphqlVars.Keywords = h.graphqlVars.Keywords
 	graphqlVars.Filters = h.graphqlVars.Filters

--- a/internal/service/subscription_handler.go
+++ b/internal/service/subscription_handler.go
@@ -330,7 +330,7 @@ func (h *SubscriptionHandler) Delete(ctx context.Context,
 
 	return
 }
-func (h *SubscriptionHandler) fetchItem(ctx context.Context,
+func (h *SubscriptionHandler) fetchItem(ctx context.Context, // nolint: unparam
 	id string) (result data.Object, err error) {
 	h.subscriptionMapLock.Lock()
 	defer h.subscriptionMapLock.Unlock()


### PR DESCRIPTION
Enabling golangci-lint unparam test. For most existing issues, the test is skipped via `nolint: unparam` directive, as the code is under development and unused parameters are likely to be used in the future.

In one case (internal/authentication/handler_wrapper.go), the warning flagged a function that always returned nil error, which is addressed by returning a wrapped error in the failure case.