### PR TITLE
Lookup search api URL dynamically

### DIFF
--- a/api/inventory/v1alpha1/inventory_types.go
+++ b/api/inventory/v1alpha1/inventory_types.go
@@ -200,6 +200,9 @@ type InventoryStatus struct {
 	// Stores the local cluster ID used as the local Cloud ID value.
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Local Cluster ID"
 	ClusterID string `json:"clusterID,omitempty"`
+	// Stores the Search API URL resolved at runtime; either from a user override or automatically computed from the
+	// Search API service.
+	SearchURL string `json:"searchURL,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/bundle/manifests/o2ims.oran.openshift.io_inventories.yaml
+++ b/bundle/manifests/o2ims.oran.openshift.io_inventories.yaml
@@ -292,6 +292,11 @@ spec:
                   Stores the ingress host domain resolved at runtime; either from a user override or automatically computed from
                   the default ingress controller.
                 type: string
+              searchURL:
+                description: |-
+                  Stores the Search API URL resolved at runtime; either from a user override or automatically computed from the
+                  Search API service.
+                type: string
               usedServerConfig:
                 properties:
                   deploymentManagerServerUsedConfig:

--- a/config/crd/bases/o2ims.oran.openshift.io_inventories.yaml
+++ b/config/crd/bases/o2ims.oran.openshift.io_inventories.yaml
@@ -292,6 +292,11 @@ spec:
                   Stores the ingress host domain resolved at runtime; either from a user override or automatically computed from
                   the default ingress controller.
                 type: string
+              searchURL:
+                description: |-
+                  Stores the Search API URL resolved at runtime; either from a user override or automatically computed from the
+                  Search API service.
+                type: string
               usedServerConfig:
                 properties:
                   deploymentManagerServerUsedConfig:

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -591,11 +591,9 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 	// Set the default reconcile time to 5 minutes.
 	nextReconcile = ctrl.Result{RequeueAfter: 5 * time.Minute}
 
-	if t.object.Status.IngressHost == "" {
-		err = t.storeIngressDomain(ctx)
-		if err != nil {
-			return
-		}
+	err = t.storeIngressDomain(ctx)
+	if err != nil {
+		return
 	}
 
 	if t.object.Status.ClusterID == "" {
@@ -605,11 +603,9 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 		}
 	}
 
-	if t.object.Status.SearchURL == "" {
-		err = t.storeSearchURL(ctx)
-		if err != nil {
-			return
-		}
+	err = t.storeSearchURL(ctx)
+	if err != nil {
+		return
 	}
 
 	// Register with SMO (if necessary)

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -568,6 +568,25 @@ func (t *reconcilerTask) storeClusterID(ctx context.Context) error {
 	return nil
 }
 
+// storeSearchURL stores the Search API URL onto the object status for later retrieval.
+func (t *reconcilerTask) storeSearchURL(ctx context.Context) error {
+	if t.object.Spec.ResourceServerConfig.BackendURL == "" {
+		searchURL, err := utils.GetSearchURL(ctx, t.client)
+		if err != nil {
+			t.logger.ErrorContext(
+				ctx,
+				"Failed to get Search API URL.",
+				slog.String("error", err.Error()))
+			return fmt.Errorf("failed to get Search API URL: %s", err.Error())
+		}
+		t.object.Status.SearchURL = searchURL
+	} else {
+		t.object.Status.SearchURL = t.object.Spec.ResourceServerConfig.BackendURL
+	}
+
+	return nil
+}
+
 func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, err error) {
 	// Set the default reconcile time to 5 minutes.
 	nextReconcile = ctrl.Result{RequeueAfter: 5 * time.Minute}
@@ -581,6 +600,13 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 
 	if t.object.Status.ClusterID == "" {
 		err = t.storeClusterID(ctx)
+		if err != nil {
+			return
+		}
+	}
+
+	if t.object.Status.SearchURL == "" {
+		err = t.storeSearchURL(ctx)
 		if err != nil {
 			return
 		}

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -63,6 +63,23 @@ var _ = DescribeTable(
 			Spec: openshiftoperatorv1.IngressControllerSpec{
 				Domain: "apps.example.com"}}
 
+		search := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "search-search-api",
+				Namespace: "open-cluster-management",
+				Labels:    map[string]string{utils.SearchApiLabelKey: utils.SearchApiLabelValue},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Port: 4010,
+						Name: "search-api",
+					},
+				},
+			},
+		}
+
 		cv := &openshiftv1.ClusterVersion{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "version",
@@ -76,7 +93,7 @@ var _ = DescribeTable(
 		Expect(err).NotTo(HaveOccurred())
 
 		// Update the testcase objects to include the Namespace.
-		objs = append(objs, ns, ingress, cv)
+		objs = append(objs, ns, ingress, search, cv)
 
 		// Get the fake client.
 		fakeClient := getFakeClientFromObjects(objs...)

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -77,10 +77,15 @@ const (
 	DefaultNamespaceEnvName = "OCLOUD_MANAGER_NAMESPACE"
 )
 
+// Search API attributes
+const (
+	SearchApiLabelKey   = "search-monitor"
+	SearchApiLabelValue = "search-api"
+)
+
 // Default values for backend URL and token:
 const (
 	defaultApiServerURL     = "https://kubernetes.default.svc"
-	defaultSearchApiURL     = "https://search-search-api.open-cluster-management.svc.cluster.local:4010"
 	defaultBackendTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"          // nolint: gosec // hardcoded path only
 	defaultBackendCABundle  = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"         // nolint: gosec // hardcoded path only
 	DefaultServiceCAFile    = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" // nolint: gosec // hardcoded path only

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -294,6 +294,43 @@ var _ = Describe("GetIngressDomain", func() {
 	})
 })
 
+var _ = Describe("GetSearchURL", func() {
+
+	It("If search-api service does not exist, return error", func() {
+		objs := []client.Object{}
+		fakeClient := getFakeClientFromObjects(objs...)
+		searchURL, err := GetSearchURL(context.TODO(), fakeClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no services found"))
+		Expect(searchURL).To(Equal(""))
+	})
+
+	It("If search-api service with proper labels", func() {
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+				Labels:    map[string]string{SearchApiLabelKey: SearchApiLabelValue},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Port: 9999,
+						Name: "test",
+					},
+				},
+			},
+		}
+
+		objs := []client.Object{service}
+		fakeClient := getFakeClientFromObjects(objs...)
+		searchURL, err := GetSearchURL(context.TODO(), fakeClient)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(searchURL).To(Equal("https://foo.bar.svc.cluster.local:9999"))
+	})
+})
+
 var _ = Describe("DeepMergeMaps and DeepMergeMapsSlices", func() {
 	var (
 		dst map[string]interface{}

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1/inventory_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1/inventory_types.go
@@ -200,6 +200,9 @@ type InventoryStatus struct {
 	// Stores the local cluster ID used as the local Cloud ID value.
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Local Cluster ID"
 	ClusterID string `json:"clusterID,omitempty"`
+	// Stores the Search API URL resolved at runtime; either from a user override or automatically computed from the
+	// Search API service.
+	SearchURL string `json:"searchURL,omitempty"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
Rather than hardcode the name and namespace of the search-api service
this commit searches for it using its well-known search labels.  As is
currently the case, if a user provides an override on the Inventory CR
then we use that rather than searching for it.