### PR TITLE
CNF-13592: bundle: Add annotations to configure the initial upgrade path

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -148,6 +148,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    olm.skipRange: '>=4.16.0 <4.16.999'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.23.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -585,4 +586,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
+  replaces: oran-o2ims.v0.0.0
   version: 4.16.0

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -17,13 +17,14 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    olm.skipRange: '>=4.16.0 <4.16.999'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     provider: Red Hat
     repository: https://github.com/openshift-kni/oran-o2ims
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
-  name: oran-o2ims.v0.0.0
+  name: oran-o2ims.v4.16.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -82,4 +83,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
+  replaces: oran-o2ims.v0.0.0
   version: 0.0.1


### PR DESCRIPTION
Adds annotations to configure the initial upgrade path for the operator.

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>