### PR TITLE
Add NodePool Provisioning Status Condition Constants

### DIFF
--- a/api/hardwaremanagement/v1alpha1/conditions.go
+++ b/api/hardwaremanagement/v1alpha1/conditions.go
@@ -23,3 +23,22 @@ const (
 	// fulfilled.
 	FailedCondition = "Failed"
 )
+
+type ConditionType string
+
+// The following constants define the different types of conditions that will be set
+const (
+	Provisioned ConditionType = "Provisioned"
+	Unknown     ConditionType = "Unknown" // indicates the condition has not been evaluated
+)
+
+type ConditionReason string
+
+// The following constants define the different reasons that conditions will be set for
+const (
+	InProgress     ConditionReason = "InProgress"
+	Completed      ConditionReason = "Completed"
+	Unprovisioned  ConditionReason = "Unprovisioned"
+	Failed         ConditionReason = "Failed"
+	NotInitialized ConditionReason = "NotInitialized"
+)

--- a/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -55,8 +55,8 @@ type NodePoolStatus struct {
 	Properties Properties `json:"properties,omitempty"`
 
 	// Conditions represent the observations of the current state of the NodePool. Possible
-	// values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
-	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	// values of the condition type are `Provisioned` and `Unknown`.
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
 // NodePool is the schema for an allocation request of nodes

--- a/config/crd/bases/hardwaremanagement.oran.openshift.io_nodepools.yaml
+++ b/config/crd/bases/hardwaremanagement.oran.openshift.io_nodepools.yaml
@@ -79,7 +79,7 @@ spec:
               conditions:
                 description: |-
                   Conditions represent the observations of the current state of the NodePool. Possible
-                  values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
+                  values of the condition type are `Provisioned` and `Unknown`.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/conditions.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/conditions.go
@@ -23,3 +23,22 @@ const (
 	// fulfilled.
 	FailedCondition = "Failed"
 )
+
+type ConditionType string
+
+// The following constants define the different types of conditions that will be set
+const (
+	Provisioned ConditionType = "Provisioned"
+	Unknown     ConditionType = "Unknown" // indicates the condition has not been evaluated
+)
+
+type ConditionReason string
+
+// The following constants define the different reasons that conditions will be set for
+const (
+	InProgress     ConditionReason = "InProgress"
+	Completed      ConditionReason = "Completed"
+	Unprovisioned  ConditionReason = "Unprovisioned"
+	Failed         ConditionReason = "Failed"
+	NotInitialized ConditionReason = "NotInitialized"
+)

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -55,8 +55,8 @@ type NodePoolStatus struct {
 	Properties Properties `json:"properties,omitempty"`
 
 	// Conditions represent the observations of the current state of the NodePool. Possible
-	// values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
-	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	// values of the condition type are `Provisioned` and `Unknown`.
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
 // NodePool is the schema for an allocation request of nodes


### PR DESCRIPTION
Use a single condition type for tracking the NodePool provisioning status, with various condition reasons to represent different states in the provisioning process. This simplifies the condition handling by focusing on one type with multiple reasons for clarity and consistency.