### PR TITLE
Missing required field "description" in resourceType attribute

### DIFF
--- a/internal/service/resource_type_handler.go
+++ b/internal/service/resource_type_handler.go
@@ -386,10 +386,11 @@ func (h *ResourceTypeHandler) mapItem(ctx context.Context,
 		"resourceClass":   resourceClass,
 		"alarmDictionary": alarmDictionary,
 		// TODO: no direct mapping
-		"extensions": "",
-		"vendor":     "",
-		"model":      "",
-		"version":    "",
+		"description": "",
+		"extensions":  "",
+		"vendor":      "",
+		"model":       "",
+		"version":     "",
 	}
 	return
 }


### PR DESCRIPTION
According to the O2ims Interface Specification document we are missing the field "description" as an attribute of the resourceType. See Table 2.1.1.1.3-1: Attributes of the ResourceType in the O-RAN WG6 O2IMS INTERFACE document.

I just added the description field returning an empty value in order to pass the conformance tests.

