### PR TITLE
Update manager config to use postgresql-16-c9s image

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -78,7 +78,7 @@ spec:
           # A placeholder for the replacement kustomization that will inject the rbac image from that container spec
           value: kube-rbac-proxy:latest
         - name: POSTGRES_IMAGE
-          value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
+          value: quay.io/sclorg/postgresql-16-c9s:c9s
         - name: HWMGR_PLUGIN_NAMESPACE
           # A placeholder for the replacement kustomization that will inject the value from the config map
           value: plugin-namespace-placeholder


### PR DESCRIPTION
Replaced the postgresql image with one that is publicly available in order to avoid requiring a pull secret in deployment automation being contributed to the ORAN-SC community.