### PR TITLE
CNF-15491: Handle ProvisioningRequest deletion

### DIFF
--- a/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -109,6 +109,12 @@ const (
 	// StateFailed means the provisioning process has failed at any stage, including resource validation
 	// and preparation prior to provisioning, hardware provisioning, cluster installation, or cluster configuration.
 	StateFailed ProvisioningState = "failed"
+
+	// StateDeleting indicates that the provisioning resources are in the process of being deleted.
+	// This state is set when the deletion process for the ProvisioningRequest and its resources
+	// has started, ensuring that all dependent resources are removed before finalizing the
+	// ProvisioningRequest deletion.
+	StateDeleting ProvisioningState = "deleting"
 )
 
 // ProvisionedResources contains the resources that were provisioned as part of the provisioning process.
@@ -119,7 +125,7 @@ type ProvisionedResources struct {
 
 type ProvisioningStatus struct {
 	// The current state of the provisioning process.
-	// +kubebuilder:validation:Enum=progressing;fulfilled;failed
+	// +kubebuilder:validation:Enum=progressing;fulfilled;failed;deleting
 	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
 
 	// The details about the current state of the provisioning process.

--- a/bundle/manifests/o2ims.provisioning.oran.org_provisioningrequests.yaml
+++ b/bundle/manifests/o2ims.provisioning.oran.org_provisioningrequests.yaml
@@ -241,6 +241,7 @@ spec:
                     - progressing
                     - fulfilled
                     - failed
+                    - deleting
                     type: string
                 type: object
             type: object

--- a/config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml
+++ b/config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml
@@ -241,6 +241,7 @@ spec:
                     - progressing
                     - fulfilled
                     - failed
+                    - deleting
                     type: string
                 type: object
             type: object

--- a/docs/cluster-provisioning.md
+++ b/docs/cluster-provisioning.md
@@ -294,6 +294,14 @@ data:
   clusterConfigurationTimeout: "40m"
 ```
 
+## Delete Provisioned Cluster
+Deleting the ProvisioningRequest CR initiates the deletion of a provisioned cluster. O-Cloud manager sets the ProvisioningState to `deleting`, ensuring that all dependent resources are fully cleaned up before completing the deletion.
+```console
+oc get oranpr sno1
+NAME      AGE   PROVISIONSTATE   PROVISIONDETAILS
+sno1      71m   deleting         Deletion is in progress
+```
+
 ## Monitoring Process
 To watch the O-Cloud Manager controller logs:
 ```console

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -148,7 +148,8 @@ defaultHugepagesSize: "1G"`,
 			// Provisioning Requests.
 			&provisioningv1alpha1.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster-1",
+					Name:       "cluster-1",
+					Finalizers: []string{provisioningRequestFinalizer},
 				},
 				Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 					TemplateName:    tName,
@@ -1686,7 +1687,8 @@ var _ = Describe("hasPolicyConfigurationTimedOut", func() {
 			// Provisioning Request.
 			&provisioningv1alpha1.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster-1",
+					Name:       "cluster-1",
+					Finalizers: []string{provisioningRequestFinalizer},
 				},
 				Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 					TemplateName:    tName,

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -556,7 +556,8 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 		// Define the provisioning request.
 		cr = &provisioningv1alpha1.ProvisioningRequest{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: crName,
+				Name:       crName,
+				Finalizers: []string{provisioningRequestFinalizer},
 			},
 			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 				TemplateName:    tName,
@@ -1851,7 +1852,8 @@ var _ = Describe("getCrClusterTemplateRef", func() {
 		// Define the provisioning request.
 		cr := &provisioningv1alpha1.ProvisioningRequest{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: crName,
+				Name:       crName,
+				Finalizers: []string{provisioningRequestFinalizer},
 			},
 			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 				TemplateName:    tName,

--- a/internal/controllers/provisioningrequest_setup.go
+++ b/internal/controllers/provisioningrequest_setup.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -34,6 +35,14 @@ func (r *ProvisioningRequestReconciler) SetupWithManager(mgr ctrl.Manager) error
 			&provisioningv1alpha1.ProvisioningRequest{},
 			// Watch for create and update event for ProvisioningRequest.
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(
+			&corev1.Namespace{},
+			builder.WithPredicates(predicate.Funcs{
+				UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+				CreateFunc:  func(ce event.CreateEvent) bool { return false },
+				GenericFunc: func(ge event.GenericEvent) bool { return false },
+				DeleteFunc:  func(de event.DeleteEvent) bool { return true },
+			})).
 		Owns(
 			&ibgu.ImageBasedGroupUpgrade{},
 			builder.WithPredicates(predicate.Funcs{

--- a/internal/controllers/utils/conditions.go
+++ b/internal/controllers/utils/conditions.go
@@ -110,6 +110,12 @@ func SetProvisioningStateFulfilled(cr *provisioningv1alpha1.ProvisioningRequest)
 	cr.Status.ProvisioningStatus.ProvisioningDetails = "Provisioning request has completed successfully"
 }
 
+// SetProvisioningStateDeleting updates the provisioning state to deleting with detailed message
+func SetProvisioningStateDeleting(cr *provisioningv1alpha1.ProvisioningRequest) {
+	cr.Status.ProvisioningStatus.ProvisioningState = provisioningv1alpha1.StateDeleting
+	cr.Status.ProvisioningStatus.ProvisioningDetails = "Deletion is in progress"
+}
+
 // IsProvisioningStateFulfilled checks if the provisioning status is fulfilled
 func IsProvisioningStateFulfilled(cr *provisioningv1alpha1.ProvisioningRequest) bool {
 	return cr.Status.ProvisioningStatus.ProvisioningState == provisioningv1alpha1.StateFulfilled

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -109,6 +109,12 @@ const (
 	// StateFailed means the provisioning process has failed at any stage, including resource validation
 	// and preparation prior to provisioning, hardware provisioning, cluster installation, or cluster configuration.
 	StateFailed ProvisioningState = "failed"
+
+	// StateDeleting indicates that the provisioning resources are in the process of being deleted.
+	// This state is set when the deletion process for the ProvisioningRequest and its resources
+	// has started, ensuring that all dependent resources are removed before finalizing the
+	// ProvisioningRequest deletion.
+	StateDeleting ProvisioningState = "deleting"
 )
 
 // ProvisionedResources contains the resources that were provisioned as part of the provisioning process.
@@ -119,7 +125,7 @@ type ProvisionedResources struct {
 
 type ProvisioningStatus struct {
 	// The current state of the provisioning process.
-	// +kubebuilder:validation:Enum=progressing;fulfilled;failed
+	// +kubebuilder:validation:Enum=progressing;fulfilled;failed;deleting
 	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
 
 	// The details about the current state of the provisioning process.


### PR DESCRIPTION
Updates included:
- Add new provisioningState `deleting`, set when ProvisioningRequest is marked for deletion.
- Add the finializer back to handle dependents deletion, ensuring dependents are removed before removing finalizer from ProvisioningRequest to complete the deletion.
- Watch for deletion of cluster namespace so reconcilation can be triggered when ns is deleted.
