### PR TITLE
NO-ISSUE: Do not reconcile on config timeout

### DIFF
--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -546,7 +546,9 @@ defaultHugepagesSize: "1G"`,
 
 		// Call the handleClusterPolicyConfiguration function.
 		requeue, err := CRTask.handleClusterPolicyConfiguration(context.Background())
-		Expect(requeue).To(BeTrue()) // there are NonCompliant policies in enforce
+		// There are NonCompliant policies in enforce and the configuration has not timed out,
+		// so we need to requeue to re-evaluate the timeout.
+		Expect(requeue).To(BeTrue())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(CRTask.object.Status.ClusterDetails.NonCompliantAt).ToNot(BeZero())
 		Expect(CRTask.object.Status.Policies).To(ConsistOf(
@@ -583,7 +585,9 @@ defaultHugepagesSize: "1G"`,
 
 		// Call the handleClusterPolicyConfiguration function.
 		requeue, err = CRTask.handleClusterPolicyConfiguration(context.Background())
-		Expect(requeue).To(BeTrue()) // there are NonCompliant policies in enforce
+		// There are NonCompliant policies in enforce, but the configuration has timed out,
+		// so we do not need to requeue.
+		Expect(requeue).To(BeFalse())
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check the status conditions.
@@ -994,7 +998,9 @@ defaultHugepagesSize: "1G"`,
 
 		// Call the handleClusterPolicyConfiguration function.
 		requeue, err = CRTask.handleClusterPolicyConfiguration(context.Background())
-		Expect(requeue).To(BeTrue()) // there are NonCompliant policies in enforce
+		// There are NonCompliant policies in enforce and the configuration has not timed out,
+		// so we need to requeue to re-evaluate the timeout.
+		Expect(requeue).To(BeTrue())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(CRTask.object.Status.ClusterDetails.NonCompliantAt).ToNot(BeZero())
 		Expect(CRTask.object.Status.Policies).To(ConsistOf(
@@ -1031,7 +1037,9 @@ defaultHugepagesSize: "1G"`,
 
 		// Call the handleClusterPolicyConfiguration function.
 		requeue, err = CRTask.handleClusterPolicyConfiguration(context.Background())
-		Expect(requeue).To(BeTrue()) // there are NonCompliant policies in enforce
+		// There are NonCompliant policies in enforce, but the configuration has timed out,
+		// so we do not need to requeue.
+		Expect(requeue).To(BeFalse())
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check the status conditions.
@@ -1048,7 +1056,9 @@ defaultHugepagesSize: "1G"`,
 		// Check that another handleClusterPolicyConfiguration call doesn't change the status if
 		// the policies are the same.
 		requeue, err = CRTask.handleClusterPolicyConfiguration(context.Background())
-		Expect(requeue).To(BeTrue()) // there are NonCompliant policies in enforce
+		// There are NonCompliant policies in enforce, but the configuration has timed out,
+		// so we do not need to requeue.
+		Expect(requeue).To(BeFalse())
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check the status conditions.

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -253,7 +253,7 @@ func (t *provisioningRequestReconcilerTask) run(ctx context.Context) (ctrl.Resul
 		}
 
 		// Requeue if cluster provisioning is not completed (in-progress or unknown)
-		// or there are enforce policies that are not Compliant
+		// or there are enforce policies that are not Compliant.
 		if !utils.IsClusterProvisionCompleted(t.object) || requeue {
 			return requeueWithLongInterval(), nil
 		}

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -78,6 +79,8 @@ var _ = BeforeSuite(func() {
 	adapter := logr.FromSlogHandler(logger.Handler())
 	ctrl.SetLogger(adapter)
 	klog.SetLogger(adapter)
+
+	os.Setenv("HWMGR_PLUGIN_NAMESPACE", "hwmgr")
 
 	// Add all the required types to the scheme used by the tests:
 	scheme.AddKnownTypes(inventoryv1alpha1.GroupVersion, &inventoryv1alpha1.Inventory{})


### PR DESCRIPTION
Do not periodically requeue if there are NonCompliant policies in enforce, but we have reached Timeout.
If the policies become Compliant in the meantime, IMS will get triggered and it will reconcile.