### PR TITLE
Refactor DB generics

### DIFF
--- a/internal/service/alarms/internal/db/repo/alarms_repository.go
+++ b/internal/service/alarms/internal/db/repo/alarms_repository.go
@@ -8,6 +8,10 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/dialect"
+	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/im"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
 
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
@@ -21,59 +25,117 @@ type AlarmsRepository struct {
 
 // GetAlarmEventRecordWithUuid grabs a row of alarm_event_record using uuid
 func (ar *AlarmsRepository) GetAlarmEventRecordWithUuid(ctx context.Context, uuid uuid.UUID) (*models.AlarmEventRecord, error) {
-	return utils.Find[models.AlarmEventRecord](ctx, ar.Db, uuid, nil)
+	dbModel := models.AlarmEventRecord{}
+
+	tags := utils.GetAllDBTagsFromStruct(dbModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(dbModel.TableName()),
+		sm.Where(psql.Quote(dbModel.PrimaryKey()).EQ(psql.Arg(uuid))),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectExactlyOneRow[models.AlarmEventRecord](ctx, ar.Db, sql, args)
 }
 
 // DeleteAlarmDictionariesNotIn deletes all alarm dictionaries that are not in the list of resource type IDs
 func (ar *AlarmsRepository) DeleteAlarmDictionariesNotIn(ctx context.Context, ids []any) error {
+	dbModel := models.AlarmDictionary{}
+
 	tags := utils.GetDBTagsFromStructFields(models.AlarmDictionary{}, "ResourceTypeID")
 
-	expr := psql.Quote(tags["ResourceTypeID"]).NotIn(psql.Arg(ids...))
-	_, err := utils.Delete[models.AlarmDictionary](ctx, ar.Db, expr)
+	query := psql.Delete(
+		dm.From(dbModel.TableName()),
+		dm.Where(psql.Quote(tags["ResourceTypeID"]).NotIn(psql.Arg(ids...))))
+
+	sql, args, err := query.Build()
+	if err != nil {
+		return fmt.Errorf("failed to build query: %w", err)
+	}
+
+	_, err = utils.ExecuteExec[models.AlarmDictionary](ctx, ar.Db, sql, args)
+
 	return err
 }
 
 // DeleteAlarmDefinitionsNotIn deletes all alarm definitions identified by the primary key that are not in the list of IDs.
 // The Where expression also uses the column "resource_type_id" to filter the records
 func (ar *AlarmsRepository) DeleteAlarmDefinitionsNotIn(ctx context.Context, ids []any, resourceTypeID uuid.UUID) error {
+	dbModel := models.AlarmDefinition{}
+
 	tags := utils.GetDBTagsFromStructFields(models.AlarmDefinition{}, "ResourceTypeID")
 
-	expr := psql.Quote(models.AlarmDefinition{}.PrimaryKey()).NotIn(psql.Arg(ids...)).And(psql.Quote(tags["ResourceTypeID"]).EQ(psql.Arg(resourceTypeID)))
-	_, err := utils.Delete[models.AlarmDefinition](ctx, ar.Db, expr)
+	query := psql.Delete(
+		dm.From(dbModel.TableName()),
+		dm.Where(psql.Quote(models.AlarmDefinition{}.PrimaryKey()).NotIn(psql.Arg(ids...)).And(psql.Quote(tags["ResourceTypeID"]).EQ(psql.Arg(resourceTypeID)))))
+
+	sql, args, err := query.Build()
+	if err != nil {
+		return fmt.Errorf("failed to build query: %w", err)
+	}
+
+	_, err = utils.ExecuteExec[models.AlarmDefinition](ctx, ar.Db, sql, args)
+
 	return err
 }
 
 // UpsertAlarmDictionary inserts or updates an alarm dictionary record
 func (ar *AlarmsRepository) UpsertAlarmDictionary(ctx context.Context, record models.AlarmDictionary) ([]models.AlarmDictionary, error) {
-	tags := utils.GetDBTagsFromStructFields(record, "AlarmDictionaryVersion", "EntityType", "Vendor", "ResourceTypeID")
+	dbModel := models.AlarmDictionary{}
 
-	// Important to keep the order. The order of tags.Columns().. is not deterministic
-	values := []bob.Expression{psql.Arg(record.AlarmDictionaryVersion, record.EntityType, record.Vendor, record.ResourceTypeID)}
-	records, err := utils.UpsertOnConflict[models.AlarmDictionary](ctx, ar.Db, []string{tags["AlarmDictionaryVersion"], tags["EntityType"], tags["Vendor"], tags["ResourceTypeID"]}, values)
+	tags := utils.GetDBTagsFromStructFields(dbModel, "AlarmDictionaryVersion", "EntityType", "Vendor", "ResourceTypeID")
+
+	columns := []string{tags["AlarmDictionaryVersion"], tags["EntityType"], tags["Vendor"], tags["ResourceTypeID"]}
+
+	query := psql.Insert(
+		im.Into(record.TableName(), columns...),
+		im.Values(psql.Arg(record.AlarmDictionaryVersion, record.EntityType, record.Vendor, record.ResourceTypeID)),
+		im.OnConflict(record.OnConflict()).DoUpdate(
+			im.SetExcluded(columns...)),
+		im.Returning(record.PrimaryKey()),
+	)
+
+	sql, args, err := query.Build()
 	if err != nil {
-		return nil, fmt.Errorf("failed to upsert alarm dictionary: %w", err)
+		return nil, fmt.Errorf("failed to build query: %w", err)
 	}
 
-	return records, nil
+	return utils.ExecuteCollectRows[models.AlarmDictionary](ctx, ar.Db, sql, args)
 }
 
 // UpsertAlarmDefinitions inserts or updates alarm definition records
 func (ar *AlarmsRepository) UpsertAlarmDefinitions(ctx context.Context, records []models.AlarmDefinition) ([]models.AlarmDefinition, error) {
+	dbModel := models.AlarmDefinition{}
+
 	if len(records) == 0 {
 		return nil, nil
 	}
 
 	tags := utils.GetDBTagsFromStructFields(records[0], "AlarmName", "AlarmLastChange", "AlarmDescription", "ProposedRepairActions", "AlarmAdditionalFields", "AlarmDictionaryID", "Severity")
-	var values []bob.Expression
+	columns := []string{tags["AlarmName"], tags["AlarmLastChange"], tags["AlarmDescription"], tags["ProposedRepairActions"], tags["AlarmAdditionalFields"], tags["AlarmDictionaryID"], tags["Severity"]}
+
+	modInsert := []bob.Mod[*dialect.InsertQuery]{
+		im.Into(dbModel.TableName(), columns...),
+		im.OnConflictOnConstraint(dbModel.OnConflict()).DoUpdate(
+			im.SetExcluded(columns...)),
+		im.Returning(dbModel.PrimaryKey()),
+	}
+
 	for _, record := range records {
-		// Important to keep the order. The order of tags.Columns().. is not deterministic
-		values = append(values, psql.Arg(record.AlarmName, record.AlarmLastChange, record.AlarmDescription, record.ProposedRepairActions, record.AlarmAdditionalFields, record.AlarmDictionaryID, record.Severity))
+		modInsert = append(modInsert, im.Values(psql.Arg(record.AlarmName, record.AlarmLastChange, record.AlarmDescription, record.ProposedRepairActions, record.AlarmAdditionalFields, record.AlarmDictionaryID, record.Severity)))
 	}
 
-	records, err := utils.UpsertOnConflictConstraint[models.AlarmDefinition](ctx, ar.Db, []string{tags["AlarmName"], tags["AlarmLastChange"], tags["AlarmDescription"], tags["ProposedRepairActions"], tags["AlarmAdditionalFields"], tags["AlarmDictionaryID"], tags["Severity"]}, values)
+	query := psql.Insert(
+		modInsert...,
+	)
+
+	sql, args, err := query.Build()
 	if err != nil {
-		return nil, fmt.Errorf("failed to upsert alarm dictionary: %w", err)
+		return nil, fmt.Errorf("failed to build query: %w", err)
 	}
 
-	return records, nil
+	return utils.ExecuteCollectRows[models.AlarmDefinition](ctx, ar.Db, sql, args)
 }

--- a/internal/service/common/utils/repository.go
+++ b/internal/service/common/utils/repository.go
@@ -6,41 +6,18 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/stephenafamo/bob"
-	"github.com/stephenafamo/bob/dialect/psql"
-	"github.com/stephenafamo/bob/dialect/psql/dialect"
-	"github.com/stephenafamo/bob/dialect/psql/dm"
-	"github.com/stephenafamo/bob/dialect/psql/im"
-	"github.com/stephenafamo/bob/dialect/psql/sm"
-	"github.com/stephenafamo/bob/dialect/psql/um"
-
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
 )
 
 // ErrNotFound represents the error returned by any repository when not record matches the requested criteria
 var ErrNotFound = errors.New("record not found")
 
-// Find retrieves a specific tuple from the database table specified.  If no record is found ErrNotFound is returned
-// as an error; otherwise a pointer to the stored record is returned or a generic error on failure.
-func Find[T db.Model](ctx context.Context, db *pgxpool.Pool, uuid uuid.UUID, columns []any) (*T, error) {
-	// Build sql query
+// ExecuteCollectExactlyOneRow executes a query and returns exactly one row or error
+func ExecuteCollectExactlyOneRow[T db.Model](ctx context.Context, db *pgxpool.Pool, sql string, args []any) (*T, error) {
 	var record T
-	if columns == nil {
-		tags := GetAllDBTagsFromStruct(record)
-		columns = tags.Columns()
-	}
-
-	sql, args, err := psql.Select(
-		sm.Columns(columns...),
-		sm.From(record.TableName()),
-		sm.Where(psql.Quote(record.PrimaryKey()).EQ(psql.Arg(uuid))),
-	).Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to build query: %w", err)
-	}
+	var err error
 
 	slog.Debug("executing statement", "sql", sql, "args", args)
 
@@ -49,67 +26,20 @@ func Find[T db.Model](ctx context.Context, db *pgxpool.Pool, uuid uuid.UUID, col
 	record, err = pgx.CollectExactlyOneRow(rows, pgx.RowToStructByNameLax[T])
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			slog.Debug("no record found", "uuid", uuid, "table", record.TableName())
+			slog.Debug("no record found", "table", record.TableName())
 			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
 
-	slog.Debug("record found", "table", record.TableName(), "uuid", uuid)
+	slog.Debug("record found", "table", record.TableName())
 	return &record, nil
 }
 
-// FindAll retrieves all tuples from the database table specified.  If no records are found then an empty array is
-// returned.
-func FindAll[T db.Model](ctx context.Context, db *pgxpool.Pool, columns []any) ([]T, error) {
-	return Search[T](ctx, db, nil, columns)
-}
-
-// Delete deletes a specific tuple from the database table specified given an expression for Where clause
-func Delete[T db.Model](ctx context.Context, db *pgxpool.Pool, expr psql.Expression) (int64, error) {
+// ExecuteCollectRows executes a query and returns all rows or empty array
+func ExecuteCollectRows[T db.Model](ctx context.Context, db *pgxpool.Pool, sql string, args []any) ([]T, error) {
 	var record T
-	query := psql.Delete(
-		dm.From(record.TableName()),
-		dm.Where(expr))
-
-	sql, args, err := query.Build()
-	if err != nil {
-		return 0, fmt.Errorf("failed to build delete query for '%s': %w", record.TableName(), err)
-	}
-
-	slog.Debug("executing statement", "query", query, "args", args)
-
-	result, err := db.Exec(ctx, sql, args...)
-	if err != nil {
-		return 0, fmt.Errorf("failed to delete '%s': %w", record.TableName(), err)
-	}
-
-	return result.RowsAffected(), nil
-}
-
-// Search retrieves a tuple from the database using arbitrary column values.  If no record is found an empty array
-// is returned.
-func Search[T db.Model](ctx context.Context, db *pgxpool.Pool, expression bob.Expression, columns []any) ([]T, error) {
-	// Build sql query
-	var record T
-	if columns == nil {
-		tags := GetAllDBTagsFromStruct(record)
-		columns = tags.Columns()
-	}
-
-	params := []bob.Mod[*dialect.SelectQuery]{
-		sm.Columns(columns...),
-		sm.From(record.TableName()),
-	}
-
-	if expression != nil {
-		params = append(params, sm.Where(expression))
-	}
-
-	sql, args, err := psql.Select(params...).Build()
-	if err != nil {
-		return []T{}, fmt.Errorf("failed to build query: %w", err)
-	}
+	var err error
 
 	slog.Debug("executing statement", "sql", sql, "args", args)
 
@@ -120,172 +50,20 @@ func Search[T db.Model](ctx context.Context, db *pgxpool.Pool, expression bob.Ex
 		return []T{}, fmt.Errorf("failed to execute query: %w", err)
 	}
 
-	slog.Debug("records found", "table", record.TableName(), "expression", expression, "count", len(records))
+	slog.Debug("records found", "table", record.TableName(), "count", len(records))
 	return records, nil
 }
 
-// Exists checks whether a record exists in the table with a primary key that matches uuid.
-func Exists[T db.Model](ctx context.Context, db *pgxpool.Pool, uuid uuid.UUID) (bool, error) {
+// ExecuteExec executes a query and returns the number of rows affected
+func ExecuteExec[T db.Model](ctx context.Context, db *pgxpool.Pool, sql string, args []any) (int64, error) {
 	var record T
-	query := psql.RawQuery(fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM %s WHERE %s=?)",
-		psql.Quote(record.TableName()), psql.Quote(record.PrimaryKey())), uuid)
-
-	sql, args, err := query.Build()
-	if err != nil {
-		return false, fmt.Errorf("failed to build query: %w", err)
-	}
-
-	slog.Error("executing query", "sql", sql, "args", args)
-
-	var result bool
-	err = db.QueryRow(ctx, sql, args...).Scan(&result)
-	if err != nil {
-		return false, fmt.Errorf("failed to execute query: %w", err)
-	}
-
-	return result, nil
-}
-
-// Create creates a record of the requested model type.  The stored record is returned on success; otherwise an error
-// is returned.
-func Create[T db.Model](ctx context.Context, db *pgxpool.Pool, record T) (*T, error) {
-	nonNilTags := GetNonNilDBTagsFromStruct(record)
-
-	// Return all columns to get any defaulted values that the DB may set
-	query := psql.Insert(im.Into(record.TableName()), im.Returning("*"))
-
-	// Add columns to the expression.  Maintain the order here so that it coincides with the order of the values
-	columns, values := GetColumnsAndValues(record, nonNilTags)
-	query.Expression.Columns = columns
-	query.Apply(im.Values(psql.Arg(values...)))
-
-	sql, args, err := query.Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create insert expression: %w", err)
-	}
-
-	slog.Debug("executing statement", "query", sql, "args", args)
-
-	// Run the query
-	result, err := db.Query(ctx, sql, args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute insert expression '%s' with args '%s': %w", sql, args, err)
-	}
-
-	record, err = pgx.CollectExactlyOneRow(result, pgx.RowToStructByName[T])
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract inserted record: %w", err)
-	}
-
-	return &record, nil
-}
-
-// Update attempts to update a record with a matching primary key.  The stored record is returned on success; otherwise
-// an error is returned.
-func Update[T db.Model](ctx context.Context, db *pgxpool.Pool, record T, uuid uuid.UUID) (*T, error) {
-	tags := GetAllDBTagsFromStruct(record)
-
-	// Set up the arguments to the call to psql.Update(...) by using an array because there's no obvious way to add
-	// multiple Set(..) operation without having to add them one at a time separately.
-	mods := []bob.Mod[*dialect.UpdateQuery]{
-		um.Table(record.TableName()),
-		um.Where(psql.Quote(record.PrimaryKey()).EQ(psql.Arg(uuid))),
-		um.Returning(tags.Columns()...)}
-
-	// Add the individual column sets
-	columns, values := GetColumnsAndValues(record, tags)
-	for i, column := range columns {
-		mods = append(mods, um.SetCol(column).ToArg(values[i]))
-	}
-
-	// Build the query
-	query := psql.Update(mods...)
-	sql, args, err := query.Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create update expression: %w", err)
-	}
 
 	slog.Debug("executing statement", "sql", sql, "args", args)
 
