### PR TITLE
CNF-13963: golangci-lint: Enable wrapcheck in linter configs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,7 @@ linters:
     - unparam
     - unused
     - usestdlibvars
-    #- wrapcheck
+    - wrapcheck
 linters-settings:
   revive:
     rules:

--- a/internal/authentication/handler_wrapper.go
+++ b/internal/authentication/handler_wrapper.go
@@ -607,7 +607,7 @@ func (h *handlerWrapper) loadKeys(ctx context.Context) error {
 func (h *handlerWrapper) loadKeysFile(ctx context.Context, file string) error {
 	reader, err := os.Open(file)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open file %s: %w", file, err)
 	}
 	return h.readKeys(ctx, reader)
 }
@@ -616,7 +616,7 @@ func (h *handlerWrapper) loadKeysFile(ctx context.Context, file string) error {
 func (h *handlerWrapper) loadKeysURL(ctx context.Context, addr string) error {
 	request, err := http.NewRequest(http.MethodGet, addr, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create new HTTP request: %w", err)
 	}
 	token := h.selectKeysToken(ctx)
 	if token != "" {
@@ -625,7 +625,7 @@ func (h *handlerWrapper) loadKeysURL(ctx context.Context, addr string) error {
 	request = request.WithContext(ctx)
 	response, err := h.keysClient.Do(request)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to execute HTTP request: %w", err)
 	}
 	defer func() {
 		err := response.Body.Close()
@@ -676,14 +676,13 @@ func (h *handlerWrapper) readKeys(ctx context.Context, reader io.Reader) error {
 	// Read the JSON data:
 	jsonData, err := io.ReadAll(reader)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read JSON data: %w", err)
 	}
 
 	// Parse the JSON data:
 	var setData setData
-	err = json.Unmarshal(jsonData, &setData)
-	if err != nil {
-		return err
+	if err = json.Unmarshal(jsonData, &setData); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON data: %w", err)
 	}
 
 	// Convert the key data to actual keys that can be used to verify the signatures of the

--- a/internal/authorization/handler_wrapper.go
+++ b/internal/authorization/handler_wrapper.go
@@ -169,21 +169,20 @@ func (b *HandlerWrapperBuilder) loadACLFile(file string, items map[string]*regex
 	// Load the YAML data:
 	yamlData, err := os.ReadFile(file)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read ACL file %s: %w", file, err)
 	}
 
 	// Parse the YAML data:
 	var listData []aclItem
-	err = yaml.Unmarshal(yamlData, &listData)
-	if err != nil {
-		return err
+	if err = yaml.Unmarshal(yamlData, &listData); err != nil {
+		return fmt.Errorf("failed to unmarshal YAML data from file %s: %w", file, err)
 	}
 
 	// Process the items:
 	for _, itemData := range listData {
 		items[itemData.Claim], err = regexp.Compile(itemData.Pattern)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to compile regex pattern %s for claim %s: %w", itemData.Pattern, itemData.Claim, err)
 		}
 	}
 

--- a/internal/cmd/server/start_alarm_notification_server.go
+++ b/internal/cmd/server/start_alarm_notification_server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -78,7 +79,7 @@ func AlarmNotificationServer() *cobra.Command {
 	return result
 }
 
-// alarmNotificationServerCommand contains the data and logic needed to run the `start
+// AlarmNotificationServerCommand contains the data and logic needed to run the `start
 // alarm-notification-server` command.
 type AlarmNotificationServerCommand struct {
 }
@@ -360,6 +361,9 @@ func (c *AlarmNotificationServerCommand) run(cmd *cobra.Command, argv []string) 
 		}
 	}()
 
-	// Wait for exit signals:
-	return exitHandler.Wait(ctx)
+	// Wait for exit signals
+	if err := exitHandler.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to wait for exit signals: %w", err)
+	}
+	return nil
 }

--- a/internal/cmd/server/start_alarm_server.go
+++ b/internal/cmd/server/start_alarm_server.go
@@ -362,8 +362,11 @@ func (c *AlarmServerCommand) run(cmd *cobra.Command, argv []string) error {
 		}
 	}()
 
-	// Wait for exit signals:
-	return exitHandler.Wait(ctx)
+	// Wait for exit signals
+	if err := exitHandler.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to wait for exit signals: %w", err)
+	}
+	return nil
 }
 
 func (c *AlarmServerCommand) createAlarmHandler(
@@ -468,7 +471,7 @@ func (c *AlarmServerCommand) createAlarmProbableCausesHandler(ctx context.Contex
 func (c *AlarmServerCommand) generateAlertmanagerApiUrl(backendURL string) (string, error) {
 	u, err := url.Parse(backendURL)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to parse Alertmanager backend URL %s: %w", backendURL, err)
 	}
 
 	// Split URL address

--- a/internal/cmd/server/start_alarm_subscription_server.go
+++ b/internal/cmd/server/start_alarm_subscription_server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -371,6 +372,9 @@ func (c *AlarmSubscriptionServerCommand) run(cmd *cobra.Command, argv []string) 
 		}
 	}()
 
-	// Wait for exit signals:
-	return exitHandler.Wait(ctx)
+	// Wait for exit signals
+	if err := exitHandler.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to wait for exit signals: %w", err)
+	}
+	return nil
 }

--- a/internal/cmd/server/start_deployment_manager_server.go
+++ b/internal/cmd/server/start_deployment_manager_server.go
@@ -403,6 +403,9 @@ func (c *DeploymentManagerServerCommand) run(cmd *cobra.Command, argv []string) 
 		}
 	}()
 
-	// Wait for exit signals:
-	return exitHandler.Wait(ctx)
+	// Wait for exit signals
+	if err := exitHandler.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to wait for exit signals: %w", err)
+	}
+	return nil
 }

