### PR TITLE
Add REPLACE to trigger creation during alarm DB up migration

### DIFF
--- a/internal/service/alarms/internal/db/migrations/000001_create_alarm_dictionary_table.up.sql
+++ b/internal/service/alarms/internal/db/migrations/000001_create_alarm_dictionary_table.up.sql
@@ -25,7 +25,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Trigger to execute update_alarm_dictionary_timestamp before each update on alarm_dictionary
-CREATE TRIGGER set_alarm_dictionary_timestamp
+CREATE OR REPLACE TRIGGER set_alarm_dictionary_timestamp
     BEFORE UPDATE ON alarm_dictionary
     FOR EACH ROW
     EXECUTE FUNCTION update_alarm_dictionary_timestamp();

--- a/internal/service/alarms/internal/db/migrations/000002_create_alarm_definition_table.up.sql
+++ b/internal/service/alarms/internal/db/migrations/000002_create_alarm_definition_table.up.sql
@@ -37,7 +37,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Trigger to populate resource_type_id
-CREATE TRIGGER populate_alarm_definition_resource_type_id
+CREATE OR REPLACE TRIGGER populate_alarm_definition_resource_type_id
     BEFORE INSERT OR UPDATE ON alarm_definition
     FOR EACH ROW
     EXECUTE FUNCTION set_alarm_definition_resource_type_id();
@@ -52,7 +52,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Trigger to execute update_alarm_definition_timestamp before each update on alarm_definition
-CREATE TRIGGER set_alarm_definition_updated_at
+CREATE OR REPLACE TRIGGER set_alarm_definition_updated_at
     BEFORE UPDATE ON alarm_definition
     FOR EACH ROW
     EXECUTE FUNCTION update_alarm_definition_timestamp();

--- a/internal/service/alarms/internal/db/migrations/000003_create_alarm_event_record_table.up.sql
+++ b/internal/service/alarms/internal/db/migrations/000003_create_alarm_event_record_table.up.sql
@@ -53,7 +53,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Trigger to execute update_alarm_event_sequence before updating alarm_event_record
-CREATE TRIGGER update_alarm_event_sequence
+CREATE OR REPLACE TRIGGER update_alarm_event_sequence
     BEFORE UPDATE ON alarm_event_record
     FOR EACH ROW
     EXECUTE FUNCTION update_alarm_event_sequence();

--- a/internal/service/alarms/internal/db/migrations/000005_create_alarm_subscription_info_table.up.sql
+++ b/internal/service/alarms/internal/db/migrations/000005_create_alarm_subscription_info_table.up.sql
@@ -22,7 +22,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Trigger execute update_subscription_timestamp to update the updated_at timestamp for alarm_subscription_info
-CREATE TRIGGER update_subscription_timestamp
+CREATE OR REPLACE TRIGGER update_subscription_timestamp
     BEFORE UPDATE ON alarm_subscription_info
     FOR EACH ROW
     EXECUTE FUNCTION update_subscription_timestamp();


### PR DESCRIPTION
CREATE TRIGGER fails if the trigger already exists