### PR TITLE
CNF-15608: Support cluster provisioning without hwTemplate

### DIFF
--- a/api/provisioning/v1alpha1/clustertemplate_types.go
+++ b/api/provisioning/v1alpha1/clustertemplate_types.go
@@ -64,8 +64,8 @@ type ClusterTemplateSpec struct {
 
 // Templates defines the references to the templates required for ClusterTemplate.
 type Templates struct {
-	// HwTemplate defines a reference to a hardware template config map
-	HwTemplate string `json:"hwTemplate"`
+	// HwTemplate defines a reference to a hardware template configmap
+	HwTemplate string `json:"hwTemplate,omitempty"`
 
 	// ClusterInstanceDefaults defines a reference to a configmap with
 	// default values for ClusterInstance

--- a/bundle/manifests/o2ims.provisioning.oran.org_clustertemplates.yaml
+++ b/bundle/manifests/o2ims.provisioning.oran.org_clustertemplates.yaml
@@ -96,7 +96,7 @@ spec:
                     type: string
                   hwTemplate:
                     description: HwTemplate defines a reference to a hardware template
-                      config map
+                      configmap
                     type: string
                   policyTemplateDefaults:
                     description: |-
@@ -110,7 +110,6 @@ spec:
                     type: string
                 required:
                 - clusterInstanceDefaults
-                - hwTemplate
                 - policyTemplateDefaults
                 type: object
               version:

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -438,11 +438,6 @@ metadata:
                 ],
                 "nodes": [
                   {
-                    "bmcAddress": "idrac-virtualmedia+https://10.16.231.87/redfish/v1/Systems/System.Embedded.1",
-                    "bmcCredentialsName": {
-                      "name": "node1-bmc-secret"
-                    },
-                    "bootMACAddress": "00:00:00:01:20:30",
                     "bootMode": "UEFI",
                     "extraAnnotations": {
                       "BareMetalHost": {
@@ -544,21 +539,7 @@ metadata:
                             }
                           ]
                         }
-                      },
-                      "interfaces": [
-                        {
-                          "macAddress": "00:00:00:01:20:30",
-                          "name": "eno1"
-                        },
-                        {
-                          "macAddress": "02:00:00:80:12:14",
-                          "name": "eth0"
-                        },
-                        {
-                          "macAddress": "02:00:00:80:12:15",
-                          "name": "eth1"
-                        }
-                      ]
+                      }
                     }
                   }
                 ],

--- a/config/crd/bases/o2ims.provisioning.oran.org_clustertemplates.yaml
+++ b/config/crd/bases/o2ims.provisioning.oran.org_clustertemplates.yaml
@@ -96,7 +96,7 @@ spec:
                     type: string
                   hwTemplate:
                     description: HwTemplate defines a reference to a hardware template
-                      config map
+                      configmap
                     type: string
                   policyTemplateDefaults:
                     description: |-
@@ -110,7 +110,6 @@ spec:
                     type: string
                 required:
                 - clusterInstanceDefaults
-                - hwTemplate
                 - policyTemplateDefaults
                 type: object
               version:

--- a/config/samples/v1alpha1_provisioningrequest.yaml
+++ b/config/samples/v1alpha1_provisioningrequest.yaml
@@ -41,11 +41,7 @@ spec:
       machineNetwork:
         - cidr: 192.0.2.0/24
       nodes:
-        - bmcAddress: idrac-virtualmedia+https://10.16.231.87/redfish/v1/Systems/System.Embedded.1
-          bmcCredentialsName:
-            name: node1-bmc-secret
-          bootMACAddress: 00:00:00:01:20:30
-          bootMode: UEFI
+        - bootMode: UEFI
           extraAnnotations:
             BareMetalHost:
               extra-annotation-key: extra-annotation-value
@@ -106,13 +102,6 @@ spec:
                     next-hop-address: 192.0.2.254
                     next-hop-interface: eno1
                     table-id: 254
-            interfaces:
-              - macAddress: 00:00:00:01:20:30
-                name: eno1
-              - macAddress: 02:00:00:80:12:14
-                name: eth0
-              - macAddress: 02:00:00:80:12:15
-                name: eth1
       serviceNetwork:
         - cidr: 233.252.0.0/24
       sshPublicKey: ssh-rsa

