### PR TITLE
NO-ISSUE: Update message for fulfilled state to be more generic

### DIFF
--- a/docs/cluster-provisioning.md
+++ b/docs/cluster-provisioning.md
@@ -259,7 +259,7 @@ ProvisioningRequestValidated -> ClusterInstanceRendered -> ClusterResourcesCreat
         status: "True"
         type: ConfigurationApplied
       provisioningStatus:
-        provisioningDetails: Cluster has installed and configured successfully
+        provisioningDetails: Provisioning request has completed successfully
         provisioningState: fulfilled
     ```
 

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -1353,7 +1353,7 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			// Verify the provisioningState sets to fulfilled when the provisioning process is completed
 			// and oCloudNodeClusterId is stored
 			verifyProvisioningStatus(reconciledCR.Status.ProvisioningStatus,
-				provisioningv1alpha1.StateFulfilled, "Cluster has installed and configured successfully",
+				provisioningv1alpha1.StateFulfilled, "Provisioning request has completed successfully",
 				&provisioningv1alpha1.ProvisionedResources{OCloudNodeClusterId: "76b8cbad-9928-48a0-bcf0-bb16a777b5f7"})
 		})
 

--- a/internal/controllers/utils/conditions.go
+++ b/internal/controllers/utils/conditions.go
@@ -105,7 +105,7 @@ func SetProvisioningStateFailed(cr *provisioningv1alpha1.ProvisioningRequest, me
 // SetProvisioningStateFulfilled updates the provisioning state to fulfilled with detailed message
 func SetProvisioningStateFulfilled(cr *provisioningv1alpha1.ProvisioningRequest) {
 	cr.Status.ProvisioningStatus.ProvisioningState = provisioningv1alpha1.StateFulfilled
-	cr.Status.ProvisioningStatus.ProvisioningDetails = "Cluster has installed and configured successfully"
+	cr.Status.ProvisioningStatus.ProvisioningDetails = "Provisioning request has completed successfully"
 }
 
 // IsClusterProvisionPresent checks if the cluster provision condition is present


### PR DESCRIPTION
Update the message for fulfilled state to be more generic that fits all scenarios.