-	// Run the query
-	result, err := db.Query(ctx, sql, args...)
+	result, err := db.Exec(ctx, sql, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute insert expression '%s' with args '%s': %w", sql, args, err)
+		return 0, fmt.Errorf("failed to delete '%s': %w", record.TableName(), err)
 	}
 
-	record, err = pgx.CollectExactlyOneRow(result, pgx.RowToStructByName[T])
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract inserted record: %w", err)
-	}
-
-	return &record, nil
-}
-
-// UpsertOnConflict inserts or updates a set of records in the database table specified. It uses the bob.Mod OnConflict to define the columns to check for conflicts.
-// Args: ctx - context, db - pgxpool.Pool, columns - columns to check for conflicts, values - values to insert or update
-// Returns: records - the records only contain the primary key, error - if any
-func UpsertOnConflict[T db.Model](ctx context.Context, db *pgxpool.Pool, columns []string, values []bob.Expression) ([]T, error) {
-	var record T
-
-	modInsert := []bob.Mod[*dialect.InsertQuery]{
-		im.Into(record.TableName(), columns...),
-		im.OnConflict(record.OnConflict()).DoUpdate(
-			im.SetExcluded(columns...)),
-		im.Returning(record.PrimaryKey()),
-	}
-
-	for _, value := range values {
-		modInsert = append(modInsert, im.Values(value))
-	}
-
-	query := psql.Insert(
-		modInsert...,
-	)
-
-	return executeUpsert[T](ctx, db, query)
-}
-
-// UpsertOnConflictConstraint inserts or updates a set of records in the database table specified. It uses the bob.Mod OnConflictOnConstraint to define the constraint to check for conflicts.
-// Args: ctx - context, db - pgxpool.Pool, columns - columns to check for conflicts, values - values to insert or update
-// Returns: records - the records only contain the primary key, error - if any
-func UpsertOnConflictConstraint[T db.Model](ctx context.Context, db *pgxpool.Pool, columns []string, values []bob.Expression) ([]T, error) {
-	var record T
-
-	modInsert := []bob.Mod[*dialect.InsertQuery]{
-		im.Into(record.TableName(), columns...),
-		im.OnConflictOnConstraint(record.OnConflict()).DoUpdate(
-			im.SetExcluded(columns...)),
-		im.Returning(record.PrimaryKey()),
-	}
-
-	for _, value := range values {
-		modInsert = append(modInsert, im.Values(value))
-	}
-
-	query := psql.Insert(
-		modInsert...,
-	)
-
-	return executeUpsert[T](ctx, db, query)
-}
-
-// executeUpsert executes the upsert query and returns the records
-// TODO: this might be used by other functions
-func executeUpsert[T db.Model](ctx context.Context, db *pgxpool.Pool, query bob.BaseQuery[*dialect.InsertQuery]) ([]T, error) {
-	var record T
-
-	sql, args, err := query.Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create upsert expression: %w", err)
-	}
-
-	// Run query
-	rows, _ := db.Query(ctx, sql, args...)
-	records, err := pgx.CollectRows(rows, pgx.RowToStructByNameLax[T])
-	if err != nil {
-		return nil, fmt.Errorf("failed to call database: %w", err)
-	}
-
-	slog.Info("upsert successful", "affected rows", len(records), "table", record.TableName())
-	return records, nil
+	return result.RowsAffected(), nil
 }

