### PR TITLE
CNF-15167: Fix RBAC role for searching managed data

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1302,18 +1302,6 @@ spec:
           - update
           - watch
         - apiGroups:
-          - search.open-cluster-management.io
-          resources:
-          - searches
-          verbs:
-          - get
-        - apiGroups:
-          - search.open-cluster-management.io
-          resources:
-          - searches/allManagedData
-          verbs:
-          - get
-        - apiGroups:
           - siteconfig.open-cluster-management.io
           resources:
           - clusterinstances
@@ -1325,6 +1313,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - view.open-cluster-management.io
+          resources:
+          - managedclusterviews
+          verbs:
+          - create
         - apiGroups:
           - authentication.k8s.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -308,18 +308,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - search.open-cluster-management.io
-  resources:
-  - searches
-  verbs:
-  - get
-- apiGroups:
-  - search.open-cluster-management.io
-  resources:
-  - searches/allManagedData
-  verbs:
-  - get
-- apiGroups:
   - siteconfig.open-cluster-management.io
   resources:
   - clusterinstances
@@ -331,3 +319,9 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - view.open-cluster-management.io
+  resources:
+  - managedclusterviews
+  verbs:
+  - create

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -48,8 +48,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-//+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches,verbs=get
-//+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches/allManagedData,verbs=get
+//+kubebuilder:rbac:groups=view.open-cluster-management.io,resources=managedclusterviews,verbs=create
 //+kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
@@ -818,14 +817,13 @@ func (t *reconcilerTask) createResourceServerClusterRole(ctx context.Context) er
 			},
 			{
 				APIGroups: []string{
-					"search.open-cluster-management.io",
+					"view.open-cluster-management.io",
 				},
 				Resources: []string{
-					"searches",
-					"searches/allManagedData",
+					"managedclusterviews",
 				},
 				Verbs: []string{
-					"get",
+					"create",
 				},
 			},
 			{


### PR DESCRIPTION
The previous PR for this Jira addressed the managed data use case, but inadvertently disabled the local cluster use case.  This change reverts the first since the allManagedData RBAC rule seems to make it such that the service account can only see managed data and not any local data.  To enable querying the managed data we require the ability to create managedclusterviews.