### PR TITLE
Aligns with the expected returned field names specified in the specification

### DIFF
--- a/internal/cmd/server/start_resource_server.go
+++ b/internal/cmd/server/start_resource_server.go
@@ -360,7 +360,7 @@ func (c *ResourceServerCommand) createResourcePoolHandler(
 	// Create the routes:
 	adapter, err := service.NewAdapter().
 		SetLogger(c.logger).
-		SetPathVariables("resourcePoolID").
+		SetPathVariables("resourcePoolId").
 		SetHandler(handler).
 		Build()
 	if err != nil {
@@ -376,7 +376,7 @@ func (c *ResourceServerCommand) createResourcePoolHandler(
 		adapter,
 	).Methods(http.MethodGet)
 	router.Handle(
-		"/o2ims-infrastructureInventory/{version}/resourcePools/{resourcePoolID}",
+		"/o2ims-infrastructureInventory/{version}/resourcePools/{resourcePoolId}",
 		adapter,
 	).Methods(http.MethodGet)
 
@@ -412,7 +412,7 @@ func (c *ResourceServerCommand) createResourceHandler(
 	// Create the routes:
 	adapter, err := service.NewAdapter().
 		SetLogger(c.logger).
-		SetPathVariables("resourcePoolID", "resourceID").
+		SetPathVariables("resourcePoolId", "resourceID").
 		SetHandler(handler).
 		Build()
 	if err != nil {
@@ -424,11 +424,11 @@ func (c *ResourceServerCommand) createResourceHandler(
 		return exit.Error(1)
 	}
 	router.Handle(
-		"/o2ims-infrastructureInventory/{version}/resourcePools/{resourcePoolID}/resources",
+		"/o2ims-infrastructureInventory/{version}/resourcePools/{resourcePoolId}/resources",
 		adapter,
 	).Methods(http.MethodGet)
 	router.Handle(
-		"/o2ims-infrastructureInventory/{version}/resourcePools/{resourcePoolID}/resources/{resourceID}",
+		"/o2ims-infrastructureInventory/{version}/resourcePools/{resourcePoolId}/resources/{resourceID}",
 		adapter,
 	).Methods(http.MethodGet)
 
@@ -463,7 +463,7 @@ func (c *ResourceServerCommand) createResourceTypeHandler(
 	// Create the collection adapter:
 	adapter, err := service.NewAdapter().
 		SetLogger(c.logger).
-		SetPathVariables("resourceTypeID").
+		SetPathVariables("resourceTypeId").
 		SetHandler(handler).
 		Build()
 	if err != nil {
@@ -479,7 +479,7 @@ func (c *ResourceServerCommand) createResourceTypeHandler(
 		adapter,
 	).Methods(http.MethodGet)
 	router.Handle(
-		"/o2ims-infrastructureInventory/{version}/resourceTypes/{resourceTypeID}",
+		"/o2ims-infrastructureInventory/{version}/resourceTypes/{resourceTypeId}",
 		adapter,
 	).Methods(http.MethodGet)
 

--- a/internal/graphql/graphql.go
+++ b/internal/graphql/graphql.go
@@ -32,10 +32,10 @@ const (
 
 	pCluster        = "cluster"
 	pDescription    = "description"
-	pGlobalAssetID  = "globalAssetID"
+	pGlobalAssetID  = "globalAssetId"
 	pName           = "name"
 	pResourceID     = "resourceID"
-	pResourcePoolID = "resourcePoolID"
+	pResourcePoolID = "resourcePoolId"
 	pSystemUUID     = "_systemUUID"
 	pUid            = "_uid"
 )

--- a/internal/graphql/graphql_test.go
+++ b/internal/graphql/graphql_test.go
@@ -43,7 +43,7 @@ var _ = Describe("GraphQL filters", func() {
 			search.Term{
 				Operator: search.Eq,
 				Path: []string{
-					"resourcePoolID",
+					"resourcePoolId",
 				},
 				Values: []any{
 					"spoke0",
@@ -63,7 +63,7 @@ var _ = Describe("GraphQL filters", func() {
 			search.Term{
 				Operator: search.Eq,
 				Path: []string{
-					"resourcePoolID",
+					"resourcePoolId",
 				},
 				Values: []any{
 					"spoke0",

--- a/internal/openapi/spec.yaml
+++ b/internal/openapi/spec.yaml
@@ -578,7 +578,7 @@ components:
         Information about a resource type.
       type: object
       properties:
-        resourceTypeID:
+        resourceTypeId:
           type: string
           example: "node_8_cores_amd64"
         name:
@@ -652,13 +652,13 @@ components:
         description:
           type: string
           example: "my-node"
-        resourceTypeID:
+        resourceTypeId:
           type: string
           example: "node_8_cores_amd64"
         resourceID:
           type: string
           example: "7c757ebe-559f-450a-9c87-32fc45af7a38"
-        globalAssetID:
+        globalAssetId:
           type: string
           example: "b6f67c72-8915-474b-b369-6198ea1f7b6f"
 
@@ -680,7 +680,7 @@ components:
         resourceID:
           type: string
           example: "my-node"
-        resourceTypeID:
+        resourceTypeId:
           type: string
           example: "node_8_cores_amd64"
         alarmRaisedTime:

--- a/internal/service/alarm_handler_test.go
+++ b/internal/service/alarm_handler_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Alarm handler", func() {
 					RespondWithList(
 						data.Object{
 							"name":           "spoke0",
-							"resourcePoolID": "spoke0",
+							"resourcePoolId": "spoke0",
 						},
 					),
 				)
@@ -429,7 +429,7 @@ var _ = Describe("Alarm handler", func() {
 						RespondWithList(
 							data.Object{
 								"name":           "spoke0",
-								"resourcePoolID": "spoke0",
+								"resourcePoolId": "spoke0",
 							},
 						),
 					),
@@ -509,7 +509,7 @@ var _ = Describe("Alarm handler", func() {
 						RespondWithList(
 							data.Object{
 								"name":           "spoke0",
-								"resourcePoolID": "spoke0",
+								"resourcePoolId": "spoke0",
 							},
 						),
 					),

--- a/internal/service/alarm_mapper.go
+++ b/internal/service/alarm_mapper.go
@@ -183,7 +183,7 @@ func (r *AlarmMapper) MapItem(ctx context.Context,
 	if err != nil {
 		// Instance is not available for cluster global alerts
 		alarmEventRecordId = fmt.Sprintf("%s_%s", alertName, resourcePoolName)
-		resourceID = resourcePool["resourcePoolID"].(string)
+		resourceID = resourcePool["resourcePoolId"].(string)
 	} else {
 		alarmEventRecordId = fmt.Sprintf("%s_%s_%s", alertName, resourcePoolName, alertInstance)
 		resource, err := r.fetchResource(ctx, resourcePoolName, alertInstance)

--- a/internal/service/resource_fetcher.go
+++ b/internal/service/resource_fetcher.go
@@ -160,7 +160,7 @@ func (b *ResourceFetcherBuilder) Build() (
 }
 
 // GetResourceTypeID generates a typeID from a search API object.
-func (h *ResourceFetcher) GetResourceTypeID(from data.Object) (resourceTypeID string, err error) {
+func (h *ResourceFetcher) GetResourceTypeID(from data.Object) (resourceTypeId string, err error) {
 	kind, err := data.GetString(from, "kind")
 	if err != nil {
 		return
@@ -177,7 +177,7 @@ func (h *ResourceFetcher) GetResourceTypeID(from data.Object) (resourceTypeID st
 		if err != nil {
 			return
 		}
-		resourceTypeID = fmt.Sprintf("node_%s_cores_%s", cpu, architecture)
+		resourceTypeId = fmt.Sprintf("node_%s_cores_%s", cpu, architecture)
 	}
 
 	return

--- a/internal/service/resource_handler.go
+++ b/internal/service/resource_handler.go
@@ -372,14 +372,14 @@ func (r *ResourceHandler) mapNodeItem(ctx context.Context, // nolint: unparam
 		return
 	}
 
-	resourcePoolID, err := data.GetString(from,
-		graphql.PropertyNode("resourcePoolID").MapProperty())
+	resourcePoolId, err := data.GetString(from,
+		graphql.PropertyNode("resourcePoolId").MapProperty())
 	if err != nil {
 		return
 	}
 
-	globalAssetID, err := data.GetString(from,
-		graphql.PropertyNode("globalAssetID").MapProperty())
+	globalAssetId, err := data.GetString(from,
+		graphql.PropertyNode("globalAssetId").MapProperty())
 	if err != nil {
 		return
 	}
@@ -390,7 +390,7 @@ func (r *ResourceHandler) mapNodeItem(ctx context.Context, // nolint: unparam
 		return
 	}
 
-	resourceTypeID, err := r.resourceFetcher.GetResourceTypeID(from)
+	resourceTypeId, err := r.resourceFetcher.GetResourceTypeID(from)
 	if err != nil {
 		return
 	}
@@ -412,12 +412,12 @@ func (r *ResourceHandler) mapNodeItem(ctx context.Context, // nolint: unparam
 	}
 
 	to = data.Object{
-		"resourceID":     resourceID,
-		"resourceTypeID": resourceTypeID,
+		"resourceId":     resourceID,
+		"resourceTypeId": resourceTypeId,
 		"description":    description,
 		"extensions":     extensionsMap,
-		"resourcePoolID": resourcePoolID,
-		"globalAssetID":  globalAssetID,
+		"resourcePoolId": resourcePoolId,
+		"globalAssetId":  globalAssetId,
 	}
 	return
 }

--- a/internal/service/resource_handler_test.go
+++ b/internal/service/resource_handler_test.go
@@ -219,18 +219,18 @@ var _ = Describe("Resource handler", func() {
 				Expect(items).To(HaveLen(2))
 
 				// Verify first result:
-				Expect(items[0]).To(MatchJQ(`.resourceID`, "node-0-system-uuid"))
+				Expect(items[0]).To(MatchJQ(`.resourceId`, "node-0-system-uuid"))
 				Expect(items[0]).To(MatchJQ(`.description`, "my-node-0"))
-				Expect(items[0]).To(MatchJQ(`.globalAssetID`, "node-0-global-uuid"))
+				Expect(items[0]).To(MatchJQ(`.globalAssetId`, "node-0-global-uuid"))
 				Expect(items[0]).To(MatchJQ(`.description`, "my-node-0"))
-				Expect(items[0]).To(MatchJQ(`.resourcePoolID`, "0"))
+				Expect(items[0]).To(MatchJQ(`.resourcePoolId`, "0"))
 
 				// Verify second result:
-				Expect(items[1]).To(MatchJQ(`.resourceID`, "node-1-system-uuid"))
+				Expect(items[1]).To(MatchJQ(`.resourceId`, "node-1-system-uuid"))
 				Expect(items[1]).To(MatchJQ(`.description`, "my-node-1"))
-				Expect(items[1]).To(MatchJQ(`.globalAssetID`, "node-1-global-uuid"))
+				Expect(items[1]).To(MatchJQ(`.globalAssetId`, "node-1-global-uuid"))
 				Expect(items[1]).To(MatchJQ(`.description`, "my-node-1"))
-				Expect(items[1]).To(MatchJQ(`.resourcePoolID`, "1"))
+				Expect(items[1]).To(MatchJQ(`.resourcePoolId`, "1"))
 			})
 
 			It("Accepts a filter", func() {
@@ -248,7 +248,7 @@ var _ = Describe("Resource handler", func() {
 						Terms: []*search.Term{{
 							Operator: search.Eq,
 							Path: []string{
-								"resourcePoolID",
+								"resourcePoolId",
 							},
 							Values: []any{
 								"spoke0",
@@ -285,7 +285,7 @@ var _ = Describe("Resource handler", func() {
 							{
 								Operator: search.Eq,
 								Path: []string{
-									"resourcePoolID",
+									"resourcePoolId",
 								},
 								Values: []any{
 									"spoke0",
@@ -336,7 +336,7 @@ var _ = Describe("Resource handler", func() {
 							{
 								Operator: search.Cont,
 								Path: []string{
-									"resourcePoolID",
+									"resourcePoolId",
 								},
 								Values: []any{
 									"spoke0",
@@ -472,10 +472,10 @@ var _ = Describe("Resource handler", func() {
 				Expect(response).ToNot(BeNil())
 
 				// Verify the result:
-				Expect(response.Object).To(MatchJQ(`.resourceID`, "node-0-system-uuid"))
+				Expect(response.Object).To(MatchJQ(`.resourceId`, "node-0-system-uuid"))
 				Expect(response.Object).To(MatchJQ(`.description`, "my-node-0"))
-				Expect(response.Object).To(MatchJQ(`.resourcePoolID`, "0"))
-				Expect(response.Object).To(MatchJQ(`.globalAssetID`, "node-0-uuid"))
+				Expect(response.Object).To(MatchJQ(`.resourcePoolId`, "0"))
+				Expect(response.Object).To(MatchJQ(`.globalAssetId`, "node-0-uuid"))
 			})
 		})
 	})

--- a/internal/service/resource_pool_fetcher.go
+++ b/internal/service/resource_pool_fetcher.go
@@ -282,8 +282,8 @@ func (r *ResourcePoolFetcher) getSearchResponse(ctx context.Context) (result io.
 // Map Cluster to an O2 ResourcePool object.
 func (r *ResourcePoolFetcher) mapClusterItem(ctx context.Context,
 	from data.Object) (to data.Object, err error) {
-	resourcePoolID, err := data.GetString(from,
-		graphql.PropertyCluster("resourcePoolID").MapProperty())
+	resourcePoolId, err := data.GetString(from,
+		graphql.PropertyCluster("resourcePoolId").MapProperty())
 	if err != nil {
 		return
 	}
@@ -330,14 +330,14 @@ func (r *ResourcePoolFetcher) mapClusterItem(ctx context.Context,
 	}
 
 	to = data.Object{
-		"resourcePoolID": resourcePoolID,
+		"resourcePoolId": resourcePoolId,
 		"name":           name,
-		"oCloudID":       r.cloudID,
+		"oCloudId":       r.cloudID,
 		"extensions":     extensionsMap,
 		"location":       location,
 		"description":    description,
 		// TODO: no direct mapping to a property in Cluster object
-		"globalLocationID": "",
+		"globalLocationId": "",
 	}
 
 	return

--- a/internal/service/resource_pool_handler_test.go
+++ b/internal/service/resource_pool_handler_test.go
@@ -204,19 +204,19 @@ var _ = Describe("Resource pool handler", func() {
 
 				// Verify first result:
 				Expect(items[0]).To(MatchJQ(`.description`, "0"))
-				Expect(items[0]).To(MatchJQ(`.globalLocationID`, ""))
+				Expect(items[0]).To(MatchJQ(`.globalLocationId`, ""))
 				Expect(items[0]).To(MatchJQ(`.location`, "US"))
 				Expect(items[0]).To(MatchJQ(`.name`, "my-cluster-0"))
-				Expect(items[0]).To(MatchJQ(`.oCloudID`, "123"))
-				Expect(items[0]).To(MatchJQ(`.resourcePoolID`, "0"))
+				Expect(items[0]).To(MatchJQ(`.oCloudId`, "123"))
+				Expect(items[0]).To(MatchJQ(`.resourcePoolId`, "0"))
 
 				// Verify second result:
 				Expect(items[1]).To(MatchJQ(`.description`, "1"))
-				Expect(items[1]).To(MatchJQ(`.globalLocationID`, ""))
+				Expect(items[1]).To(MatchJQ(`.globalLocationId`, ""))
 				Expect(items[1]).To(MatchJQ(`.location`, "EU"))
 				Expect(items[1]).To(MatchJQ(`.name`, "my-cluster-1"))
-				Expect(items[1]).To(MatchJQ(`.oCloudID`, "123"))
-				Expect(items[1]).To(MatchJQ(`.resourcePoolID`, "1"))
+				Expect(items[1]).To(MatchJQ(`.oCloudId`, "123"))
+				Expect(items[1]).To(MatchJQ(`.resourcePoolId`, "1"))
 			})
 
 			It("Accepts a filter", func() {
@@ -231,7 +231,7 @@ var _ = Describe("Resource pool handler", func() {
 						Terms: []*search.Term{{
 							Operator: search.Eq,
 							Path: []string{
-								"resourcePoolID",
+								"resourcePoolId",
 							},
 							Values: []any{
 								"spoke0",
@@ -265,7 +265,7 @@ var _ = Describe("Resource pool handler", func() {
 							{
 								Operator: search.Eq,
 								Path: []string{
-									"resourcePoolID",
+									"resourcePoolId",
 								},
 								Values: []any{
 									"spoke0",
@@ -313,7 +313,7 @@ var _ = Describe("Resource pool handler", func() {
 							{
 								Operator: search.Cont,
 								Path: []string{
-									"resourcePoolID",
+									"resourcePoolId",
 								},
 								Values: []any{
 									"spoke0",
@@ -440,11 +440,11 @@ var _ = Describe("Resource pool handler", func() {
 
 				// Verify the result:
 				Expect(response.Object).To(MatchJQ(`.description`, "0"))
-				Expect(response.Object).To(MatchJQ(`.globalLocationID`, ""))
+				Expect(response.Object).To(MatchJQ(`.globalLocationId`, ""))
 				Expect(response.Object).To(MatchJQ(`.location`, "US"))
 				Expect(response.Object).To(MatchJQ(`.name`, "my-cluster-0"))
-				Expect(response.Object).To(MatchJQ(`.oCloudID`, "123"))
-				Expect(response.Object).To(MatchJQ(`.resourcePoolID`, "0"))
+				Expect(response.Object).To(MatchJQ(`.oCloudId`, "123"))
+				Expect(response.Object).To(MatchJQ(`.resourcePoolId`, "0"))
 			})
 		})
 	})

--- a/internal/service/resource_type_handler.go
+++ b/internal/service/resource_type_handler.go
@@ -252,7 +252,7 @@ func (h *ResourceTypeHandler) getUniqueSlice(items []data.Object) []data.Object 
 	allKeys := make(map[string]bool)
 	list := []data.Object{}
 	for _, item := range items {
-		id := item["resourceTypeID"].(string)
+		id := item["resourceTypeId"].(string)
 		if _, value := allKeys[id]; !value {
 			allKeys[id] = true
 			list = append(list, item)
@@ -276,7 +276,7 @@ func (h *ResourceTypeHandler) fetchItem(ctx context.Context,
 	resourceTypes = data.Select(
 		resourceTypes,
 		func(ctx context.Context, item data.Object) (result bool, err error) {
-			result = item["resourceTypeID"] == id
+			result = item["resourceTypeId"] == id
 			return
 		},
 	)
@@ -363,12 +363,12 @@ func (h *ResourceTypeHandler) mapItem(ctx context.Context,
 		return
 	}
 
-	var resourceClass, resourceKind, resourceTypeID string
+	var resourceClass, resourceKind, resourceTypeId string
 	switch kind { // nolint: gocritic
 	case KindNode:
 		resourceClass = ResourceClassCompute
 		resourceKind = ResourceKindPhysical
-		resourceTypeID, err = h.resourceFetcher.GetResourceTypeID(from)
+		resourceTypeId, err = h.resourceFetcher.GetResourceTypeID(from)
 		if err != nil {
 			return
 		}
@@ -380,8 +380,8 @@ func (h *ResourceTypeHandler) mapItem(ctx context.Context,
 	}
 
 	to = data.Object{
-		"resourceTypeID":  resourceTypeID,
-		"name":            resourceTypeID,
+		"resourceTypeId":  resourceTypeId,
+		"name":            resourceTypeId,
 		"resourceKind":    resourceKind,
 		"resourceClass":   resourceClass,
 		"alarmDictionary": alarmDictionary,

--- a/internal/service/resource_type_handler_test.go
+++ b/internal/service/resource_type_handler_test.go
@@ -203,14 +203,14 @@ var _ = Describe("Resource type handler", func() {
 				Expect(items).To(HaveLen(2))
 
 				// Verify first result:
-				Expect(items[0]).To(MatchJQ(`.resourceTypeID`, "node_8_cores_amd64"))
+				Expect(items[0]).To(MatchJQ(`.resourceTypeId`, "node_8_cores_amd64"))
 				Expect(items[0]).To(MatchJQ(`.name`, "node_8_cores_amd64"))
 				Expect(items[0]).To(MatchJQ(`.resourceKind`, "PHYSICAL"))
 				Expect(items[0]).To(MatchJQ(`.resourceClass`, "COMPUTE"))
 				Expect(items[0]).To(HaveKey("alarmDictionary"))
 
 				// Verify second result:
-				Expect(items[1]).To(MatchJQ(`.resourceTypeID`, "node_4_cores_arm64"))
+				Expect(items[1]).To(MatchJQ(`.resourceTypeId`, "node_4_cores_arm64"))
 				Expect(items[1]).To(MatchJQ(`.name`, "node_4_cores_arm64"))
 				Expect(items[1]).To(MatchJQ(`.resourceKind`, "PHYSICAL"))
 				Expect(items[1]).To(MatchJQ(`.resourceClass`, "COMPUTE"))
@@ -258,7 +258,7 @@ var _ = Describe("Resource type handler", func() {
 				Expect(response).ToNot(BeNil())
 
 				// Verify the result:
-				Expect(response.Object).To(MatchJQ(`.resourceTypeID`, "node_8_cores_amd64"))
+				Expect(response.Object).To(MatchJQ(`.resourceTypeId`, "node_8_cores_amd64"))
 				Expect(response.Object).To(MatchJQ(`.name`, "node_8_cores_amd64"))
 				Expect(response.Object).To(MatchJQ(`.resourceKind`, "PHYSICAL"))
 				Expect(response.Object).To(MatchJQ(`.resourceClass`, "COMPUTE"))


### PR DESCRIPTION
The returned fields for some API endpoints are returning incorrect field names based on the specification (O-RAN 2IMS INTERFACE v6 spec). See for instance tables:

- Table 2.1.1.1.3-1: Attributes of the ResourceType
- Table 2.1.1.1.4-1: Attributes of the ResourcePool
- Table 2.1.1.1.5-1: Attributes of the Resource

This fix modifies the returned value and replaces:

- resourceTypeID by resourcetTypeId
- globalLocationID by globalLocationId
- resourcePoolID by resourcePoolId

With these changes, some faulty [O2IMS Compliance Test](https://github.com/o-ran-sc/it-test/tree/master/test_scripts/O2IMS_Compliance_Test) pass. 

PD. For testing you can use my ORAN-O2IMS operator image, which already contains the fix at quay.io/alosadag/oran-o2ims:v4.16.1
