### PR TITLE
NO-ISSUE: Add missing sample CRs, address scorecard suggestions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,4 +378,5 @@ clean:
 .PHONY: scorecard-test
 scorecard-test: operator-sdk
 	@test -n "$(KUBECONFIG)" || (echo "The environment variable KUBECONFIG must not empty" && false)
-	$(OPERATOR_SDK) scorecard bundle -o text --kubeconfig "$(KUBECONFIG)" -n $(OCLOUD_MANAGER_NAMESPACE)
+	oc create ns $(OCLOUD_MANAGER_NAMESPACE) --dry-run=client -o yaml | oc apply -f -
+	$(OPERATOR_SDK) scorecard bundle -o text --kubeconfig "$(KUBECONFIG)" -n $(OCLOUD_MANAGER_NAMESPACE) --pod-security=restricted

--- a/api/hardwaremanagement/v1alpha1/node.go
+++ b/api/hardwaremanagement/v1alpha1/node.go
@@ -50,14 +50,18 @@ type BMC struct {
 // NodeStatus describes the observed state of a request to allocate and prepare
 // a node that will eventually be part of a deployment manager.
 type NodeStatus struct {
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	BMC *BMC `json:"bmc,omitempty"`
 
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Interfaces []*Interface `json:"interfaces,omitempty"`
 
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Hostname string `json:"hostname,omitempty"`
 
 	// Conditions represent the observations of the NodeStatus's current state.
 	// Possible values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -43,8 +43,10 @@ type NodePoolSpec struct {
 	LocationSpec `json:",inline"`
 
 	// HwMgrId is the identifier for the hardware manager plugin adaptor.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hardware Manager ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	HwMgrId string `json:"hwMgrId,omitempty"`
 
+	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	NodeGroup []NodeGroup `json:"nodeGroup"`
 }
 
@@ -69,14 +71,19 @@ type GenerationStatus struct {
 // a node that will eventually be part of a deployment manager.
 type NodePoolStatus struct {
 	// Properties represent the node properties in the pool
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Properties Properties `json:"properties,omitempty"`
 
 	// Conditions represent the observations of the NodePool's current state.
 	// Possible values of the condition type are `Provisioned` and `Unknown`.
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	CloudManager GenerationStatus `json:"cloudManager,omitempty"`
-	HwMgrPlugin  GenerationStatus `json:"hwMgrPlugin,omitempty"`
+
+	//+operator-sdk:csv:customresourcedefinitions:type=status
+	HwMgrPlugin GenerationStatus `json:"hwMgrPlugin,omitempty"`
 }
 
 // NodePool is the schema for an allocation request of nodes

--- a/api/provisioning/v1alpha1/clustertemplate_types.go
+++ b/api/provisioning/v1alpha1/clustertemplate_types.go
@@ -77,6 +77,7 @@ type ClusterTemplateStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -98,15 +98,19 @@ type ProvisioningRequestStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ClusterDetails references to the ClusterInstance.
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	ClusterDetails *ClusterDetails `json:"clusterDetails,omitempty"`
 
 	// NodePoolRef references to the NodePool.
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	NodePoolRef *NodePoolRef `json:"nodePoolRef,omitempty"`
 
 	// Holds policies that are matched with the ManagedCluster created by the ProvisioningRequest.
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Policies []PolicyDetails `json:"policies,omitempty"`
 }
 

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -5,6 +5,113 @@ metadata:
     alm-examples: |-
       [
         {
+          "apiVersion": "o2ims-hardwaremanagement.oran.openshift.io/v1alpha1",
+          "kind": "Node",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "oran-o2ims",
+              "app.kubernetes.io/instance": "inventory-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "inventory",
+              "app.kubernetes.io/part-of": "oran-o2ims"
+            },
+            "name": "sample-node",
+            "namespace": "oran-hwmgr-plugin"
+          },
+          "spec": {
+            "groupName": "master",
+            "hwProfile": "sample-profile",
+            "nodePool": "sample-nodepool"
+          },
+          "status": {
+            "bmc": {
+              "address": "idrac-virtualmedia+https://198.51.100.1/redfish/v1/Systems/System.Embedded.1",
+              "credentialsName": "sample-node-bmc-secret"
+            },
+            "conditions": [
+              {
+                "lastTransitionTime": "2024-10-09T15:36:31Z",
+                "message": "Provisioned",
+                "reason": "Completed",
+                "status": "True",
+                "type": "Provisioned"
+              }
+            ],
+            "hostname": "sample-node.example.com",
+            "interfaces": [
+              {
+                "label": "bootable-interface",
+                "macAddress": "00:11:22:33:44:55",
+                "name": "eno1"
+              },
+              {
+                "label": "",
+                "macAddress": "00:11:22:33:44:66",
+                "name": "eno2"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "o2ims-hardwaremanagement.oran.openshift.io/v1alpha1",
+          "kind": "NodePool",
+          "metadata": {
+            "annotations": {
+              "bootInterfaceLabel": "bootable-interface"
+            },
+            "generation": 1,
+            "labels": {
+              "app.kubernetes.io/created-by": "oran-o2ims",
+              "app.kubernetes.io/instance": "inventory-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "inventory",
+              "app.kubernetes.io/part-of": "oran-o2ims"
+            },
+            "name": "sample-nodepool",
+            "namespace": "oran-hwmgr-plugin"
+          },
+          "spec": {
+            "cloudID": "sample",
+            "hwMgrId": "loopback-1",
+            "nodeGroup": [
+              {
+                "hwProfile": "sample-master-profile",
+                "interfaces": [
+                  "eno1"
+                ],
+                "name": "master",
+                "size": 1
+              },
+              {
+                "hwProfile": "sample-worker-profile",
+                "name": "worker",
+                "size": 0
+              }
+            ],
+            "site": "ottawa"
+          },
+          "status": {
+            "cloudManager": {
+              "observedGeneration": 1
+            },
+            "conditions": [
+              {
+                "lastTransitionTime": "2024-10-09T15:36:41Z",
+                "message": "Created",
+                "reason": "Completed",
+                "status": "True",
+                "type": "Provisioned"
+              }
+            ],
+            "hwMgrPlugin": {},
+            "properties": {
+              "nodeNames": [
+                "sample-node"
+              ]
+            }
+          }
+        },
+        {
           "apiVersion": "o2ims.oran.openshift.io/v1alpha1",
           "kind": "Inventory",
           "metadata": {
@@ -24,6 +131,10 @@ metadata:
             "resourceServerConfig": {
               "enabled": false
             }
+          },
+          "status": {
+            "deploymentStatus": {},
+            "usedServerConfig": {}
           }
         },
         {
@@ -345,6 +456,9 @@ metadata:
               "policyTemplateDefaults": "clustertemplate-sample.v1.0.0-policytemplate-defaults"
             },
             "version": "v1.0.0"
+          },
+          "status": {
+            "conditions": []
           }
         },
         {
@@ -538,6 +652,9 @@ metadata:
               }
             },
             "templateVersion": "v1.0.0"
