### PR TITLE
NO-ISSUE: Add shortnames for ORAN CRs

### DIFF
--- a/api/hardwaremanagement/v1alpha1/node.go
+++ b/api/hardwaremanagement/v1alpha1/node.go
@@ -69,6 +69,9 @@ type NodeStatus struct {
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:path=nodes,shortName=orannode
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].reason"
 // +operator-sdk:csv:customresourcedefinitions:displayName="Node",resources={{Namespace, v1}}
 type Node struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -88,9 +88,11 @@ type NodePoolStatus struct {
 
 // NodePool is the schema for an allocation request of nodes
 //
-// +kubebuilder:resource:shortName=np
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:path=nodepools,shortName=orannp
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].reason"
 // +operator-sdk:csv:customresourcedefinitions:displayName="Node Pool",resources={{Namespace, v1}}
 type NodePool struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/provisioning/v1alpha1/clustertemplate_types.go
+++ b/api/provisioning/v1alpha1/clustertemplate_types.go
@@ -83,6 +83,10 @@ type ClusterTemplateStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:path=clustertemplates,shortName=oranct
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+//+kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].reason"
+//+kubebuilder:printcolumn:name="Details",type="string",JSONPath=".status.conditions[-1:].message"
 
 // ClusterTemplate is the Schema for the clustertemplates API
 // +kubebuilder:validation:XValidation:message="Spec changes are not allowed for a ClusterTemplate that has passed the validation", rule="!has(oldSelf.status) || oldSelf.status.conditions.exists(c, c.type=='ClusterTemplateValidated' && c.status=='False') || oldSelf.spec == self.spec"

--- a/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -116,7 +116,11 @@ type ProvisioningRequestStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,shortName=oranpr
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+//+kubebuilder:printcolumn:name="HW Provisioning",type="string",JSONPath=".status.conditions[?(@.type=='HardwareProvisioned')].reason"
+//+kubebuilder:printcolumn:name="Installation",type="string",JSONPath=".status.conditions[?(@.type=='ClusterProvisioned')].reason"
+//+kubebuilder:printcolumn:name="Configuration",type="string",JSONPath=".status.conditions[?(@.type=='ConfigurationApplied')].reason"
 
 // ProvisioningRequest is the Schema for the provisioningrequests API
 // +operator-sdk:csv:customresourcedefinitions:displayName="ORAN O2IMS Provisioning Request",resources={{Namespace, v1},{ClusterInstance, siteconfig.open-cluster-management.io/v1alpha1}}

--- a/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
+++ b/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
@@ -12,11 +12,18 @@ spec:
     listKind: NodePoolList
     plural: nodepools
     shortNames:
-    - np
+    - orannp
     singular: nodepool
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[-1:].reason
+      name: State
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NodePool is the schema for an allocation request of nodes

--- a/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
+++ b/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
@@ -11,10 +11,19 @@ spec:
     kind: Node
     listKind: NodeList
     plural: nodes
+    shortNames:
+    - orannode
     singular: node
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[-1:].reason
+      name: State
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Node is the schema for an allocated node

--- a/bundle/manifests/o2ims.provisioning.oran.org_clustertemplates.yaml
+++ b/bundle/manifests/o2ims.provisioning.oran.org_clustertemplates.yaml
@@ -11,10 +11,22 @@ spec:
     kind: ClusterTemplate
     listKind: ClusterTemplateList
     plural: clustertemplates
+    shortNames:
+    - oranct
     singular: clustertemplate
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[-1:].reason
+      name: State
+      type: string
+    - jsonPath: .status.conditions[-1:].message
+      name: Details
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ClusterTemplate is the Schema for the clustertemplates API

--- a/bundle/manifests/o2ims.provisioning.oran.org_provisioningrequests.yaml
+++ b/bundle/manifests/o2ims.provisioning.oran.org_provisioningrequests.yaml
@@ -11,10 +11,25 @@ spec:
     kind: ProvisioningRequest
     listKind: ProvisioningRequestList
     plural: provisioningrequests
+    shortNames:
+    - oranpr
     singular: provisioningrequest
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=='HardwareProvisioned')].reason
+      name: HW Provisioning
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='ClusterProvisioned')].reason
+      name: Installation
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='ConfigurationApplied')].reason
+      name: Configuration
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ProvisioningRequest is the Schema for the provisioningrequests

--- a/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
+++ b/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
@@ -12,11 +12,18 @@ spec:
     listKind: NodePoolList
     plural: nodepools
     shortNames:
-    - np
+    - orannp
     singular: nodepool
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[-1:].reason
+      name: State
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NodePool is the schema for an allocation request of nodes

