### PR TITLE
Remove unnecessary -R option for chmod command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	@chmod -R u+w $(LOCALBIN)
+	@chmod u+w $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: operator-sdk


### PR DESCRIPTION
If the kubectl target was previously executed (e.g., through make undeploy or make deploy) and the symbolic link $(LOCALBIN)/kubectl exists, subsequent make commands would fail at chmod u+w $(LOCALBIN) due to the inability to change permissions on the symbolic link. Removing the unnecessary -R option from chmod resolves this issue by avoiding recursive permission changes on symbolic links within $(LOCALBIN).