### PR TITLE
NO-ISSUE: Copy Containerfile.tools to Dockerfile.tools for CI changes

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+FROM registry.access.redhat.com/ubi9/ubi:9.2 AS builder
+
+# Install packages.
+RUN \
+  dnf install -y \
+  make \
+  && \
+  dnf clean all
+
+# Currently RHEL 9 doesn't provide a Go 1.21 compiler, so we need to install it from the Go
+# downloads site.
+RUN \
+  curl -Lo tarball https://go.dev/dl/go1.21.3.linux-amd64.tar.gz && \
+  echo 1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8 tarball | sha256sum -c && \
+  tar -C /usr/local -xf tarball && \
+  rm tarball
+
+# Install git - required by the ci-operator.
+RUN dnf install -y \
+    git \
+    diffutils
+
+# Update GOPATH, GOCACHE, GOLANGCI_LINT_CACHE, PATH.
+ENV \
+  GOPATH=/go
+ENV \
+  GOCACHE=/tmp/
+ENV \
+  GOLANGCI_LINT_CACHE=/tmp/.cache
+ENV \
+  PATH="${PATH}:/usr/local/go/bin:${GOPATH}/bin"
+


### PR DESCRIPTION
This update is to support the change to reduce to one image build in: https://github.com/openshift/release/pull/54191