--- a/docs/cluster-provisioning.md
+++ b/docs/cluster-provisioning.md
@@ -31,7 +31,7 @@ The [CRD](../config/crd/bases/o2ims.provisioning.oran.org_clustertemplates.yaml)
 - version: Defines the version of the ClusterTemplate.
 - description: A description of the ClusterTemplate.
 - templates:
-    - hwTemplate: References the ConfigMap containing the hardware template used for node allocation.
+    - hwTemplate: (Optional) References the ConfigMap containing the hardware template used for node allocation. See note below.
     - clusterInstanceDefaults: References the ConfigMap containing default values for ClusterInstance.
     - policyTemplateDefaults: References the ConfigMap containing default values for ACM policy templates.
 - templateParameterSchema: Specifies the OpenAPI v3 schema that defines the accepted and required parameters for provisioning a cluster. This schema is used to validate the parameters passed in the ProvisioningRequest.
@@ -62,6 +62,10 @@ status:
     status: "True"
     type: ClusterTemplateValidated
 ```
+
+> [!NOTE]
+>  `spec.templates.hwTemplate` is optional. In scenarios where the hwTemplate ConfigMap is not provided, hardware provisioning will not be performed, and hardware-related parameters for each node
+> (e.g, bmcAddress, bmcCredentialsDetails, bootMACAddress, nodeNetwork.interfaces[*].macAddress) should be specified in the ProvisioningRequest. See this [example](samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1-no-hwtemplate.yaml) of a ClusterTemplate without `hwTemplate`.
 
 ## ProvisioningRequest CR
 

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/kustomization.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/kustomization.yaml
@@ -24,3 +24,5 @@ resources:
 # sno-ran-du.v4-Y-Z-4 ClusterTemplate:
 - sno-ran-du/sno-ran-du-v4-Y-Z-4.yaml
 - sno-ran-du/clusterinstance-defaults-v4.yaml
+# sno-ran-du.v4-Y-Z-1-no-hwtemplate ClusterTemplate:
+- sno-ran-du/sno-ran-du-v4-Y-Z-1-no-hwtemplate.yaml

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1-no-hwtemplate.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1-no-hwtemplate.yaml
@@ -1,0 +1,247 @@
+apiVersion: o2ims.provisioning.oran.org/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: sno-ran-du.v4-Y-Z-1-no-hwtemplate
+  namespace: sno-ran-du-v4-Y-Z
+spec:
+  name: sno-ran-du
+  version: v4-Y-Z-1-no-hwtemplate
+  release: 4.Y.Z
+  templates:
+    clusterInstanceDefaults: clusterinstance-defaults-v1
+    policyTemplateDefaults: policytemplate-defaults-v1
+  templateParameterSchema:
+    properties:
+      nodeClusterName:
+        type: string
+      oCloudSiteId:
+        type: string
+      policyTemplateParameters:
+        description: policyTemplateSchema defines the available parameters for cluster configuration
+        properties:
+          sriov-network-vlan-1:
+            type: string
+          sriov-network-pfNames-1:
+            type: string
+          cpu-isolated:
+            type: string
+          cpu-reserved:
+            type: string
+          hugepages-default:
+            type: string
+          hugepages-size:
+            type: string
+          hugepages-count:
+            type: string
+          install-plan-approval:
+            type: string
+        type: object
+      #####################################################################################
+      # In scenarios where hardware provisioning is not required, the provisioningRequest
+      # must provide additional hardware-related parameters to support cluster installation.
+      # The following fields should be added to the clusterInstanceParameters schema under
+      # "nodes" section, as shown in the example:
+      # - bmcAddress
+      # - bmcCredentialsDetails
+      # - bootMACAddress
+      # - nodeNetwork.interfaces[*].macAddress
+      # ###################################################################################
+      clusterInstanceParameters:
+        description: clusterInstanceParameters defines the available parameters for cluster installation
+        properties:
+          additionalNTPSources:
+            description: AdditionalNTPSources is a list of NTP sources (hostname
+              or IP) to be added to all cluster hosts. They are added to any NTP
+              sources that were configured through other means.
+            items:
+              type: string
+            type: array
+          apiVIPs:
+            description: APIVIPs are the virtual IPs used to reach the OpenShift
+              cluster's API. Enter one IP address for single-stack clusters, or
+              up to two for dual-stack clusters (at most one IP address per IP
+              stack used). The order of stacks should be the same as order of
+              subnets in Cluster Networks, Service Networks, and Machine Networks.
+            items:
+              type: string
+            maxItems: 2
+            type: array
+          baseDomain:
+            description: BaseDomain is the base domain to use for the deployed
+              cluster.
+            type: string
+          clusterName:
+            description: ClusterName is the name of the cluster.
+            type: string
+          extraAnnotations:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            description: Additional cluster-wide annotations to be applied to
+              the rendered templates
+            type: object
+          extraLabels:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            description: Additional cluster-wide labels to be applied to the rendered
+              templates
+            type: object
+          ingressVIPs:
+            description: IngressVIPs are the virtual IPs used for cluster ingress
+              traffic. Enter one IP address for single-stack clusters, or up to
+              two for dual-stack clusters (at most one IP address per IP stack
+              used). The order of stacks should be the same as order of subnets
+              in Cluster Networks, Service Networks, and Machine Networks.
+            items:
+              type: string
+            maxItems: 2
+            type: array
+          machineNetwork:
+            description: MachineNetwork is the list of IP address pools for machines.
+            items:
+              description: MachineNetworkEntry is a single IP address block for
+                node IP blocks.
+              properties:
+                cidr:
+                  description: CIDR is the IP block address pool for machines
+                    within the cluster.
+                  type: string
+              required:
+              - cidr
+              type: object
+            type: array
+          nodes:
+            items:
+              description: NodeSpec
+              properties:
+                bmcAddress:
+                  description: BmcAddress holds the URL for accessing the controller
+                    on the network.
+                  type: string
+                bmcCredentialsDetails:
+                  description: BmcCredentialsDetails provides BMC credentials, where
+                    both the username and password must be base64-encoded strings.
+                  properties:
+                    username:
+                      type: string
+                      pattern: ^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+                    password:
+                      type: string
+                      pattern: ^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+                  required:
+                  - username
+                  - password
+                bootMACAddress:
+                  description: Which MAC address will PXE boot? This is optional
+                    for some types, but required for libvirt VMs driven by vbmc.
+                  pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+                  type: string
+                extraAnnotations:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Additional node-level annotations to be applied
+                    to the rendered templates
+                  type: object
+                extraLabels:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Additional node-level labels to be applied to the
+                    rendered templates
+                  type: object
+                hostName:
+                  description: Hostname is the desired hostname for the host
+                  type: string
+                nodeLabels:
+                  additionalProperties:
+                    type: string
+                  description: NodeLabels allows the specification of custom roles
+                    for your nodes in your managed clusters. These are additional
+                    roles are not used by any OpenShift Container Platform components,
+                    only by the user. When you add a custom role, it can be associated
+                    with a custom machine config pool that references a specific
+                    configuration for that role. Adding custom labels or roles
+                    during installation makes the deployment process more effective
+                    and prevents the need for additional reboots after the installation
+                    is complete.
+                  type: object
+                nodeNetwork:
+                  description: NodeNetwork is a set of configurations pertaining
+                    to the network settings for the node.
+                  properties:
+                    config:
+                      description: yaml that can be processed by nmstate, using
+                        custom marshaling/unmarshaling that will allow to populate
+                        nmstate config as plain yaml.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    interfaces:
+                      description: Interfaces is an array of interface objects
+                        containing the name and MAC address for interfaces that
+                        are referenced in the raw nmstate config YAML. Interfaces
+                        listed here will be automatically renamed in the nmstate
+                        config YAML to match the real device name that is observed
+                        to have the corresponding MAC address. At least one interface
+                        must be listed so that it can be used to identify the
+                        correct host, which is done by matching any MAC address
+                        in this list to any MAC address observed on the host.
+                      items:
+                        properties:
+                          macAddress:
+                            description: mac address present on the host.
+                            pattern: ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
+                            type: string
+                          name:
+                            description: 'nic name used in the yaml, which relates
+                              1:1 to the mac address. Name in REST API: logicalNICName'
+                        required:
+                        - macAddress
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - interfaces
+                  type: object
+              required:
+              - bmcAddress
+              - bmcCredentialsDetails
+              - bootMACAddress
+              - hostName
+              - nodeNetwork
+              type: object
+            type: array
+          serviceNetwork:
+            description: ServiceNetwork is the list of IP address pools for services.
+            items:
+              description: ServiceNetworkEntry is a single IP address block for
+                node IP blocks.
+              properties:
+                cidr:
+                  description: CIDR is the IP block address pool for machines
+                    within the cluster.
+                  type: string
+              required:
+              - cidr
+              type: object
+            type: array
+          sshPublicKey:
+            description: SSHPublicKey is the public Secure Shell (SSH) key to
+              provide access to instances. This key will be added to the host
+              to allow ssh access
+            type: string
+        required:
+        - clusterName
+        - nodes
+        type: object
+    required:
+      - nodeClusterName
+      - oCloudSiteId
+      - policyTemplateParameters
+      - clusterInstanceParameters
+    type: object

--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -184,19 +184,21 @@ func (t *clusterTemplateReconcilerTask) validateClusterTemplateCR(ctx context.Co
 		validationErrs = append(validationErrs, err.Error())
 	}
 
-	// Validate the HW template configmap
-	err = validateConfigmapReference[[]hwv1alpha1.NodeGroup](
-		ctx, t.client,
-		t.object.Spec.Templates.HwTemplate,
-		utils.InventoryNamespace,
-		utils.HwTemplateNodePool,
-		utils.HardwareProvisioningTimeoutConfigKey)
-	if err != nil {
-		if !utils.IsInputError(err) {
-			return false, fmt.Errorf("failed to validate the ConfigMap %s for hw template: %w",
-				t.object.Spec.Templates.HwTemplate, err)
+	// Validate the HW template configmap if it's provided
+	if t.object.Spec.Templates.HwTemplate != "" {
+		err = validateConfigmapReference[[]hwv1alpha1.NodeGroup](
+			ctx, t.client,
+			t.object.Spec.Templates.HwTemplate,
+			utils.InventoryNamespace,
+			utils.HwTemplateNodePool,
+			utils.HardwareProvisioningTimeoutConfigKey)
+		if err != nil {
+			if !utils.IsInputError(err) {
+				return false, fmt.Errorf("failed to validate the ConfigMap %s for hw template: %w",
+					t.object.Spec.Templates.HwTemplate, err)
+			}
+			validationErrs = append(validationErrs, err.Error())
 		}
-		validationErrs = append(validationErrs, err.Error())
 	}
 
 	// Validate the ClusterInstance defaults configmap

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -939,10 +939,12 @@ defaultHugepagesSize: "1G"`,
 		Expect(err).ToNot(HaveOccurred())
 
 		CRTask = &provisioningRequestReconcilerTask{
-			logger:      CRReconciler.Logger,
-			client:      CRReconciler.Client,
-			object:      provisioningRequest, // cluster-1 request
-			ctNamespace: ctNamespace,
+			logger: CRReconciler.Logger,
+			client: CRReconciler.Client,
+			object: provisioningRequest, // cluster-1 request
+			ctDetails: &clusterTemplateDetails{
+				namespace: ctNamespace,
+			},
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
 				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
@@ -1142,10 +1144,12 @@ defaultHugepagesSize: "1G"`,
 		Expect(err).ToNot(HaveOccurred())
 
 		CRTask = &provisioningRequestReconcilerTask{
-			logger:      CRReconciler.Logger,
-			client:      CRReconciler.Client,
-			object:      provisioningRequest, // cluster-1 request
-			ctNamespace: ctNamespace,
+			logger: CRReconciler.Logger,
+			client: CRReconciler.Client,
+			object: provisioningRequest, // cluster-1 request
+			ctDetails: &clusterTemplateDetails{
+				namespace: ctNamespace,
+			},
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
 				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
@@ -1309,7 +1313,9 @@ defaultHugepagesSize: "1G"`,
 			client:       CRReconciler.Client,
 			object:       provisioningRequest, // cluster-1 request
 			clusterInput: &clusterInput{},
-			ctNamespace:  ctNamespace,
+			ctDetails: &clusterTemplateDetails{
+				namespace: ctNamespace,
+			},
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
 				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
@@ -1414,7 +1420,9 @@ defaultHugepagesSize: "1G"`,
 			client:       CRReconciler.Client,
 			object:       provisioningRequest, // cluster-1 request
 			clusterInput: &clusterInput{},
-			ctNamespace:  ctNamespace,
+			ctDetails: &clusterTemplateDetails{
+				namespace: ctNamespace,
+			},
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
 				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
@@ -1515,10 +1523,12 @@ defaultHugepagesSize: "1G"`,
 		Expect(err).ToNot(HaveOccurred())
 
 		CRTask = &provisioningRequestReconcilerTask{
-			logger:      CRReconciler.Logger,
-			client:      CRReconciler.Client,
-			object:      provisioningRequest, // cluster-1 request
-			ctNamespace: ctNamespace,
+			logger: CRReconciler.Logger,
+			client: CRReconciler.Client,
+			object: provisioningRequest, // cluster-1 request
+			ctDetails: &clusterTemplateDetails{
+				namespace: ctNamespace,
+			},
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
 				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,
@@ -1619,10 +1629,12 @@ defaultHugepagesSize: "1G"`,
 		Expect(err).ToNot(HaveOccurred())
 
 		CRTask = &provisioningRequestReconcilerTask{
-			logger:      CRReconciler.Logger,
-			client:      CRReconciler.Client,
-			object:      provisioningRequest, // cluster-1 request
-			ctNamespace: ctNamespace,
+			logger: CRReconciler.Logger,
+			client: CRReconciler.Client,
+			object: provisioningRequest, // cluster-1 request
+			ctDetails: &clusterTemplateDetails{
+				namespace: ctNamespace,
+			},
 			timeouts: &timeouts{
 				hardwareProvisioning: utils.DefaultHardwareProvisioningTimeout,
 				clusterProvisioning:  utils.DefaultClusterInstallationTimeout,

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -101,7 +101,9 @@ nodes:
 			client:       reconciler.Client,
 			object:       cr,
 			clusterInput: &clusterInput{},
-			ctNamespace:  ctNamespace,
+			ctDetails: &clusterTemplateDetails{
+				namespace: ctNamespace,
+			},
 		}
 
 		clusterInstanceInputParams, err := utils.ExtractMatchingInput(

--- a/internal/controllers/provisioningrequest_resourcecreation_test.go
+++ b/internal/controllers/provisioningrequest_resourcecreation_test.go
@@ -2,17 +2,22 @@ package controllers
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 )
 
 var _ = Describe("createPolicyTemplateConfigMap", func() {
@@ -50,7 +55,9 @@ var _ = Describe("createPolicyTemplateConfigMap", func() {
 			client:       reconciler.Client,
 			object:       cr,
 			clusterInput: &clusterInput{},
-			ctNamespace:  ctNamespace,
+			ctDetails: &clusterTemplateDetails{
+				namespace: ctNamespace,
+			},
 		}
 
 		// Define the cluster template.
@@ -126,5 +133,255 @@ var _ = Describe("GetLabelsForPolicies", func() {
 		clusterLabels["cluster-version"] = "v4.17"
 		err := checkClusterLabelsForPolicies(clusterName, clusterLabels)
 		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("createClusterInstanceBMCSecrets", func() {
+	var (
+		ctx         context.Context
+		c           client.Client
+		reconciler  *ProvisioningRequestReconciler
+		task        *provisioningRequestReconcilerTask
+		tName       = "clustertemplate-a"
+		tVersion    = "v1.0.0"
+		ctNamespace = "clustertemplate-a-v4-16"
+		crName      = "cluster-1"
+	)
+
+	BeforeEach(func() {
+		// Define the provisioning request.
+		cr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crName,
+			},
+			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
+				TemplateName:       tName,
+				TemplateVersion:    tVersion,
+				TemplateParameters: runtime.RawExtension{},
+			},
+		}
+
+		c = getFakeClientFromObjects([]client.Object{cr}...)
+		reconciler = &ProvisioningRequestReconciler{
+			Client: c,
+			Logger: logger,
+		}
+		task = &provisioningRequestReconcilerTask{
+			logger:       reconciler.Logger,
+			client:       reconciler.Client,
+			object:       cr,
+			clusterInput: &clusterInput{},
+			ctDetails: &clusterTemplateDetails{
+				namespace: ctNamespace,
+			},
+		}
+	})
+
+	It("It returns error if bmcCredentialsDetails is missing in the input", func() {
+		input := `{
+			"clusterInstanceParameters": {
+				"nodes": [
+					{
+						"bmcAddress": "idrac-virtualmedia+https://203.0.113.5/redfish/v1/Systems/System.Embedded.1",
+						"bootMACAddress": "00:00:00:01:20:30",
+						"hostName": "node1",
+						"nodeNetwork": {
+							"interfaces": [
+								{
+									"macAddress": "00:00:00:01:20:30"
+						  		}
+							]
+						}
+				  	}
+				]
+			}
+		}`
+		task.object.Spec.TemplateParameters = runtime.RawExtension{Raw: []byte(input)}
+		err := task.createClusterInstanceBMCSecrets(ctx, crName)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(
+			`\"bmcCredentialsDetails\" key expected to exist in spec.templateParameters.clusterInstanceParameters`))
+	})
+
+	It("it creates the BMC secret with correct content", func() {
+		input := `{
+			"clusterInstanceParameters": {
+				"nodes": [
+					{
+						"bmcAddress": "idrac-virtualmedia+https://203.0.113.5/redfish/v1/Systems/System.Embedded.1",
+						"bootMACAddress": "00:00:00:01:20:30",
+						"bmcCredentialsDetails": {
+							"username": "QURNSU4K",
+							"password": "QURNSU4K"
+						},
+						"hostName": "node1",
+						"nodeNetwork": {
+							"interfaces": [
+								{
+									"macAddress": "00:00:00:01:20:30"
+						  		}
+							]
+						}
+				  	}
+				]
+			}
+		}`
+		task.object.Spec.TemplateParameters = runtime.RawExtension{Raw: []byte(input)}
+		err := task.createClusterInstanceBMCSecrets(ctx, crName)
+		Expect(err).ToNot(HaveOccurred())
+
+		bmcSecret := &corev1.Secret{}
+		err = c.Get(context.Background(), types.NamespacedName{Name: "node1-bmc-secret", Namespace: "cluster-1"}, bmcSecret)
+		Expect(err).ToNot(HaveOccurred())
+		decoded, _ := base64.StdEncoding.DecodeString("QURNSU4K")
+		Expect(bmcSecret.Data["username"]).To(Equal(decoded))
+		Expect(bmcSecret.Data["password"]).To(Equal(decoded))
+	})
+
+	It("It creates the BMC secret with provided bmcCredentialsName name", func() {
+		input := `{
+			"clusterInstanceParameters": {
+				"nodes": [
+					{
+						"bmcAddress": "idrac-virtualmedia+https://203.0.113.5/redfish/v1/Systems/System.Embedded.1",
+						"bootMACAddress": "00:00:00:01:20:30",
+						"bmcCredentialsName": {
+							"name": "node1-secret"
+						},
+						"bmcCredentialsDetails": {
+							"username": "QURNSU4K",
+							"password": "QURNSU4K"
+						},
+						"hostName": "node1",
+						"nodeNetwork": {
+							"interfaces": [
+								{
+									"macAddress": "00:00:00:01:20:30"
+						  		}
+							]
+						}
+				  	}
+				]
+			}
+		}`
+		task.object.Spec.TemplateParameters = runtime.RawExtension{Raw: []byte(input)}
+		err := task.createClusterInstanceBMCSecrets(ctx, crName)
+		Expect(err).ToNot(HaveOccurred())
+
+		bmcSecret := &corev1.Secret{}
+		err = c.Get(context.Background(), types.NamespacedName{Name: "node1-secret", Namespace: "cluster-1"}, bmcSecret)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("createOrUpdateClusterResources", func() {
+	var (
+		ctx         context.Context
+		c           client.Client
+		reconciler  *ProvisioningRequestReconciler
+		task        *provisioningRequestReconcilerTask
+		tName       = "clustertemplate-a"
+		tVersion    = "v1.0.0"
+		ctNamespace = "clustertemplate-a-v4-16"
+		crName      = "cluster-1"
+	)
+
+	BeforeEach(func() {
+		// Define the provisioning request.
+		cr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crName,
+			},
+			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
+				TemplateName:       tName,
+				TemplateVersion:    tVersion,
+				TemplateParameters: runtime.RawExtension{},
+			},
+		}
+		pull_secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pull-secret",
+				Namespace: ctNamespace,
+			},
+			Data: map[string][]byte{},
+		}
+		c = getFakeClientFromObjects([]client.Object{cr, pull_secret}...)
+		reconciler = &ProvisioningRequestReconciler{
+			Client: c,
+			Logger: logger,
+		}
+		task = &provisioningRequestReconcilerTask{
+			logger:       reconciler.Logger,
+			client:       reconciler.Client,
+			object:       cr,
+			clusterInput: &clusterInput{},
+			ctDetails: &clusterTemplateDetails{
+				namespace: ctNamespace,
+				templates: provisioningv1alpha1.Templates{},
+			},
+		}
+	})
+
+	It("It creates BMC secret when hwTemplate is not provided", func() {
+		renderedClusterInstance := &siteconfig.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      crName,
+				Namespace: crName,
+			},
+			Spec: siteconfig.ClusterInstanceSpec{
+				PullSecretRef: corev1.LocalObjectReference{Name: "pull-secret"},
+			},
+		}
+
+		input := `{
+			"clusterInstanceParameters": {
+				"nodes": [
+					{
+						"bmcAddress": "idrac-virtualmedia+https://203.0.113.5/redfish/v1/Systems/System.Embedded.1",
+						"bootMACAddress": "00:00:00:01:20:30",
+						"bmcCredentialsDetails": {
+							"username": "QURNSU4K",
+							"password": "QURNSU4K"
+						},
+						"hostName": "node1",
+						"nodeNetwork": {
+							"interfaces": [
+								{
+									"macAddress": "00:00:00:01:20:30"
+						  		}
+							]
+						}
+				  	}
+				]
+			}
+		}`
+		task.object.Spec.TemplateParameters = runtime.RawExtension{Raw: []byte(input)}
+		err := task.createOrUpdateClusterResources(ctx, renderedClusterInstance)
+		Expect(err).To(HaveOccurred())
+
+		bmcSecret := &corev1.Secret{}
+		err = c.Get(context.Background(), types.NamespacedName{Name: "node1-bmc-secret", Namespace: "cluster-1"}, bmcSecret)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("No BMC secret is created when hwTemplate is provided", func() {
+		renderedClusterInstance := &siteconfig.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      crName,
+				Namespace: crName,
+			},
+			Spec: siteconfig.ClusterInstanceSpec{
+				PullSecretRef: corev1.LocalObjectReference{Name: "pull-secret"},
+			},
+		}
+
+		task.ctDetails.templates.HwTemplate = "hwTemplate-v1"
+		err := task.createOrUpdateClusterResources(ctx, renderedClusterInstance)
+		Expect(err).To(HaveOccurred())
+
+		bmcSecret := &corev1.Secret{}
+		err = c.Get(context.Background(), types.NamespacedName{Name: "node1-bmc-secret", Namespace: "cluster-1"}, bmcSecret)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.IsNotFound(err)).To(BeTrue())
 	})
 })

