### PR TITLE
NO-ISSUE: Add validator du policy in the PG examples

### DIFF
--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v1.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v1.yaml
@@ -21,7 +21,6 @@ policyDefaults:
   evaluationInterval:
     compliant: 5m
     noncompliant: 10s
-  consolidateManifests: false
   orderPolicies: true
 policies:
 - name: v1-subscriptions-policy
@@ -99,7 +98,7 @@ policies:
         spec:
           resourceName: du_fh
           vlan: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-vlan-1" | toInt hub}}'
-    - path: source-crs/SriovNetwork.yaml # wave 100
+    - path: source-crs/SriovNetwork.yaml
       patches:
       - metadata:
           name: sriov-nw-du-mh
@@ -126,3 +125,12 @@ policies:
                 [service]
                 service.stalld=start,enable
                 service.chronyd=stop,disable
+- name: v1-du-validator-policy
+  remediationAction: inform
+  # This policy is not re-evaluated after it becomes
+  # compliant to reduce resource usage.
+  evaluationInterval:
+    compliant: never
+    noncompliant: 10s
+  manifests:
+    - path: source-crs/validatorCRs/informDuValidatorMaster.yaml

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v2.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v2.yaml
@@ -21,7 +21,6 @@ policyDefaults:
   evaluationInterval:
     compliant: 5m
     noncompliant: 10s
-  consolidateManifests: false
   orderPolicies: true
 policies:
 - name: v2-subscriptions-policy
@@ -99,7 +98,7 @@ policies:
         spec:
           resourceName: du_fh
           vlan: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-vlan-1" | toInt hub}}'
-    - path: source-crs/SriovNetwork.yaml # wave 100
+    - path: source-crs/SriovNetwork.yaml
       patches:
       - metadata:
           name: sriov-nw-du-mh
@@ -131,3 +130,12 @@ policies:
                 [service]
                 service.stalld=start,enable
                 service.chronyd=stop,disable
+- name: v2-du-validator-policy
+  remediationAction: inform
+  # This policy is not re-evaluated after it becomes
+  # compliant to reduce resource usage.
+  evaluationInterval:
+    compliant: never
+    noncompliant: 10s
+  manifests:
+    - path: source-crs/validatorCRs/informDuValidatorMaster.yaml

--- a/internal/controllers/utils/conditions.go
+++ b/internal/controllers/utils/conditions.go
@@ -3,6 +3,7 @@ package utils
 import (
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	siteconfigv1alpha1 "github.com/stolostron/siteconfig/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -111,10 +112,15 @@ func IsClusterProvisionPresent(cr *provisioningv1alpha1.ProvisioningRequest) boo
 	return condition != nil
 }
 
-// IsClusterProvisionCompleted checks if the cluster provision condition status is completed
+// IsClusterProvisionCompleted checks if the cluster provision condition status is completed.
+// The staleCondition is set when the ClusterDeployment's spec.installed has become true, but its status
+// conditions have not been properly updated due to the known issue (https://issues.redhat.com/browse/ACM-13064).
+// In this case, the cluster has actually been successfully installed and is ready for configuration,
+// but the status wasn't updated correctly. Therefore, we treat it as completed so that the provisioningStatus
+// be updated properly. This workaround can be removed after ACM 2.12 GA.
 func IsClusterProvisionCompleted(cr *provisioningv1alpha1.ProvisioningRequest) bool {
 	condition := meta.FindStatusCondition(cr.Status.Conditions, (string(PRconditionTypes.ClusterProvisioned)))
-	return condition != nil && condition.Status == metav1.ConditionTrue
+	return condition != nil && (condition.Status == metav1.ConditionTrue || condition.Reason == string(siteconfigv1alpha1.StaleConditions))
 }
 
 // IsClusterProvisionTimedOutOrFailed checks if the cluster provision condition status is timedout or failed


### PR DESCRIPTION
A few updates:
- Add du validator policy in the PGs and set `evaluationInterval` to `never` for compliant so that the policy is not re-evaluated after it becomes compliant (to match with the legacy ZTP). We will also try out the configuration policy event-driven feature [ACM-11666](https://issues.redhat.com/browse/ACM-11666) introduced in ACM 2.12 for all policies.
- Remove `consolidateManifests: false` since all manifests added in a single policy have no dependencies and should be able to apply in parallel.
- Treat Cluster installation as completed when ClusterInstance status condition reason has `staleCondition`. As described in the comment, that is due to issue [ACM-13064](https://issues.redhat.com/browse/ACM-13064). In this case, the cluster is actually installed successfully and configurations can be applied through policies, it's just that clusterdeployment status condition was not udpated properly.