### PR TITLE
Adds missing "elements" array to the attributes of a Resource

### DIFF
--- a/internal/service/resource_handler.go
+++ b/internal/service/resource_handler.go
@@ -418,6 +418,8 @@ func (r *ResourceHandler) mapNodeItem(ctx context.Context, // nolint: unparam
 		"extensions":     extensionsMap,
 		"resourcePoolId": resourcePoolId,
 		"globalAssetId":  globalAssetId,
+		// TODO: no direct mapping
+		"elements": []string{},
 	}
 	return
 }


### PR DESCRIPTION
As detailed in **Table 2.1.1.1.5-1: Attributes of the Resource** from the O-RAN WG6 O2IMS Interface the Attribute elements is mandatory and it was missing in the returning information.

Notice that the description of this field says that the resource might be composed of smaller resources or other resource instances. Also, the conformance tests are expecting an array. Therefore I created an empty array of strings to include the elements attribute and pass the tests. Let me know if there is a way to include an array of type Resources instead (I did not find the proper way) if it makes sense.

cc/ @alegacy 