### PR TITLE
Add HardwareNodeConfigApplied status to Provisioning Request

### DIFF
--- a/docs/cluster-provisioning.md
+++ b/docs/cluster-provisioning.md
@@ -81,6 +81,7 @@ The status of the provisioning process is tracked via the following `status.cond
 - ClusterResourcesCreated: The necessary cluster resources have been created.
 - HardwareTemplateRendered: The hardware template has been successfully rendered.
 - HardwareProvisioned: Hardware provisioning is complete.
+- HardwareNodeConfigApplied: Hardware node configuration is applied.
 - ClusterProvisioned: Cluster installation is complete.
 - ConfigurationApplied: Configuration has been successfully applied via ACM enforce policies.
 
@@ -171,6 +172,11 @@ ProvisioningRequestValidated -> ClusterInstanceRendered -> ClusterResourcesCreat
         reason: Completed
         status: "True"
         type: HardwareProvisioned
+      - lastTransitionTime: "2024-10-19T00:27:30Z"
+        message: Node configuration has been applied to the rendered ClusterInstance
+        reason: Completed
+        status: "True"
+        type: HardwareNodeConfigApplied
       - lastTransitionTime: "2024-10-19T00:27:31Z"
         message: Applied and processed ClusterInstance (sno1) successfully
         reason: Completed
@@ -207,6 +213,11 @@ ProvisioningRequestValidated -> ClusterInstanceRendered -> ClusterResourcesCreat
         reason: Completed
         status: "True"
         type: HardwareProvisioned
+      - lastTransitionTime: "2024-10-19T00:27:30Z"
+        message: Node configuration has been applied to the rendered ClusterInstance
+        reason: Completed
+        status: "True"
+        type: HardwareNodeConfigApplied
       - lastTransitionTime: "2024-10-19T00:27:31Z"
         message: Applied and processed ClusterInstance (sno1) successfully
         reason: Completed
@@ -243,6 +254,11 @@ ProvisioningRequestValidated -> ClusterInstanceRendered -> ClusterResourcesCreat
         reason: Completed
         status: "True"
         type: HardwareProvisioned
+      - lastTransitionTime: "2024-10-19T00:27:30Z"
+        message: Node configuration has been applied to the rendered ClusterInstance
+        reason: Completed
+        status: "True"
+        type: HardwareNodeConfigApplied
       - lastTransitionTime: "2024-10-19T00:27:31Z"
         message: Applied and processed ClusterInstance (sno1) successfully
         reason: Completed
@@ -262,6 +278,23 @@ ProvisioningRequestValidated -> ClusterInstanceRendered -> ClusterResourcesCreat
         provisioningDetails: Provisioning request has completed successfully
         provisioningState: fulfilled
     ```
+
+## Interface Label ##
+Each node interface listed in the `clusterInstanceDefaults` ConfigMap must have an assigned label. This label is essential for retrieving the interface MAC address from the hardware manager.
+
+The hardware manager associates a label with each interface on the server. The label-to-port mappings are established during the hardware onboarding process. The template author must be familiar with these label-to-port mappings on the server.
+
+An example is provided below:
+``` yaml
+nodes:
+  - role: master
+    nodeNetwork:
+      interfaces:
+        - name: eno1
+          label: bootable-interface
+        - name: eno2
+          label: data-interface
+```
 
 ## Immutable ClusterInstance ##
 Once cluster installation has started (indicated by the `ClusterProvisioned` condition being InProgress), only the `extraLabels` and `extraAnnotations` fields can be modified in the ProvisioningRequest. Any changes to other immutable fields will cause the `ClusterInstanceRendered` condition to fail.

--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -307,7 +307,7 @@ func validateConfigmapReference[T any](
 	}
 
 	// Extract and validate the template from the configmap
-	_, err = utils.ExtractTemplateDataFromConfigMap[T](existingConfigmap, templateDataKey)
+	data, err := utils.ExtractTemplateDataFromConfigMap[T](existingConfigmap, templateDataKey)
 	if err != nil {
 		return err
 	}
@@ -315,6 +315,12 @@ func validateConfigmapReference[T any](
 	if templateDataKey == utils.HwTemplateNodePool {
 		if err = utils.ValidateConfigMapFields(existingConfigmap); err != nil {
 			return utils.NewInputError("failed to validate the hardware template ConfigMap %s: %w", existingConfigmap.Name, err)
+		}
+	}
+
+	if templateDataKey == utils.ClusterInstanceTemplateDefaultsConfigmapKey {
+		if err = utils.ValidateDefaultInterfaces(data); err != nil {
+			return utils.NewInputError("failed to validate the default ConfigMap: %w", err)
 		}
 	}
 

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -817,13 +817,18 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 				Name: crName, Namespace: crName}, clusterInstance)).To(Succeed())
 
 			// Verify the ProvisioningRequest's status conditions
