### PR TITLE
CNF-13958: Enable TLS verification for in-cluster deployments

### DIFF
--- a/internal/authentication/handler_wrapper_test.go
+++ b/internal/authentication/handler_wrapper_test.go
@@ -716,10 +716,6 @@ var _ = Describe("Handler wapper", func() {
 	It("Doesn't load insecure keys by default", func() {
 		var err error
 
-		// TODO(alegacy): Remove this override once it is fixed for production
-		err = os.Setenv(utils.TLSSkipVerifyEnvName, "false")
-		Expect(err).ToNot(HaveOccurred())
-
 		// Prepare the server:
 		server, ca := MakeTCPTLSServer()
 		defer func() {

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -77,7 +77,9 @@ var (
 // Default values for backend URL and token:
 const (
 	defaultBackendURL       = "https://kubernetes.default.svc"
-	defaultBackendTokenFile = "/run/secrets/kubernetes.io/serviceaccount/token" // nolint: gosec // hardcoded path only
+	defaultBackendTokenFile = "/run/secrets/kubernetes.io/serviceaccount/token"          // nolint: gosec // hardcoded path only
+	defaultBackendCABundle  = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"         // nolint: gosec // hardcoded path only
+	defaultServiceCAFile    = "/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" // nolint: gosec // hardcoded path only
 )
 
 // ClusterInstance template constants
@@ -128,5 +130,5 @@ const (
 // Environment variable names
 const (
 	TLSSkipVerifyEnvName      = "INSECURE_SKIP_VERIFY"
-	TLSSkipVerifyDefaultValue = true // TODO(alegacy): need to set to false for production
+	TLSSkipVerifyDefaultValue = false
 )

--- a/internal/service/alarm_fetcher.go
+++ b/internal/service/alarm_fetcher.go
@@ -16,7 +16,6 @@ package service
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -24,8 +23,6 @@ import (
 	neturl "net/url"
 
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"k8s.io/apimachinery/pkg/util/net"
-
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/jq"
 	"github.com/openshift-kni/oran-o2ims/internal/k8s"
@@ -154,11 +151,11 @@ func (b *AlarmFetcherBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: utils.GetTLSSkipVerify(), // nolint: gosec  // defaulted to false; logged if disabled
-		},
-	})
+	backendTransport, err := utils.GetDefaultBackendTransport()
+	if err != nil {
+		err = fmt.Errorf("failed to create default HTTP backend transport: %w", err)
+		return
+	}
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/alarm_handler.go
+++ b/internal/service/alarm_handler.go
@@ -16,7 +16,6 @@ package service
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -24,8 +23,6 @@ import (
 	"slices"
 
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"k8s.io/apimachinery/pkg/util/net"
-
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/search"
 )
@@ -150,11 +147,11 @@ func (b *AlarmHandlerBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: utils.GetTLSSkipVerify(), // nolint: gosec  // defaulted to false; logged if disabled
-		},
-	})
+	backendTransport, err := utils.GetDefaultBackendTransport()
+	if err != nil {
+		err = fmt.Errorf("failed to create default HTTP backend transport: %w", err)
+		return
+	}
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/deployment_manager_handler.go
+++ b/internal/service/deployment_manager_handler.go
@@ -16,7 +16,6 @@ package service
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,11 +25,9 @@ import (
 	"slices"
 	"sync"
 
-	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"k8s.io/apimachinery/pkg/util/net"
-
 	"github.com/imdario/mergo"
 	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -177,11 +174,11 @@ func (b *DeploymentManagerHandlerBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: utils.GetTLSSkipVerify(), // nolint: gosec  // defaulted to false; logged if disabled
-		},
-	})
+	backendTransport, err := utils.GetDefaultBackendTransport()
+	if err != nil {
+		err = fmt.Errorf("failed to create default HTTP backend transport: %w", err)
+		return
+	}
 	if b.loggingWrapper != nil {
 		backendTransport = b.loggingWrapper(backendTransport)
 	}

--- a/internal/service/resource_fetcher.go
+++ b/internal/service/resource_fetcher.go
@@ -17,7 +17,6 @@ package service
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,8 +25,6 @@ import (
 	"net/http"
 
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"k8s.io/apimachinery/pkg/util/net"
-
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/k8s"
 	"github.com/openshift-kni/oran-o2ims/internal/model"
@@ -137,11 +134,11 @@ func (b *ResourceFetcherBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: utils.GetTLSSkipVerify(), // nolint: gosec  // defaulted to false; logged if disabled
-		},
-	})
+	backendTransport, err := utils.GetDefaultBackendTransport()
+	if err != nil {
+		err = fmt.Errorf("failed to create default HTTP backend transport: %w", err)
+		return
+	}
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/resource_handler.go
+++ b/internal/service/resource_handler.go
@@ -16,16 +16,14 @@ package service
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"slices"
 
-	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"k8s.io/apimachinery/pkg/util/net"
-
 	"github.com/itchyny/gojq"
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/graphql"
@@ -149,11 +147,11 @@ func (b *ResourceHandlerBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: utils.GetTLSSkipVerify(), // nolint: gosec  // defaulted to false; logged if disabled
-		},
-	})
+	backendTransport, err := utils.GetDefaultBackendTransport()
+	if err != nil {
+		err = fmt.Errorf("failed to create default HTTP backend transport: %w", err)
+		return
+	}
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/resource_pool_fetcher.go
+++ b/internal/service/resource_pool_fetcher.go
@@ -17,7 +17,6 @@ package service
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,8 +26,6 @@ import (
 	"strings"
 
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"k8s.io/apimachinery/pkg/util/net"
-
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/graphql"
 	"github.com/openshift-kni/oran-o2ims/internal/jq"
@@ -148,11 +145,11 @@ func (b *ResourcePoolFetcherBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: utils.GetTLSSkipVerify(), // nolint: gosec  // defaulted to false; logged if disabled
-		},
-	})
+	backendTransport, err := utils.GetDefaultBackendTransport()
+	if err != nil {
+		err = fmt.Errorf("failed to create default HTTP backend transport: %w", err)
+		return
+	}
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/resource_pool_handler.go
+++ b/internal/service/resource_pool_handler.go
@@ -16,15 +16,13 @@ package service
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"slices"
 
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"k8s.io/apimachinery/pkg/util/net"
-
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/graphql"
 	"github.com/openshift-kni/oran-o2ims/internal/model"