--- a/internal/cmd/server/start_infrastructure_inventory_subscription_server.go
+++ b/internal/cmd/server/start_infrastructure_inventory_subscription_server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -372,6 +373,9 @@ func (c *InfrastructureInventorySubscriptionServerCommand) run(cmd *cobra.Comman
 		}
 	}()
 
-	// Wait for exit signals:
-	return exitHandler.Wait(ctx)
+	// Wait for exit signals
+	if err := exitHandler.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to wait for exit signals: %w", err)
+	}
+	return nil
 }

--- a/internal/cmd/server/start_metadata_server.go
+++ b/internal/cmd/server/start_metadata_server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -311,6 +312,9 @@ func (c *MetadataServerCommand) run(cmd *cobra.Command, argv []string) error {
 		}
 	}()
 
-	// Wait for exit signals:
-	return exitHandler.Wait(ctx)
+	// Wait for exit signals
+	if err := exitHandler.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to wait for exit signals: %w", err)
+	}
+	return nil
 }

--- a/internal/cmd/server/start_resource_server.go
+++ b/internal/cmd/server/start_resource_server.go
@@ -315,8 +315,11 @@ func (c *ResourceServerCommand) run(cmd *cobra.Command, argv []string) error {
 		}
 	}()
 
-	// Wait for exit signals:
-	return exitHandler.Wait(ctx)
+	// Wait for exit signals
+	if err := exitHandler.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to wait for exit signals: %w", err)
+	}
+	return nil
 }
 
 func (c *ResourceServerCommand) createResourcePoolHandler(
@@ -477,7 +480,7 @@ func (c *ResourceServerCommand) createResourceTypeHandler(
 func (c *ResourceServerCommand) generateSearchApiUrl(backendURL string) (string, error) {
 	u, err := url.Parse(backendURL)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to parse backend URL %s: %w", backendURL, err)
 	}
 
 	// Split URL address

--- a/internal/controllers/clusterrequest_controller.go
+++ b/internal/controllers/clusterrequest_controller.go
@@ -50,7 +50,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// clusterRequestReconciler reconciles a ClusterRequest object
+// ClusterRequestReconciler reconciles a ClusterRequest object
 type ClusterRequestReconciler struct {
 	client.Client
 	Logger *slog.Logger
@@ -359,13 +359,13 @@ func (t *clusterRequestReconcilerTask) renderClusterInstanceTemplate(
 		slog.String("name", t.object.Name),
 	)
 
-	// Wrap the merged clusterinstance data in a map with key "Cluster"
+	// Wrap the merged ClusterInstance data in a map with key "Cluster"
 	// This data object will be consumed by the clusterInstance template
 	mergedClusterInstanceData := map[string]any{
 		"Cluster": t.clusterInput.clusterInstanceData,
 	}
 
-	// TODO: Consider unsharmalling into siteconfig.ClusterInstance type
+	// TODO: Consider unmarshalling into siteconfig.ClusterInstance type
 	// to catch any type issue in advance
 	renderedClusterInstance, err := utils.RenderTemplateForK8sCR(
 		"ClusterInstance", utils.ClusterInstanceTemplatePath, mergedClusterInstanceData)
@@ -410,7 +410,10 @@ func (t *clusterRequestReconcilerTask) renderClusterInstanceTemplate(
 		return nil, fmt.Errorf("failed to update status for ClusterRequest %s: %w", t.object.Name, updateErr)
 	}
 
-	return renderedClusterInstance, err
+	if err != nil {
+		return nil, fmt.Errorf("failed to render ClusterInstanceTemplate: %w", err)
+	}
+	return renderedClusterInstance, nil
 }
 
 func (t *clusterRequestReconcilerTask) handleClusterResources(ctx context.Context, clusterInstance *unstructured.Unstructured) error {
@@ -513,7 +516,7 @@ func (t *clusterRequestReconcilerTask) handleRenderHardwareTemplate(ctx context.
 			"failed to get the Hardware template from ConfigMap %s, err: %w", hwTemplateCmName, err)
 	}
 
-	// count the nodes  per group
+	// count the nodes per group
 	roleCounts := make(map[string]int)
 	specInterface, specExists := clusterInstance.Object["spec"].(map[string]any)
 	if !specExists {
@@ -603,14 +606,14 @@ func (t *clusterRequestReconcilerTask) handleClusterInstallation(ctx context.Con
 		existingClusterInstance)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			return err
+			return fmt.Errorf("failed to get ClusterInstance: %w", err)
 		}
 
 		// Create the ClusterInstance
 		err = t.client.Create(ctx, clusterInstance)
 		if err != nil {
 			if !errors.IsInvalid(err) && !errors.IsBadRequest(err) {
-				return err
+				return fmt.Errorf("failed to create ClusterInstance: %w", err)
 			}
 			// Invalid or webhook error
 			err = utils.NewInputError(err.Error())
@@ -640,7 +643,7 @@ func (t *clusterRequestReconcilerTask) handleClusterInstallation(ctx context.Con
 		patch := client.MergeFrom(existingClusterInstance.DeepCopy())
 		if err := t.client.Patch(ctx, clusterInstance, patch); err != nil {
 			if !errors.IsInvalid(err) && !errors.IsBadRequest(err) {
-				return err
+				return fmt.Errorf("failed to patch ClusterInstance: %w", err)
 			}
 			// Invalid or webhook error
 			err = utils.NewInputError(err.Error())
@@ -674,11 +677,11 @@ func (t *clusterRequestReconcilerTask) handleClusterInstallation(ctx context.Con
 			managedCluster,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to check if managed cluster exists: %w", err)
 		}
 
 		if managedClusterExists {
-			// If the ztp-done label exists, update the status to completed.
+			// If the ztp-done label exists, update the status to complete.
 			labels := managedCluster.GetLabels()
 			_, hasZtpDone := labels[ztpDoneLabel]
 			if hasZtpDone {
@@ -861,7 +864,7 @@ func (t *clusterRequestReconcilerTask) createExtraManifestsConfigMap(
 		configMapExists, err := utils.DoesK8SResourceExist(
 			ctx, t.client, extraManifestCmName, t.object.Namespace, configMap)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to check if ConfigMap exists: %w", err)
 		}
 		if !configMapExists {
 			return utils.NewInputError(
@@ -878,7 +881,7 @@ func (t *clusterRequestReconcilerTask) createExtraManifestsConfigMap(
 			Data: configMap.Data,
 		}
 		if err := utils.CreateK8sCR(ctx, t.client, newExtraManifestsConfigMap, t.object, utils.UPDATE); err != nil {
-			return err
+			return fmt.Errorf("failed to create extra-manifests ConfigMap: %w", err)
 		}
 	}
 
@@ -911,13 +914,16 @@ func (t *clusterRequestReconcilerTask) createPullSecret(
 	}
 
 	// Check the pull secret already exists in the clusterTemplate namespace.
-	// The clusterRequest namespace is same as the clusterTemplate namespace.
+	// The clusterRequest namespace is the same as the clusterTemplate namespace.
 	pullSecret := &corev1.Secret{}
 	pullSecretName := pullSecretNameInterface.(string)
 	pullSecretExistsInTemplateNamespace, err := utils.DoesK8SResourceExist(
 		ctx, t.client, pullSecretName, t.object.Namespace, pullSecret)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"failed to check if pull secret %s exists in namespace %s: %w",
+			t.object.Spec.ClusterTemplateRef, t.object.Spec.ClusterTemplateRef, err,
+		)
 	}
 	if !pullSecretExistsInTemplateNamespace {
 		return utils.NewInputError(
@@ -934,7 +940,11 @@ func (t *clusterRequestReconcilerTask) createPullSecret(
 		Type: corev1.SecretTypeDockerConfigJson,
 	}
 
-	return utils.CreateK8sCR(ctx, t.client, newClusterInstancePullSecret, nil, utils.UPDATE)
+	if err := utils.CreateK8sCR(ctx, t.client, newClusterInstancePullSecret, nil, utils.UPDATE); err != nil {
+		return fmt.Errorf("failed to create Kubernetes CR for ClusterInstancePullSecret: %w", err)
+	}
+
+	return nil
 }
 
 // createClusterInstanceNamespace creates the namespace of the ClusterInstance
@@ -957,7 +967,7 @@ func (t *clusterRequestReconcilerTask) createClusterInstanceNamespace(
 
 	err := utils.CreateK8sCR(ctx, t.client, namespace, nil, utils.UPDATE)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create or update namespace %s: %w", clusterName, err)
 	}
 
 	if namespace.Status.Phase == corev1.NamespaceTerminating {
@@ -975,7 +985,7 @@ func (t *clusterRequestReconcilerTask) createClusterInstanceBMCSecrets(
 	// The BMC credential details are for now obtained from the ClusterRequest.
 	inputData, err := t.getClusterTemplateInputFromClusterRequest(&t.object.Spec.ClusterTemplateInput.ClusterInstanceInput)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal ClusterInstanceInput raw data: %w", err)
 	}
 
 	// If we got to this point, we can assume that all the keys up to the BMC details
@@ -997,7 +1007,7 @@ func (t *clusterRequestReconcilerTask) createClusterInstanceBMCSecrets(
 		username, password, secretName, err :=
 			utils.GetBMCDetailsForClusterInstance(node, t.object.Name)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get BMC details for cluster instance %s: %w", t.object.Name, err)
 		}
 
 		// Create the node's BMC secret.
@@ -1012,9 +1022,8 @@ func (t *clusterRequestReconcilerTask) createClusterInstanceBMCSecrets(
 			},
 		}
 
-		err = utils.CreateK8sCR(ctx, t.client, bmcSecret, nil, utils.UPDATE)
-		if err != nil {
-			return err
+		if err = utils.CreateK8sCR(ctx, t.client, bmcSecret, nil, utils.UPDATE); err != nil {
+			return fmt.Errorf("failed to create Kubernetes CR: %w", err)
 		}
 	}
 
@@ -1029,7 +1038,7 @@ func (t *clusterRequestReconcilerTask) copyHwMgrPluginBMCSecret(ctx context.Cont
 	exists, err := utils.DoesK8SResourceExist(
 		ctx, t.client, name, targetNamespace, secret)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to check if secret exists in namespace %s: %w", targetNamespace, err)
 	}
 	if exists {
 		t.logger.Info(
@@ -1039,7 +1048,12 @@ func (t *clusterRequestReconcilerTask) copyHwMgrPluginBMCSecret(ctx context.Cont
 		)
 		return nil
 	}
-	return utils.CopyK8sSecret(ctx, t.client, name, sourceNamespace, targetNamespace)
+
+	if err := utils.CopyK8sSecret(ctx, t.client, name, sourceNamespace, targetNamespace); err != nil {
+		return fmt.Errorf("failed to copy Kubernetes secret: %w", err)
+	}
+
+	return nil
 }
 
 // createHwMgrPluginNamespace creates the namespace of the hardware manager plugin
@@ -1058,9 +1072,8 @@ func (t *clusterRequestReconcilerTask) createHwMgrPluginNamespace(
 			Name: name,
 		},
 	}
-	err := utils.CreateK8sCR(ctx, t.client, namespace, nil, utils.UPDATE)
-	if err != nil {
-		return err
+	if err := utils.CreateK8sCR(ctx, t.client, namespace, nil, utils.UPDATE); err != nil {
+		return fmt.Errorf("failed to create Kubernetes CR for namespace %s: %w", namespace, err)
 	}
 
 	return nil
@@ -1115,7 +1128,7 @@ func (t *clusterRequestReconcilerTask) getCrClusterTemplateRef(ctx context.Conte
 
 	// If there was an error in trying to get the ClusterTemplate, return it.
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get ClusterTemplate: %w", err)
 	}
 
 	// If the referenced ClusterTemplate does not exist, log and return an appropriate error.
@@ -1156,9 +1169,8 @@ func (t *clusterRequestReconcilerTask) createPoliciesConfigMap(
 	ctx context.Context, clusterName string, spec map[string]interface{}) error {
 
 	// Check the cluster version for the cluster-version label.
-	err := utils.CheckClusterLabelsForPolicies(spec, clusterName)
-	if err != nil {
-		return err
+	if err := utils.CheckClusterLabelsForPolicies(spec, clusterName); err != nil {
+		return fmt.Errorf("failed to check cluster labels: %w", err)
 	}
 
 	return t.createPolicyTemplateConfigMap(ctx, clusterName)
@@ -1170,7 +1182,7 @@ func (t *clusterRequestReconcilerTask) createPoliciesConfigMap(
 func (t *clusterRequestReconcilerTask) createPolicyTemplateConfigMap(
 	ctx context.Context, clusterName string) error {
 
-	// If there is no policy configuration data, log a message and return without error.
+	// If there is no policy configuration data, log a message and return without an error.
 	if len(t.clusterInput.policyTemplateData) == 0 {
 		t.logger.InfoContext(ctx, "Policy template data is empty")
 		return nil
@@ -1193,7 +1205,11 @@ func (t *clusterRequestReconcilerTask) createPolicyTemplateConfigMap(
 		Data: finalPolicyTemplateData,
 	}
 
-	return utils.CreateK8sCR(ctx, t.client, policyTemplateConfigMap, t.object, utils.UPDATE)
+	if err := utils.CreateK8sCR(ctx, t.client, policyTemplateConfigMap, t.object, utils.UPDATE); err != nil {
+		return fmt.Errorf("failed to create Kubernetes CR: %w", err)
+	}
+
+	return nil
 }
 
 func (r *ClusterRequestReconciler) finalizeClusterRequest(
@@ -1210,11 +1226,11 @@ func (r *ClusterRequestReconciler) finalizeClusterRequest(
 	// Query the NodePool created by this ClusterRequest. Delete it if exists.
 	nodePoolList := &hwv1alpha1.NodePoolList{}
 	if err := r.Client.List(ctx, nodePoolList, listOpts...); err != nil {
-		return err
+		return fmt.Errorf("failed to list node pools: %w", err)
 	}
 	for _, nodePool := range nodePoolList.Items {
 		if err := r.Client.Delete(ctx, &nodePool); client.IgnoreNotFound(err) != nil {
-			return err
+			return fmt.Errorf("failed to delete node pool: %w", err)
 		}
 	}
 
@@ -1222,11 +1238,11 @@ func (r *ClusterRequestReconciler) finalizeClusterRequest(
 	// The SiteConfig operator will also delete the namespace.
 	clusterInstanceList := &siteconfig.ClusterInstanceList{}
 	if err := r.Client.List(ctx, clusterInstanceList, listOpts...); err != nil {
-		return err
+		return fmt.Errorf("failed to list cluster instances: %w", err)
 	}
 	for _, clusterInstance := range clusterInstanceList.Items {
 		if err := r.Client.Delete(ctx, &clusterInstance); client.IgnoreNotFound(err) != nil {
-			return err
+			return fmt.Errorf("failed to delete cluster instance: %w", err)
 		}
 	}
 
@@ -1235,11 +1251,11 @@ func (r *ClusterRequestReconciler) finalizeClusterRequest(
 		// this ClusterRequest. Delete it if exists.
 		namespaceList := &corev1.NamespaceList{}
 		if err := r.Client.List(ctx, namespaceList, listOpts...); err != nil {
-			return err
+			return fmt.Errorf("failed to list namespaces: %w", err)
 		}
 		for _, ns := range namespaceList.Items {
 			if err := r.Client.Delete(ctx, &ns); client.IgnoreNotFound(err) != nil {
-				return err
+				return fmt.Errorf("failed to delete namespace: %w", err)
 			}
 		}
 	}
@@ -1257,7 +1273,10 @@ func (r *ClusterRequestReconciler) handleFinalizer(
 		if !controllerutil.ContainsFinalizer(clusterRequest, clusterRequestFinalizer) {
 			controllerutil.AddFinalizer(clusterRequest, clusterRequestFinalizer)
 			// Update and requeue since the finalizer has been added.
-			return ctrl.Result{Requeue: true}, true, r.Update(ctx, clusterRequest)
+			if err := r.Update(ctx, clusterRequest); err != nil {
+				return ctrl.Result{}, true, fmt.Errorf("failed to update ClusterRequest with finalizer: %w", err)
+			}
+			return ctrl.Result{Requeue: true}, true, nil
 		}
 		return ctrl.Result{}, false, nil
 	} else if controllerutil.ContainsFinalizer(clusterRequest, clusterRequestFinalizer) {
@@ -1272,7 +1291,8 @@ func (r *ClusterRequestReconciler) handleFinalizer(
 		r.Logger.Info("Removing ClusterRequest finalizer", "name", clusterRequest.Name)
 		patch := client.MergeFrom(clusterRequest.DeepCopy())
 		if controllerutil.RemoveFinalizer(clusterRequest, clusterRequestFinalizer) {
-			return ctrl.Result{}, true, r.Patch(ctx, clusterRequest, patch)
+			err := r.Patch(ctx, clusterRequest, patch)
+			return ctrl.Result{}, true, fmt.Errorf("failed to patch ClusterRequest: %w", err)
 		}
 	}
 	return ctrl.Result{}, false, nil
@@ -1321,7 +1341,7 @@ func (t *clusterRequestReconcilerTask) waitForNodePoolProvision(ctx context.Cont
 	return false
 }
 
-// updateClusterInstance updates the given clusterinstance object based on the provisioned nodePool.
+// updateClusterInstance updates the given ClusterInstance object based on the provisioned nodePool.
 func (t *clusterRequestReconcilerTask) updateClusterInstance(ctx context.Context,
 	clusterInstance *unstructured.Unstructured, nodePool *hwv1alpha1.NodePool) bool {
 
@@ -1440,7 +1460,6 @@ func (t *clusterRequestReconcilerTask) waitForHardwareData(ctx context.Context,
 func (t *clusterRequestReconcilerTask) updateHardwareProvisioningStatus(
 	ctx context.Context, nodePool *hwv1alpha1.NodePool) error {
 
-	var err error
 	if t.object.Status.NodePoolRef == nil {
 		t.object.Status.NodePoolRef = &oranv1alpha1.NodePoolRef{}
 	}
@@ -1489,13 +1508,14 @@ func (t *clusterRequestReconcilerTask) updateHardwareProvisioningStatus(
 			}
 		}
 
-		err = utils.UpdateK8sCRStatus(ctx, t.client, t.object)
-		if err != nil {
+		if err := utils.UpdateK8sCRStatus(ctx, t.client, t.object); err != nil {
 			t.logger.ErrorContext(
 				ctx,
 				"Failed to update the HardwareProvisioning status for ClusterRequest",
 				slog.String("name", t.object.Name),
+				slog.Any("specificError", err),
 			)
+			return fmt.Errorf("failed to update HardwareProvisioning status: %w", err)
 		}
 	} else {
 		meta.SetStatusCondition(
@@ -1506,20 +1526,21 @@ func (t *clusterRequestReconcilerTask) updateHardwareProvisioningStatus(
 				Reason: "NotInitialized",
 			},
 		)
-		err = utils.UpdateK8sCRStatus(ctx, t.client, nodePool)
-		if err != nil {
+		if err := utils.UpdateK8sCRStatus(ctx, t.client, nodePool); err != nil {
 			t.logger.ErrorContext(
 				ctx,
 				"Failed to update the NodePool status",
 				slog.String("name", nodePool.Name),
+				slog.Any("specificError", err),
 			)
+			return fmt.Errorf("failed to update NodePool status: %w", err)
 		}
 	}
-	return err
+	return nil
 }
 
 // findClusterInstanceForClusterRequest maps the ClusterInstance created by a
-// a ClusterRequest to a reconciliation request.
+// ClusterRequest to a reconciliation request.
 func (r *ClusterRequestReconciler) findClusterInstanceForClusterRequest(
 	ctx context.Context, event event.UpdateEvent,
 	queue workqueue.RateLimitingInterface) {
@@ -1545,7 +1566,7 @@ func (r *ClusterRequestReconciler) findClusterInstanceForClusterRequest(
 }
 
 // findNodePoolForClusterRequest maps the NodePool created by a
-// a ClusterRequest to a reconciliation request.
+// ClusterRequest to a reconciliation request.
 func (r *ClusterRequestReconciler) findNodePoolForClusterRequest(
 	ctx context.Context, event event.UpdateEvent,
 	queue workqueue.RateLimitingInterface) {
@@ -1577,7 +1598,7 @@ func (r *ClusterRequestReconciler) findClusterTemplateForClusterRequest(
 	ctx context.Context, event event.UpdateEvent,
 	queue workqueue.RateLimitingInterface) {
 
-	// For this case we can use either new or old object.
+	// For this case, we can use either new or old object.
 	newClusterTemplate := event.ObjectNew.(*oranv1alpha1.ClusterTemplate)
 
 	// Get all the clusterRequests.
@@ -1613,7 +1634,7 @@ func (r *ClusterRequestReconciler) findManagedClusterForClusterRequest(
 	ctx context.Context, event event.UpdateEvent,
 	queue workqueue.RateLimitingInterface) {
 
-	// For this case we can use either new or old object.
+	// For this case, we can use either new or old object.
 	newManagedCluster := event.ObjectNew.(*clusterv1.ManagedCluster)
 
 	// Get the ClusterInstance
@@ -1624,7 +1645,7 @@ func (r *ClusterRequestReconciler) findManagedClusterForClusterRequest(
 	}, clusterInstance)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// Return as this managedcluster is not deployed/managed by ClusterInstance
+			// Return as this ManagedCluster is not deployed/managed by ClusterInstance
 			return
 		}
 		r.Logger.Error("[findManagedClusterForClusterRequest] Error getting ClusterInstance. ", "Error: ", err)
@@ -1650,6 +1671,7 @@ func (r *ClusterRequestReconciler) findManagedClusterForClusterRequest(
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	//nolint:wrapcheck
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("orano2ims-cluster-request").
 		For(

--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -214,7 +214,7 @@ func validateConfigmapReference[T any](
 
 	existingConfigmap, err := utils.GetConfigmap(ctx, c, name, namespace)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get ConfigmapReference: %w", err)
 	}
 
 	// Extract and validate the template from the configmap
@@ -233,7 +233,7 @@ func validateConfigmapReference[T any](
 		newConfigmap.Immutable = &immutable
 
 		if err := utils.CreateK8sCR(ctx, c, newConfigmap, nil, utils.PATCH); err != nil {
-			return err
+			return fmt.Errorf("failed to patch ConfigMap as immutable: %w", err)
 		}
 	}
 
@@ -327,10 +327,11 @@ func (r *ClusterTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	//nolint:wrapcheck
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("orano2ims-cluster-template").
 		For(&oranv1alpha1.ClusterTemplate{},
-			// Watch for create and update event for ClusterTemplate.
+			// Watch for create and update events for ClusterTemplate.
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					oldGeneration := e.ObjectOld.GetGeneration()

--- a/internal/controllers/clustertemplate_controller_test.go
+++ b/internal/controllers/clustertemplate_controller_test.go
@@ -398,7 +398,7 @@ key: value`,
 		Expect(err).To(HaveOccurred())
 		Expect(utils.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(Equal(fmt.Sprintf(
-			"the ConfigMap %s is not found in the namespace %s", configmapName, namespace)))
+			"failed to get ConfigmapReference: the ConfigMap %s is not found in the namespace %s", configmapName, namespace)))
 	})
 
 	It("should return validation error message for missing expected key in configmap", func() {

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -9,34 +9,36 @@ import (
 	"strings"
 	"text/template"
 
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	sprig "github.com/go-task/slim-sprig/v3"
+	"github.com/xeipuuv/gojsonschema"
+
 	oranv1alpha1 "github.com/openshift-kni/oran-o2ims/api/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/files"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
-
-	gojsonschema "github.com/xeipuuv/gojsonschema"
 )
 
 var oranUtilsLog = ctrl.Log.WithName("oranUtilsLog")
 
 func UpdateK8sCRStatus(ctx context.Context, c client.Client, object client.Object) error {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		err := c.Status().Update(ctx, object)
-		return err
+		if err := c.Status().Update(ctx, object); err != nil {
+			return fmt.Errorf("failed to update status: %w", err)
+		}
+		return nil
 	})
 
 	if err != nil {
-		return err
+		return fmt.Errorf("status update failed after retries: %w", err)
 	}
 
 	return nil
@@ -49,7 +51,7 @@ func ValidateJsonAgainstJsonSchema(schema, input string) error {
 	result, err := gojsonschema.Validate(schemaLoader, inputLoader)
 	if err != nil {
 		oranUtilsLog.Error(err, "Error validating the input against the schema")
-		return err
+		return fmt.Errorf("failed when validating the input against the schema: %w", err)
 	}
 
 	if result.Valid() {
@@ -129,12 +131,12 @@ func CreateK8sCR(ctx context.Context, c client.Client,
 
 	// We can set the owner reference only for objects that live in the same namespace, as cross
 	// namespace owners are forbidden. This also applies to non-namespaced objects like cluster
-	// roles or cluster role bindings; those have empty namespaces so the equals comparison
+	// roles or cluster role bindings; those have empty namespaces, so the equals comparison
 	// should also work.
 	if ownerObject != nil && ownerObject.GetNamespace() == key.Namespace {
 		err = controllerutil.SetControllerReference(ownerObject, newObject, c.Scheme())
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to set controller reference: %w", err)
 		}
 	}
 
@@ -152,7 +154,7 @@ func CreateK8sCR(ctx context.Context, c client.Client,
 	err = c.Get(ctx, key, oldObject)
 
 	// If there was an error obtaining the CR and the error was "Not found", create the object.
-	// If any other other occurred, return the error.
+	// If any other occurred, return the error.
 	// If the CR already exists, patch it or update it.
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -162,10 +164,10 @@ func CreateK8sCR(ctx context.Context, c client.Client,
 				"namespace", newObject.GetNamespace())
 			err = c.Create(ctx, newObject)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create CR %s/%s: %w", newObject.GetNamespace(), newObject.GetName(), err)
 			}
 		} else {
-			return err
+			return fmt.Errorf("failed to get CR %s/%s: %w", newObject.GetNamespace(), newObject.GetName(), err)
 		}
 	} else {
 		newObject.SetResourceVersion(oldObject.GetResourceVersion())
@@ -173,12 +175,18 @@ func CreateK8sCR(ctx context.Context, c client.Client,
 			oranUtilsLog.Info("[CreateK8sCR] CR already present, PATCH it",
 				"name", newObject.GetName(),
 				"namespace", newObject.GetNamespace())
-			return c.Patch(ctx, newObject, client.MergeFrom(oldObject))
+			if err := c.Patch(ctx, newObject, client.MergeFrom(oldObject)); err != nil {
+				return fmt.Errorf("failed to patch object %s/%s: %w", newObject.GetNamespace(), newObject.GetName(), err)
+			}
+			return nil
 		} else if operation == UPDATE {
 			oranUtilsLog.Info("[CreateK8sCR] CR already present, UPDATE it",
 				"name", newObject.GetName(),
 				"namespace", newObject.GetNamespace())
-			return c.Update(ctx, newObject)
+			if err := c.Update(ctx, newObject); err != nil {
+				return fmt.Errorf("failed to update object %s/%s: %w", newObject.GetNamespace(), newObject.GetName(), err)
+			}
+			return nil
 		}
 	}
 
@@ -194,7 +202,7 @@ func DoesK8SResourceExist(ctx context.Context, c client.Client, name, namespace 
 				"name", name, "namespace", namespace)
 			return false, nil
 		} else {
-			return false, err
+			return false, fmt.Errorf("failed to check existence of resource '%s' in namespace '%s': %w", name, namespace, err)
 		}
 	} else {
 		oranUtilsLog.Info("[doesK8SResourceExist] Resource already present, return. ",
@@ -471,10 +479,10 @@ func RenderTemplateForK8sCR(templateName, templatePath string, templateDataObj m
 
 // toYaml converts an interface to a YAML string and trims the trailing newline
 func toYaml(v interface{}) (string, error) {
-	// yaml.Marshal adds a trailling newline to its output
+	// yaml.Marshal adds a trailing newline to its output
 	yamlData, err := yaml.Marshal(v)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to marshal interface to YAML: %w", err)
 	}
 
 	return strings.TrimRight(string(yamlData), "\n"), nil

--- a/internal/jq/query.go
+++ b/internal/jq/query.go
@@ -214,7 +214,12 @@ func (q *Query) convert(input, output any) error {
 func (q *Query) clone(input, output any) error {
 	data, err := jsoniter.Marshal(input)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to marshal JSON input: %w", err)
 	}
-	return jsoniter.Unmarshal(data, output)
+
+	if err = jsoniter.Unmarshal(data, output); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON data into output: %w", err)
+	}
+
+	return nil
 }

--- a/internal/jq/tool.go
+++ b/internal/jq/tool.go
@@ -167,9 +167,8 @@ func (t *Tool) Evaluate(source string, input, output any, variables ...Variable)
 // a JSON document.
 func (t *Tool) EvaluateString(source, input string, output any, variables ...Variable) error {
 	var tmp any
-	err := jsoniter.Unmarshal([]byte(input), &tmp)
-	if err != nil {
-		return err
+	if err := jsoniter.Unmarshal([]byte(input), &tmp); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON input: %w", err)
 	}
 	return t.Evaluate(source, tmp, output, variables...)
 }
@@ -178,9 +177,8 @@ func (t *Tool) EvaluateString(source, input string, output any, variables ...Var
 // containing a JSON document.
 func (t *Tool) EvaluateBytes(source string, input []byte, output any, variables ...Variable) error {
 	var tmp any
-	err := jsoniter.Unmarshal(input, &tmp)
-	if err != nil {
-		return err
+	if err := jsoniter.Unmarshal(input, &tmp); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON input: %w", err)
 	}
 	return t.Evaluate(source, tmp, output, variables...)
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -240,34 +240,55 @@ var _ clnt.Client = (*Client)(nil)
 
 func (c *Client) Get(ctx context.Context, key types.NamespacedName, obj clnt.Object,
 	opts ...clnt.GetOption) error {
-	return c.delegate.Get(ctx, key, obj, opts...)
+	if err := c.delegate.Get(ctx, key, obj, opts...); err != nil {
+		return fmt.Errorf("failed Get operation: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) List(ctx context.Context, list clnt.ObjectList,
 	opts ...clnt.ListOption) error {
-	return c.delegate.List(ctx, list, opts...)
+	if err := c.delegate.List(ctx, list, opts...); err != nil {
+		return fmt.Errorf("failed List operation: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) Create(ctx context.Context, obj clnt.Object, opts ...clnt.CreateOption) error {
-	return c.delegate.Create(ctx, obj, opts...)
+	if err := c.delegate.Create(ctx, obj, opts...); err != nil {
+		return fmt.Errorf("failed Create operation: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) Delete(ctx context.Context, obj clnt.Object, opts ...clnt.DeleteOption) error {
-	return c.delegate.Delete(ctx, obj, opts...)
+	if err := c.delegate.Delete(ctx, obj, opts...); err != nil {
+		return fmt.Errorf("failed Delete operation: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) DeleteAllOf(ctx context.Context, obj clnt.Object,
 	opts ...clnt.DeleteAllOfOption) error {
-	return c.delegate.DeleteAllOf(ctx, obj, opts...)
+	if err := c.delegate.DeleteAllOf(ctx, obj, opts...); err != nil {
+		return fmt.Errorf("failed DeleteAllOf operation: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) Patch(ctx context.Context, obj clnt.Object, patch clnt.Patch,
 	opts ...clnt.PatchOption) error {
-	return c.delegate.Patch(ctx, obj, patch, opts...)
+	if err := c.delegate.Patch(ctx, obj, patch, opts...); err != nil {
+		return fmt.Errorf("failed Patch operation: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) Update(ctx context.Context, obj clnt.Object, opts ...clnt.UpdateOption) error {
-	return c.delegate.Update(ctx, obj, opts...)
+	if err := c.delegate.Update(ctx, obj, opts...); err != nil {
+		return fmt.Errorf("failed Update operation: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) Status() clnt.SubResourceWriter {
@@ -287,20 +308,31 @@ func (c *Client) Scheme() *runtime.Scheme {
 }
 
 func (c *Client) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
-	return c.delegate.GroupVersionKindFor(obj)
+	gvk, err := c.delegate.GroupVersionKindFor(obj)
+	if err != nil {
+		return schema.GroupVersionKind{}, fmt.Errorf("failed to get GroupVersionKind for object: %w", err)
+	}
+	return gvk, nil
 }
 
 func (c *Client) IsObjectNamespaced(obj runtime.Object) (bool, error) {
-	return c.delegate.IsObjectNamespaced(obj)
+	isNamespaced, err := c.delegate.IsObjectNamespaced(obj)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if object is namespaced: %w", err)
+	}
+	return isNamespaced, nil
 }
 
-// watch
 func (c *Client) Watch(ctx context.Context, obj clnt.ObjectList, opts ...clnt.ListOption) (watch.Interface, error) {
-	return c.delegate.Watch(ctx, obj, opts...)
+	watcher, err := c.delegate.Watch(ctx, obj, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to watch object list: %w", err)
+	}
+	return watcher, nil
 }
 
 // Close closes the client and releases all the resources it is using. It is specially important to
-// call this method when the client is using as SSH tunnel, as otherwise the tunnel will remain
+// call this method when the client is using an SSH tunnel, as otherwise the tunnel will remain
 // open.
 func (c *Client) Close() error {
 	return nil

--- a/internal/logging/transport_wrapper.go
+++ b/internal/logging/transport_wrapper.go
@@ -310,7 +310,10 @@ func (r *requestReader) Read(p []byte) (n int, err error) {
 }
 
 func (r *requestReader) Close() error {
-	return r.reader.Close()
+	if err := r.reader.Close(); err != nil {
+		return fmt.Errorf("failed to close reader: %w", err)
+	}
+	return nil
 }
 
 func (r *responseReader) Read(p []byte) (n int, err error) {
@@ -328,5 +331,8 @@ func (r *responseReader) Read(p []byte) (n int, err error) {
 }
 
 func (r *responseReader) Close() error {
-	return r.reader.Close()
+	if err := r.reader.Close(); err != nil {
+		return fmt.Errorf("failed to close reader: %w", err)
+	}
+	return nil
 }

--- a/internal/persiststorage/persiststorage.go
+++ b/internal/persiststorage/persiststorage.go
@@ -3,6 +3,7 @@ package persiststorage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
@@ -10,10 +11,10 @@ import (
 
 var ErrNotFound = errors.New("not found")
 
-// process change function
+// ProcessFunc process change function
 type ProcessFunc func(dataMap *map[string]data.Object)
 
-// interface for persistent storage
+// Storage interface for persistent storage
 type Storage interface {
 	// notification from db to application about db entry changes
 	// currently assume the notification is granular to indivial entry
@@ -26,21 +27,45 @@ type Storage interface {
 }
 
 func Add(so Storage, ctx context.Context, key, value string) (err error) {
-	return so.AddEntry(ctx, key, value)
+	if err := so.AddEntry(ctx, key, value); err != nil {
+		return fmt.Errorf("failed to add entry: %w", err)
+	}
+	return nil
 }
+
 func Get(so Storage, ctx context.Context, key string) (value string, err error) {
-	return so.ReadEntry(ctx, key)
+	value, err = so.ReadEntry(ctx, key)
+	if err != nil {
+		return "", fmt.Errorf("failed to read entry: %w", err)
+	}
+	return value, nil
 }
+
 func GetAll(so Storage, ctx context.Context) (result map[string]data.Object, err error) {
-	return so.ReadAllEntries(ctx)
+	entries, err := so.ReadAllEntries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read all entries: %w", err)
+	}
+	return entries, nil
 }
+
 func Delete(so Storage, ctx context.Context, key string) (err error) {
-	return so.DeleteEntry(ctx, key)
+	if err := so.DeleteEntry(ctx, key); err != nil {
+		return fmt.Errorf("failed to delete entry: %w", err)
+	}
+	return nil
 }
+
 func ProcessChanges(so Storage, ctx context.Context, dataMap **map[string]data.Object, lock *sync.Mutex) (err error) {
-	return so.ProcessChanges(ctx, dataMap, lock)
+	if err := so.ProcessChanges(ctx, dataMap, lock); err != nil {
+		return fmt.Errorf("failed to process changes: %w", err)
+	}
+	return nil
 }
 
 func ProcessChangesWithFunction(so Storage, ctx context.Context, function ProcessFunc) (err error) {
-	return so.ProcessChangesWithFunction(ctx, function)
+	if err := so.ProcessChangesWithFunction(ctx, function); err != nil {
+		return fmt.Errorf("failed to process changes with function: %w", err)
+	}
+	return nil
 }

--- a/internal/service/alarm_definition_handler.go
+++ b/internal/service/alarm_definition_handler.go
@@ -111,7 +111,7 @@ func (h *AlarmDefinitionHandler) Get(ctx context.Context,
 func (h *AlarmDefinitionHandler) fetchItems() (result data.Stream, err error) {
 	jsonFile, err := files.Alarms.ReadFile(alarmsDefinitionsPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read JSON file at path %s: %w", alarmsDefinitionsPath, err)
 	}
 	reader := bytes.NewReader(jsonFile)
 
@@ -119,6 +119,9 @@ func (h *AlarmDefinitionHandler) fetchItems() (result data.Stream, err error) {
 		SetLogger(h.logger).
 		SetReader(reader).
 		Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build stream from reader: %w", err)
+	}
 
 	// Transform to AlarmDefinitions objects
 	result = data.Map(definitions, h.mapItem)

--- a/internal/service/alarm_probable_cause_handler.go
+++ b/internal/service/alarm_probable_cause_handler.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
@@ -105,7 +106,7 @@ func (h *AlarmProbableCauseHandler) Get(ctx context.Context,
 func (h *AlarmProbableCauseHandler) fetchItems() (result data.Stream, err error) {
 	jsonFile, err := files.Alarms.ReadFile(alarmsProbableCausesPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read file at path %s: %w", alarmsProbableCausesPath, err)
 	}
 	reader := bytes.NewReader(jsonFile)
 
@@ -113,6 +114,9 @@ func (h *AlarmProbableCauseHandler) fetchItems() (result data.Stream, err error)
 		SetLogger(h.logger).
 		SetReader(reader).
 		Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build stream from reader: %w", err)
+	}
 
 	// Transform AlarmProbableCauses
 	result = data.Map(definitions, h.mapItem)

--- a/internal/tool.go
+++ b/internal/tool.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"runtime"
@@ -149,12 +150,12 @@ func (b *ToolBuilder) Build() (result *Tool, err error) {
 	return
 }
 
-// Run rus the tool.
+// Run runs the tool.
 func (t *Tool) Run(ctx context.Context) error {
 	// Create the main command:
 	err := t.createCommand()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create default logger: %w", err)
 	}
 
 	// Create a default logger that we can use while we haven't yet parsed the command line
@@ -183,7 +184,7 @@ func (t *Tool) Run(ctx context.Context) error {
 			"error", err,
 		)
 	}
-	return err
+	return fmt.Errorf("failed to run command: %w", err)
 }
 
 func (t *Tool) run(cmd *cobra.Command, args []string) error {
@@ -225,7 +226,11 @@ func (t *Tool) createCommand() error {
 
 	// Add sub-commands:
 	for _, sub := range t.sub {
-		t.cmd.AddCommand(sub())
+		cmd := sub()
+		if cmd == nil {
+			return fmt.Errorf("failed to create sub-command")
+		}
+		t.cmd.AddCommand(cmd)
 	}
 
 	return nil


### PR DESCRIPTION
Enables wrapcheck in `.golangci.yml` and fixes issues highlighted by the linter.

/cc @donpenney @alegacy 