+          },
+          "status": {
+            "conditions": []
           }
         }
       ]
@@ -627,6 +744,9 @@ spec:
         path: version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
       version: v1alpha1
     - description: Inventory is the Schema for the Inventory API
       displayName: ORAN O2IMS Inventory
@@ -779,16 +899,36 @@ spec:
         path: cloudID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HwMgrId is the identifier for the hardware manager plugin adaptor.
+        displayName: Hardware Manager ID
+        path: hwMgrId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Location
         displayName: Location
         path: location
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Node Group
+        path: nodeGroup
       - description: Site
         displayName: Site
         path: site
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Cloud Manager
+        path: cloudManager
+      - description: |-
+          Conditions represent the observations of the NodePool's current state.
+          Possible values of the condition type are `Provisioned` and `Unknown`.
+        displayName: Conditions
+        path: conditions
+      - displayName: Hw Mgr Plugin
+        path: hwMgrPlugin
+      - description: Properties represent the node properties in the pool
+        displayName: Properties
+        path: properties
       version: v1alpha1
     - description: Node is the schema for an allocated node
       displayName: Node
@@ -814,6 +954,18 @@ spec:
         path: nodePool
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: BMC
+        path: bmc
+      - description: |-
+          Conditions represent the observations of the NodeStatus's current state.
+          Possible values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
+        displayName: Conditions
+        path: conditions
+      - displayName: Hostname
+        path: hostname
+      - displayName: Interfaces
+        path: interfaces
       version: v1alpha1
     - description: ProvisioningRequest is the Schema for the provisioningrequests
         API
@@ -866,6 +1018,19 @@ spec:
         path: templateVersion
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: ClusterDetails references to the ClusterInstance.
+        displayName: Cluster Details
+        path: clusterDetails
+      - displayName: Conditions
+        path: conditions
+      - description: NodePoolRef references to the NodePool.
+        displayName: Node Pool Ref
+        path: nodePoolRef
+      - description: Holds policies that are matched with the ManagedCluster created
+          by the ProvisioningRequest.
+        displayName: Policies
+        path: policies
       version: v1alpha1
   description: |
     # O-RAN O2IMS operator
