### PR TITLE
Adds missing mandatory AlarmDefinition attributes

### DIFF
--- a/internal/service/alarm_definition_handler.go
+++ b/internal/service/alarm_definition_handler.go
@@ -198,6 +198,10 @@ func (h *AlarmDefinitionHandler) mapItem(ctx context.Context,
 		"managementInterfaceId": "O2IMS",
 		"pkNotificationField":   "alarmDefinitionID",
 		"alarmAdditionalFields": alarmAdditionalFields,
+		// TODO: no direct mapping
+		"alarmLastChange": "",
+		"alarmChangeType": "",
+		"clearingType":    "",
 	}
 
 	return

--- a/internal/service/alarm_definition_handler_test.go
+++ b/internal/service/alarm_definition_handler_test.go
@@ -78,6 +78,9 @@ var _ = Describe("Alarm definition handler", func() {
 					Expect(item).To(HaveKey("managementInterfaceId"))
 					Expect(item).To(HaveKey("pkNotificationField"))
 					Expect(item).To(HaveKey("alarmAdditionalFields"))
+					Expect(item).To(HaveKey("alarmLastChange"))
+					Expect(item).To(HaveKey("alarmChangeType"))
+					Expect(item).To(HaveKey("clearingType"))
 				}
 			})
 


### PR DESCRIPTION
These fields are missing as part of the AlarmDefinition table (Table 3.2.6.2.9‑1 Definition of type AlarmDefinition) in the O-RAN WG6 O2-IMS INTERFACE document. They're mandatory fields that needs to be sent back to pass the conformance tests.

cc/ @pixelsoccupied @alegacy 