### PR TITLE
NO-ISSUE: Add diffutils package to buildroot image

### DIFF
--- a/Containerfile.tools
+++ b/Containerfile.tools
@@ -30,7 +30,9 @@ RUN \
   rm tarball
 
 # Install git - required by the ci-operator.
-RUN dnf install git -y
+RUN dnf install -y \
+    git \
+    diffutils
 
 # Update GOPATH, GOCACHE, GOLANGCI_LINT_CACHE, PATH.
 ENV \


### PR DESCRIPTION
Certain golangci-lint linters require the diff util, which is not installed by default in the ubi-minimal image, which is used for the buildroot image in the CI. This must be a standalone commit as the CI gets the Containerfile.tools file from the branch HEAD, rather than the PR being tested.