### PR TITLE
Proposal: Add DLV debugging capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,16 @@ ginkgo_flags:=
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 4.16.0
 
+ifeq (${DEBUG}, yes)
+	DOCKER_TARGET = debug
+	GOBUILD_GCFLAGS = all=-N -l
+	KUSTOMIZE_OVERLAY = debug
+else
+	DOCKER_TARGET = production
+	GOBUILD_GCFLAGS = ""
+	KUSTOMIZE_OVERLAY = default
+endif
+
 # DEFAULT_CHANNEL defines the default channel used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
@@ -125,7 +135,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 ##@ Build
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build
+	go build -gcflags "${GOBUILD_GCFLAGS}"
 
 .PHONY: run
 run: manifests generate fmt vet binary ## Run a controller from your host.
@@ -136,7 +146,7 @@ run: manifests generate fmt vet binary ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} -f Dockerfile .
+	$(CONTAINER_TOOL) build -t ${IMG} -f Dockerfile --target ${DOCKER_TARGET} --build-arg "GOBUILD_GCFLAGS=${GOBUILD_GCFLAGS}" .
 
 .PHONY: docker-push
 docker-push: docker-build ## Push docker image with the manager.
@@ -177,11 +187,11 @@ uninstall: manifests kustomize kubectl ## Uninstall CRDs from the K8s cluster sp
 deploy: manifests kustomize kubectl ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	@$(KUBECTL) create configmap env-config --from-literal=HWMGR_PLUGIN_NAMESPACE=$(HWMGR_PLUGIN_NAMESPACE) --dry-run=client -o yaml > config/manager/env-config.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/$(KUSTOMIZE_OVERLAY) | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize kubectl ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/$(KUSTOMIZE_OVERLAY) | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Build Dependencies
 

--- a/README.md
+++ b/README.md
@@ -515,3 +515,39 @@ Status:
       Type:                  SmoRegistrationCompleted
 ...
 ```
+
+## Using the development debug mode to attach the DLV debugger
+
+The following instructions provide a mechanism to build an image that is based on a more full-featured distro so that
+debug tools are available in the image. It also tailors the deployment configuration so that certain features are
+disabled which would otherwise cause debugging with a debugger to be more difficult (or impossible).
+
+1. Build and deploy the debug image
+
+```shell
+make IMAGE_TAG_BASE=quay.io/${USER}/oran-o2ims VERSION=latest DEBUG=yes build docker-build docker-push install deploy
+```
+
+2. Forward a port to the Pod to be debugged so the debugger can attach to it. This command will remain active until
+   it is terminated with ctrl+c therefore you will need to execute it in a dedicated window (or move it to the
+   background).
+
+```shell
+oc port-forward -n oran-o2ims pods/oran-o2ims-controller-manager-85b4bbcf58-4fc9s 40000:40000
+```
+
+3. Execute a shell into the Pod to be debugged.
+
+```shell
+oc rsh -n oran-o2ims pods/oran-o2ims-controller-manager-85b4bbcf58-4fc9s
+```
+
+4. Attach the DLV debugger to the process. This is usually PID 1, but this may vary based on the deployment. Use the
+   same port number that was specified earlier in the `port-forward` command.
+
+```shell
+dlv attach --continue --accept-multiclient --api-version 2 --headless --listen :40000 --log 1
+```
+
+5. Use your IDE's debug capabilities to attach to `localhost:40000` to start your debug session. This will vary based
+   on which IDE is being used.

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1395,15 +1395,13 @@ spec:
                   capabilities:
                     drop:
                     - ALL
-              - args:
-                - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
-                - --leader-elect
-                command:
+              - command:
                 - /usr/bin/oran-o2ims
                 - start
                 - controller-manager
                 - --leader-elect
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
                 env:
                 - name: IMAGE
                   value: quay.io/openshift-kni/oran-o2ims-operator:4.16.0

--- a/config/debug/disable-health-probes.yaml
+++ b/config/debug/disable-health-probes.yaml
@@ -1,0 +1,4 @@
+-   path: /spec/template/spec/containers/1/livenessProbe
+    op: remove
+-   path: /spec/template/spec/containers/1/readinessProbe
+    op: remove

--- a/config/debug/disable-leader-election.yaml
+++ b/config/debug/disable-leader-election.yaml
@@ -1,0 +1,8 @@
+-   path: /spec/template/spec/containers/1/command
+    op: replace
+    value:
+        - /usr/bin/oran-o2ims
+        - start
+        - controller-manager
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080

--- a/config/debug/kustomization.yaml
+++ b/config/debug/kustomization.yaml
@@ -1,0 +1,17 @@
+# Applies patches to the default resources so that debugging is simplified and compatible with using the DLV debugger.
+# Since using the debugger implies that the program will occasionally be suspended we must ensure that critical parts
+# of the process do not erroneously flagged errors or cause shutdowns (i.e., health probes, and leader election)
+#
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - ../default
+patches:
+    -   target:
+            kind: Deployment
+            name: controller-manager
+        path: disable-health-probes.yaml
+    -   target:
+            kind: Deployment
+            name: controller-manager
+        path: disable-leader-election.yaml

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -32,8 +32,3 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
-      - name: manager
-        args:
-        - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -85,6 +85,8 @@ spec:
           -  start
           -  controller-manager
           -  --leader-elect
+          - --health-probe-bind-address=:8081
+          - --metrics-bind-address=127.0.0.1:8080
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
This adds the changes required so that a developer can build an image capable of using the DLV debugger to debug any of the deployed servers or controller.

Some functionality needed to be disabled in order to make suspending the program being debugged possible (i.e., health checks,
leader election, etc).  This is only true if DEBUG=yes when the build command is executed.