@@ -1334,6 +1499,7 @@ spec:
   - email: imihai@redhat.com
     name: IrinaMihai
   maturity: alpha
+  minKubeVersion: 1.28.0
   provider:
     name: Red Hat
   replaces: oran-o2ims.v0.0.0

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -87,6 +87,9 @@ spec:
         path: version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
       version: v1alpha1
     - description: Inventory is the Schema for the Inventory API
       displayName: ORAN O2IMS Inventory
@@ -239,16 +242,36 @@ spec:
         path: cloudID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HwMgrId is the identifier for the hardware manager plugin adaptor.
+        displayName: Hardware Manager ID
+        path: hwMgrId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Location
         displayName: Location
         path: location
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Node Group
+        path: nodeGroup
       - description: Site
         displayName: Site
         path: site
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Cloud Manager
+        path: cloudManager
+      - description: |-
+          Conditions represent the observations of the NodePool's current state.
+          Possible values of the condition type are `Provisioned` and `Unknown`.
+        displayName: Conditions
+        path: conditions
+      - displayName: Hw Mgr Plugin
+        path: hwMgrPlugin
+      - description: Properties represent the node properties in the pool
+        displayName: Properties
+        path: properties
       version: v1alpha1
     - description: Node is the schema for an allocated node
       displayName: Node
@@ -274,6 +297,18 @@ spec:
         path: nodePool
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: BMC
+        path: bmc
+      - description: |-
+          Conditions represent the observations of the NodeStatus's current state.
+          Possible values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
+        displayName: Conditions
+        path: conditions
+      - displayName: Hostname
+        path: hostname
+      - displayName: Interfaces
+        path: interfaces
       version: v1alpha1
     - description: ProvisioningRequest is the Schema for the provisioningrequests
         API
@@ -326,6 +361,19 @@ spec:
         path: templateVersion
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: ClusterDetails references to the ClusterInstance.
+        displayName: Cluster Details
+        path: clusterDetails
+      - displayName: Conditions
+        path: conditions
+      - description: NodePoolRef references to the NodePool.
+        displayName: Node Pool Ref
+        path: nodePoolRef
+      - description: Holds policies that are matched with the ManagedCluster created
+          by the ProvisioningRequest.
+        displayName: Policies
+        path: policies
       version: v1alpha1
   description: |
     # O-RAN O2IMS operator
@@ -364,6 +412,7 @@ spec:
   - email: imihai@redhat.com
     name: IrinaMihai
   maturity: alpha
+  minKubeVersion: 1.28.0
   provider:
     name: Red Hat
   replaces: oran-o2ims.v0.0.0

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
 - v1alpha1_inventory.yaml
 
 # Hardware management:
+- v1alpha1_node.yaml
+- v1alpha1_nodepool.yaml
 
 # Provisioning:
 - v1alpha1_clustertemplate.yaml

--- a/config/samples/v1alpha1_clustertemplate.yaml
+++ b/config/samples/v1alpha1_clustertemplate.yaml
@@ -281,3 +281,5 @@ spec:
       - policyTemplateParameters
       - clusterInstanceParameters
     type: object
+status:
+  conditions: []

--- a/config/samples/v1alpha1_inventory.yaml
+++ b/config/samples/v1alpha1_inventory.yaml
@@ -14,4 +14,6 @@ spec:
   ingressHost: o2ims.apps.global-hub.karmalabs.corp
   resourceServerConfig:
     enabled: false
-
+status:
+  deploymentStatus: {}
+  usedServerConfig: {}

--- a/config/samples/v1alpha1_node.yaml
+++ b/config/samples/v1alpha1_node.yaml
@@ -1,0 +1,33 @@
+apiVersion: o2ims-hardwaremanagement.oran.openshift.io/v1alpha1
+kind: Node
+metadata:
+  labels:
+    app.kubernetes.io/name: inventory
+    app.kubernetes.io/instance: inventory-sample
+    app.kubernetes.io/part-of: oran-o2ims
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: oran-o2ims
+  name: sample-node
+  namespace: oran-hwmgr-plugin
+spec:
+  groupName: master
+  hwProfile: sample-profile
+  nodePool: sample-nodepool
+status:
+  bmc:
+    address: idrac-virtualmedia+https://198.51.100.1/redfish/v1/Systems/System.Embedded.1
+    credentialsName: sample-node-bmc-secret
+  conditions:
+  - lastTransitionTime: "2024-10-09T15:36:31Z"
+    message: Provisioned
+    reason: Completed
+    status: "True"
+    type: Provisioned
+  hostname: sample-node.example.com
+  interfaces:
+  - label: bootable-interface
+    macAddress: 00:11:22:33:44:55
+    name: eno1
+  - label: ""
+    macAddress: 00:11:22:33:44:66
+    name: eno2

