### PR TITLE
CNF-14303: Update deployment configuration

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -521,7 +521,7 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
-                    memory: 128Mi
+                    memory: 256Mi
                   requests:
                     cpu: 10m
                     memory: 64Mi

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: oran-o2ims-system
+namespace: oran-o2ims
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 10m
             memory: 64Mi


### PR DESCRIPTION
Rename the namespace from oran-o2ims-system to oran-o2ims and increase memory limit to 256Mi