### PR TITLE
Remove NodePool Status Updates from Cloud Manager

### DIFF
--- a/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -80,9 +80,6 @@ type NodePoolStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
 	//+operator-sdk:csv:customresourcedefinitions:type=status
-	CloudManager GenerationStatus `json:"cloudManager,omitempty"`
-
-	//+operator-sdk:csv:customresourcedefinitions:type=status
 	HwMgrPlugin GenerationStatus `json:"hwMgrPlugin,omitempty"`
 }
 

--- a/api/hardwaremanagement/v1alpha1/zz_generated.deepcopy.go
+++ b/api/hardwaremanagement/v1alpha1/zz_generated.deepcopy.go
@@ -257,7 +257,6 @@ func (in *NodePoolStatus) DeepCopyInto(out *NodePoolStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.CloudManager = in.CloudManager
 	out.HwMgrPlugin = in.HwMgrPlugin
 }
 

--- a/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
+++ b/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
@@ -94,14 +94,6 @@ spec:
               NodePoolStatus describes the observed state of a request to allocate and prepare
               a node that will eventually be part of a deployment manager.
             properties:
-              cloudManager:
-                description: GenerationStatus represents the observed generation for
-                  an operator.
-                properties:
-                  observedGeneration:
-                    format: int64
-                    type: integer
-                type: object
               conditions:
                 description: |-
                   Conditions represent the observations of the NodePool's current state.

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -91,9 +91,6 @@ metadata:
             "site": "ottawa"
           },
           "status": {
-            "cloudManager": {
-              "observedGeneration": 1
-            },
             "conditions": [
               {
                 "lastTransitionTime": "2024-10-09T15:36:41Z",
@@ -867,8 +864,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - displayName: Cloud Manager
-        path: cloudManager
       - description: |-
           Conditions represent the observations of the NodePool's current state.
           Possible values of the condition type are `Provisioned` and `Unknown`.

--- a/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
+++ b/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
@@ -94,14 +94,6 @@ spec:
               NodePoolStatus describes the observed state of a request to allocate and prepare
               a node that will eventually be part of a deployment manager.
             properties:
-              cloudManager:
-                description: GenerationStatus represents the observed generation for
-                  an operator.
-                properties:
-                  observedGeneration:
-                    format: int64
-                    type: integer
-                type: object
               conditions:
                 description: |-
                   Conditions represent the observations of the NodePool's current state.

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -285,8 +285,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - displayName: Cloud Manager
-        path: cloudManager
       - description: |-
           Conditions represent the observations of the NodePool's current state.
           Possible values of the condition type are `Provisioned` and `Unknown`.

--- a/config/samples/v1alpha1_nodepool.yaml
+++ b/config/samples/v1alpha1_nodepool.yaml
@@ -26,8 +26,6 @@ spec:
     size: 0
   site: ottawa
 status:
-  cloudManager:
-    observedGeneration: 1
   conditions:
   - lastTransitionTime: "2024-10-09T15:36:41Z"
     message: Created

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -40,13 +40,6 @@ func (t *provisioningRequestReconcilerTask) createOrUpdateNodePool(ctx context.C
 			return fmt.Errorf("failed to patch NodePool %s in namespace %s: %w", nodePool.GetName(), nodePool.GetNamespace(), err)
 		}
 
-		// After successful patch, update the status
-		existingNodePool.Status.CloudManager.ObservedGeneration = existingNodePool.ObjectMeta.Generation
-		err := utils.UpdateNodePoolStatus(ctx, t.client, existingNodePool, hwv1alpha1.Configured, metav1.ConditionFalse,
-			hwv1alpha1.ConfigUpdate, hwv1alpha1.AwaitConfig)
-		if err != nil {
-			return fmt.Errorf("failed to update status of NodePool %s in namespace %s: %w", nodePool.GetName(), nodePool.GetNamespace(), err)
-		}
 		t.logger.InfoContext(
 			ctx,
 			fmt.Sprintf(
@@ -104,11 +97,7 @@ func (t *provisioningRequestReconcilerTask) createNodePoolResources(ctx context.
 			nodePool.GetNamespace(),
 		),
 	)
-	// Set the CloudManager's ObservedGeneration on the node pool resource status field
-	err = utils.SetCloudManagerInitialObservedGeneration(ctx, t.client, nodePool)
-	if err != nil {
-		return fmt.Errorf("failed to set CloudManager's ObservedGeneration: %w", err)
-	}
+
 	return nil
 }
 

--- a/internal/controllers/utils/hardware_utils.go
+++ b/internal/controllers/utils/hardware_utils.go
@@ -15,7 +15,6 @@ import (
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -255,26 +254,6 @@ func GetHwMgrPluginNS() string {
 	return hwMgrPluginNameSpace
 }
 
-// SetCloudManagerInitialObservedGeneration sets the CloudManager's ObservedGeneration
-func SetCloudManagerInitialObservedGeneration(ctx context.Context, c client.Client, nodePool *hwv1alpha1.NodePool) error {
-	// Get the generated NodePool
-	exists, err := DoesK8SResourceExist(ctx, c, nodePool.GetName(),
-		nodePool.GetNamespace(), nodePool)
-	if err != nil {
-		return fmt.Errorf("failed to get NodePool %s in namespace %s: %w", nodePool.GetName(), nodePool.GetNamespace(), err)
-	}
-	if !exists {
-		return fmt.Errorf("nodePool %s does not exist in namespace %s: %w", nodePool.GetName(), nodePool.GetNamespace(), err)
-	}
-	// Set ObservedGeneration to the current generation of the resource
-	nodePool.Status.CloudManager.ObservedGeneration = nodePool.ObjectMeta.Generation
-	err = UpdateK8sCRStatus(ctx, c, nodePool)
-	if err != nil {
-		return fmt.Errorf("failed to update status for NodePool %s %s: %w", nodePool.GetName(), nodePool.GetNamespace(), err)
-	}
-	return nil
-}
-
 // getInterfaces extracts the interfaces from the node map.
 func getInterfaces(nodeMap map[string]interface{}) []map[string]interface{} {
 	if nodeNetwork, ok := nodeMap["nodeNetwork"].(map[string]interface{}); ok {
@@ -461,29 +440,6 @@ func CompareConfigMapWithNodePool(configMap *corev1.ConfigMap, nodePool *hwv1alp
 		}
 	}
 	return changesDetected, nil
-}
-
-// UpdateNodePoolStatus updates the NodePool status fields
-func UpdateNodePoolStatus(ctx context.Context, client client.Client, nodePool *hwv1alpha1.NodePool,
-	conditionType hwv1alpha1.ConditionType, status metav1.ConditionStatus,
-	reason hwv1alpha1.ConditionReason, message hwv1alpha1.ConditionMessage) error {
-
-	meta.SetStatusCondition(
-		&nodePool.Status.Conditions,
-		metav1.Condition{
-			Type:               string(conditionType),
-			Status:             status,
-			Reason:             string(reason),
-			Message:            string(message),
-			LastTransitionTime: metav1.Now(),
-		},
-	)
-
-	// Update the Kubernetes Custom Resource status and handle any errors
-	if err := UpdateK8sCRStatus(ctx, client, nodePool); err != nil {
-		return fmt.Errorf("failed to update status for NodePool %s in namespace %s: %w", nodePool.GetName(), nodePool.GetNamespace(), err)
-	}
-	return nil
 }
 
 // GetStatusMessage returns a status message based on the given condition typ

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -80,9 +80,6 @@ type NodePoolStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
 	//+operator-sdk:csv:customresourcedefinitions:type=status
-	CloudManager GenerationStatus `json:"cloudManager,omitempty"`
-
-	//+operator-sdk:csv:customresourcedefinitions:type=status
 	HwMgrPlugin GenerationStatus `json:"hwMgrPlugin,omitempty"`
 }
 

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/zz_generated.deepcopy.go
@@ -257,7 +257,6 @@ func (in *NodePoolStatus) DeepCopyInto(out *NodePoolStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.CloudManager = in.CloudManager
 	out.HwMgrPlugin = in.HwMgrPlugin
 }
 


### PR DESCRIPTION
This update removes node pool status updates from the Cloud Manager to maintain a clear separation of responsibilities: the Cloud Manager exclusively updates spec fields, while the hwMgr plugin is responsible for status fields.

The hwMgr plugin uses the ObservedGeneration status field to detect changes in the node pool spec and adjust its operations accordingly, without needing to modify spec fields. This design strengthens single-responsibility principles, reducing potential update conflicts.