### PR TITLE
NO-ISSUE: Install additional packages in base image for CI

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -34,6 +34,12 @@ RUN dnf install -y \
     git \
     diffutils
 
+# Install packages required for ci-job
+RUN dnf install -y \
+    jq \
+    wget \
+    xz
+
 # Update GOPATH, GOCACHE, GOLANGCI_LINT_CACHE, PATH.
 ENV \
   GOPATH=/go


### PR DESCRIPTION
Due to the way CI is setup, the Dockerfile.tools file must be updated with new packages installed before those packages can be used in CI. ie. if adding tools to ci-job test that require additional packages, the Dockerfile.tools update must be merged first.