### PR TITLE
CNF-13594: Use IMAGE env variable as default image

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,9 +13,9 @@ images:
   newTag: 4.16.0
 
 
-# This replacment copies the controller image into the `IMAGE` environment variable of the pod,
-# which is in turn passed to the `--image` command line flag of the `start controller-manager`
-# command. The net result is that the operator knows what is its image and can use it as the
+# This replacement copies the controller image into the `IMAGE` environment variable of the pod,
+# which is in turn used as the default value of the `--image` command line flag of the `start controller-manager`
+# command. The net result is that the operator knows what its image is and can use it as the
 # default for the servers.
 replacements:
 - source:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,18 +69,12 @@ spec:
       - name: manager
         image: controller:latest
         env:
-        # Note that we have a kustomization replacement that copies the above `image` into this
-        # environment variable.
+          # Note that we have a kustomization replacement that copies the above `image` into this
+          # environment variable.  It is used as a default value for the --image command line argument
+          # since it and all other arguments are implemented as CLI arguments.
         - name: IMAGE
           value: controller:latest
         command:
-        # We use a shell script here in order to be able to pass the value of the `IMAGE`
-        # environment variable in the `--image` flag. We don't wan to read environment variables
-        # directly from the binary because all the other command use flags as their main
-        # configuration mechanism, and we don't want to deviate from that.
-        #
-        # Please keep the `exec` before the command, it removes the shell from the picture once
-        # the controller manager starts.
           - /usr/bin/oran-o2ims
           -  start
           -  controller-manager

--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -17,6 +17,7 @@ package operator
 import (
 	"log/slog"
 
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -73,7 +74,9 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.image,
 		imageFlagName,
-		"quay.io/openshift-kni/oran-o2ims-operator:latest",
+		// Intentionally setting the default value to "" if the environment variable is not set to ensure we never
+		// run an image that we didn't intend on running.
+		utils.GetEnvOrDefault("IMAGE", ""),
 		"Reference of the container image containing the servers.",
 	)
 	return result

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -967,3 +967,13 @@ func TimeoutExceeded(clusterRequest *oranv1alpha1.ClusterRequest) bool {
 	timeout := time.Duration(clusterRequest.Spec.Timeout.Configuration) * time.Minute
 	return timeSince > timeout
 }
+
+// GetEnvOrDefault returns the value of the named environment variable or the supplied default value if the environment
+// variable is not set.
+func GetEnvOrDefault(name, defaultValue string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}


### PR DESCRIPTION
This allows the --image parameter to default to whatever image reference has been specified in the IMAGE environment variable.  This is to facilitate the midstream build overlay which will set the image to be used to the official image reference.