### PR TITLE
CNF-15660: Filter out policies outside the ztp-<clustertemplate-ns> namespace

### DIFF
--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -1052,10 +1052,10 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			// Create Non-compliant enforce policy
 			policy = &policiesv1.Policy{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ztp-clustertemplate-a-v4-15.v1-sriov-configuration-policy",
+					Name:      "ztp-clustertemplate-a-v4-16.v1-sriov-configuration-policy",
 					Namespace: "cluster-1",
 					Labels: map[string]string{
-						utils.ChildPolicyRootPolicyLabel:       "ztp-clustertemplate-a-v4-15.v1-sriov-configuration-policy",
+						utils.ChildPolicyRootPolicyLabel:       "ztp-clustertemplate-a-v4-16.v1-sriov-configuration-policy",
 						utils.ChildPolicyClusterNameLabel:      "cluster-1",
 						utils.ChildPolicyClusterNamespaceLabel: "cluster-1",
 					},

--- a/internal/controllers/utils/provision.go
+++ b/internal/controllers/utils/provision.go
@@ -360,3 +360,18 @@ func ValidateDefaultInterfaces[T any](data T) error {
 	}
 	return nil
 }
+
+// GetParentPolicyNameAndNamespace extracts the parent policy name and namespace
+// from the child policy name. The child policy name follows the format:
+// "<parent_policy_namespace>.<parent_policy_name>". Since the namespace is disallowed
+// to contain ".", splitting the string with "." into two substrings is safe.
+func GetParentPolicyNameAndNamespace(childPolicyName string) (policyName, policyNamespace string) {
+	res := strings.SplitN(childPolicyName, ".", 2)
+	return res[1], res[0]
+}
+
+// IsParentPolicyInZtpClusterTemplateNs checks whether the parent policy resides
+// in the namespace "ztp-<clustertemplate-ns>".
+func IsParentPolicyInZtpClusterTemplateNs(policyNamespace, ctNamespace string) bool {
+	return policyNamespace == fmt.Sprintf("ztp-%s", ctNamespace)
+}


### PR DESCRIPTION
The controller should only handle/consider the child policies whose parent policies are from the `ztp-<clustertemplate-ns> `namespace. Other bound policies should neither trigger the reconcilation nor be considered in the policy configuration process.