@@ -145,11 +143,11 @@ func (b *ResourcePoolHandlerBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: utils.GetTLSSkipVerify(), // nolint: gosec  // defaulted to false; logged if disabled
-		},
-	})
+	backendTransport, err := utils.GetDefaultBackendTransport()
+	if err != nil {
+		err = fmt.Errorf("failed to create default HTTP backend transport: %w", err)
+		return
+	}
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/resource_type_handler.go
+++ b/internal/service/resource_type_handler.go
@@ -16,14 +16,12 @@ package service
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"k8s.io/apimachinery/pkg/util/net"
-
 	"github.com/openshift-kni/oran-o2ims/internal/data"
 	"github.com/openshift-kni/oran-o2ims/internal/files"
 	"github.com/openshift-kni/oran-o2ims/internal/model"
@@ -146,11 +144,11 @@ func (b *ResourceTypeHandlerBuilder) Build() (
 	}
 
 	// Create the HTTP client that we will use to connect to the backend:
-	var backendTransport http.RoundTripper = net.SetTransportDefaults(&http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: utils.GetTLSSkipVerify(), // nolint: gosec  // defaulted to false; logged if disabled
-		},
-	})
+	backendTransport, err := utils.GetDefaultBackendTransport()
+	if err != nil {
+		err = fmt.Errorf("failed to create default HTTP backend transport: %w", err)
+		return
+	}
 	if b.transportWrapper != nil {
 		backendTransport = b.transportWrapper(backendTransport)
 	}

--- a/internal/service/suite_test.go
+++ b/internal/service/suite_test.go
@@ -16,10 +16,12 @@ package service
 
 import (
 	"log/slog"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
 func TestService(t *testing.T) {
@@ -37,4 +39,9 @@ var _ = BeforeSuite(func() {
 	}
 	handler := slog.NewJSONHandler(GinkgoWriter, options)
 	logger = slog.New(handler)
+
+	// Disable TLS verification, none of these tests use a TLS server anyway so there is no point in running (and
+	// failing) the code that attempts to setup the TLS client.
+	err := os.Setenv(utils.TLSSkipVerifyEnvName, "true")
+	Expect(err).NotTo(HaveOccurred())
 })


### PR DESCRIPTION
This configures the TLS clients using the service account root CA bundles so that we can properly verify the identity of backend servers.