### PR TITLE
CNF-15570: Add support for updating only some fields

### DIFF
--- a/internal/service/common/utils/repository.go
+++ b/internal/service/common/utils/repository.go
@@ -151,9 +151,10 @@ func Exists[T db.Model](ctx context.Context, db *pgxpool.Pool, uuid uuid.UUID) (
 // is returned.
 func Create[T db.Model](ctx context.Context, db *pgxpool.Pool, record T) (*T, error) {
 	nonNilTags := GetNonNilDBTagsFromStruct(record)
+	tags := GetAllDBTagsFromStruct(record)
 
 	// Return all columns to get any defaulted values that the DB may set
-	query := psql.Insert(im.Into(record.TableName()), im.Returning("*"))
+	query := psql.Insert(im.Into(record.TableName()), im.Returning(tags.Columns()...))
 
 	// Add columns to the expression.  Maintain the order here so that it coincides with the order of the values
 	columns, values := GetColumnsAndValues(record, nonNilTags)
@@ -182,16 +183,18 @@ func Create[T db.Model](ctx context.Context, db *pgxpool.Pool, record T) (*T, er
 }
 
 // Update attempts to update a record with a matching primary key.  The stored record is returned on success; otherwise
-// an error is returned.
-func Update[T db.Model](ctx context.Context, db *pgxpool.Pool, record T, uuid uuid.UUID) (*T, error) {
-	tags := GetAllDBTagsFromStruct(record)
+// an error is returned.  If the `fields` argument is set then only those columns are updated but the returned object
+// will contain all columns.
+func Update[T db.Model](ctx context.Context, db *pgxpool.Pool, record T, uuid uuid.UUID, fields ...string) (*T, error) {
+	all := GetAllDBTagsFromStruct(record)
+	tags := GetDBTagsFromStructFields(record, fields...)
 
 	// Set up the arguments to the call to psql.Update(...) by using an array because there's no obvious way to add
 	// multiple Set(..) operation without having to add them one at a time separately.
 	mods := []bob.Mod[*dialect.UpdateQuery]{
 		um.Table(record.TableName()),
 		um.Where(psql.Quote(record.PrimaryKey()).EQ(psql.Arg(uuid))),
-		um.Returning(tags.Columns()...)}
+		um.Returning(all.Columns()...)}
 
 	// Add the individual column sets
 	columns, values := GetColumnsAndValues(record, tags)
@@ -216,7 +219,7 @@ func Update[T db.Model](ctx context.Context, db *pgxpool.Pool, record T, uuid uu
 
 	record, err = pgx.CollectExactlyOneRow(result, pgx.RowToStructByName[T])
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract inserted record: %w", err)
+		return nil, fmt.Errorf("failed to extract updated record: %w", err)
 	}
 
 	return &record, nil

--- a/internal/service/common/utils/utils.go
+++ b/internal/service/common/utils/utils.go
@@ -21,6 +21,16 @@ func (r DBTag) Columns() []any {
 	return columns
 }
 
+// Fields is used get the list of field names from the DBTag map
+func (r DBTag) Fields() []string {
+	fields := make([]string, 0, len(r))
+	for f := range r {
+		fields = append(fields, f)
+	}
+
+	return fields
+}
+
 // getDBTagsFromStruct returns a map of field names to their db tags.
 func getDBTagsFromStruct[T db.Model](s T, excludeNilValues bool) DBTag {
 	tags := make(DBTag)
@@ -111,6 +121,55 @@ func GetDBTagsFromStructFields[T db.Model](s T, fields ...string) DBTag {
 		}
 
 		tags[f.Name] = f.Tag.Get("db")
+	}
+
+	return tags
+}
+
+// CompareObjects compares two objects and returns the tags for fields having differing values.  Any field names listed
+// in `excluded` are ignored.
+func CompareObjects[T db.Model](a, b T, excluded ...string) DBTag {
+	tags := make(DBTag)
+	excludedFields := make(map[string]bool)
+	for _, field := range excluded {
+		excludedFields[field] = true
+	}
+
+	ta := reflect.TypeOf(a)
+	va := reflect.ValueOf(a)
+	vb := reflect.ValueOf(b)
+	if ta.Kind() != reflect.Struct {
+		ta = ta.Elem()
+		va = va.Elem()
+		vb = vb.Elem()
+	}
+
+	for i := 0; i < ta.NumField(); i++ {
+		field := ta.Field(i)
+		fieldName := field.Name
+		tagValue := field.Tag.Get("db")
+		aFieldValue := va.FieldByName(fieldName)
+		bFieldValue := vb.FieldByName(fieldName)
+		if _, found := excludedFields[fieldName]; found {
+			// ignore any fields that were explicitly excluded by the caller.
+			continue
+		}
+
+		switch {
+		case field.Type.Kind() != reflect.Ptr:
+			// Non-pointer value compare them directly
+			if !reflect.DeepEqual(aFieldValue.Interface(), bFieldValue.Interface()) {
+				tags[fieldName] = tagValue
+			}
+		case aFieldValue.IsNil() != bFieldValue.IsNil():
+			// Pointer nil-ness are different so include this field
+			tags[fieldName] = tagValue
+		case !aFieldValue.IsNil():
+			// Pointer nil-ness are the same, so compare their values
+			if !reflect.DeepEqual(aFieldValue.Interface(), bFieldValue.Interface()) {
+				tags[fieldName] = tagValue
+			}
+		}
 	}
 
 	return tags

--- a/internal/service/common/utils/utils_test.go
+++ b/internal/service/common/utils/utils_test.go
@@ -4,16 +4,20 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 type mockDBModel struct {
-	RecordID    int                    `db:"record_id"`
-	RaisedTime  time.Time              `db:"raised_time"`
-	ChangedTime *time.Time             `db:"changed_time"`
-	Extensions  map[string]interface{} `db:"extensions"`
-	CreatedAt   time.Time              `db:"created_at"`
+	RecordID      int                    `db:"record_id"`
+	SomeUUID      uuid.UUID              `db:"some_uuid"`
+	SomeMapPtr    *map[string]string     `db:"some_map_ptr"`
+	SomeStringPtr *string                `db:"some_string_ptr"`
+	RaisedTime    time.Time              `db:"raised_time"`
+	ChangedTime   *time.Time             `db:"changed_time"`
+	Extensions    map[string]interface{} `db:"extensions"`
+	CreatedAt     time.Time              `db:"created_at"`
 }
 
 func (m *mockDBModel) TableName() string {
@@ -34,6 +38,7 @@ var _ = Describe("Utils", func() {
 			Expect(tags).To(HaveLen(st.NumField()))
 			Expect(tags).To(ConsistOf(
 				"record_id", "raised_time", "changed_time",
+				"some_uuid", "some_map_ptr", "some_string_ptr",
 				"extensions", "created_at"))
 		})
 
@@ -56,12 +61,12 @@ var _ = Describe("Utils", func() {
 			ar := mockDBModel{}
 			tags := GetNonNilDBTagsFromStruct(&ar)
 			Expect(tags).To(ConsistOf(
-				"record_id", "raised_time",
+				"record_id", "raised_time", "some_uuid",
 				"extensions", "created_at"))
 			columns, values := GetColumnsAndValues(&ar, tags)
 			Expect(columns).To(ConsistOf(tags.Columns()))
 			Expect(len(values)).To(Equal(len(columns)))
-			Expect(values).To(ConsistOf(ar.RecordID, ar.RaisedTime, ar.Extensions, ar.CreatedAt))
+			Expect(values).To(ConsistOf(ar.RecordID, ar.RaisedTime, ar.SomeUUID, ar.Extensions, ar.CreatedAt))
 		})
 
 		It("includes non-nil pointers", func() {
@@ -71,12 +76,85 @@ var _ = Describe("Utils", func() {
 			}
 			tags := GetNonNilDBTagsFromStruct(&ar)
 			Expect(tags.Columns()).To(ConsistOf(
-				"record_id", "raised_time", "changed_time",
+				"record_id", "raised_time", "some_uuid", "changed_time",
 				"extensions", "created_at"))
 			columns, values := GetColumnsAndValues(&ar, tags)
 			Expect(columns).To(ConsistOf(tags.Columns()))
 			Expect(len(values)).To(Equal(len(columns)))
-			Expect(values).To(ConsistOf(ar.RecordID, ar.RaisedTime, ar.ChangedTime, ar.Extensions, ar.CreatedAt))
+			Expect(values).To(ConsistOf(ar.RecordID, ar.RaisedTime, ar.SomeUUID, ar.ChangedTime, ar.Extensions, ar.CreatedAt))
+		})
+
+		It("returns no fields when compare the same structs", func() {
+			ar := mockDBModel{}
+			tags := CompareObjects(&ar, &ar)
+			Expect(tags).To(BeEmpty())
+		})
+
+		It("returns no fields when different but identical structs", func() {
+			t1 := mockDBModel{}
+			t2 := mockDBModel{}
+			tags := CompareObjects(&t1, &t2)
+			Expect(tags).To(BeEmpty())
+		})
+
+		It("returns fields of differing non-pointers", func() {
+			t1 := mockDBModel{RaisedTime: time.Now()}
+			t2 := mockDBModel{}
+			tags := CompareObjects(&t1, &t2)
+			Expect(tags.Columns()).To(ConsistOf("raised_time"))
+		})
+
+		It("ignores excluded fields", func() {
+			t1 := mockDBModel{RaisedTime: time.Now()}
+			t2 := mockDBModel{}
+			tags := CompareObjects(&t1, &t2, "RaisedTime")
+			Expect(tags.Columns()).To(BeEmpty())
+		})
+
+		It("returns fields of pointers with different nil-ness", func() {
+			now := time.Now()
+			t1 := mockDBModel{ChangedTime: &now}
+			t2 := mockDBModel{}
+			tags := CompareObjects(&t1, &t2)
+			Expect(tags.Columns()).To(ConsistOf("changed_time"))
+		})
+
+		It("returns fields of pointers with different values", func() {
+			someMap := map[string]string{"a": "1"}
+			anotherMap := map[string]string{"a": "2"}
+			someString := "some string"
+			anotherString := "another string"
+			now := time.Now()
+			later := time.Now().Add(1 * time.Minute)
+			t1 := mockDBModel{
+				ChangedTime:   &now,
+				SomeStringPtr: &someString,
+				SomeMapPtr:    &someMap}
+			t2 := mockDBModel{
+				ChangedTime:   &later,
+				SomeStringPtr: &anotherString,
+				SomeMapPtr:    &anotherMap}
+			tags := CompareObjects(&t1, &t2)
+			Expect(tags.Columns()).To(ConsistOf("changed_time", "some_string_ptr", "some_map_ptr"))
+		})
+
+		It("returns no fields when pointer addresses are different but the values are the same", func() {
+			someMap := map[string]string{"a": "1"}
+			sameMap := map[string]string{"a": "1"}
+			something := ""
+			somethingAgain := ""
+			now := time.Now()
+			again := now
+			t1 := mockDBModel{
+				ChangedTime:   &now,
+				SomeStringPtr: &something,
+				SomeMapPtr:    &someMap}
+			t2 := mockDBModel{
+				ChangedTime:   &again,
+				SomeStringPtr: &somethingAgain,
+				SomeMapPtr:    &sameMap}
+			tags := CompareObjects(&t1, &t2)
+			Expect(tags.Columns()).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
This makes changes to the Update utility so that it is possible to request that only some fields be set in the update operation.  This is to facilitate changes required by the upcoming resource data collector functionality that will be synchronizing data between ACM and our persistent storage.