### PR TITLE
CNF-14144: Add migration init container for resource server

### DIFF
--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -83,7 +83,7 @@ const (
 	defaultSearchApiURL     = "https://search-search-api.open-cluster-management.svc.cluster.local:4010"
 	defaultBackendTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"          // nolint: gosec // hardcoded path only
 	defaultBackendCABundle  = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"         // nolint: gosec // hardcoded path only
-	defaultServiceCAFile    = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" // nolint: gosec // hardcoded path only
+	DefaultServiceCAFile    = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" // nolint: gosec // hardcoded path only
 )
 
 // Default timeout values
@@ -190,8 +190,9 @@ const (
 
 // POD Container Names
 const (
-	ServerContainerName = "server"
-	RbacContainerName   = "rbac"
+	MigrationContainerName = "migration"
+	RbacContainerName      = "rbac"
+	ServerContainerName    = "server"
 )
 
 // POD Port Values

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -203,21 +203,6 @@ func GetDeploymentVolumes(serverName string) []corev1.Volume {
 		}
 	}
 
-	if HasDatabase(serverName) || serverName == InventoryDatabaseServerName {
-		defaultMode := int32(os.FileMode(0o400))
-		return []corev1.Volume{
-			{
-				Name: "database-passwords",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						DefaultMode: &defaultMode,
-						SecretName:  fmt.Sprintf("%s-passwords", InventoryDatabaseServerName),
-					},
-				},
-			},
-		}
-	}
-
 	return []corev1.Volume{}
 }
 

--- a/internal/service/common/db/migration.go
+++ b/internal/service/common/db/migration.go
@@ -96,6 +96,12 @@ func NewHandler(cfg MigrationConfig) (*MigrationHandler, error) {
 		connStr += fmt.Sprintf("&x-migrations-table=%s", cfg.MigrationsTable)
 	}
 
+	if _, err := os.Stat(utils.DefaultServiceCAFile); err == nil {
+		connStr += fmt.Sprintf("&sslrootcert=%s", utils.DefaultServiceCAFile)
+	} else {
+		slog.Warn("No service CA file found")
+	}
+
 	m, err := migrate.NewWithSourceInstance("iofs", cfg.Source, connStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create migrate instance: %w", err)


### PR DESCRIPTION
This commit adds the init container for the resource server.  The container runs prior to starting the resource server container so that its database schema is created and migrated up to the latest schema version.  The init container is run any time the resource server pod is recreated, and if there is a transient failure in the init due to a race condition in bringing up the database server it is automatically retried until it succeeds.