### PR TITLE
Add placeholders for values that come from NodePool

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -374,9 +374,6 @@ metadata:
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "macAddress"
-                                ],
                                 "type": "object"
                               },
                               "minItems": 1,

--- a/config/samples/v1alpha1_clustertemplate.yaml
+++ b/config/samples/v1alpha1_clustertemplate.yaml
@@ -186,8 +186,6 @@ spec:
                           description: 'nic name used in the yaml, which relates
                             1:1 to the mac address. Name in REST API: logicalNICName'
                           type: string
-                      required:
-                      - macAddress
                       type: object
                     minItems: 1
                     type: array

--- a/internal/controllers/clusterrequest_controller_test.go
+++ b/internal/controllers/clusterrequest_controller_test.go
@@ -186,7 +186,7 @@ const (
 					  "items": {
 						"properties": {
 						  "macAddress": {
-							"description": "mac address present on the host.",
+							"description": "(workaround)mac address present on the host.",
 							"pattern": "^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$",
 							"type": "string"
 						  },
@@ -195,9 +195,6 @@ const (
 							"type": "string"
 						  }
 						},
-						"required": [
-						  "macAddress"
-						],
 						"type": "object"
 					  },
 					  "minItems": 1,

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -543,8 +543,6 @@ properties:
                     type: string
                   name:
                     type: string
-                required:
-                - macAddress
                 type: object
               minItems: 1
               type: array
@@ -660,8 +658,6 @@ properties:
                     type: string
                   name:
                     type: string
-                required:
-                - macAddress
                 type: object
               minItems: 1
               type: array

--- a/internal/files/controllers/clusterinstance-template.yaml
+++ b/internal/files/controllers/clusterinstance-template.yaml
@@ -104,6 +104,11 @@ spec:
 {{ .Cluster.suppressedManifests | toYaml | indent 4 }}
 {{- end }}
   nodes:
+  # The fields bmcAddress, bmcCredentialsName, bootMACAddress, and nodeNetwork.interfaces[*].macAddress
+  # are expected to be populated from the NodePool. However, we run the ClusterInstance dry-run validation
+  # before HW provisioning to catch any input errors early. Since these fields are required, we must provide
+  # placeholder values to pass the dry-run validation. These placeholders will be replaced with the actual
+  # data returned from the HW plugin before the ClusterInstance is created.
   {{- $_ := .Cluster.nodes | validateNonEmpty "spec.nodes" }}
   {{- $_ := .Cluster.nodes | validateArrayType "spec.nodes"}}
   {{- range $n_index, $n_ref := .Cluster.nodes }}
@@ -114,10 +119,11 @@ spec:
     {{- if .bmcCredentialsName.name }}
       {{- $bmcCredname = .bmcCredentialsName.name | quote }}
     {{- end }}
-    - bmcAddress: "{{ .bmcAddress }}"
+    - bmcAddress: "{{ default "placeholder" .bmcAddress }}"
       bmcCredentialsName:
         name: {{ $bmcCredname }}
-      bootMACAddress: "{{ .bootMACAddress }}"
+      # This placeholder address (using the “00:00:5E” prefix) is for documentation purpose only
+      bootMACAddress: "{{ default "00:00:5E:00:53:AF" .bootMACAddress }}"
       bootMode: "{{ default "UEFI" .bootMode }}"
       hostName: "{{ .hostName | validateNonEmpty (printf "spec.nodes[%d].hostName" $n_index) }}"
       templateRefs:
@@ -161,7 +167,8 @@ spec:
         {{- $_ := .nodeNetwork.interfaces | validateNonEmpty $i_path }}
         {{- $_ := .nodeNetwork.interfaces | validateArrayType $i_path }}
         {{- range $i_index, $i_ref := .nodeNetwork.interfaces }}
-          - macAddress: "{{ $i_ref.macAddress | validateNonEmpty (printf "%s[%d].macAddress" $i_path $i_index) }}"
+          # This placeholder address (using the “00:00:5E” prefix) is for documentation purpose only
+          - macAddress: "{{ default "00:00:5E:00:53:AF" $i_ref.macAddress }}"
             name: "{{ $i_ref.name | validateNonEmpty (printf "%s[%d].name" $i_path $i_index) }}"
         {{- end }}
       {{- end }}


### PR DESCRIPTION
bmcAddress, bmcCredentialsName, bootMACAddress, and nodeNetwork.interfaces[*].macAddress are meant to come from the NodePool (hardware) and should not be exposed in the ClusterRequest when hw plugin is fully utilized.

Placeholders for these fields have been added to pass the ClusterInstance dry-run validation since they are required fields. These placeholders will be replaced with data retrieved from NodePool later on.

Before hw plugin is fully utilized, these fields can still be provided through the ClusterRequest.

Remove the creation of ClusterInstance template configmap since the configmap is useless.