### PR TITLE
CNF-15167: Fix RBAC role for searching managed data

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1329,6 +1329,18 @@ spec:
           - update
           - watch
         - apiGroups:
+          - search.open-cluster-management.io
+          resources:
+          - searches
+          verbs:
+          - get
+        - apiGroups:
+          - search.open-cluster-management.io
+          resources:
+          - searches/allManagedData
+          verbs:
+          - get
+        - apiGroups:
           - siteconfig.open-cluster-management.io
           resources:
           - clusterinstances

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -282,6 +282,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - search.open-cluster-management.io
+  resources:
+  - searches
+  verbs:
+  - get
+- apiGroups:
+  - search.open-cluster-management.io
+  resources:
+  - searches/allManagedData
+  verbs:
+  - get
+- apiGroups:
   - siteconfig.open-cluster-management.io
   resources:
   - clusterinstances

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -48,6 +48,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+//+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches,verbs=get
+//+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches/allManagedData,verbs=get
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:groups=o2ims.oran.openshift.io,resources=inventories,verbs=get;list;watch;create;update;patch;delete
@@ -753,6 +755,18 @@ func (t *reconcilerTask) createResourceServerClusterRole(ctx context.Context) er
 					"get",
 					"list",
 					"watch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"search.open-cluster-management.io",
+				},
+				Resources: []string{
+					"searches",
+					"searches/allManagedData",
+				},
+				Verbs: []string{
+					"get",
 				},
 			},
 			{


### PR DESCRIPTION
This adds resources to the RBAC role to allow servers to query managed data from the search api; otherwise, the servers can only query data that was collected on the hub and not any of the data collected on the managed clusters.