### PR TITLE
Fix suppressedManifests getting removed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/openshift-kni/cluster-group-upgrades-operator v0.0.0-20241015193426-dd5c5bc228e8
+	github.com/openshift-kni/lifecycle-agent v0.0.0-20241010194013-9d0e25438512
 	github.com/openshift-kni/oran-o2ims/api/hardwaremanagement v0.0.0-20241001130125-a052f08603f7
 	github.com/openshift-kni/oran-o2ims/api/inventory v0.0.0-00010101000000-000000000000
 	github.com/openshift-kni/oran-o2ims/api/provisioning v0.0.0-00010101000000-000000000000
@@ -94,7 +95,6 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/openshift-kni/lifecycle-agent v0.0.0-20241010194013-9d0e25438512 // indirect
 	github.com/openshift/assisted-service/models v0.0.0 // indirect
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 // indirect
 	github.com/openshift/hive/apis v0.0.0-20240306163002-9c5806a63531 // indirect

--- a/internal/controllers/provisioningrequest_upgrade.go
+++ b/internal/controllers/provisioningrequest_upgrade.go
@@ -150,6 +150,10 @@ func (t *provisioningRequestReconcilerTask) handleUpgrade(
 		} else {
 			// Clean up IBGU and the condition if it doesn't match the current template ocp release version,
 			// i.e. the failed and revert case
+			t.logger.InfoContext(
+				ctx,
+				"IBGU is not progressing and cluster is not upgraded. Delete IBGU and UpgradeCompleted condition",
+			)
 			err := t.client.Delete(ctx, ibgu)
 			if err != nil {
 				return requeueWithError(fmt.Errorf("failed to cleanup IBGU: %w", err))

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	ibguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
 	hwv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
@@ -111,4 +112,5 @@ var _ = BeforeSuite(func() {
 	scheme.AddKnownTypes(clusterv1.SchemeGroupVersion, &clusterv1.ManagedClusterList{})
 	scheme.AddKnownTypes(openshiftv1.SchemeGroupVersion, &openshiftv1.ClusterVersion{})
 	scheme.AddKnownTypes(openshiftoperatorv1.SchemeGroupVersion, &openshiftoperatorv1.IngressController{})
+	scheme.AddKnownTypes(ibguv1alpha1.SchemeGroupVersion, &ibguv1alpha1.ImageBasedGroupUpgrade{})
 })

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -202,3 +202,10 @@ const ClusterVersionName = "version"
 const (
 	UpgradeDefaultsConfigmapKey = "ibgu"
 )
+
+// CRDs needed to be suppressed in ClusterInstance for upgrade
+var (
+	CRDsToBeSuppressedForUpgrade = []string{
+		"AgentClusterInstall",
+	}
+)


### PR DESCRIPTION
For upgrade process AgentClusterInstall should be added to
ClusterInstance's suppressedManifests in order to prevent updates to it.
This commit fixes suppressedManifests getting removed on subsequent
reconciles after adding on the first reconcile.