### PR TITLE
upgrade golangci-lint to 1.62.2

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.59.1"
+VERSION="1.62.2"
 
 rootdir=$(git rev-parse --show-toplevel)
 if [ -z "${rootdir}" ]; then

--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -268,7 +268,7 @@ func validateUpgradeDefaultsConfigmap(
 		if !errors.IsInvalid(err) && !errors.IsBadRequest(err) {
 			return fmt.Errorf("failed to create IBGU: %w", err)
 		}
-		return utils.NewInputError(err.Error())
+		return utils.NewInputError("%s", err.Error())
 	}
 	existingConfigmap, err := utils.GetConfigmap(ctx, c, name, namespace)
 	if err != nil {
@@ -455,21 +455,21 @@ func validateTemplateParameterSchema(object *provisioningv1alpha1.ClusterTemplat
 	if len(badType) != 0 {
 		validationFailureReason += fmt.Sprintf(" The following entries are present but have a unexpected type: %s.",
 			strings.Join(badType, ","))
-		return utils.NewInputError(validationFailureReason)
+		return utils.NewInputError("%s", validationFailureReason)
 	}
 	if len(missingRequired) != 0 {
 		validationFailureReason += fmt.Sprintf(" The following entries are missing in the required section of the template: %s",
 			strings.Join(missingRequired, ","))
-		return utils.NewInputError(validationFailureReason)
+		return utils.NewInputError("%s", validationFailureReason)
 	}
 
 	policyTemplateParamsSchema := subSchemas[utils.TemplateParamPolicyConfig].(map[string]any)
 	if err := validatePolicyTemplateParamsSchema(policyTemplateParamsSchema); err != nil {
-		return utils.NewInputError(fmt.Sprintf("Error validating the policyTemplateParameters schema: %s", err.Error()))
+		return utils.NewInputError("Error validating the policyTemplateParameters schema: %s", err.Error())
 	}
 	clusterInstanceParamsSchema := subSchemas[utils.TemplateParamClusterInstance].(map[string]any)
 	if err := validateClusterInstanceParamsSchema(object.Spec.Templates.HwTemplate, clusterInstanceParamsSchema); err != nil {
-		return utils.NewInputError(fmt.Sprintf("Error validating the clusterInstanceParameters schema: %s", err.Error()))
+		return utils.NewInputError("Error validating the clusterInstanceParameters schema: %s", err.Error())
 	}
 	return nil
 }

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -111,8 +111,8 @@ func (t *provisioningRequestReconcilerTask) renderClusterInstanceTemplate(
 				}
 
 				if len(disallowedChanges) != 0 {
-					return nil, utils.NewInputError(fmt.Sprintf(
-						"detected changes in immutable fields: %s", strings.Join(disallowedChanges, ", ")))
+					return nil, utils.NewInputError(
+						"detected changes in immutable fields: %s", strings.Join(disallowedChanges, ", "))
 				}
 			}
 		}
@@ -216,7 +216,7 @@ func (t *provisioningRequestReconcilerTask) applyClusterInstance(ctx context.Con
 				return fmt.Errorf("failed to create ClusterInstance: %w", err)
 			}
 			// Invalid or webhook error
-			return utils.NewInputError(err.Error())
+			return utils.NewInputError("%s", err.Error())
 		}
 	} else {
 		if _, ok := clusterInstance.(*siteconfig.ClusterInstance); ok {
@@ -245,7 +245,7 @@ func (t *provisioningRequestReconcilerTask) applyClusterInstance(ctx context.Con
 				return fmt.Errorf("failed to patch ClusterInstance: %w", err)
 			}
 			// Invalid or webhook error
-			return utils.NewInputError(err.Error())
+			return utils.NewInputError("%s", err.Error())
 		}
 	}
 

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -588,9 +588,8 @@ func (t *provisioningRequestReconcilerTask) getCrClusterTemplateRef(ctx context.
 
 	// If the referenced ClusterTemplate does not exist, log and return an appropriate error.
 	return nil, utils.NewInputError(
-		fmt.Sprintf(
-			"a valid (%s) ClusterTemplate does not exist in any namespace",
-			clusterTemplateRefName))
+		"a valid (%s) ClusterTemplate does not exist in any namespace",
+		clusterTemplateRefName)
 }
 
 func (r *ProvisioningRequestReconciler) handleFinalizer(

--- a/internal/controllers/provisioningrequest_validation.go
+++ b/internal/controllers/provisioningrequest_validation.go
@@ -33,7 +33,7 @@ func (t *provisioningRequestReconcilerTask) validateProvisioningRequestCR(ctx co
 	}
 
 	if err = t.validateTemplateInputMatchesSchema(clusterTemplate); err != nil {
-		return utils.NewInputError(err.Error())
+		return utils.NewInputError("%s", err.Error())
 	}
 
 	if err = t.validateClusterInstanceInputMatchesSchema(ctx, clusterTemplate); err != nil {
@@ -312,7 +312,7 @@ func (t *provisioningRequestReconcilerTask) getMergedClusterInputData(
 		// if same labels/annotations exist in both.
 		if err := t.overrideClusterInstanceLabelsOrAnnotations(
 			clusterTemplateInput, clusterTemplateDefaultsMap); err != nil {
-			return nil, utils.NewInputError(err.Error())
+			return nil, utils.NewInputError("%s", err.Error())
 		}
 	}
 

--- a/internal/controllers/utils/hardware_utils.go
+++ b/internal/controllers/utils/hardware_utils.go
@@ -475,7 +475,7 @@ func GetTimeoutFromHWTemplate(ctx context.Context, c client.Client, name string)
 				// nolint: wrapcheck
 				return 0, updateErr
 			}
-			return 0, NewInputError(errMessage)
+			return 0, NewInputError("%s", errMessage)
 		}
 		return timeout, nil
 	}

--- a/internal/jq/query.go
+++ b/internal/jq/query.go
@@ -131,6 +131,9 @@ func (q *Query) convert(input, output any) error {
 		case *int:
 			*output = input
 		case *int32:
+			if input < math.MinInt32 || input > math.MaxInt32 {
+				return fmt.Errorf("value %d overflows int32", input)
+			}
 			*output = int32(input)
 		case *int64:
 			*output = int64(input)

--- a/internal/service/subscription_handler.go
+++ b/internal/service/subscription_handler.go
@@ -148,10 +148,8 @@ func (b *SubscriptionHandlerBuilder) Build(ctx context.Context) (
 	if b.subscriptionIdString != SubscriptionIdAlarm &&
 		b.subscriptionIdString != SubscriptionIdInfrastructureInventory {
 		err = fmt.Errorf(
-			fmt.Sprintf(
-				"subscription type can only be %s or %s",
-				SubscriptionIdAlarm, SubscriptionIdInfrastructureInventory,
-			),
+			"subscription type can only be %s or %s",
+			SubscriptionIdAlarm, SubscriptionIdInfrastructureInventory,
 		)
 		return
 	}


### PR DESCRIPTION
This update upgrades golangci-lint to 1.62.2 and resolves the linting errors.