--- a/internal/service/resources/db/repo/repository.go
+++ b/internal/service/resources/db/repo/repository.go
@@ -2,10 +2,15 @@ package repo
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/im"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
 
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/models"
@@ -18,67 +23,236 @@ type ResourcesRepository struct {
 
 // GetDeploymentManagers retrieves all DeploymentManager tuples or returns an empty array if no tuples are found
 func (r *ResourcesRepository) GetDeploymentManagers(ctx context.Context) ([]models.DeploymentManager, error) {
-	return utils.FindAll[models.DeploymentManager](ctx, r.Db, nil)
+	dbModel := models.DeploymentManager{}
+
+	tags := utils.GetAllDBTagsFromStruct(dbModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(dbModel.TableName()),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectRows[models.DeploymentManager](ctx, r.Db, sql, args)
 }
 
 // GetDeploymentManager retrieves a specific DeploymentManager tuple or returns nil if not found
 func (r *ResourcesRepository) GetDeploymentManager(ctx context.Context, id uuid.UUID) (*models.DeploymentManager, error) {
-	return utils.Find[models.DeploymentManager](ctx, r.Db, id, nil)
+	dbModel := models.DeploymentManager{}
+
+	tags := utils.GetAllDBTagsFromStruct(dbModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(dbModel.TableName()),
+		sm.Where(psql.Quote(dbModel.PrimaryKey()).EQ(psql.Arg(id))),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectExactlyOneRow[models.DeploymentManager](ctx, r.Db, sql, args)
 }
 
 // GetSubscriptions retrieves all Subscription tuples or returns an empty array if no tuples are found
 func (r *ResourcesRepository) GetSubscriptions(ctx context.Context) ([]models.Subscription, error) {
-	return utils.FindAll[models.Subscription](ctx, r.Db, nil)
+	dbModel := models.Subscription{}
+
+	tags := utils.GetAllDBTagsFromStruct(dbModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(dbModel.TableName()),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectRows[models.Subscription](ctx, r.Db, sql, args)
 }
 
 // GetSubscription retrieves a specific Subscription tuple or returns nil if not found
 func (r *ResourcesRepository) GetSubscription(ctx context.Context, id uuid.UUID) (*models.Subscription, error) {
-	return utils.Find[models.Subscription](ctx, r.Db, id, nil)
+	dbModel := models.Subscription{}
+
+	tags := utils.GetAllDBTagsFromStruct(dbModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(dbModel.TableName()),
+		sm.Where(psql.Quote(dbModel.PrimaryKey()).EQ(psql.Arg(id))),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectExactlyOneRow[models.Subscription](ctx, r.Db, sql, args)
 }
 
 // DeleteSubscription deletes a Subscription tuple.  The caller should ensure that it exists prior to calling this.
 func (r *ResourcesRepository) DeleteSubscription(ctx context.Context, id uuid.UUID) (int64, error) {
-	expr := psql.Quote(models.Subscription{}.PrimaryKey()).EQ(psql.Arg(id))
-	return utils.Delete[models.Subscription](ctx, r.Db, expr)
+	dbModel := models.Subscription{}
+
+	query := psql.Delete(
+		dm.From(dbModel.TableName()),
+		dm.Where(psql.Quote(models.Subscription{}.PrimaryKey()).EQ(psql.Arg(id))))
+
+	sql, args, err := query.Build()
+	if err != nil {
+		return 0, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteExec[models.Subscription](ctx, r.Db, sql, args)
 }
 
 // CreateSubscription create a new Subscription tuple or returns nil if not found
 func (r *ResourcesRepository) CreateSubscription(ctx context.Context, subscription *models.Subscription) (*models.Subscription, error) {
-	return utils.Create[models.Subscription](ctx, r.Db, *subscription)
+	nonNilTags := utils.GetNonNilDBTagsFromStruct(subscription)
+
+	// Return all columns to get any defaulted values that the DB may set
+	query := psql.Insert(im.Into(subscription.TableName()), im.Returning("*"))
+
+	// Add columns to the expression.  Maintain the order here so that it coincides with the order of the values
+	columns, values := utils.GetColumnsAndValues[models.Subscription](*subscription, nonNilTags)
+	query.Expression.Columns = columns
+	query.Apply(im.Values(psql.Arg(values...)))
+
+	sql, args, err := query.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create insert expression: %w", err)
+	}
+
+	return utils.ExecuteCollectExactlyOneRow[models.Subscription](ctx, r.Db, sql, args)
 }
 
 // GetResourceTypes retrieves all ResourceType tuples or returns an empty array if no tuples are found
 func (r *ResourcesRepository) GetResourceTypes(ctx context.Context) ([]models.ResourceType, error) {
-	return utils.FindAll[models.ResourceType](ctx, r.Db, nil)
+	dbModel := models.ResourceType{}
+
+	tags := utils.GetAllDBTagsFromStruct(dbModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(dbModel.TableName()),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectRows[models.ResourceType](ctx, r.Db, sql, args)
 }
 
 // GetResourceType retrieves a specific ResourceType tuple or returns nil if not found
 func (r *ResourcesRepository) GetResourceType(ctx context.Context, id uuid.UUID) (*models.ResourceType, error) {
-	return utils.Find[models.ResourceType](ctx, r.Db, id, nil)
+	dbModel := models.ResourceType{}
+
+	tags := utils.GetAllDBTagsFromStruct(dbModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(dbModel.TableName()),
+		sm.Where(psql.Quote(dbModel.PrimaryKey()).EQ(psql.Arg(id))),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectExactlyOneRow[models.ResourceType](ctx, r.Db, sql, args)
 }
 
 // GetResourcePools retrieves all ResourcePool tuples or returns an empty array if no tuples are found
 func (r *ResourcesRepository) GetResourcePools(ctx context.Context) ([]models.ResourcePool, error) {
-	return utils.FindAll[models.ResourcePool](ctx, r.Db, nil)
+	dbModel := models.ResourcePool{}
+
+	tags := utils.GetAllDBTagsFromStruct(dbModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(dbModel.TableName()),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectRows[models.ResourcePool](ctx, r.Db, sql, args)
 }
 
 // GetResourcePool retrieves a specific ResourcePool tuple or returns nil if not found
 func (r *ResourcesRepository) GetResourcePool(ctx context.Context, id uuid.UUID) (*models.ResourcePool, error) {
-	return utils.Find[models.ResourcePool](ctx, r.Db, id, nil)
+	dbModel := models.ResourcePool{}
+
+	tags := utils.GetAllDBTagsFromStruct(dbModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(dbModel.TableName()),
+		sm.Where(psql.Quote(dbModel.PrimaryKey()).EQ(psql.Arg(id))),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectExactlyOneRow[models.ResourcePool](ctx, r.Db, sql, args)
 }
 
 // ResourcePoolExists determines whether a ResourcePool exists or not
 func (r *ResourcesRepository) ResourcePoolExists(ctx context.Context, id uuid.UUID) (bool, error) {
-	return utils.Exists[models.ResourcePool](ctx, r.Db, id)
+	dbModel := models.ResourcePool{}
+
+	query := psql.RawQuery(fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM %s WHERE %s=?)",
+		psql.Quote(dbModel.TableName()), psql.Quote(dbModel.PrimaryKey())), id)
+
+	sql, args, err := query.Build()
+	if err != nil {
+		return false, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	slog.Error("executing query", "sql", sql, "args", args)
+
+	var result bool
+	err = r.Db.QueryRow(ctx, sql, args...).Scan(&result)
+	if err != nil {
+		return false, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	return result, nil
 }
 
 // GetResourcePoolResources retrieves all Resource tuples for a specific ResourcePool returns an empty array if not found
 func (r *ResourcesRepository) GetResourcePoolResources(ctx context.Context, id uuid.UUID) ([]models.Resource, error) {
-	e := psql.Quote("resource_pool_id").EQ(psql.Arg(id))
-	return utils.Search[models.Resource](ctx, r.Db, e, nil)
+	resourceDBModel := models.Resource{}
+	resourcePoolDBModel := models.ResourcePool{}
+
+	tags := utils.GetAllDBTagsFromStruct(resourceDBModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(resourceDBModel.TableName()),
+		sm.Where(psql.Quote(resourcePoolDBModel.PrimaryKey()).EQ(psql.Arg(id))),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectRows[models.Resource](ctx, r.Db, sql, args)
 }
 
 // GetResource retrieves a specific ResourceType tuple or returns nil if not found
 func (r *ResourcesRepository) GetResource(ctx context.Context, id uuid.UUID) (*models.Resource, error) {
-	return utils.Find[models.Resource](ctx, r.Db, id, nil)
+	dbModel := models.Resource{}
+
+	tags := utils.GetAllDBTagsFromStruct(dbModel)
+
+	sql, args, err := psql.Select(
+		sm.Columns(tags.Columns()...),
+		sm.From(dbModel.TableName()),
+		sm.Where(psql.Quote(dbModel.PrimaryKey()).EQ(psql.Arg(id))),
+	).Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	return utils.ExecuteCollectExactlyOneRow[models.Resource](ctx, r.Db, sql, args)
 }


### PR DESCRIPTION
Simplify code by moving the creating of query
directly in the db repositories and use generics
only to execute the queries