### PR TITLE
CNF-14658: Replace clusterTemplateRef field with templateName and templateVersion

### DIFF
--- a/api/v1alpha1/clusterrequest_types.go
+++ b/api/v1alpha1/clusterrequest_types.go
@@ -33,8 +33,15 @@ type ClusterRequestSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Location Spec",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	hwv1alpha1.LocationSpec `json:",inline"`
 
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Cluster Template Reference",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
-	ClusterTemplateRef string `json:"clusterTemplateRef"`
+	// TemplateName defines the base name of the referenced ClusterTemplate.
+	// The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Template Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	TemplateName string `json:"templateName"`
+
+	// TemplateVersion defines the version of the referenced ClusterTemplate.
+	// The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Template Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	TemplateVersion string `json:"templateVersion"`
 
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Cluster Template Input",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	ClusterTemplateInput ClusterTemplateInput `json:"clusterTemplateInput"`

--- a/bundle/manifests/o2ims.oran.openshift.io_clusterrequests.yaml
+++ b/bundle/manifests/o2ims.oran.openshift.io_clusterrequests.yaml
@@ -61,13 +61,21 @@ spec:
                 - clusterInstanceInput
                 - policyTemplateInput
                 type: object
-              clusterTemplateRef:
-                type: string
               location:
                 description: Location
                 type: string
               site:
                 description: Site
+                type: string
+              templateName:
+                description: |-
+                  TemplateName defines the base name of the referenced ClusterTemplate.
+                  The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+                type: string
+              templateVersion:
+                description: |-
+                  TemplateVersion defines the version of the referenced ClusterTemplate.
+                  The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
                 type: string
               timeout:
                 description: |-
@@ -92,8 +100,9 @@ spec:
                 type: object
             required:
             - clusterTemplateInput
-            - clusterTemplateRef
             - site
+            - templateName
+            - templateVersion
             type: object
           status:
             description: ClusterRequestStatus defines the observed state of ClusterRequest

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -189,8 +189,9 @@ metadata:
                 "sriov-network-vlan-2": "111"
               }
             },
-            "clusterTemplateRef": "clustertemplate-sample",
             "site": "local",
+            "templateName": "clustertemplate-sample",
+            "templateVersion": "v1.0.0",
             "timeout": {
               "clusterProvisioning": 80,
               "configuration": 40,
@@ -209,7 +210,7 @@ metadata:
               "app.kubernetes.io/name": "clustertemplate",
               "app.kubernetes.io/part-of": "oran-o2ims"
             },
