### PR TITLE
MGMT-18997: Get default domain from status rather than spec

### DIFF
--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -240,14 +240,14 @@ func GetIngressDomain(ctx context.Context, c client.Client) (string, error) {
 		return "", fmt.Errorf("default ingress controller object not found: %w", err)
 	}
 
-	spec := ingressController.Object["spec"].(map[string]interface{})
-	domain, ok := spec["domain"]
+	status := ingressController.Object["status"].(map[string]interface{})
+	domain, ok := status["domain"]
 
 	if ok {
 		return domain.(string), nil
 	}
 
-	return "", fmt.Errorf("default ingress controller does not have expected 'spec.domain' attribute")
+	return "", fmt.Errorf("default ingress controller does not have expected 'status.domain' attribute")
 }
 
 func GetServerArgs(inventory *inventoryv1alpha1.Inventory, serverName string) (result []string, err error) {

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -283,7 +283,7 @@ var _ = Describe("GetIngressDomain", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "default",
 				Namespace: "openshift-ingress-operator"},
-			Spec: openshiftv1.IngressControllerSpec{
+			Status: openshiftv1.IngressControllerStatus{
 				Domain: "apps.example.com"}}
 
 		objs := []client.Object{ingress}


### PR DESCRIPTION
This changes how we acquire the default domain so that we look at the ingress controller's Status field rather than its Spec field since in some cases it may not be explicitly set in the Spec which causes it to go get it from another source.  Ultimately, we do not care where it gets it from so we look at its final decision which is stored in the Status field.