### PR TITLE
CNF-15906: Add validation for clusterInstanceParams schema without hwtemplate

### DIFF
--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1-no-hwtemplate.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1-no-hwtemplate.yaml
@@ -131,6 +131,7 @@ spec:
                     password:
                       type: string
                       pattern: ^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+                  type: object
                   required:
                   - username
                   - password

--- a/internal/controllers/utils/provision.go
+++ b/internal/controllers/utils/provision.go
@@ -23,6 +23,51 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
+// ClusterInstanceParamsSubSchemaForNoHWTemplate is the expected subschema for the
+// ClusterInstanceParams when no hardware template is provided.
+const ClusterInstanceParamsSubSchemaForNoHWTemplate = `
+type: object
+properties:
+  nodes:
+    items:
+      properties:
+        bmcAddress:
+          type: string
+        bmcCredentialsDetails:
+          type: object
+          properties:
+            username:
+              type: string
+            password:
+              type: string
+          required:
+          - username
+          - password
+        bootMACAddress:
+          type: string
+        nodeNetwork:
+          type: object
+          properties:
+            interfaces:
+              type: array
+              items:
+                type: object
+                properties:
+                  macAddress:
+                    type: string
+              required:
+              - macAddress
+          required:
+          - interfaces
+      required:
+      - bmcAddress
+      - bmcCredentialsDetails
+      - bootMACAddress
+      - nodeNetwork
+required:
+- nodes
+`
+
 // ExtractSubSchema extracts a Sub schema indexed by subSchemaKey from a Main schema
 func ExtractSubSchema(mainSchema []byte, subSchemaKey string) (subSchema map[string]any, err error) {
 	jsonObject := make(map[string]any)


### PR DESCRIPTION
This update ensures that the schema contains required properties such as BMC details, bootMacAddress, interfaces, and other necessary fields for provisioningRequest to provide when hwtemplate is not specified.