--- a/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
+++ b/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
@@ -11,10 +11,19 @@ spec:
     kind: Node
     listKind: NodeList
     plural: nodes
+    shortNames:
+    - orannode
     singular: node
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[-1:].reason
+      name: State
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Node is the schema for an allocated node

--- a/config/crd/bases/o2ims.provisioning.oran.org_clustertemplates.yaml
+++ b/config/crd/bases/o2ims.provisioning.oran.org_clustertemplates.yaml
@@ -11,10 +11,22 @@ spec:
     kind: ClusterTemplate
     listKind: ClusterTemplateList
     plural: clustertemplates
+    shortNames:
+    - oranct
     singular: clustertemplate
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[-1:].reason
+      name: State
+      type: string
+    - jsonPath: .status.conditions[-1:].message
+      name: Details
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ClusterTemplate is the Schema for the clustertemplates API

--- a/config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml
+++ b/config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml
@@ -11,10 +11,25 @@ spec:
     kind: ProvisioningRequest
     listKind: ProvisioningRequestList
     plural: provisioningrequests
+    shortNames:
+    - oranpr
     singular: provisioningrequest
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=='HardwareProvisioned')].reason
+      name: HW Provisioning
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='ClusterProvisioned')].reason
+      name: Installation
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='ConfigurationApplied')].reason
+      name: Configuration
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ProvisioningRequest is the Schema for the provisioningrequests

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node.go
@@ -69,6 +69,9 @@ type NodeStatus struct {
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:path=nodes,shortName=orannode
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].reason"
 // +operator-sdk:csv:customresourcedefinitions:displayName="Node",resources={{Namespace, v1}}
 type Node struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -88,9 +88,11 @@ type NodePoolStatus struct {
 
 // NodePool is the schema for an allocation request of nodes
 //
-// +kubebuilder:resource:shortName=np
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:path=nodepools,shortName=orannp
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].reason"
 // +operator-sdk:csv:customresourcedefinitions:displayName="Node Pool",resources={{Namespace, v1}}
 type NodePool struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/clustertemplate_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/clustertemplate_types.go
@@ -83,6 +83,10 @@ type ClusterTemplateStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:path=clustertemplates,shortName=oranct
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+//+kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].reason"
+//+kubebuilder:printcolumn:name="Details",type="string",JSONPath=".status.conditions[-1:].message"
 
 // ClusterTemplate is the Schema for the clustertemplates API
 // +kubebuilder:validation:XValidation:message="Spec changes are not allowed for a ClusterTemplate that has passed the validation", rule="!has(oldSelf.status) || oldSelf.status.conditions.exists(c, c.type=='ClusterTemplateValidated' && c.status=='False') || oldSelf.spec == self.spec"

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -116,7 +116,11 @@ type ProvisioningRequestStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,shortName=oranpr
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+//+kubebuilder:printcolumn:name="HW Provisioning",type="string",JSONPath=".status.conditions[?(@.type=='HardwareProvisioned')].reason"
+//+kubebuilder:printcolumn:name="Installation",type="string",JSONPath=".status.conditions[?(@.type=='ClusterProvisioned')].reason"
+//+kubebuilder:printcolumn:name="Configuration",type="string",JSONPath=".status.conditions[?(@.type=='ConfigurationApplied')].reason"
 
 // ProvisioningRequest is the Schema for the provisioningrequests API
 // +operator-sdk:csv:customresourcedefinitions:displayName="ORAN O2IMS Provisioning Request",resources={{Namespace, v1},{ClusterInstance, siteconfig.open-cluster-management.io/v1alpha1}}


### PR DESCRIPTION
Description:
- add `oranct`, `oranpr`, `onrannode` and `orannp` as shortnames
- add printcolumns for all CRs to show their age and main conditions

Examples:
```
$  oc get oranct -A
NAMESPACE                 NAME                   AGE     STATE       DETAILS
clustertemplate-a-v4-16   clustertemplate-a.v1   4d21h   Completed   The cluster template validation succeeded
clustertemplate-a-v4-16   clustertemplate-a.v2   4d21h   Completed   The cluster template validation succeeded

$  oc get oranpr
NAME      AGE     HW PROVISIONING   INSTALLATION   CONFIGURATION
cnfdg11   2m10s   Completed         InProgress     ClusterNotReady

$  oc get orannode -A
NAMESPACE                NAME      AGE    STATE
oran-hwmgr-plugin-test   cnfdg11   2m8s   Completed

$  oc get orannp -A
NAMESPACE                NAME      AGE     STATE
oran-hwmgr-plugin-test   cnfdg11   2m22s   Completed

```