-            "name": "clustertemplate-sample"
+            "name": "clustertemplate-sample.v1.0.0"
           },
           "spec": {
             "inputDataSchema": {
@@ -514,10 +515,6 @@ spec:
         path: clusterTemplateInput
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Cluster Template Reference
-        path: clusterTemplateRef
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Location
         displayName: Location
         path: location
@@ -526,6 +523,20 @@ spec:
       - description: Site
         displayName: Site
         path: site
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          TemplateName defines the base name of the referenced ClusterTemplate.
+          The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+        displayName: Template Name
+        path: templateName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          TemplateVersion defines the version of the referenced ClusterTemplate.
+          The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+        displayName: Template Version
+        path: templateVersion
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Timeout

--- a/config/crd/bases/o2ims.oran.openshift.io_clusterrequests.yaml
+++ b/config/crd/bases/o2ims.oran.openshift.io_clusterrequests.yaml
@@ -61,13 +61,21 @@ spec:
                 - clusterInstanceInput
                 - policyTemplateInput
                 type: object
-              clusterTemplateRef:
-                type: string
               location:
                 description: Location
                 type: string
               site:
                 description: Site
+                type: string
+              templateName:
+                description: |-
+                  TemplateName defines the base name of the referenced ClusterTemplate.
+                  The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+                type: string
+              templateVersion:
+                description: |-
+                  TemplateVersion defines the version of the referenced ClusterTemplate.
+                  The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
                 type: string
               timeout:
                 description: |-
@@ -92,8 +100,9 @@ spec:
                 type: object
             required:
             - clusterTemplateInput
-            - clusterTemplateRef
             - site
+            - templateName
+            - templateVersion
             type: object
           status:
             description: ClusterRequestStatus defines the observed state of ClusterRequest

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -125,10 +125,6 @@ spec:
         path: clusterTemplateInput
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Cluster Template Reference
-        path: clusterTemplateRef
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Location
         displayName: Location
         path: location
@@ -137,6 +133,20 @@ spec:
       - description: Site
         displayName: Site
         path: site
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          TemplateName defines the base name of the referenced ClusterTemplate.
+          The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+        displayName: Template Name
+        path: templateName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          TemplateVersion defines the version of the referenced ClusterTemplate.
+          The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
+        displayName: Template Version
+        path: templateVersion
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Timeout

--- a/config/samples/v1alpha1_clusterrequest.yaml
+++ b/config/samples/v1alpha1_clusterrequest.yaml
@@ -14,7 +14,8 @@ spec:
     clusterProvisioning: 80
     configuration: 40
     hardwareProvisioning: 60
-  clusterTemplateRef: clustertemplate-sample
+  templateName: clustertemplate-sample
+  templateVersion: v1.0.0
   clusterTemplateInput:
     policyTemplateInput:
       sriov-network-vlan-1: "114"

--- a/config/samples/v1alpha1_clustertemplate.yaml
+++ b/config/samples/v1alpha1_clustertemplate.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: oran-o2ims
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: oran-o2ims
-  name: clustertemplate-sample
+  name: clustertemplate-sample.v1.0.0
 spec:
   templates:
     clusterInstanceDefaults: clusterinstance-defaults-v1

--- a/internal/controllers/clusterrequest_controller_test.go
+++ b/internal/controllers/clusterrequest_controller_test.go
@@ -467,7 +467,8 @@ var _ = Describe("ClusterRequestReconcile", func() {
 		req          reconcile.Request
 		cr           *oranv1alpha1.ClusterRequest
 		ct           *oranv1alpha1.ClusterTemplate
-		ctName       = "clustertemplate-a-v1"
+		tName        = "clustertemplate-a"
+		tVersion     = "v1.0.0"
 		ctNamespace  = "clustertemplate-a-v4-16"
 		ciDefaultsCm = "clusterinstance-defaults-v1"
 		ptDefaultsCm = "policytemplate-defaults-v1"
@@ -547,7 +548,7 @@ var _ = Describe("ClusterRequestReconcile", func() {
 		// Define the cluster template.
 		ct = &oranv1alpha1.ClusterTemplate{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      ctName,
+				Name:      getClusterTemplateRefName(tName, tVersion),
 				Namespace: ctNamespace,
 			},
 			Spec: oranv1alpha1.ClusterTemplateSpec{
@@ -584,7 +585,8 @@ var _ = Describe("ClusterRequestReconcile", func() {
 				Finalizers: []string{clusterRequestFinalizer},
 			},
 			Spec: oranv1alpha1.ClusterRequestSpec{
-				ClusterTemplateRef: ctName,
+				TemplateName:    tName,
+				TemplateVersion: tVersion,
 				ClusterTemplateInput: oranv1alpha1.ClusterTemplateInput{
 					ClusterInstanceInput: runtime.RawExtension{
 						Raw: []byte(testClusterTemplateInput),
@@ -1435,7 +1437,8 @@ var _ = Describe("getCrClusterTemplateRef", func() {
 		c            client.Client
 		reconciler   *ClusterRequestReconciler
 		task         *clusterRequestReconcilerTask
-		ctName       = "clustertemplate-a-v1"
+		tName        = "clustertemplate-a"
+		tVersion     = "v1.0.0"
 		ctNamespace  = "clustertemplate-a-v4-16"
 		ciDefaultsCm = "clusterinstance-defaults-v1"
 		ptDefaultsCm = "policytemplate-defaults-v1"
@@ -1452,7 +1455,8 @@ var _ = Describe("getCrClusterTemplateRef", func() {
 				Namespace: ctNamespace,
 			},
 			Spec: oranv1alpha1.ClusterRequestSpec{
-				ClusterTemplateRef: ctName,
+				TemplateName:    tName,
+				TemplateVersion: tVersion,
 			},
 		}
 
@@ -1492,12 +1496,13 @@ var _ = Describe("getCrClusterTemplateRef", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(
 			fmt.Sprintf("the referenced ClusterTemplate (%s) does not exist in the %s namespace",
-				ctName, ctNamespace)))
+				getClusterTemplateRefName(tName, tVersion), ctNamespace)))
 		Expect(retCt).To(Equal((*oranv1alpha1.ClusterTemplate)(nil)))
 	})
 
 	It("returns the referred ClusterTemplate if it exists", func() {
 		// Define the cluster template.
+		ctName := getClusterTemplateRefName(tName, tVersion)
 		ct := &oranv1alpha1.ClusterTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ctName,
@@ -1700,7 +1705,8 @@ var _ = Describe("createPolicyTemplateConfigMap", func() {
 		c           client.Client
 		reconciler  *ClusterRequestReconciler
 		task        *clusterRequestReconcilerTask
-		ctName      = "clustertemplate-a-v1"
+		tName       = "clustertemplate-a"
+		tVersion    = "v1.0.0"
 		ctNamespace = "clustertemplate-a-v4-16"
 		crName      = "cluster-1"
 	)
@@ -1714,7 +1720,8 @@ var _ = Describe("createPolicyTemplateConfigMap", func() {
 				Namespace: ctNamespace,
 			},
 			Spec: oranv1alpha1.ClusterRequestSpec{
-				ClusterTemplateRef: ctName,
+				TemplateName:    tName,
+				TemplateVersion: tVersion,
 			},
 		}
 
@@ -1781,7 +1788,8 @@ var _ = Describe("renderHardwareTemplate", func() {
 		task            *clusterRequestReconcilerTask
 		clusterInstance *siteconfig.ClusterInstance
 		ct              *oranv1alpha1.ClusterTemplate
-		ctName          = "clustertemplate-a-v1"
+		tName           = "clustertemplate-a"
+		tVersion        = "v1.0.0"
 		ctNamespace     = "clustertemplate-a-v4-16"
 		hwTemplateCm    = "hwTemplate-v1"
 		crName          = "cluster-1"
@@ -1835,14 +1843,15 @@ var _ = Describe("renderHardwareTemplate", func() {
 				Namespace: ctNamespace,
 			},
 			Spec: oranv1alpha1.ClusterRequestSpec{
-				ClusterTemplateRef: ctName,
+				TemplateName:    tName,
+				TemplateVersion: tVersion,
 			},
 		}
 
 		// Define the cluster template.
 		ct = &oranv1alpha1.ClusterTemplate{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      ctName,
+				Name:      getClusterTemplateRefName(tName, tVersion),
 				Namespace: ctNamespace,
 			},
 			Spec: oranv1alpha1.ClusterTemplateSpec{
@@ -2346,7 +2355,8 @@ var _ = Describe("policyManagement", func() {
 		CRReconciler *ClusterRequestReconciler
 		CRTask       *clusterRequestReconcilerTask
 		CTReconciler *ClusterTemplateReconciler
-		ctName       = "clustertemplate-a-v1"
+		tName        = "clustertemplate-a"
+		tVersion     = "v1.0.0"
 		ctNamespace  = "clustertemplate-a-v4-16"
 		ciDefaultsCm = "clusterinstance-defaults-v1"
 		ptDefaultsCm = "policytemplate-defaults-v1"
@@ -2366,7 +2376,7 @@ var _ = Describe("policyManagement", func() {
 			// Cluster Template.
 			&oranv1alpha1.ClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      ctName,
+					Name:      getClusterTemplateRefName(tName, tVersion),
 					Namespace: ctNamespace,
 				},
 				Spec: oranv1alpha1.ClusterTemplateSpec{
@@ -2458,7 +2468,8 @@ defaultHugepagesSize: "1G"`,
 					Finalizers: []string{clusterRequestFinalizer},
 				},
 				Spec: oranv1alpha1.ClusterRequestSpec{
-					ClusterTemplateRef: ctName,
+					TemplateName:    tName,
+					TemplateVersion: tVersion,
 					ClusterTemplateInput: oranv1alpha1.ClusterTemplateInput{
 						ClusterInstanceInput: runtime.RawExtension{
 							Raw: []byte(testClusterTemplateInput),
@@ -2503,7 +2514,7 @@ defaultHugepagesSize: "1G"`,
 
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Name:      ctName,
+				Name:      getClusterTemplateRefName(tName, tVersion),
 				Namespace: ctNamespace,
 			},
 		}
@@ -3971,7 +3982,8 @@ var _ = Describe("hasPolicyConfigurationTimedOut", func() {
 		CRReconciler *ClusterRequestReconciler
 		CRTask       *clusterRequestReconcilerTask
 		CTReconciler *ClusterTemplateReconciler
-		ctName       = "clustertemplate-a-v1"
+		tName        = "clustertemplate-a"
+		tVersion     = "v1.0.0"
 		ctNamespace  = "clustertemplate-a-v4-16"
 	)
 
@@ -3992,7 +4004,8 @@ var _ = Describe("hasPolicyConfigurationTimedOut", func() {
 					Finalizers: []string{clusterRequestFinalizer},
 				},
 				Spec: oranv1alpha1.ClusterRequestSpec{
-					ClusterTemplateRef: ctName,
+					TemplateName:    tName,
+					TemplateVersion: tVersion,
 					ClusterTemplateInput: oranv1alpha1.ClusterTemplateInput{
 						ClusterInstanceInput: runtime.RawExtension{
 							Raw: []byte(testClusterTemplateInput),
@@ -4020,7 +4033,7 @@ var _ = Describe("hasPolicyConfigurationTimedOut", func() {
 
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Name:      ctName,
+				Name:      getClusterTemplateRefName(tName, tVersion),
 				Namespace: ctNamespace,
 			},
 		}

--- a/internal/controllers/clusterrequest_controller_test.go
+++ b/internal/controllers/clusterrequest_controller_test.go
@@ -1538,7 +1538,8 @@ var _ = Describe("handleRenderClusterInstance", func() {
 		task         *clusterRequestReconcilerTask
 		cr           *oranv1alpha1.ClusterRequest
 		ciDefaultsCm = "clusterinstance-defaults-v1"
-		ctName       = "clustertemplate-a-v1"
+		tName        = "clustertemplate-a"
+		tVersion     = "v1.0.0"
 		ctNamespace  = "clustertemplate-a-v4-16"
 		crName       = "cluster-1"
 	)
@@ -1552,7 +1553,8 @@ var _ = Describe("handleRenderClusterInstance", func() {
 				Namespace: ctNamespace,
 			},
 			Spec: oranv1alpha1.ClusterRequestSpec{
-				ClusterTemplateRef: ctName,
+				TemplateName:    tName,
+				TemplateVersion: tVersion,
 				ClusterTemplateInput: oranv1alpha1.ClusterTemplateInput{
 					ClusterInstanceInput: runtime.RawExtension{Raw: []byte(testClusterTemplateInput)},
 				},
@@ -1562,7 +1564,7 @@ var _ = Describe("handleRenderClusterInstance", func() {
 		// Define the cluster template.
 		ct := &oranv1alpha1.ClusterTemplate{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      ctName,
+				Name:      getClusterTemplateRefName(tName, tVersion),
 				Namespace: ctNamespace,
 			},
 			Spec: oranv1alpha1.ClusterTemplateSpec{


### PR DESCRIPTION
- Replace clusterTemplateRef with two new fields - templateName and templateVersion, which represent the referenced ClusterTemplate.
- The name of ClusterTemplate should be formatted as <templateName.templateVersion> 