### PR TITLE
CNF-14862: Configure AlertManager to send alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,15 @@ sync-submodules:
 ##@ O-RAN Alarms Server
 
 .PHNOY: alarms
-alarms: clean-postgres run-postgres run-alarms-migrate run-alarms ##Run full alarms stack
+alarms: clean-postgres clean-am-service run-postgres run-alarms-migrate create-am-service run-alarms ##Run full alarms stack
+
+create-am-service: ##Creates alarm manager service and endpoint to expose a DNS entry.
+	oc apply -k ./internal/service/alarms/k8s/base --wait=true
+	@echo "Service and Endpoint for alarm manager created."
+
+clean-am-service: ##Deletes alarm manager service and endpoint.
+	-oc delete -k ./internal/service/alarms/k8s/base --wait=true
+	@echo "Service and Endpoint for alarm manager deleted."
 
 .PHONY: run-alarms
 run-alarms: go-generate binary ##Run alarms server locally

--- a/internal/service/alarms/internal/alarms_server.go
+++ b/internal/service/alarms/internal/alarms_server.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -82,8 +83,13 @@ func (a *AlarmsServer) GetProbableCause(ctx context.Context, request api.GetProb
 }
 
 func (a *AlarmsServer) AmNotification(ctx context.Context, request api.AmNotificationRequestObject) (api.AmNotificationResponseObject, error) {
-	// TODO implement me
-	panic("implement me")
+	// TODO: Implement the logic to handle the AM notification
+	slog.Debug("Received AM notification", "groupLabels", request.Body.GroupLabels)
+	for _, alert := range request.Body.Alerts {
+		slog.Debug("Alert", "fingerprint", alert.Fingerprint, "startsAt", alert.StartsAt, "status", alert.Status)
+	}
+
+	return api.AmNotification200Response{}, nil
 }
 
 func (a *AlarmsServer) HwNotification(ctx context.Context, request api.HwNotificationRequestObject) (api.HwNotificationResponseObject, error) {

--- a/internal/service/alarms/internal/alertmanager/alertmanager.go
+++ b/internal/service/alarms/internal/alertmanager/alertmanager.go
@@ -1,0 +1,42 @@
+package alertmanager
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	namespace  = "open-cluster-management-observability"
+	secretName = "alertmanager-config"
+	secretKey  = "alertmanager.yaml"
+)
+
+//go:embed alertmanager.yaml
+var alertManagerConfig []byte
+
+// Setup updates the alertmanager config secret with the new configuration
+func Setup(ctx context.Context, cl client.Client) error {
+	// ACM recreates the secret when it is deleted, so we can safely assume it exists
+	var secret corev1.Secret
+	err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretName}, &secret)
+	if err != nil {
+		return fmt.Errorf("failed to get secret %s/%s: %w", namespace, secretName, err)
+	}
+
+	// Verify that Data has the key "alertmanager.yaml"
+	if _, ok := secret.Data[secretKey]; !ok {
+		return fmt.Errorf("%s not found in secret %s/%s", secretKey, namespace, secretName)
+	}
+
+	secret.Data[secretKey] = alertManagerConfig
+	err = cl.Update(ctx, &secret)
+	if err != nil {
+		return fmt.Errorf("failed to update secret %s/%s: %w", namespace, secretName, err)
+	}
+
+	return nil
+}

--- a/internal/service/alarms/internal/alertmanager/alertmanager.yaml
+++ b/internal/service/alarms/internal/alertmanager/alertmanager.yaml
@@ -1,0 +1,30 @@
+---
+global:
+  resolve_timeout: 5m
+route:
+  group_wait: 30s
+  group_interval: 1m
+  repeat_interval: 4h
+  # Default receiver - Alerts without cluster identifier label will still be sent to this receiver
+  receiver: oran_alarm_receiver
+  routes:
+  # Route to skip alerts
+  - receiver: "null"
+    matchers:
+      # Always firing alert to verify alertmanager is working
+      - Watchdog
+  - receiver: oran_alarm_receiver
+    group_by:
+      # This label is guaranteed to be present in all alerts
+      - managed_cluster
+    matchers:
+      # Match alerts with a non-empty managed_cluster label
+      - managed_cluster=~".+"
+receivers:
+  - name: oran_alarm_receiver
+    webhook_configs:
+    - send_resolved: true
+      # Hardcoded 8080 port (same as http server)
+      # TODO: delete port from url once we have a proper k8s service
+      url: http://alarm-server.oran-o2ims.svc.cluster.local:8080/internal/v1/caas-alerts/alertmanager
+  - name: "null"

