### PR TITLE
CNF-15060: Switch to use ownerReference for ProvisioningRequest created CRs

### DIFF
--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -369,7 +369,7 @@ func generateTemplateID(ctx context.Context, c client.Client, object *provisioni
 	newTemplate := object.DeepCopy()
 	newTemplate.Spec.TemplateID = newID.String()
 
-	err := utils.CreateK8sCR(ctx, c, newTemplate, object, utils.PATCH)
+	err := utils.CreateK8sCR(ctx, c, newTemplate, nil, utils.PATCH)
 	if err != nil {
 		return fmt.Errorf("failed to patch templateID in ClusterTemplate %s: %w", object.Name, err)
 	}

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -139,8 +139,7 @@ defaultHugepagesSize: "1G"`,
 			// Provisioning Requests.
 			&provisioningv1alpha1.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "cluster-1",
-					Finalizers: []string{provisioningRequestFinalizer},
+					Name: "cluster-1",
 				},
 				Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 					TemplateName:    tName,
@@ -1638,8 +1637,7 @@ var _ = Describe("hasPolicyConfigurationTimedOut", func() {
 			// Provisioning Request.
 			&provisioningv1alpha1.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "cluster-1",
-					Finalizers: []string{provisioningRequestFinalizer},
+					Name: "cluster-1",
 				},
 				Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 					TemplateName:    tName,

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hwv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
@@ -190,6 +191,11 @@ func (t *provisioningRequestReconcilerTask) applyClusterInstance(ctx context.Con
 		if isDryRun {
 			opts = append(opts, client.DryRunAll)
 			operationType = utils.OperationTypeDryRun
+		}
+
+		err = ctrl.SetControllerReference(t.object, clusterInstance, t.client.Scheme())
+		if err != nil {
+			return fmt.Errorf("failed to set controller reference: %w", err)
 		}
 
 		// Create the ClusterInstance

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -36,8 +36,7 @@ var _ = Describe("handleRenderClusterInstance", func() {
 		// Define the provisioning request.
 		cr = &provisioningv1alpha1.ProvisioningRequest{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      crName,
-				Namespace: ctNamespace,
+				Name: crName,
 			},
 			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 				TemplateName:    tName,

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -615,8 +615,7 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 		// Define the provisioning request.
 		cr = &provisioningv1alpha1.ProvisioningRequest{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:       crName,
-				Finalizers: []string{provisioningRequestFinalizer},
+				Name: crName,
 			},
 			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 				TemplateName:    tName,
@@ -1876,8 +1875,7 @@ var _ = Describe("getCrClusterTemplateRef", func() {
 		// Define the provisioning request.
 		cr := &provisioningv1alpha1.ProvisioningRequest{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      crName,
-				Namespace: ctNamespace,
+				Name: crName,
 			},
 			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 				TemplateName:    tName,

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -81,8 +81,7 @@ var _ = Describe("renderHardwareTemplate", func() {
 		// Define the provisioning request.
 		cr := &provisioningv1alpha1.ProvisioningRequest{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      crName,
-				Namespace: ctNamespace,
+				Name: crName,
 			},
 			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 				TemplateName:    tName,

--- a/internal/controllers/provisioningrequest_resourcecreation.go
+++ b/internal/controllers/provisioningrequest_resourcecreation.go
@@ -195,7 +195,7 @@ func (t *provisioningRequestReconcilerTask) createPullSecret(
 		Type: corev1.SecretTypeDockerConfigJson,
 	}
 
-	if err := utils.CreateK8sCR(ctx, t.client, newClusterInstancePullSecret, nil, utils.UPDATE); err != nil {
+	if err := utils.CreateK8sCR(ctx, t.client, newClusterInstancePullSecret, t.object, utils.UPDATE); err != nil {
 		return fmt.Errorf("failed to create Kubernetes CR for ClusterInstancePullSecret: %w", err)
 	}
 
@@ -254,7 +254,7 @@ func (t *provisioningRequestReconcilerTask) createClusterInstanceNamespace(
 	labels[provisioningRequestNameLabel] = t.object.Name
 	namespace.SetLabels(labels)
 
-	err := utils.CreateK8sCR(ctx, t.client, namespace, nil, "")
+	err := utils.CreateK8sCR(ctx, t.client, namespace, t.object, "")
 	if err != nil {
 		return fmt.Errorf("failed to create or update namespace %s: %w", clusterName, err)
 	}

--- a/internal/controllers/provisioningrequest_resourcecreation_test.go
+++ b/internal/controllers/provisioningrequest_resourcecreation_test.go
@@ -32,8 +32,7 @@ var _ = Describe("createPolicyTemplateConfigMap", func() {
 		// Define the provisioning request.
 		cr := &provisioningv1alpha1.ProvisioningRequest{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      crName,
-				Namespace: ctNamespace,
+				Name: crName,
 			},
 			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 				TemplateName:    tName,


### PR DESCRIPTION
Switch to use ownerReference to simplify the resources cleanup and watchers:
- Set the ProvisioningRequest as the owner for its created resources that haven't been set yet
- Remove finalizers
- Remove watch mappers for NodePool and ClusterInstance