--- a/internal/controllers/provisioningrequest_validation_test.go
+++ b/internal/controllers/provisioningrequest_validation_test.go
@@ -423,7 +423,7 @@ var _ = Describe("overrideClusterInstanceLabelsOrAnnotations", func() {
 			client:       nil,
 			object:       nil,
 			clusterInput: &clusterInput{},
-			ctNamespace:  "",
+			ctDetails:    &clusterTemplateDetails{},
 		}
 	})
 

--- a/internal/controllers/utils/provision_test.go
+++ b/internal/controllers/utils/provision_test.go
@@ -300,6 +300,30 @@ spec:
 		}
 	})
 
+	It("Renders the cluster instance template with default bmcCredentialsName", func() {
+		// Remove the bmcCredentialsName
+		node1 := clusterInstanceObj["Cluster"].(map[string]any)["nodes"].([]any)[0]
+		delete(node1.(map[string]any), "bmcCredentialsName")
+
+		expectedRenderedClusterInstance := &unstructured.Unstructured{}
+		err := yaml.Unmarshal([]byte(expectedRenderedYaml), expectedRenderedClusterInstance)
+		Expect(err).ToNot(HaveOccurred())
+
+		renderedClusterInstance, err := RenderTemplateForK8sCR(
+			ClusterInstanceTemplateName, ClusterInstanceTemplatePath, clusterInstanceObj)
+		Expect(err).ToNot(HaveOccurred())
+
+		yamlString, err := yaml.Marshal(renderedClusterInstance)
+		Expect(err).ToNot(HaveOccurred())
+		fmt.Println(string(yamlString))
+
+		if !reflect.DeepEqual(renderedClusterInstance, expectedRenderedClusterInstance) {
+			err = fmt.Errorf("renderedClusterInstance not equal, expected = %v, got = %v",
+				renderedClusterInstance, expectedRenderedClusterInstance)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
 	It("Return error if a required string field is empty", func() {
 		// Update the required field baseDomain to empty string
 		clusterInstanceObj["Cluster"].(map[string]any)["baseDomain"] = ""

--- a/internal/files/controllers/clusterinstance-template.yaml
+++ b/internal/files/controllers/clusterinstance-template.yaml
@@ -104,11 +104,14 @@ spec:
 {{ .Cluster.suppressedManifests | toYaml | indent 4 }}
 {{- end }}
   nodes:
-  # The fields bmcAddress, bmcCredentialsName, bootMACAddress, and nodeNetwork.interfaces[*].macAddress
-  # are expected to be populated from the NodePool. However, we run the ClusterInstance dry-run validation
-  # before HW provisioning to catch any input errors early. Since these fields are required, we must provide
-  # placeholder values to pass the dry-run validation. These placeholders will be replaced with the actual
-  # data returned from the HW plugin before the ClusterInstance is created.
+  # If hwTemplate configmap is provided, the fields bmcAddress, bmcCredentialsName, bootMACAddress, and
+  # nodeNetwork.interfaces[*].macAddress are expected to be populated from the NodePool. However, we run
+  # the ClusterInstance dry-run validation before HW provisioning to catch any input errors early.
+  # Since these fields are required, we must provide placeholder values to pass the dry-run validation.
+  # These placeholders will be replaced with the actual data returned from the HW plugin before the
+  # ClusterInstance is created.
+  # If the hwTemplate ConfigMap is not provided, these fields must be specified in the ProvisioningRequest
+  # and are validated in the early stage.
   {{- $_ := .Cluster.nodes | validateNonEmpty "spec.nodes" }}
   {{- $_ := .Cluster.nodes | validateArrayType "spec.nodes"}}
   {{- range $n_index, $n_ref := .Cluster.nodes }}

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/clustertemplate_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/clustertemplate_types.go
@@ -64,8 +64,8 @@ type ClusterTemplateSpec struct {
 
 // Templates defines the references to the templates required for ClusterTemplate.
 type Templates struct {
-	// HwTemplate defines a reference to a hardware template config map
-	HwTemplate string `json:"hwTemplate"`
+	// HwTemplate defines a reference to a hardware template configmap
+	HwTemplate string `json:"hwTemplate,omitempty"`
 
 	// ClusterInstanceDefaults defines a reference to a configmap with
 	// default values for ClusterInstance


### PR DESCRIPTION
In the case where hwTemplate is not provided, hw provisioning is skipped and only cluster installation and configuration will be performed.  The hardware-related parameters (such as bmcAddress, bmcCreds - username and password are all base64-encoded strings, bootMacAddress, nodeNetwork macAddress) should instead be passed in the ProvisioningRequest. The ClusterTemplate schema should include these parameters, allowing them to be specified in the ProvisioningRequest.

Updates:
- change `templates.hwTemplate` to be optional
- skip hw provisioning when hwTemplate is not provided
- create BMC secret when hwTemplate is not provided
- add example ClusterTemplate without hwTemplate

Todo:
Consider validating the schema to ensure that the hardware-related parameters are present and marked as required.

E2E testing has been done for both with and without hwtemplate cases.