--- a/internal/service/alarms/internal/alertmanager/alertmanager_test.go
+++ b/internal/service/alarms/internal/alertmanager/alertmanager_test.go
@@ -1,0 +1,55 @@
+package alertmanager
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Alertmanager", func() {
+	Describe("Setup", func() {
+		var (
+			ctx    context.Context
+			scheme *runtime.Scheme
+			c      client.Client
+		)
+
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+
+			ctx = context.Background()
+			c = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					secretKey: []byte(""),
+				},
+			}
+
+			err := c.Create(ctx, secret)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("verifies that the alertmanager.yaml key is populated", func() {
+			err := Setup(ctx, c)
+			Expect(err).ToNot(HaveOccurred())
+
+			secret := &corev1.Secret{}
+			err = c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretName}, secret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret.Data[secretKey]).To(Equal(alertManagerConfig))
+		})
+	})
+})

--- a/internal/service/alarms/internal/alertmanager/suite_test.go
+++ b/internal/service/alarms/internal/alertmanager/suite_test.go
@@ -1,0 +1,13 @@
+package alertmanager
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDictionary(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Alertmanager Suite")
+}

--- a/internal/service/alarms/k8s/README.md
+++ b/internal/service/alarms/k8s/README.md
@@ -1,0 +1,10 @@
+# Service for Alertmanager
+
+# IMPORTANT NOTE: Only an operator will finally manage the alarm server. Files here are simply here to unblock any work with api implementation and test. Please delete these static k8s files once we have this integrated. Update anything else as needed (e.g makefile).
+
+This directory contains everything to expose a DNS entry for Alertmanager URL config.
+Replace the IP address with the actual IP address of your cluster in the [endpoints.yaml](base/endpoints.yaml) file.
+
+```shell
+make create-am-service
+```

--- a/internal/service/alarms/k8s/base/endpoints.yaml
+++ b/internal/service/alarms/k8s/base/endpoints.yaml
@@ -1,0 +1,9 @@
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: alarm-server
+subsets:
+  - addresses:
+      # Change me
+      - ip: 0.0.0.0

--- a/internal/service/alarms/k8s/base/kustomization.yaml
+++ b/internal/service/alarms/k8s/base/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: oran-o2ims
+resources:
+  - service.yaml
+  - endpoints.yaml

--- a/internal/service/alarms/k8s/base/service.yaml
+++ b/internal/service/alarms/k8s/base/service.yaml
@@ -1,0 +1,7 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: alarm-server
+spec:
+  clusterIP: None

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -13,12 +13,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal"
-	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/db"
-	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/k8s_client"
-
 	api "github.com/openshift-kni/oran-o2ims/internal/service/alarms/api/generated"
+	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal"
+	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/alertmanager"
+	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/db"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/dictionary"
+	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/k8s_client"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api/generated"
 )
 
@@ -61,6 +61,12 @@ func Serve() error {
 	if err != nil {
 		return fmt.Errorf("error creating client for hub: %w", err)
 	}
+
+	err = alertmanager.Setup(ctx, hubClient)
+	if err != nil {
+		return fmt.Errorf("error configuring alert manager: %w", err)
+	}
+
 	alarmsDict := dictionary.New(hubClient)
 	alarmsDict.Load(ctx)
 


### PR DESCRIPTION
Add a webhook receiver to AlertManager configuration so that alarm server is notified to the internal endpoint.