-			Expect(len(conditions)).To(Equal(6))
+			Expect(len(conditions)).To(Equal(7))
 			verifyStatusCondition(conditions[4], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.HardwareProvisioned),
 				Status: metav1.ConditionTrue,
 				Reason: string(utils.CRconditionReasons.Completed),
 			})
 			verifyStatusCondition(conditions[5], metav1.Condition{
+				Type:   string(utils.PRconditionTypes.HardwareNodeConfigApplied),
+				Status: metav1.ConditionTrue,
+				Reason: string(utils.CRconditionReasons.Completed),
+			})
+			verifyStatusCondition(conditions[6], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterInstanceProcessed),
 				Status: metav1.ConditionUnknown,
 				Reason: string(utils.CRconditionReasons.Unknown),
@@ -1081,19 +1086,19 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			conditions := reconciledCR.Status.Conditions
 
 			// Verify the ProvisioningRequest's status conditions
-			Expect(len(conditions)).To(Equal(8))
-			verifyStatusCondition(conditions[5], metav1.Condition{
+			Expect(len(conditions)).To(Equal(9))
+			verifyStatusCondition(conditions[6], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterInstanceProcessed),
 				Status: metav1.ConditionTrue,
 				Reason: string(utils.CRconditionReasons.Completed),
 			})
-			verifyStatusCondition(conditions[6], metav1.Condition{
+			verifyStatusCondition(conditions[7], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ClusterProvisioned),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.InProgress),
 				Message: "Provisioning cluster",
 			})
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.ClusterNotReady),
@@ -1139,13 +1144,13 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			conditions := reconciledCR.Status.Conditions
 
 			// Verify the ProvisioningRequest's status conditions
-			Expect(len(conditions)).To(Equal(8))
-			verifyStatusCondition(conditions[6], metav1.Condition{
+			Expect(len(conditions)).To(Equal(9))
+			verifyStatusCondition(conditions[7], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterProvisioned),
 				Status: metav1.ConditionFalse,
 				Reason: string(utils.CRconditionReasons.TimedOut),
 			})
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.ClusterNotReady),
@@ -1178,8 +1183,8 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			conditions := reconciledCR.Status.Conditions
 
 			// Verify the ProvisioningRequest's status conditions
-			Expect(len(conditions)).To(Equal(7))
-			verifyStatusCondition(conditions[6], metav1.Condition{
+			Expect(len(conditions)).To(Equal(8))
+			verifyStatusCondition(conditions[7], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterProvisioned),
 				Status: metav1.ConditionFalse,
 				Reason: string(utils.CRconditionReasons.Failed),
@@ -1217,13 +1222,13 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			conditions := reconciledCR.Status.Conditions
 
 			// Verify the ProvisioningRequest's status conditions
-			Expect(len(conditions)).To(Equal(8))
-			verifyStatusCondition(conditions[6], metav1.Condition{
+			Expect(len(conditions)).To(Equal(9))
+			verifyStatusCondition(conditions[7], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterProvisioned),
 				Status: metav1.ConditionTrue,
 				Reason: string(utils.CRconditionReasons.Completed),
 			})
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.InProgress),
@@ -1271,13 +1276,13 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			conditions := reconciledCR.Status.Conditions
 
 			// Verify the ProvisioningRequest's status conditions
-			Expect(len(conditions)).To(Equal(8))
-			verifyStatusCondition(conditions[6], metav1.Condition{
+			Expect(len(conditions)).To(Equal(9))
+			verifyStatusCondition(conditions[7], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterProvisioned),
 				Status: metav1.ConditionTrue,
 				Reason: string(utils.CRconditionReasons.Completed),
 			})
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionTrue,
 				Reason:  string(utils.CRconditionReasons.Completed),
@@ -1325,19 +1330,19 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 
 			// Verify that the Validated condition fails but ClusterProvisioned condition
 			// is also up-to-date with the current status timeout.
-			Expect(len(conditions)).To(Equal(8))
+			Expect(len(conditions)).To(Equal(9))
 			verifyStatusCondition(conditions[0], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.Validated),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.Failed),
 				Message: "nodes.0: hostName is required",
 			})
