### PR TITLE
MGMT-18997: Use downward API to acquire namespace

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1397,6 +1397,10 @@ spec:
                   value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
                 - name: HWMGR_PLUGIN_NAMESPACE
                   value: oran-hwmgr-plugin
+                - name: OCLOUD_MANAGER_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 image: quay.io/openshift-kni/oran-o2ims-operator:4.16.0
                 livenessProbe:
                   httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -80,6 +80,10 @@ spec:
         - name: HWMGR_PLUGIN_NAMESPACE
           # A placeholder for the replacement kustomization that will inject the value from the config map
           value: plugin-namespace-placeholder
+        - name: OCLOUD_MANAGER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         command:
           - /usr/bin/oran-o2ims
           -  start

--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -185,25 +185,15 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		return exit.Error(1)
 	}
 
-	// Determine our current namespace
-	namespace, err := utils.ReadDefaultNamespace()
-	if err != nil {
-		logger.ErrorContext(
-			ctx,
-			"Failed to read current namespace",
-			slog.String("error", err.Error()),
-		)
-		return exit.Error(1)
-	}
-
 	// Create the default inventory CR
-	err = utils.CreateDefaultInventoryCR(ctx, mgr.GetClient(), namespace)
+	err = utils.CreateDefaultInventoryCR(ctx, mgr.GetClient())
 	if err != nil {
 		logger.ErrorContext(
 			ctx,
 			"Failed to create default inventory CR",
 			slog.String("error", err.Error()),
 		)
+		return exit.Error(1)
 	}
 
 	// Start the O2IMS controller.

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -68,8 +68,12 @@ const DefaultOCloudID = "undefined"
 // DefaultAppName defines the name prepended to the ingress host to form our FQDN hostname.
 const DefaultAppName = "o2ims"
 
-// DefaultInventoryCR defines the name used for the default Inventory CR instance.
-const DefaultInventoryCR = "default"
+// Defines information related to the operator instance in a namespace
+const (
+	DefaultInventoryCR      = "default"
+	DefaultNamespace        = "oran-o2ims"
+	DefaultNamespaceEnvName = "OCLOUD_MANAGER_NAMESPACE"
+)
 
 // Default values for backend URL and token:
 const (
@@ -78,7 +82,6 @@ const (
 	defaultBackendTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"          // nolint: gosec // hardcoded path only
 	defaultBackendCABundle  = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"         // nolint: gosec // hardcoded path only
 	defaultServiceCAFile    = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" // nolint: gosec // hardcoded path only
-	defaultNamespaceFile    = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 )
 
 // Default timeout values

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -775,21 +775,12 @@ func GetCertFromSecret(ctx context.Context, c client.Client, name, namespace str
 	return &cert, nil
 }
 
-// ReadDefaultNamespace reads the current namespace from the service account namespace file.
-func ReadDefaultNamespace() (string, error) {
-	namespaceBytes, err := os.ReadFile(defaultNamespaceFile)
-	if err != nil {
-		return "", fmt.Errorf("failed to read default namespace from file '%s': %w", defaultNamespaceFile, err)
-	}
-	return string(namespaceBytes), nil
-}
-
 // CreateDefaultInventoryCR creates the default Inventory CR so that the system has running servers
-func CreateDefaultInventoryCR(ctx context.Context, c client.Client, namespace string) error {
+func CreateDefaultInventoryCR(ctx context.Context, c client.Client) error {
 	inventory := inventoryv1alpha1.Inventory{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DefaultInventoryCR,
-			Namespace: namespace,
+			Namespace: GetEnvOrDefault(DefaultNamespaceEnvName, DefaultNamespace),
 		},
 		Spec: inventoryv1alpha1.InventorySpec{
 			AlarmSubscriptionServerConfig: inventoryv1alpha1.AlarmSubscriptionServerConfig{


### PR DESCRIPTION
Rather than get the namespace from the service account static files we are able to get it from an environment variable.  This benefits being able to run the controller from the command line for testing purposes.