### PR TITLE
fix incorrect init of logger for alarms server

### DIFF
--- a/internal/service/alarms/cmd/root.go
+++ b/internal/service/alarms/cmd/root.go
@@ -12,6 +12,9 @@ import (
 var AlarmRootCmd = &cobra.Command{
 	Use:   "alarms-server",
 	Short: "All things needed for alarms server",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		configureAlarmLogger()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Nothing to do. Use sub-commands instead.")
 	},
@@ -19,10 +22,6 @@ var AlarmRootCmd = &cobra.Command{
 
 func GetAlarmRootCmd() *cobra.Command {
 	return AlarmRootCmd
-}
-
-func init() {
-	configureAlarmLogger()
 }
 
 func configureAlarmLogger() {


### PR DESCRIPTION
Originally it was incorrectly initializing the logger for all CLI commands (root/sub)...as init func is called regardless of which  cmd is executed. `PersistentPreRun` should be used instead so that alarms logging is initialized as long as alarm's sub commands are called (serve or migrate) 

/cc @alegacy 