### PR TITLE
NO-ISSUE: Update hack/update_deps.sh to handle exported API submodule

### DIFF
--- a/hack/update_deps.sh
+++ b/hack/update_deps.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+set -e
+
+# Handle the exported api/hardwaremanagement submodule first
+pushd api/hardwaremanagement >/dev/null
+go mod tidy
+popd >/dev/null
+
 go mod vendor
 go mod tidy
 


### PR DESCRIPTION
The api/hardwaremanagement folder is exported as a submodule for use by the oran-hwmgr-plugin, with its own go.mod and go.sum files. Should anything be changed in the submodule that impacts imports, it is important that the go.mod and go.sum are updated. By extending the hack/update_deps.sh to include a `go mod tidy` in the subfolder, we ensure that any missing changes are caught by the `ci-job` test to prevent issues.