### PR TITLE
Change operation type to update for services

### DIFF
--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -896,7 +896,7 @@ func (t *reconcilerTask) createService(ctx context.Context, resourceName string)
 	}
 
 	t.logger.InfoContext(ctx, "[createService] Create/Update/Patch Service: ", "name", resourceName)
-	if err := utils.CreateK8sCR(ctx, t.client, newService, t.object, utils.PATCH); err != nil {
+	if err := utils.CreateK8sCR(ctx, t.client, newService, t.object, utils.UPDATE); err != nil {
 		return fmt.Errorf("failed to create Service for deployment: %w", err)
 	}
 


### PR DESCRIPTION
The fact that we were using a "patch" operation on services is leading to some errors in the reconcile loop.  The "patch" should be reserved to use cases where we read an object from the system, make some changes to our local copy, and then want to "patch" it using the API to only send those fields that have changed.  What we were doing was creating a brand new object and attempting to "patch" that against what the running system already had which lead to trying to delete several runtime only attributes which I believe is what was leading to the errors.