--- a/config/samples/v1alpha1_nodepool.yaml
+++ b/config/samples/v1alpha1_nodepool.yaml
@@ -1,0 +1,40 @@
+apiVersion: o2ims-hardwaremanagement.oran.openshift.io/v1alpha1
+kind: NodePool
+metadata:
+  annotations:
+    bootInterfaceLabel: bootable-interface
+  generation: 1
+  labels:
+    app.kubernetes.io/name: inventory
+    app.kubernetes.io/instance: inventory-sample
+    app.kubernetes.io/part-of: oran-o2ims
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: oran-o2ims
+  name: sample-nodepool
+  namespace: oran-hwmgr-plugin
+spec:
+  cloudID: sample
+  hwMgrId: loopback-1
+  nodeGroup:
+  - hwProfile: sample-master-profile
+    interfaces:
+    - eno1
+    name: master
+    size: 1
+  - hwProfile: sample-worker-profile
+    name: worker
+    size: 0
+  site: ottawa
+status:
+  cloudManager:
+    observedGeneration: 1
+  conditions:
+  - lastTransitionTime: "2024-10-09T15:36:41Z"
+    message: Created
+    reason: Completed
+    status: "True"
+    type: Provisioned
+  hwMgrPlugin: {}
+  properties:
+    nodeNames:
+    - sample-node

--- a/config/samples/v1alpha1_provisioningrequest.yaml
+++ b/config/samples/v1alpha1_provisioningrequest.yaml
@@ -116,3 +116,5 @@ spec:
       serviceNetwork:
         - cidr: 233.252.0.0/24
       sshPublicKey: ssh-rsa
+status:
+  conditions: []

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node.go
@@ -50,14 +50,18 @@ type BMC struct {
 // NodeStatus describes the observed state of a request to allocate and prepare
 // a node that will eventually be part of a deployment manager.
 type NodeStatus struct {
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	BMC *BMC `json:"bmc,omitempty"`
 
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Interfaces []*Interface `json:"interfaces,omitempty"`
 
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Hostname string `json:"hostname,omitempty"`
 
 	// Conditions represent the observations of the NodeStatus's current state.
 	// Possible values of the condition type are `Provisioned`, `Unprovisioned`, `Updating` and `Failed`.
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -43,8 +43,10 @@ type NodePoolSpec struct {
 	LocationSpec `json:",inline"`
 
 	// HwMgrId is the identifier for the hardware manager plugin adaptor.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hardware Manager ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	HwMgrId string `json:"hwMgrId,omitempty"`
 
+	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	NodeGroup []NodeGroup `json:"nodeGroup"`
 }
 
@@ -69,14 +71,19 @@ type GenerationStatus struct {
 // a node that will eventually be part of a deployment manager.
 type NodePoolStatus struct {
 	// Properties represent the node properties in the pool
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Properties Properties `json:"properties,omitempty"`
 
 	// Conditions represent the observations of the NodePool's current state.
 	// Possible values of the condition type are `Provisioned` and `Unknown`.
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	CloudManager GenerationStatus `json:"cloudManager,omitempty"`
-	HwMgrPlugin  GenerationStatus `json:"hwMgrPlugin,omitempty"`
+
+	//+operator-sdk:csv:customresourcedefinitions:type=status
+	HwMgrPlugin GenerationStatus `json:"hwMgrPlugin,omitempty"`
 }
 
 // NodePool is the schema for an allocation request of nodes

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/clustertemplate_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/clustertemplate_types.go
@@ -77,6 +77,7 @@ type ClusterTemplateStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -98,15 +98,19 @@ type ProvisioningRequestStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ClusterDetails references to the ClusterInstance.
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	ClusterDetails *ClusterDetails `json:"clusterDetails,omitempty"`
 
 	// NodePoolRef references to the NodePool.
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	NodePoolRef *NodePoolRef `json:"nodePoolRef,omitempty"`
 
 	// Holds policies that are matched with the ManagedCluster created by the ProvisioningRequest.
+	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Policies []PolicyDetails `json:"policies,omitempty"`
 }
 


### PR DESCRIPTION
This update adds sample CRs for Node and NodePool, and adds status fields to other sample CRs that were missing it.

In addition, API markers have been added to spec and status fields where they were previously missing, to address scorecard warnings and suggestions.