### PR TITLE
Align postgres image var name with midstream process

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1459,7 +1459,7 @@ spec:
                   value: quay.io/openshift-kni/oran-o2ims-operator:4.16.0
                 - name: KUBE_RBAC_PROXY_IMAGE
                   value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
-                - name: POSTGRES_IMAGE
+                - name: RELATED_IMAGE_POSTGRES_IMAGE
                   value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
                 - name: HWMGR_PLUGIN_NAMESPACE
                   value: oran-hwmgr-plugin
@@ -1558,5 +1558,8 @@ spec:
   minKubeVersion: 1.28.0
   provider:
     name: Red Hat
+  relatedImages:
+  - image: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
+    name: postgres-image
   replaces: oran-o2ims.v0.0.0
   version: 4.16.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,7 +77,7 @@ spec:
         - name: KUBE_RBAC_PROXY_IMAGE
           # A placeholder for the replacement kustomization that will inject the rbac image from that container spec
           value: kube-rbac-proxy:latest
-        - name: POSTGRES_IMAGE
+        - name: RELATED_IMAGE_POSTGRES_IMAGE
           value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
         - name: HWMGR_PLUGIN_NAMESPACE
           # A placeholder for the replacement kustomization that will inject the value from the config map

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -216,7 +216,7 @@ const (
 const (
 	ServerImageName        = "IMAGE"
 	KubeRbacProxyImageName = "KUBE_RBAC_PROXY_IMAGE"
-	PostgresImageName      = "POSTGRES_IMAGE"
+	PostgresImageName      = "RELATED_IMAGE_POSTGRES_IMAGE"
 	HwMgrPluginNameSpace   = "HWMGR_PLUGIN_NAMESPACE"
 )
 


### PR DESCRIPTION
This updates the name of the postgres image to have the RELATED_IMAGE_ prefix required by the midstream process.