### PR TITLE
CNF-13952: Enable additional golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,23 +6,32 @@ linters:
   disable-all: true
   enable:
     - depguard
+    - errcheck
+    - errorlint
     - goconst
     - gocritic
-    - revive
+    - gocyclo
     - gofmt
     - goimports
+    #- gosec
+    - gosimple
     - govet
+    - importas
     - ineffassign
+    - loggercheck
+    #- maintidx
     - misspell
+    - nilnil
+    - predeclared
+    - promlinter
+    - revive
     - staticcheck
+    - sloglint
     - typecheck
     - unconvert
     - unparam
-    - gocyclo
     - unused
-    - errorlint
-    - loggercheck
-    #- gosec
+    - usestdlibvars
     #- wrapcheck
 linters-settings:
   revive:
@@ -128,3 +137,14 @@ linters-settings:
       - .WithStack(
       # from kyaml's errors package
       - .WrapPrefixf(
+  importas:
+    # List of aliases
+    # Default: []
+    alias:
+      # You can specify the package path by regular expression,
+      # and alias by regular expression expansion syntax like below.
+      # see https://github.com/julz/importas#use-regular-expression for details
+      - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: k8s.io/apimachinery/pkg/apis/(\w+)/(v[\w\d]+)
+        alias: $1$2

--- a/internal/search/projector_evaluator_test.go
+++ b/internal/search/projector_evaluator_test.go
@@ -25,7 +25,7 @@ import (
 var _ = Describe("Projector evaluator", func() {
 	// nop is a simple path evaluator that always return nil.
 	var nop = func(context.Context, Path, any) (any, error) {
-		return nil, nil
+		return nil, nil // nolint: nilnil
 	}
 
 	Describe("Creation", func() {

--- a/internal/search/selector_evaluator_test.go
+++ b/internal/search/selector_evaluator_test.go
@@ -25,7 +25,7 @@ import (
 var _ = Describe("Selector evaluator", func() {
 	// nop is a simple path evaluator that always return nil.
 	var nop = func(context.Context, Path, any) (any, error) {
-		return nil, nil
+		return nil, nil // nolint: nilnil
 	}
 
 	Describe("Creation", func() {

--- a/internal/service/alarm_notification_searcher.go
+++ b/internal/service/alarm_notification_searcher.go
@@ -173,7 +173,7 @@ func (h *AlarmNotificationHandler) getSubscriptionIdsFromAlarm(ctx context.Conte
 			h.logger.Debug(
 				"pocessSubscriptionMapForSearcher ",
 				"subscription: ", subId,
-				slog.String("error", err.Error()),
+				" error", err.Error(),
 			)
 			continue
 		}


### PR DESCRIPTION
The following golangci-lint linters are enabled:
- errcheck
- gosimple
- importas
- nilnil
- predeclared
- promlinter
- sloglint
- usestdlibvars