### PR TITLE
CNF-15631: policyTemplateParameters in a CT has only string type properties

### DIFF
--- a/internal/controllers/provisioningrequest_resourcecreation.go
+++ b/internal/controllers/provisioningrequest_resourcecreation.go
@@ -176,7 +176,13 @@ func (t *provisioningRequestReconcilerTask) createPolicyTemplateConfigMap(
 	// Update the keys to match the ClusterTemplate name and the version.
 	finalPolicyTemplateData := make(map[string]string)
 	for key, value := range t.clusterInput.policyTemplateData {
-		finalPolicyTemplateData[key] = value.(string)
+		data, ok := value.(string)
+		if !ok {
+			return utils.NewInputError(
+				"policyTemplateParameters/policyTemplateSchema for the %s key (%v) is not a string",
+				key, value)
+		}
+		finalPolicyTemplateData[key] = data
 	}
 
 	// Put all the data from the mergedPolicyTemplateData in a configMap in the same

--- a/internal/controllers/provisioningrequest_resourcecreation_test.go
+++ b/internal/controllers/provisioningrequest_resourcecreation_test.go
@@ -94,6 +94,19 @@ var _ = Describe("createPolicyTemplateConfigMap", func() {
 			},
 		))
 	})
+
+	It("it returns an error for a type different than string", func() {
+		// Declare the merged policy template data.
+		task.clusterInput.policyTemplateData = map[string]any{
+			"cpu-isolated":    "0-1,64-65",
+			"hugepages-count": 32,
+		}
+
+		// Create the configMap.
+		err := task.createPolicyTemplateConfigMap(ctx, crName)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("policyTemplateParameters/policyTemplateSchema for the hugepages-count key (32) is not a string"))
+	})
 })
 
 var _ = Describe("GetLabelsForPolicies", func() {


### PR DESCRIPTION
Description:
- check that spec.policyTemplateParameters in a ClusterTemplate has only properties of type string. This ensures that the PGs will decide the final type by using toInt/toLiteral.
- ClusterTemplate validation errors appear in the status:
```console
$  oc get oranct -A
NAMESPACE            NAME                   AGE     STATE       DETAILS
sno-ran-du-v4-17-3   sno-ran-du.v4-17-3-1   2m48s   Failed      Error validating the policyTemplateParameters schema: expected type string for the sriov-network-vlan-1 property
```