### PR TITLE
CNF-13704: fully utilize HW manager plugin for cluster provision

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -156,7 +156,7 @@ metadata:
             "templateParameterSchema": {
               "properties": {
                 "clusterInstanceParameters": {
-                  "description": "clusterInstanceParameters defines the available parameters for cluster provisioning",
+                  "description": "clusterInstanceParameters defines the available parameters for cluster installation",
                   "properties": {
                     "additionalNTPSources": {
                       "description": "AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster hosts. They are added to any NTP sources that were configured through other means.",
@@ -230,38 +230,6 @@ metadata:
                       "items": {
                         "description": "NodeSpec",
                         "properties": {
-                          "bmcAddress": {
-                            "description": "BmcAddress holds the URL for accessing the controller on the network.",
-                            "type": "string"
-                          },
-                          "bmcCredentialsDetails": {
-                            "description": "A workaround to provide bmc creds through ProvisioningRequest",
-                            "properties": {
-                              "password": {
-                                "type": "string"
-                              },
-                              "username": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "bmcCredentialsName": {
-                            "description": "BmcCredentialsName is the name of the secret containing the BMC credentials (requires keys \"username\" and \"password\").",
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object"
-                          },
-                          "bootMACAddress": {
-                            "description": "Which MAC address will PXE boot? This is optional for some types, but required for libvirt VMs driven by vbmc.",
-                            "pattern": "[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}",
-                            "type": "string"
-                          },
                           "extraAnnotations": {
                             "additionalProperties": {
                               "additionalProperties": {
@@ -270,6 +238,16 @@ metadata:
                               "type": "object"
                             },
                             "description": "Additional node-level annotations to be applied to the rendered templates",
+                            "type": "object"
+                          },
+                          "extraLabels": {
+                            "additionalProperties": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "description": "Additional node-level labels to be applied to the rendered templates",
                             "type": "object"
                           },
                           "hostName": {
@@ -290,75 +268,6 @@ metadata:
                                 "description": "yaml that can be processed by nmstate, using custom marshaling/unmarshaling that will allow to populate nmstate config as plain yaml.",
                                 "type": "object",
                                 "x-kubernetes-preserve-unknown-fields": true
-                              },
-                              "interfaces": {
-                                "description": "Interfaces is an array of interface objects containing the name and MAC address for interfaces that are referenced in the raw nmstate config YAML. Interfaces listed here will be automatically renamed in the nmstate config YAML to match the real device name that is observed to have the corresponding MAC address. At least one interface must be listed so that it can be used to identify the correct host, which is done by matching any MAC address in this list to any MAC address observed on the host.",
-                                "items": {
-                                  "properties": {
-                                    "macAddress": {
-                                      "description": "mac address present on the host.",
-                                      "pattern": "^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$",
-                                      "type": "string"
-                                    },
-                                    "name": {
-                                      "description": "nic name used in the yaml, which relates 1:1 to the mac address. Name in REST API: logicalNICName",
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "macAddress"
-                                  ],
-                                  "type": "object"
-                                },
-                                "minItems": 1,
-                                "type": "array"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "rootDeviceHints": {
-                            "description": "RootDeviceHints specifies the device for deployment. Identifiers that are stable across reboots are recommended, for example, wwn: \u003cdisk_wwn\u003e or deviceName: /dev/disk/by-path/\u003cdevice_path\u003e",
-                            "properties": {
-                              "deviceName": {
-                                "description": "A Linux device name like \"/dev/vda\", or a by-path link to it like \"/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0\". The hint must match the actual value exactly.",
-                                "type": "string"
-                              },
-                              "hctl": {
-                                "description": "A SCSI bus address like 0:0:0:0. The hint must match the actual value exactly.",
-                                "type": "string"
-                              },
-                              "minSizeGigabytes": {
-                                "description": "The minimum size of the device in Gigabytes.",
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "model": {
-                                "description": "A vendor-specific device identifier. The hint can be a substring of the actual value.",
-                                "type": "string"
-                              },
-                              "rotational": {
-                                "description": "True if the device should use spinning media, false otherwise.",
-                                "type": "boolean"
-                              },
-                              "serialNumber": {
-                                "description": "Device serial number. The hint must match the actual value exactly.",
-                                "type": "string"
-                              },
-                              "vendor": {
-                                "description": "The name of the vendor or manufacturer of the device. The hint can be a substring of the actual value.",
-                                "type": "string"
-                              },
-                              "wwn": {
-                                "description": "Unique storage identifier. The hint must match the actual value exactly.",
-                                "type": "string"
-                              },
-                              "wwnVendorExtension": {
-                                "description": "Unique vendor storage identifier. The hint must match the actual value exactly.",
-                                "type": "string"
-                              },
-                              "wwnWithExtension": {
-                                "description": "Unique storage identifier with the vendor extension appended. The hint must match the actual value exactly.",
-                                "type": "string"
                               }
                             },
                             "type": "object"

--- a/config/samples/v1alpha1_clustertemplate.yaml
+++ b/config/samples/v1alpha1_clustertemplate.yaml
@@ -46,7 +46,7 @@ spec:
             type: string
         type: object
       clusterInstanceParameters:
-        description: clusterInstanceParameters defines the available parameters for cluster provisioning
+        description: clusterInstanceParameters defines the available parameters for cluster installation
         properties:
           additionalNTPSources:
             description: AdditionalNTPSources is a list of NTP sources (hostname
@@ -69,14 +69,6 @@ spec:
             description: BaseDomain is the base domain to use for the deployed
               cluster.
             type: string
-          extraLabels:
-            additionalProperties:
-              additionalProperties:
-                type: string
-              type: object
-            description: Additional cluster-wide labels to be applied to the rendered
-              templates
-            type: object
           clusterName:
             description: ClusterName is the name of the cluster.
             type: string
@@ -87,6 +79,14 @@ spec:
               type: object
             description: Additional cluster-wide annotations to be applied to
               the rendered templates
+            type: object
+          extraLabels:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            description: Additional cluster-wide labels to be applied to the rendered
+              templates
             type: object
           ingressVIPs:
             description: IngressVIPs are the virtual IPs used for cluster ingress
@@ -116,31 +116,6 @@ spec:
             items:
               description: NodeSpec
               properties:
-                bmcAddress:
-                  description: BmcAddress holds the URL for accessing the controller
-                    on the network.
-                  type: string
-                bmcCredentialsName:
-                  description: BmcCredentialsName is the name of the secret containing
-                    the BMC credentials (requires keys "username" and "password").
-                  properties:
-                    name:
-                      type: string
-                  required:
-                  - name
-                  type: object
-                bmcCredentialsDetails:
-                  description: A workaround to provide bmc creds through ProvisioningRequest
-                  properties:
-                    username:
-                      type: string
-                    password:
-                      type: string
-                bootMACAddress:
-                  description: Which MAC address will PXE boot? This is optional
-                    for some types, but required for libvirt VMs driven by vbmc.
-                  pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
-                  type: string
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
@@ -148,6 +123,14 @@ spec:
                     type: object
                   description: Additional node-level annotations to be applied
                     to the rendered templates
+                  type: object
+                extraLabels:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Additional node-level labels to be applied to the
+                    rendered templates
                   type: object
                 hostName:
                   description: Hostname is the desired hostname for the host
@@ -175,78 +158,6 @@ spec:
                         nmstate config as plain yaml.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                    interfaces:
-                      description: Interfaces is an array of interface objects
-                        containing the name and MAC address for interfaces that
-                        are referenced in the raw nmstate config YAML. Interfaces
-                        listed here will be automatically renamed in the nmstate
-                        config YAML to match the real device name that is observed
-                        to have the corresponding MAC address. At least one interface
-                        must be listed so that it can be used to identify the
-                        correct host, which is done by matching any MAC address
-                        in this list to any MAC address observed on the host.
-                      items:
-                        properties:
-                          macAddress:
-                            description: mac address present on the host.
-                            pattern: ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
-                            type: string
-                          name:
-                            description: 'nic name used in the yaml, which relates
-                              1:1 to the mac address. Name in REST API: logicalNICName'
-                            type: string
-                        required:
-                        - macAddress
-                        type: object
-                      minItems: 1
-                      type: array
-                  type: object
-                rootDeviceHints:
-                  description: 'RootDeviceHints specifies the device for deployment.
-                    Identifiers that are stable across reboots are recommended,
-                    for example, wwn: <disk_wwn> or deviceName: /dev/disk/by-path/<device_path>'
-                  properties:
-                    deviceName:
-                      description: A Linux device name like "/dev/vda", or a by-path
-                        link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
-                        The hint must match the actual value exactly.
-                      type: string
-                    hctl:
-                      description: A SCSI bus address like 0:0:0:0. The hint must
-                        match the actual value exactly.
-                      type: string
-                    minSizeGigabytes:
-                      description: The minimum size of the device in Gigabytes.
-                      minimum: 0
-                      type: integer
-                    model:
-                      description: A vendor-specific device identifier. The hint
-                        can be a substring of the actual value.
-                      type: string
-                    rotational:
-                      description: True if the device should use spinning media,
-                        false otherwise.
-                      type: boolean
-                    serialNumber:
-                      description: Device serial number. The hint must match the
-                        actual value exactly.
-                      type: string
-                    vendor:
-                      description: The name of the vendor or manufacturer of the
-                        device. The hint can be a substring of the actual value.
-                      type: string
-                    wwn:
-                      description: Unique storage identifier. The hint must match
-                        the actual value exactly.
-                      type: string
-                    wwnVendorExtension:
-                      description: Unique vendor storage identifier. The hint
-                        must match the actual value exactly.
-                      type: string
-                    wwnWithExtension:
-                      description: Unique storage identifier with the vendor extension
-                        appended. The hint must match the actual value exactly.
-                      type: string
                   type: object
               required:
               - hostName

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v1.yaml
@@ -40,6 +40,8 @@ data:
     nodes:
       - role: master
         bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
         nodeNetwork:
           interfaces:
             - name: eno1

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v2.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v2.yaml
@@ -43,6 +43,8 @@ data:
     nodes:
       - role: master
         bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
         nodeNetwork:
           interfaces:
             - name: eno1

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v3.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v3.yaml
@@ -43,6 +43,8 @@ data:
     nodes:
       - role: master
         bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
         nodeNetwork:
           interfaces:
             - name: eno1

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v4.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v4.yaml
@@ -43,6 +43,8 @@ data:
     nodes:
       - role: master
         bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
         nodeNetwork:
           interfaces:
             - name: eno1

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1.yaml
@@ -107,31 +107,6 @@ spec:
             items:
               description: NodeSpec
               properties:
-                bmcAddress:
-                  description: BmcAddress holds the URL for accessing the controller
-                    on the network.
-                  type: string
-                bmcCredentialsName:
-                  description: BmcCredentialsName is the name of the secret containing
-                    the BMC credentials (requires keys "username" and "password").
-                  properties:
-                    name:
-                      type: string
-                  required:
-                  - name
-                  type: object
-                bmcCredentialsDetails:
-                  description: A workaround to provide bmc creds through ClusterRequest
-                  properties:
-                    username:
-                      type: string
-                    password:
-                      type: string
-                bootMACAddress:
-                  description: Which MAC address will PXE boot? This is optional
-                    for some types, but required for libvirt VMs driven by vbmc.
-                  pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
-                  type: string
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
@@ -174,78 +149,6 @@ spec:
                         nmstate config as plain yaml.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                    interfaces:
-                      description: Interfaces is an array of interface objects
-                        containing the name and MAC address for interfaces that
-                        are referenced in the raw nmstate config YAML. Interfaces
-                        listed here will be automatically renamed in the nmstate
-                        config YAML to match the real device name that is observed
-                        to have the corresponding MAC address. At least one interface
-                        must be listed so that it can be used to identify the
-                        correct host, which is done by matching any MAC address
-                        in this list to any MAC address observed on the host.
-                      items:
-                        properties:
-                          macAddress:
-                            description: mac address present on the host.
-                            pattern: ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
-                            type: string
-                          name:
-                            description: 'nic name used in the yaml, which relates
-                              1:1 to the mac address. Name in REST API: logicalNICName'
-                            type: string
-                        required:
-                        - macAddress
-                        type: object
-                      minItems: 1
-                      type: array
-                  type: object
-                rootDeviceHints:
-                  description: 'RootDeviceHints specifies the device for deployment.
-                    Identifiers that are stable across reboots are recommended,
-                    for example, wwn: <disk_wwn> or deviceName: /dev/disk/by-path/<device_path>'
-                  properties:
-                    deviceName:
-                      description: A Linux device name like "/dev/vda", or a by-path
-                        link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
-                        The hint must match the actual value exactly.
-                      type: string
-                    hctl:
-                      description: A SCSI bus address like 0:0:0:0. The hint must
-                        match the actual value exactly.
-                      type: string
-                    minSizeGigabytes:
-                      description: The minimum size of the device in Gigabytes.
-                      minimum: 0
-                      type: integer
-                    model:
-                      description: A vendor-specific device identifier. The hint
-                        can be a substring of the actual value.
-                      type: string
-                    rotational:
-                      description: True if the device should use spinning media,
-                        false otherwise.
-                      type: boolean
-                    serialNumber:
-                      description: Device serial number. The hint must match the
-                        actual value exactly.
-                      type: string
-                    vendor:
-                      description: The name of the vendor or manufacturer of the
-                        device. The hint can be a substring of the actual value.
-                      type: string
-                    wwn:
-                      description: Unique storage identifier. The hint must match
-                        the actual value exactly.
-                      type: string
-                    wwnVendorExtension:
-                      description: Unique vendor storage identifier. The hint
-                        must match the actual value exactly.
-                      type: string
-                    wwnWithExtension:
-                      description: Unique storage identifier with the vendor extension
-                        appended. The hint must match the actual value exactly.
-                      type: string
                   type: object
               required:
               - hostName
@@ -274,12 +177,3 @@ spec:
         - clusterName
         - nodes
         type: object
-
-# Notes:
-# clusterInstanceParameters contains only params that are exposed to the ProvisioningRequest.
-#
-# When HW is ready, bmcAddress, bmcCredentialsName, bootMACAddress and nodes.nodeNetwork.macAddress
-# should be removed from the schema as they are supposed to come from HW.
-#
-# Ideally, rootDeviceHints should come from default configmap. Keep it in the schema to make this template
-# be able to used for multiple SNOs with different rootDeviceHints.

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-2.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-2.yaml
@@ -107,31 +107,6 @@ spec:
             items:
               description: NodeSpec
               properties:
-                bmcAddress:
-                  description: BmcAddress holds the URL for accessing the controller
-                    on the network.
-                  type: string
-                bmcCredentialsName:
-                  description: BmcCredentialsName is the name of the secret containing
-                    the BMC credentials (requires keys "username" and "password").
-                  properties:
-                    name:
-                      type: string
-                  required:
-                  - name
-                  type: object
-                bmcCredentialsDetails:
-                  description: A workaround to provide bmc creds through ClusterRequest
-                  properties:
-                    username:
-                      type: string
-                    password:
-                      type: string
-                bootMACAddress:
-                  description: Which MAC address will PXE boot? This is optional
-                    for some types, but required for libvirt VMs driven by vbmc.
-                  pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
-                  type: string
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
@@ -174,78 +149,6 @@ spec:
                         nmstate config as plain yaml.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                    interfaces:
-                      description: Interfaces is an array of interface objects
-                        containing the name and MAC address for interfaces that
-                        are referenced in the raw nmstate config YAML. Interfaces
-                        listed here will be automatically renamed in the nmstate
-                        config YAML to match the real device name that is observed
-                        to have the corresponding MAC address. At least one interface
-                        must be listed so that it can be used to identify the
-                        correct host, which is done by matching any MAC address
-                        in this list to any MAC address observed on the host.
-                      items:
-                        properties:
-                          macAddress:
-                            description: mac address present on the host.
-                            pattern: ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
-                            type: string
-                          name:
-                            description: 'nic name used in the yaml, which relates
-                              1:1 to the mac address. Name in REST API: logicalNICName'
-                            type: string
-                        required:
-                        - macAddress
-                        type: object
-                      minItems: 1
-                      type: array
-                  type: object
-                rootDeviceHints:
-                  description: 'RootDeviceHints specifies the device for deployment.
-                    Identifiers that are stable across reboots are recommended,
-                    for example, wwn: <disk_wwn> or deviceName: /dev/disk/by-path/<device_path>'
-                  properties:
-                    deviceName:
-                      description: A Linux device name like "/dev/vda", or a by-path
-                        link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
-                        The hint must match the actual value exactly.
-                      type: string
-                    hctl:
-                      description: A SCSI bus address like 0:0:0:0. The hint must
-                        match the actual value exactly.
-                      type: string
-                    minSizeGigabytes:
-                      description: The minimum size of the device in Gigabytes.
-                      minimum: 0
-                      type: integer
-                    model:
-                      description: A vendor-specific device identifier. The hint
-                        can be a substring of the actual value.
-                      type: string
-                    rotational:
-                      description: True if the device should use spinning media,
-                        false otherwise.
-                      type: boolean
-                    serialNumber:
-                      description: Device serial number. The hint must match the
-                        actual value exactly.
-                      type: string
-                    vendor:
-                      description: The name of the vendor or manufacturer of the
-                        device. The hint can be a substring of the actual value.
-                      type: string
-                    wwn:
-                      description: Unique storage identifier. The hint must match
-                        the actual value exactly.
-                      type: string
-                    wwnVendorExtension:
-                      description: Unique vendor storage identifier. The hint
-                        must match the actual value exactly.
-                      type: string
-                    wwnWithExtension:
-                      description: Unique storage identifier with the vendor extension
-                        appended. The hint must match the actual value exactly.
-                      type: string
                   type: object
               required:
               - hostName
@@ -274,12 +177,3 @@ spec:
         - clusterName
         - nodes
         type: object
-
-# Notes:
-# clusterInstanceParameters contains only params that are exposed to the ProvisioningRequest.
-#
-# When HW is ready, bmcAddress, bmcCredentialsName, bootMACAddress and nodes.nodeNetwork.macAddress
-# should be removed from the schema as they are supposed to come from HW.
-#
-# Ideally, rootDeviceHints should come from default configmap. Keep it in the schema to make this template
-# be able to used for multiple SNOs with different rootDeviceHints.

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-3.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-3.yaml
@@ -107,31 +107,6 @@ spec:
             items:
               description: NodeSpec
               properties:
-                bmcAddress:
-                  description: BmcAddress holds the URL for accessing the controller
-                    on the network.
-                  type: string
-                bmcCredentialsName:
-                  description: BmcCredentialsName is the name of the secret containing
-                    the BMC credentials (requires keys "username" and "password").
-                  properties:
-                    name:
-                      type: string
-                  required:
-                  - name
-                  type: object
-                bmcCredentialsDetails:
-                  description: A workaround to provide bmc creds through ClusterRequest
-                  properties:
-                    username:
-                      type: string
-                    password:
-                      type: string
-                bootMACAddress:
-                  description: Which MAC address will PXE boot? This is optional
-                    for some types, but required for libvirt VMs driven by vbmc.
-                  pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
-                  type: string
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
@@ -174,78 +149,6 @@ spec:
                         nmstate config as plain yaml.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                    interfaces:
-                      description: Interfaces is an array of interface objects
-                        containing the name and MAC address for interfaces that
-                        are referenced in the raw nmstate config YAML. Interfaces
-                        listed here will be automatically renamed in the nmstate
-                        config YAML to match the real device name that is observed
-                        to have the corresponding MAC address. At least one interface
-                        must be listed so that it can be used to identify the
-                        correct host, which is done by matching any MAC address
-                        in this list to any MAC address observed on the host.
-                      items:
-                        properties:
-                          macAddress:
-                            description: mac address present on the host.
-                            pattern: ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
-                            type: string
-                          name:
-                            description: 'nic name used in the yaml, which relates
-                              1:1 to the mac address. Name in REST API: logicalNICName'
-                            type: string
-                        required:
-                        - macAddress
-                        type: object
-                      minItems: 1
-                      type: array
-                  type: object
-                rootDeviceHints:
-                  description: 'RootDeviceHints specifies the device for deployment.
-                    Identifiers that are stable across reboots are recommended,
-                    for example, wwn: <disk_wwn> or deviceName: /dev/disk/by-path/<device_path>'
-                  properties:
-                    deviceName:
-                      description: A Linux device name like "/dev/vda", or a by-path
-                        link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
-                        The hint must match the actual value exactly.
-                      type: string
-                    hctl:
-                      description: A SCSI bus address like 0:0:0:0. The hint must
-                        match the actual value exactly.
-                      type: string
-                    minSizeGigabytes:
-                      description: The minimum size of the device in Gigabytes.
-                      minimum: 0
-                      type: integer
-                    model:
-                      description: A vendor-specific device identifier. The hint
-                        can be a substring of the actual value.
-                      type: string
-                    rotational:
-                      description: True if the device should use spinning media,
-                        false otherwise.
-                      type: boolean
-                    serialNumber:
-                      description: Device serial number. The hint must match the
-                        actual value exactly.
-                      type: string
-                    vendor:
-                      description: The name of the vendor or manufacturer of the
-                        device. The hint can be a substring of the actual value.
-                      type: string
-                    wwn:
-                      description: Unique storage identifier. The hint must match
-                        the actual value exactly.
-                      type: string
-                    wwnVendorExtension:
-                      description: Unique vendor storage identifier. The hint
-                        must match the actual value exactly.
-                      type: string
-                    wwnWithExtension:
-                      description: Unique storage identifier with the vendor extension
-                        appended. The hint must match the actual value exactly.
-                      type: string
                   type: object
               required:
               - hostName
@@ -274,12 +177,3 @@ spec:
         - clusterName
         - nodes
         type: object
-
-# Notes:
-# clusterInstanceParameters contains only params that are exposed to the ProvisioningRequest.
-#
-# When HW is ready, bmcAddress, bmcCredentialsName, bootMACAddress and nodes.nodeNetwork.macAddress
-# should be removed from the schema as they are supposed to come from HW.
-#
-# Ideally, rootDeviceHints should come from default configmap. Keep it in the schema to make this template
-# be able to used for multiple SNOs with different rootDeviceHints.

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-4.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-4.yaml
@@ -111,31 +111,6 @@ spec:
             items:
               description: NodeSpec
               properties:
-                bmcAddress:
-                  description: BmcAddress holds the URL for accessing the controller
-                    on the network.
-                  type: string
-                bmcCredentialsName:
-                  description: BmcCredentialsName is the name of the secret containing
-                    the BMC credentials (requires keys "username" and "password").
-                  properties:
-                    name:
-                      type: string
-                  required:
-                  - name
-                  type: object
-                bmcCredentialsDetails:
-                  description: A workaround to provide bmc creds through ClusterRequest
-                  properties:
-                    username:
-                      type: string
-                    password:
-                      type: string
-                bootMACAddress:
-                  description: Which MAC address will PXE boot? This is optional
-                    for some types, but required for libvirt VMs driven by vbmc.
-                  pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
-                  type: string
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
@@ -178,78 +153,6 @@ spec:
                         nmstate config as plain yaml.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                    interfaces:
-                      description: Interfaces is an array of interface objects
-                        containing the name and MAC address for interfaces that
-                        are referenced in the raw nmstate config YAML. Interfaces
-                        listed here will be automatically renamed in the nmstate
-                        config YAML to match the real device name that is observed
-                        to have the corresponding MAC address. At least one interface
-                        must be listed so that it can be used to identify the
-                        correct host, which is done by matching any MAC address
-                        in this list to any MAC address observed on the host.
-                      items:
-                        properties:
-                          macAddress:
-                            description: mac address present on the host.
-                            pattern: ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
-                            type: string
-                          name:
-                            description: 'nic name used in the yaml, which relates
-                              1:1 to the mac address. Name in REST API: logicalNICName'
-                            type: string
-                        required:
-                        - macAddress
-                        type: object
-                      minItems: 1
-                      type: array
-                  type: object
-                rootDeviceHints:
-                  description: 'RootDeviceHints specifies the device for deployment.
-                    Identifiers that are stable across reboots are recommended,
-                    for example, wwn: <disk_wwn> or deviceName: /dev/disk/by-path/<device_path>'
-                  properties:
-                    deviceName:
-                      description: A Linux device name like "/dev/vda", or a by-path
-                        link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
-                        The hint must match the actual value exactly.
-                      type: string
-                    hctl:
-                      description: A SCSI bus address like 0:0:0:0. The hint must
-                        match the actual value exactly.
-                      type: string
-                    minSizeGigabytes:
-                      description: The minimum size of the device in Gigabytes.
-                      minimum: 0
-                      type: integer
-                    model:
-                      description: A vendor-specific device identifier. The hint
-                        can be a substring of the actual value.
-                      type: string
-                    rotational:
-                      description: True if the device should use spinning media,
-                        false otherwise.
-                      type: boolean
-                    serialNumber:
-                      description: Device serial number. The hint must match the
-                        actual value exactly.
-                      type: string
-                    vendor:
-                      description: The name of the vendor or manufacturer of the
-                        device. The hint can be a substring of the actual value.
-                      type: string
-                    wwn:
-                      description: Unique storage identifier. The hint must match
-                        the actual value exactly.
-                      type: string
-                    wwnVendorExtension:
-                      description: Unique vendor storage identifier. The hint
-                        must match the actual value exactly.
-                      type: string
-                    wwnWithExtension:
-                      description: Unique storage identifier with the vendor extension
-                        appended. The hint must match the actual value exactly.
-                      type: string
                   type: object
               required:
               - hostName
@@ -278,12 +181,3 @@ spec:
         - clusterName
         - nodes
         type: object
-
-# Notes:
-# clusterInstanceParameters contains only params that are exposed to the ProvisioningRequest.
-#
-# When HW is ready, bmcAddress, bmcCredentialsName, bootMACAddress and nodes.nodeNetwork.macAddress
-# should be removed from the schema as they are supposed to come from HW.
-#
-# Ideally, rootDeviceHints should come from default configmap. Keep it in the schema to make this template
-# be able to used for multiple SNOs with different rootDeviceHints.

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	hwv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
@@ -89,6 +90,14 @@ templateRefs:
   namespace: "siteconfig-operator"
 nodes:
 - hostname: "node1"
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: bootable-interface
+    - name: eth0
+      label: base-interface
+    - name: eth1
+      label: data-interface
   templateRefs:
   - name: "ai-node-templates-v1"
     namespace: "siteconfig-operator"
@@ -191,6 +200,27 @@ defaultHugepagesSize: "1G"`,
 			Client: c,
 			Logger: logger,
 		}
+
+		// Create the provisioned NodePool
+		hwPluginNs := &corev1.Namespace{}
+		hwPluginNs.SetName(utils.UnitTestHwmgrNamespace)
+		Expect(c.Create(ctx, hwPluginNs)).To(Succeed())
+		nodePool := &hwv1alpha1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-1",
+				Namespace: utils.UnitTestHwmgrNamespace,
+			},
+			Status: hwv1alpha1.NodePoolStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(hwv1alpha1.Provisioned),
+						Status: metav1.ConditionTrue,
+						Reason: string(hwv1alpha1.Completed),
+					},
+				},
+			},
+		}
+		Expect(c.Create(ctx, nodePool)).To(Succeed())
 
 		// Update the managedCluster cluster-1 to be available, joined and accepted.
 		managedCluster1 := &clusterv1.ManagedCluster{}

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -78,6 +78,14 @@ templateRefs:
 nodes:
 - hostname: "node1"
   ironicInspect: ""
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: bootable-interface
+    - name: eth0
+      label: base-interface
+    - name: eth1
+      label: data-interface
   templateRefs:
     - name: "ai-node-templates-v1"
       namespace: "siteconfig-operator"`,

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -222,25 +222,13 @@ func (t *provisioningRequestReconcilerTask) run(ctx context.Context) (ctrl.Resul
 				renderedNodePool.GetNamespace(),
 			),
 		)
-		// TODO: Remove this check once hwmgr plugin(s) are fully utilized
-		if renderedNodePool.ObjectMeta.Namespace != utils.UnitTestHwmgrNamespace {
-			return requeueWithMediumInterval(), nil
-		}
+		return requeueWithMediumInterval(), nil
 	}
 
-	hwProvisionedCond := meta.FindStatusCondition(
-		t.object.Status.Conditions,
-		string(utils.PRconditionTypes.HardwareProvisioned))
-
-	if hwProvisionedCond != nil {
-		// TODO: check hwProvisionedCond.Status == metav1.ConditionTrue
-		// after hw plugin is ready
-
-		// Handle the cluster install with ClusterInstance
-		err := t.handleClusterInstallation(ctx, renderedClusterInstance)
-		if err != nil {
-			return requeueWithError(err)
-		}
+	// Handle the cluster install with ClusterInstance
+	err = t.handleClusterInstallation(ctx, renderedClusterInstance)
+	if err != nil {
+		return requeueWithError(err)
 	}
 
 	// Handle policy configuration only after the cluster provisioning
@@ -288,61 +276,57 @@ func (t *provisioningRequestReconcilerTask) run(ctx context.Context) (ctrl.Resul
 // and policy configuration when applicable, and update the corresponding ProvisioningRequest
 // status conditions
 func (t *provisioningRequestReconcilerTask) checkClusterDeployConfigState(ctx context.Context) (result ctrl.Result, err error) {
-	defer func() {
-		// Check resources validation and preparation failures at the end
-		if updateErr := t.checkResourcePreparationStatus(ctx); updateErr != nil {
-			err = updateErr
-		}
-	}()
-
 	// Check the NodePool status if exists
 	if t.object.Status.NodePoolRef == nil {
+		if err = t.checkResourcePreparationStatus(ctx); err != nil {
+			return requeueWithError(err)
+		}
 		return doNotRequeue(), nil
 	}
 	nodePool := &hwv1alpha1.NodePool{}
 	nodePool.SetName(t.object.Status.NodePoolRef.Name)
 	nodePool.SetNamespace(t.object.Status.NodePoolRef.Namespace)
-	provisioned, timedOutOrFailed, err := t.checkNodePoolProvisionStatus(ctx, nodePool)
+	hwProvisioned, timedOutOrFailed, err := t.checkNodePoolProvisionStatus(ctx, nodePool)
 	if err != nil {
 		return requeueWithError(err)
 	}
 	if timedOutOrFailed {
+		if err = t.checkResourcePreparationStatus(ctx); err != nil {
+			return requeueWithError(err)
+		}
 		// Timeout occurred or failed, stop requeuing
 		return doNotRequeue(), nil
 	}
-	// TODO: remove the namespace check once the hwmgr plugin are fully utilized
-	if !provisioned && nodePool.Namespace != utils.UnitTestHwmgrNamespace {
+	if !hwProvisioned {
 		return requeueWithMediumInterval(), nil
 	}
 
-	hwProvisionedCond := meta.FindStatusCondition(
-		t.object.Status.Conditions,
-		string(utils.PRconditionTypes.HardwareProvisioned))
-	if hwProvisionedCond != nil {
-		// Check the ClusterInstance status if exists
-		if t.object.Status.ClusterDetails == nil {
-			return doNotRequeue(), nil
-		}
-		err := t.checkClusterProvisionStatus(
+	// Check the ClusterInstance status if exists
+	if t.object.Status.ClusterDetails != nil {
+		err = t.checkClusterProvisionStatus(
 			ctx, t.object.Status.ClusterDetails.Name)
 		if err != nil {
 			return requeueWithError(err)
 		}
+
+		// Check the policy configuration status only after the cluster provisioning
+		// has started, and not failed or timedout
+		if utils.IsClusterProvisionPresent(t.object) &&
+			!utils.IsClusterProvisionTimedOutOrFailed(t.object) {
+			requeue, err := t.handleClusterPolicyConfiguration(ctx)
+			if err != nil {
+				return requeueWithError(err)
+			}
+			// Requeue if Cluster Provisioned is not completed (in-progress or unknown)
+			// or there are enforce policies that are not Compliant
+			if !utils.IsClusterProvisionCompleted(t.object) || requeue {
+				return requeueWithLongInterval(), nil
+			}
+		}
 	}
 
-	// Check the policy configuration status only after the cluster provisioning
-	// has started, and not failed or timedout
-	if utils.IsClusterProvisionPresent(t.object) &&
-		!utils.IsClusterProvisionTimedOutOrFailed(t.object) {
-		requeue, err := t.handleClusterPolicyConfiguration(ctx)
-		if err != nil {
-			return requeueWithError(err)
-		}
-		// Requeue if Cluster Provisioned is not completed (in-progress or unknown)
-		// or there are enforce policies that are not Compliant
-		if !utils.IsClusterProvisionCompleted(t.object) || requeue {
-			return requeueWithLongInterval(), nil
-		}
+	if err = t.checkResourcePreparationStatus(ctx); err != nil {
+		return requeueWithError(err)
 	}
 	return doNotRequeue(), nil
 }
@@ -350,11 +334,6 @@ func (t *provisioningRequestReconcilerTask) checkClusterDeployConfigState(ctx co
 // checkResourcePreparationStatus checks for validation and preparation failures, setting the
 // provisioningState to failed if no provisioning is currently in progress and issues are found.
 func (t *provisioningRequestReconcilerTask) checkResourcePreparationStatus(ctx context.Context) error {
-	if t.object.Status.ProvisioningStatus.ProvisioningState == provisioningv1alpha1.StateProgressing {
-		// On-going provisioning is in progress, skip checking resource validation/preparation
-		return nil
-	}
-
 	conditionTypes := []utils.ConditionType{
 		utils.PRconditionTypes.Validated,
 		utils.PRconditionTypes.ClusterInstanceRendered,

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -19,13 +19,6 @@ func (t *provisioningRequestReconcilerTask) createNodePoolResources(ctx context.
 	pluginNameSpace := nodePool.ObjectMeta.Namespace
 	if exists, err := utils.HwMgrPluginNamespaceExists(ctx, t.client, pluginNameSpace); err != nil {
 		return fmt.Errorf("failed check if hardware manager plugin namespace exists %s, err: %w", pluginNameSpace, err)
-	} else if !exists && pluginNameSpace == utils.UnitTestHwmgrNamespace {
-		// TODO: For test purposes only. Code to be removed once hwmgr plugin(s) are fully utilized
-		createErr := utils.CreateHwMgrPluginNamespace(ctx, t.client, pluginNameSpace)
-		if createErr != nil {
-			return fmt.Errorf(
-				"failed to create hardware manager plugin namespace %s, err: %w", pluginNameSpace, createErr)
-		}
 	} else if !exists {
 		return fmt.Errorf("specified hardware manager plugin namespace does not exist: %s", pluginNameSpace)
 	}

--- a/internal/controllers/utils/provision.go
+++ b/internal/controllers/utils/provision.go
@@ -228,6 +228,12 @@ func FindClusterInstanceImmutableFieldUpdates(
 		  {"type": "update", "path": ["nodes", "0", "nodeNetwork", "config", "dns-resolver", "config", "server", "0"], "from": "192.10.1.2", "to": "192.10.1.3"}
 		*/
 
+		// Check if the path matches any ignored fields
+		if matchesAnyPattern(diff.Path, IgnoredClusterInstanceFields) {
+			// Ignored field; skip
+			continue
+		}
+
 		oranUtilsLog.Info(
 			fmt.Sprintf(
 				"Detected field change in the newly rendered ClusterInstance(%s) type: %s, path: %s, from: %+v, to: %+v",
@@ -238,11 +244,6 @@ func FindClusterInstanceImmutableFieldUpdates(
 		// Check if the path matches any allowed fields
 		if matchesAnyPattern(diff.Path, AllowedClusterInstanceFields) {
 			// Allowed field; skip
-			continue
-		}
-		// Check if the path matches any ignored fields
-		if matchesAnyPattern(diff.Path, IgnoredClusterInstanceFields) {
-			// Ignored field; skip
 			continue
 		}
 


### PR DESCRIPTION
With this commit, HW manager plugin([loopback adaptor](https://github.com/openshift-kni/oran-hwmgr-plugin/blob/main/adaptors/loopback/README.md)) is required for cluster provisioning.

Updates included:
- Remove the checks for `hwgmr` ns that could bypass the HW manager plugin
- Remove the workaround code for `hwgmr` ns creation originally for unittest(ns is now created within unittests)
- Remove the workaround code for BMC secret creation
- ClusterInstance Schema updates in the ClusterTemplate samples:
    - Remove `BMC` related parameters, `bootMacAddress` and the entire `nodeNetwork.interfaces` (name should be added in the default ClusterInstance configmap)
    - Remove `rootDeviceHints` from schema, adding it to the default ClusterInstance configmap
 - Fix an issue with updating the overall provisioning state for preparation work failures that is exposed in unittests with fully enabled plugin