### PR TITLE
CNF-15570: Fix test client RBAC

### DIFF
--- a/config/testing/client-service-account-rbac.yaml
+++ b/config/testing/client-service-account-rbac.yaml
@@ -9,13 +9,21 @@ kind: ClusterRole
 metadata:
   name: oran-o2ims-test-client-role
 rules:
-  - nonResourceURLs:
-      - /o2ims-infrastructureInventory/v1
-      - /o2ims-infrastructureInventory/v1/*
-      - /o2ims-infrastructureInventory/api_versions
-      - /o2ims-infrastructureMonitoring/v1
-    verbs:
-      - get
+- nonResourceURLs:
+  - /o2ims-infrastructureInventory/v1
+  - /o2ims-infrastructureInventory/v1/*
+  - /o2ims-infrastructureInventory/api_versions
+  - /o2ims-infrastructureMonitoring/v1
+  - /o2ims-infrastructureMonitoring/v1/*
+  - /o2ims-infrastructureMonitoring/api_versions
+  verbs:
+  - get
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions
+  - /o2ims-infrastructureInventory/v1/subscriptions
+  verbs:
+  - get
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Fixes the test client service account RBAC to be able to access the alarm and subscription endpoints.