### PR TITLE
fix: update pg image to use registry.redhat.io instead

### DIFF
--- a/internal/service/postgres/k8s/base/deployment.yaml
+++ b/internal/service/postgres/k8s/base/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: o-cloud-db
-          image: registry.access.redhat.com/rhel9/postgresql-16:1-29.1726696141
+          image: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873 # NOTE: to run locally you would need to login to registry as noted here https://catalog.redhat.com/software/containers/rhel9/postgresql-16/657b03866783e1b1fb87e142?container-tabs=gti&gti-tabs=registry-tokens
           env:
             - name: POSTGRESQL_ADMIN_PASSWORD
               valueFrom:


### PR DESCRIPTION
Last few weeks there was a bug in OCP that allowed for downloading rhel/pg-16 without any additional creds/accepting terms. This has been fixed...and now we cant download the image without additional steps. 

update to use registry.redhat.io instead

/cc @browsell 
/cc @alegacy 
/cc @mlguerrero12 