-			verifyStatusCondition(conditions[6], metav1.Condition{
+			verifyStatusCondition(conditions[7], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterProvisioned),
 				Status: metav1.ConditionFalse,
 				Reason: string(utils.CRconditionReasons.InProgress),
 			})
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.ClusterNotReady),
@@ -1388,19 +1393,19 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 
 			// Verify that the Validated condition fails but ClusterProvisioned condition
 			// has changed to Completed.
-			Expect(len(conditions)).To(Equal(8))
+			Expect(len(conditions)).To(Equal(9))
 			verifyStatusCondition(conditions[0], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.Validated),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.Failed),
 				Message: "nodes.0: hostName is required",
 			})
-			verifyStatusCondition(conditions[6], metav1.Condition{
+			verifyStatusCondition(conditions[7], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterProvisioned),
 				Status: metav1.ConditionTrue,
 				Reason: string(utils.CRconditionReasons.Completed),
 			})
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.InProgress),
@@ -1444,19 +1449,19 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 
 			// Verify that the Validated condition fails but ClusterProvisioned condition
 			// is also up-to-date with the current status timeout.
-			Expect(len(conditions)).To(Equal(8))
+			Expect(len(conditions)).To(Equal(9))
 			verifyStatusCondition(conditions[0], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.Validated),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.Failed),
 				Message: "nodes.0: hostName is required",
 			})
-			verifyStatusCondition(conditions[6], metav1.Condition{
+			verifyStatusCondition(conditions[7], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterProvisioned),
 				Status: metav1.ConditionFalse,
 				Reason: string(utils.CRconditionReasons.TimedOut),
 			})
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.ClusterNotReady),
@@ -1509,19 +1514,19 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 
 			// Verify that the ClusterInstanceRendered condition fails but configurationApplied
 			// has changed to Completed
-			Expect(len(conditions)).To(Equal(8))
+			Expect(len(conditions)).To(Equal(9))
 			verifyStatusCondition(conditions[1], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ClusterInstanceRendered),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.Failed),
 				Message: "spec.nodes[0].templateRefs must be provided",
 			})
-			verifyStatusCondition(conditions[6], metav1.Condition{
+			verifyStatusCondition(conditions[7], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterProvisioned),
 				Status: metav1.ConditionTrue,
 				Reason: string(utils.CRconditionReasons.Completed),
 			})
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionTrue,
 				Reason:  string(utils.CRconditionReasons.Completed),
@@ -1576,13 +1581,13 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			Expect(c.Get(ctx, req.NamespacedName, reconciledCR)).To(Succeed())
 			conditions := reconciledCR.Status.Conditions
 
-			Expect(len(conditions)).To(Equal(8))
-			verifyStatusCondition(conditions[6], metav1.Condition{
+			Expect(len(conditions)).To(Equal(9))
+			verifyStatusCondition(conditions[7], metav1.Condition{
 				Type:   string(utils.PRconditionTypes.ClusterProvisioned),
 				Status: metav1.ConditionTrue,
 				Reason: string(utils.CRconditionReasons.Completed),
 			})
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionTrue,
 				Reason:  string(utils.CRconditionReasons.Completed),
@@ -1641,8 +1646,8 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			Expect(c.Get(ctx, req.NamespacedName, reconciledCR)).To(Succeed())
 			conditions := reconciledCR.Status.Conditions
 
-			Expect(len(conditions)).To(Equal(8))
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			Expect(len(conditions)).To(Equal(9))
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.InProgress),
@@ -1770,7 +1775,7 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			Expect(reconciledCR.Status.ClusterDetails.ZtpStatus).To(Equal(utils.ClusterZtpNotDone))
 			conditions := reconciledCR.Status.Conditions
 			// Verify the ProvisioningRequest's status conditions
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.InProgress),
@@ -1796,7 +1801,7 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			Expect(reconciledCR.Status.ClusterDetails.ZtpStatus).To(Equal(utils.ClusterZtpDone))
 			// Verify the ProvisioningRequest's status conditions
 			conditions := reconciledCR.Status.Conditions
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionTrue,
 				Reason:  string(utils.CRconditionReasons.Completed),
@@ -1821,7 +1826,7 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			Expect(reconciledCR.Status.ClusterDetails.ZtpStatus).To(Equal(utils.ClusterZtpDone))
 			conditions := reconciledCR.Status.Conditions
 			// Verify the ProvisioningRequest's status conditions
