### PR TITLE
Requires permission to contact the /o2ims-infrastructureInventory/v1

### DIFF
--- a/config/samples/testing/client-service-account-rbac.yaml
+++ b/config/samples/testing/client-service-account-rbac.yaml
@@ -10,6 +10,7 @@ metadata:
   name: oran-o2ims-test-client-role
 rules:
   - nonResourceURLs:
+      - /o2ims-infrastructureInventory/v1
       - /o2ims-infrastructureInventory/v1/*
       - /o2ims-infrastructureInventory/api_versions
     verbs:


### PR DESCRIPTION
Missing permission to contact the  /o2ims-infrastructureInventory/v1 API. 