### PR TITLE
No-ISSUE: cluster install timeout rename and doc updates for timeout

### DIFF
--- a/docs/cluster-provisioning.md
+++ b/docs/cluster-provisioning.md
@@ -266,6 +266,34 @@ ProvisioningRequestValidated -> ClusterInstanceRendered -> ClusterResourcesCreat
 ## Immutable ClusterInstance ##
 Once cluster installation has started (indicated by the `ClusterProvisioned` condition being InProgress), only the `extraLabels` and `extraAnnotations` fields can be modified in the ProvisioningRequest. Any changes to other immutable fields will cause the `ClusterInstanceRendered` condition to fail.
 
+## Timeout configuration ##
+Each stage of the cluster provisioning process has a default timeout. If an operation does not complete within the allowed time, the provisioning process is considered failed, and the relevant status conditions and overall provisioning status will be updated to reflect the timeout.
+
+Default timeouts:
+- Hardware provisioning: 90m
+- Cluster installation: 90m
+- Cluster configuration 30m
+
+These timeouts can be configured in their respective ConfigMaps. The timeout value should be a duration string. For example:
+
+For hardware provisioning, set in the `spec.templates.hwTemplate` ConfigMap:
+``` yaml
+data:
+  hardwareProvisioningTimeout: "100m"
+```
+
+For cluster installation, set in the `spec.templates.clusterInstanceDefaults` ConfigMap:
+``` yaml
+data:
+  clusterInstallationTimeout: "100m"
+```
+
+For cluster configuration, set in the `spec.templates.policyTemplateDefaults` ConfigMap:
+``` yaml
+data:
+  clusterConfigurationTimeout: "40m"
+```
+
 ## Monitoring Process
 To watch the O-Cloud Manager controller logs:
 ```console

--- a/docs/samples/git-setup/clustertemplates/hardwaretemplates/sno-ran-du/placeholder-du-template-configmap-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/hardwaretemplates/sno-ran-du/placeholder-du-template-configmap-v1.yaml
@@ -7,7 +7,7 @@ data:
   # hardwareProvisioningTimeout is optional.
   # The value should be a duration string
   # (e.g., "30m" for 30 minutes)
-  hardwareProvisioningTimeout: "30m"
+  # hardwareProvisioningTimeout: "30m"
   hwMgrId: oran-hwmgr-plugin-test
   bootInterfaceLabel: bootable-interface
   node-pools-data: |

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v1.yaml
@@ -4,10 +4,10 @@ metadata:
   name: clusterinstance-defaults-v1
   namespace: sno-ran-du-v4-Y-Z
 data:
-  # clusterProvisioningTimeout is optional.
+  # clusterInstallationTimeout is optional.
   # The value should be a duration string
   # (e.g., "80m" for 80 minutes)
-  clusterProvisioningTimeout: "80m"
+  # clusterInstallationTimeout: "80m"
   clusterinstance-defaults: |
     baseDomain: example.com
     extraLabels:

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v2.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v2.yaml
@@ -4,10 +4,10 @@ metadata:
   name: clusterinstance-defaults-v2
   namespace: sno-ran-du-v4-Y-Z
 data:
-  # clusterProvisioningTimeout is optional.
+  # clusterInstallationTimeout is optional.
   # The value should be a duration string
   # (e.g., "80m" for 80 minutes)
-  clusterProvisioningTimeout: "80m"
+  # clusterInstallationTimeout: "80m"
   clusterinstance-defaults: |
     baseDomain: example.com
     extraLabels:

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v3.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v3.yaml
@@ -4,10 +4,10 @@ metadata:
   name: clusterinstance-defaults-v3
   namespace: sno-ran-du-v4-Y-Z
 data:
-  # clusterProvisioningTimeout is optional.
+  # clusterInstallationTimeout is optional.
   # The value should be a duration string
   # (e.g., "80m" for 80 minutes)
-  clusterProvisioningTimeout: "80m"
+  # clusterInstallationTimeout: "80m"
   clusterinstance-defaults: |
     baseDomain: example.com
     extraLabels:

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v4.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v4.yaml
@@ -4,10 +4,10 @@ metadata:
   name: clusterinstance-defaults-v4
   namespace: sno-ran-du-v4-Y-Z
 data:
-  # clusterProvisioningTimeout is optional.
+  # clusterInstallationTimeout is optional.
   # The value should be a duration string
   # (e.g., "80m" for 80 minutes)
-  clusterProvisioningTimeout: "80m"
+  # clusterInstallationTimeout: "80m"
   clusterinstance-defaults: |
     baseDomain: example.com
     extraLabels:

--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -205,7 +205,7 @@ func (t *clusterTemplateReconcilerTask) validateClusterTemplateCR(ctx context.Co
 		t.object.Spec.Templates.ClusterInstanceDefaults,
 		t.object.Namespace,
 		utils.ClusterInstanceTemplateDefaultsConfigmapKey,
-		utils.ClusterProvisioningTimeoutConfigKey)
+		utils.ClusterInstallationTimeoutConfigKey)
 	if err != nil {
 		if !utils.IsInputError(err) {
 			return false, fmt.Errorf("failed to validate the ConfigMap %s for ClusterInstance defaults: %w",

--- a/internal/controllers/clustertemplate_controller_test.go
+++ b/internal/controllers/clustertemplate_controller_test.go
@@ -295,7 +295,7 @@ var _ = Describe("validateClusterTemplateCR", func() {
 					Namespace: ctNamespace,
 				},
 				Data: map[string]string{
-					utils.ClusterProvisioningTimeoutConfigKey: "80m",
+					utils.ClusterInstallationTimeoutConfigKey: "80m",
 					utils.ClusterInstanceTemplateDefaultsConfigmapKey: `
 key: value`,
 				},
@@ -373,7 +373,7 @@ clustertemplate-a-policy-v1-defaultHugepagesSize: "1G"`,
 	})
 
 	It("should return false and set status condition to false if timeouts in ConfigMaps are invalid", func() {
-		cms[0].Data[utils.ClusterProvisioningTimeoutConfigKey] = "invalidCiTimeout"
+		cms[0].Data[utils.ClusterInstallationTimeoutConfigKey] = "invalidCiTimeout"
 		cms[1].Data[utils.ClusterConfigurationTimeoutConfigKey] = "invalidPtTimeout"
 		cms[2].Data[utils.HardwareProvisioningTimeoutConfigKey] = "40"
 		for _, cm := range cms {
@@ -395,7 +395,7 @@ clustertemplate-a-policy-v1-defaultHugepagesSize: "1G"`,
 		Expect(conditions[0].Message).To(ContainSubstring(fmt.Sprintf(
 			"the value of key %s from ConfigMap %s is not a valid duration string", utils.ClusterConfigurationTimeoutConfigKey, ptDefaultsCm)))
 		Expect(conditions[0].Message).To(ContainSubstring(fmt.Sprintf(
-			"the value of key %s from ConfigMap %s is not a valid duration string", utils.ClusterProvisioningTimeoutConfigKey, ciDefaultsCm)))
+			"the value of key %s from ConfigMap %s is not a valid duration string", utils.ClusterInstallationTimeoutConfigKey, ciDefaultsCm)))
 	})
 })
 
@@ -420,7 +420,7 @@ var _ = Describe("validateConfigmapReference", func() {
 				Namespace: namespace,
 			},
 			Data: map[string]string{
-				utils.ClusterProvisioningTimeoutConfigKey: "40m",
+				utils.ClusterInstallationTimeoutConfigKey: "40m",
 				utils.ClusterInstanceTemplateDefaultsConfigmapKey: `
 key: value`,
 			},
@@ -429,7 +429,7 @@ key: value`,
 		err := validateConfigmapReference[map[string]any](
 			ctx, c, configmapName, namespace,
 			utils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			utils.ClusterProvisioningTimeoutConfigKey)
+			utils.ClusterInstallationTimeoutConfigKey)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -438,7 +438,7 @@ key: value`,
 		err := validateConfigmapReference[map[string]any](
 			ctx, c, configmapName, namespace,
 			utils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			utils.ClusterProvisioningTimeoutConfigKey)
+			utils.ClusterInstallationTimeoutConfigKey)
 		Expect(err).To(HaveOccurred())
 		Expect(utils.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(Equal(fmt.Sprintf(
@@ -461,7 +461,7 @@ key: value`,
 		err := validateConfigmapReference[map[string]any](
 			ctx, c, configmapName, namespace,
 			utils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			utils.ClusterProvisioningTimeoutConfigKey)
+			utils.ClusterInstallationTimeoutConfigKey)
 		Expect(err).To(HaveOccurred())
 		Expect(utils.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(Equal(fmt.Sprintf(
@@ -484,7 +484,7 @@ key: value`,
 		err := validateConfigmapReference[map[string]any](
 			ctx, c, configmapName, namespace,
 			utils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			utils.ClusterProvisioningTimeoutConfigKey)
+			utils.ClusterInstallationTimeoutConfigKey)
 		Expect(err).To(HaveOccurred())
 		Expect(utils.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(ContainSubstring("the value of key"))
@@ -498,7 +498,7 @@ key: value`,
 				Namespace: namespace,
 			},
 			Data: map[string]string{
-				utils.ClusterProvisioningTimeoutConfigKey: "invalid-timeout",
+				utils.ClusterInstallationTimeoutConfigKey: "invalid-timeout",
 				utils.ClusterInstanceTemplateDefaultsConfigmapKey: `
 key: value`,
 			},
@@ -508,7 +508,7 @@ key: value`,
 		err := validateConfigmapReference[map[string]any](
 			ctx, c, configmapName, namespace,
 			utils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			utils.ClusterProvisioningTimeoutConfigKey)
+			utils.ClusterInstallationTimeoutConfigKey)
 		Expect(err).To(HaveOccurred())
 		Expect(utils.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(ContainSubstring("is not a valid duration string"))
@@ -533,7 +533,7 @@ key: value`,
 		err := validateConfigmapReference[map[string]any](
 			ctx, c, configmapName, namespace,
 			utils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			utils.ClusterProvisioningTimeoutConfigKey)
+			utils.ClusterInstallationTimeoutConfigKey)
 		Expect(err).To(HaveOccurred())
 		Expect(utils.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(Equal(fmt.Sprintf(
@@ -557,7 +557,7 @@ key: value`,
 		err := validateConfigmapReference[map[string]any](
 			ctx, c, configmapName, namespace,
 			utils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			utils.ClusterProvisioningTimeoutConfigKey)
+			utils.ClusterInstallationTimeoutConfigKey)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify that the configmap is patched to be immutable

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -245,7 +245,7 @@ defaultHugepagesSize: "1G"`,
 			object: provisioningRequest, // cluster-1 request
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -319,7 +319,7 @@ defaultHugepagesSize: "1G"`,
 			object: provisioningRequest, // cluster-1 request
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -347,7 +347,7 @@ defaultHugepagesSize: "1G"`,
 			clusterInput: &clusterInput{},
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -387,7 +387,7 @@ defaultHugepagesSize: "1G"`,
 			object: provisioningRequest, // cluster-1 request
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -498,7 +498,7 @@ defaultHugepagesSize: "1G"`,
 			object: provisioningRequest, // cluster-1 request
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: 60 * time.Second,
 			},
 		}
@@ -651,7 +651,7 @@ defaultHugepagesSize: "1G"`,
 			object: provisioningRequest, // cluster-1 request
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -803,7 +803,7 @@ defaultHugepagesSize: "1G"`,
 			object: provisioningRequest, // cluster-1 request
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -896,7 +896,7 @@ defaultHugepagesSize: "1G"`,
 			ctNamespace: ctNamespace,
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: 1 * time.Minute,
 			},
 		}
@@ -1099,7 +1099,7 @@ defaultHugepagesSize: "1G"`,
 			ctNamespace: ctNamespace,
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -1263,7 +1263,7 @@ defaultHugepagesSize: "1G"`,
 			ctNamespace:  ctNamespace,
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -1368,7 +1368,7 @@ defaultHugepagesSize: "1G"`,
 			ctNamespace:  ctNamespace,
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -1472,7 +1472,7 @@ defaultHugepagesSize: "1G"`,
 			ctNamespace: ctNamespace,
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -1576,7 +1576,7 @@ defaultHugepagesSize: "1G"`,
 			ctNamespace: ctNamespace,
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: utils.DefaultClusterConfigurationTimeout,
 			},
 		}
@@ -1682,7 +1682,7 @@ var _ = Describe("hasPolicyConfigurationTimedOut", func() {
 			object: crs[1].(*provisioningv1alpha1.ProvisioningRequest), // cluster-1 request
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
-				clusterProvisioning:  utils.DefaultClusterProvisioningTimeout,
+				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
 				clusterConfiguration: 1 * time.Minute,
 			},
 		}

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -530,7 +530,7 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 					Namespace: ctNamespace,
 				},
 				Data: map[string]string{
-					utils.ClusterProvisioningTimeoutConfigKey: "60s",
+					utils.ClusterInstallationTimeoutConfigKey: "60s",
 					utils.ClusterInstanceTemplateDefaultsConfigmapKey: `
     clusterImageSetNameRef: "4.15"
     pullSecretRef:

--- a/internal/controllers/provisioningrequest_validation.go
+++ b/internal/controllers/provisioningrequest_validation.go
@@ -55,7 +55,7 @@ func (t *provisioningRequestReconcilerTask) validateProvisioningRequestCR(ctx co
 func (t *provisioningRequestReconcilerTask) validateAndLoadTimeouts(
 	ctx context.Context, clusterTemplate *provisioningv1alpha1.ClusterTemplate) error {
 	// Initialize with default timeouts
-	t.timeouts.clusterProvisioning = utils.DefaultClusterProvisioningTimeout
+	t.timeouts.clusterProvisioning = utils.DefaultClusterInstallationTimeout
 	t.timeouts.hardwareProvisioning = utils.DefaultHardwareProvisioningTimeout
 	t.timeouts.clusterConfiguration = utils.DefaultClusterConfigurationTimeout
 
@@ -83,7 +83,7 @@ func (t *provisioningRequestReconcilerTask) validateAndLoadTimeouts(
 		return fmt.Errorf("failed to get ConfigMap %s: %w", ciCmName, err)
 	}
 	ciTimeout, err := utils.ExtractTimeoutFromConfigMap(
-		ciCm, utils.ClusterProvisioningTimeoutConfigKey)
+		ciCm, utils.ClusterInstallationTimeoutConfigKey)
 	if err != nil {
 		return fmt.Errorf("failed to get timeout config for cluster provisioning: %w", err)
 	}

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -73,7 +73,7 @@ const (
 // Default timeout values
 const (
 	DefaultHardwareProvisioningTimeout = 90 * time.Minute
-	DefaultClusterProvisioningTimeout  = 90 * time.Minute
+	DefaultClusterInstallationTimeout  = 90 * time.Minute
 	DefaultClusterConfigurationTimeout = 30 * time.Minute
 )
 
@@ -82,7 +82,7 @@ const (
 // If not specified, the default timeout values will be applied.
 const (
 	HardwareProvisioningTimeoutConfigKey = "hardwareProvisioningTimeout"
-	ClusterProvisioningTimeoutConfigKey  = "clusterProvisioningTimeout"
+	ClusterInstallationTimeoutConfigKey  = "clusterInstallationTimeout"
 	ClusterConfigurationTimeoutConfigKey = "clusterConfigurationTimeout"
 )
 


### PR DESCRIPTION
- Rename the timeout config key for cluster install from `clusterProvisioningTimeout` to `clusterInstallationTimeout` to avoid confusion (since cluster provisioning refers to the process from hw provisioning to cluster configuration).
- Add a brief description for timeout.