-			verifyStatusCondition(conditions[7], metav1.Condition{
+			verifyStatusCondition(conditions[8], metav1.Condition{
 				Type:    string(utils.PRconditionTypes.ConfigurationApplied),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(utils.CRconditionReasons.InProgress),

--- a/internal/controllers/utils/conditions.go
+++ b/internal/controllers/utils/conditions.go
@@ -20,27 +20,29 @@ var CTconditionTypes = struct {
 
 // The following constants define the different types of conditions that will be set for ProvisioningRequest
 var PRconditionTypes = struct {
-	Validated                ConditionType
-	HardwareTemplateRendered ConditionType
-	HardwareProvisioned      ConditionType
-	HardwareConfigured       ConditionType
-	ClusterInstanceRendered  ConditionType
-	ClusterResourcesCreated  ConditionType
-	ClusterInstanceProcessed ConditionType
-	ClusterProvisioned       ConditionType
-	ConfigurationApplied     ConditionType
-	UpgradeCompleted         ConditionType
+	Validated                 ConditionType
+	HardwareTemplateRendered  ConditionType
+	HardwareProvisioned       ConditionType
+	HardwareNodeConfigApplied ConditionType
+	HardwareConfigured        ConditionType
+	ClusterInstanceRendered   ConditionType
+	ClusterResourcesCreated   ConditionType
+	ClusterInstanceProcessed  ConditionType
+	ClusterProvisioned        ConditionType
+	ConfigurationApplied      ConditionType
+	UpgradeCompleted          ConditionType
 }{
-	Validated:                "ProvisioningRequestValidated",
-	HardwareTemplateRendered: "HardwareTemplateRendered",
-	HardwareProvisioned:      "HardwareProvisioned",
-	HardwareConfigured:       "HardwareConfigured",
-	ClusterInstanceRendered:  "ClusterInstanceRendered",
-	ClusterResourcesCreated:  "ClusterResourcesCreated",
-	ClusterInstanceProcessed: "ClusterInstanceProcessed",
-	ClusterProvisioned:       "ClusterProvisioned",
-	ConfigurationApplied:     "ConfigurationApplied",
-	UpgradeCompleted:         "UpgradeCompleted",
+	Validated:                 "ProvisioningRequestValidated",
+	HardwareTemplateRendered:  "HardwareTemplateRendered",
+	HardwareProvisioned:       "HardwareProvisioned",
+	HardwareNodeConfigApplied: "HardwareNodeConfigApplied",
+	HardwareConfigured:        "HardwareConfigured",
+	ClusterInstanceRendered:   "ClusterInstanceRendered",
+	ClusterResourcesCreated:   "ClusterResourcesCreated",
+	ClusterInstanceProcessed:  "ClusterInstanceProcessed",
+	ClusterProvisioned:        "ClusterProvisioned",
+	ConfigurationApplied:      "ConfigurationApplied",
+	UpgradeCompleted:          "UpgradeCompleted",
 }
 
 // ConditionReason is a string representing the condition's reason

--- a/internal/controllers/utils/hardware_utils.go
+++ b/internal/controllers/utils/hardware_utils.go
@@ -278,7 +278,13 @@ func SetCloudManagerInitialObservedGeneration(ctx context.Context, c client.Clie
 // getInterfaces extracts the interfaces from the node map.
 func getInterfaces(nodeMap map[string]interface{}) []map[string]interface{} {
 	if nodeNetwork, ok := nodeMap["nodeNetwork"].(map[string]interface{}); ok {
+		if !ok {
+			return nil
+		}
 		if interfaces, ok := nodeNetwork["interfaces"].([]any); ok {
+			if !ok {
+				return nil
+			}
 			var result []map[string]interface{}
 			for _, iface := range interfaces {
 				if eth, ok := iface.(map[string]interface{}); ok {
@@ -320,7 +326,7 @@ OuterLoop:
 			// Extraction of interfaces from the node map in the cluster input
 			interfaces := getInterfaces(nodeMapInput)
 			if interfaces == nil {
-				return fmt.Errorf("failed to extrace the interfaces from the node map")
+				return fmt.Errorf("failed to extract the interfaces from the node map")
 			}
 			// Iterate over extracted interfaces and hardware interfaces to find matches.
 			// If an interface in the input data has a label that matches a hardware interface’s label,


### PR DESCRIPTION
This update introduces the HardwareNodeConfigApplied status in the Provisioning Request to signify that essential hardware node attributes—such as BMC details, interface MAC addresses, and the boot MAC address—have been successfully applied to the Cluster Instance. A failure status may be triggered if incorrect interface labels are provided or if a mismatched boot interface label is specified that conflicts with the defined hardware profile. This status serves as an indication for users to verify and adjust their configuration if necessary.

Additionally, this update includes a validation check for missing or empty interface labels within the cluster instance default map, ensuring accurate configuration and alignment with hardware requirements.