### PR TITLE
NO-ISSUE: Add git tree check to ci-job and fix operator-sdk Makefile usage

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=oran-o2ims
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.23.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.36.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -149,7 +149,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.23.0
+    operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     provider: Red Hat
     repository: https://github.com/openshift-kni/oran-o2ims

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: oran-o2ims
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.23.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.36.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/hack/check-git-tree.sh
+++ b/hack/check-git-tree.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+RC=0
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Unstaged or untracked changes exist:"
+    git status --porcelain
+    git diff
+    RC=1
+else
+    echo "git tree is clean"
+fi
+
+exit ${RC}

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node.go
@@ -26,7 +26,7 @@ type NodeSpec struct {
 }
 
 type BMC struct {
-	// Address contains the URL for accessing the BMC over the network.
+	// The Address contains the URL for accessing the BMC over the network.
 	Address string `json:"address,omitempty"`
 
 	// CredentialsName is a reference to a secret containing the credentials. That secret
@@ -34,7 +34,7 @@ type BMC struct {
 	CredentialsName string `json:"credentialsName,omitempty"`
 }
 
-// NodePoolStatus describes the observed state of a request to allocate and prepare
+// NodeStatus describes the observed state of a request to allocate and prepare
 // a node that will eventually be part of a deployment manager.
 type NodeStatus struct {
 	BMC *BMC `json:"bmc,omitempty"`
@@ -43,13 +43,13 @@ type NodeStatus struct {
 
 	Hostname string `json:"hostname,omitempty"`
 
-	// Conditions represent the observations of the current state of the NodePool. Possible
-	// values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
+	// Conditions represent the observations of the NodeStatus's current state.
+	// Possible values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // Node is the schema for an allocated node
-
+//
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 type Node struct {

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -51,11 +51,11 @@ type Properties struct {
 // NodePoolStatus describes the observed state of a request to allocate and prepare
 // a node that will eventually be part of a deployment manager.
 type NodePoolStatus struct {
-	// Properties represents the node properties in the pool
+	// Properties represent the node properties in the pool
 	Properties Properties `json:"properties,omitempty"`
 
-	// Conditions represent the observations of the current state of the NodePool. Possible
-	// values of the condition type are `Provisioned` and `Unknown`.
+	// Conditions represent the observations of the NodePool's current state.
+	// Possible values of the condition type are `Provisioned` and `Unknown`.
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 


### PR DESCRIPTION
This update includes the following changes:
- Added a git tree check to the ci-job to ensure all changes are included in a PR.
- Update vendor folder with missing changes from earlier PR
- Update Makefile operator-sdk rules to use the downloaded executable, rather than the executable in the user's PATH