### PR TITLE
CNF-15570: Add notification support

### DIFF
--- a/internal/service/common/notifier/event.go
+++ b/internal/service/common/notifier/event.go
@@ -1,0 +1,87 @@
+package notifier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// sendNotification sends the inventory change notification to the subscriber
+func sendNotification(ctx context.Context, client *http.Client, url string, event Notification) error {
+	body, err := json.Marshal(event.Payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal notification payload: %w", err)
+	}
+
+	buffer := bytes.NewBuffer(body)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, buffer)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("failed to send notification: %w", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("notification failed: %v", response.StatusCode)
+	}
+
+	return nil
+}
+
+// processEvent attempts to send a notification to the subscriber.  It does so until it succeeds or the maximum
+// number of retries has been reached.  When it completes or timeout it sends a job completion event and signals back
+// to the worker that this current event is complete
+func processEvent(ctx context.Context, logger *slog.Logger, client *http.Client,
+	completionChannel chan *SubscriptionJobComplete, event Notification, subscriptionID uuid.UUID, url string) {
+	logger.Info("processing data change event",
+		"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+
+	var err error = nil
+	delay := retryDelay
+	for i := 0; i < maxRetries; i++ {
+		err = sendNotification(ctx, client, url, event)
+		if err == nil {
+			break
+		}
+
+		logger.Warn("failed to send notification", "error", err,
+			"notificationID", event.NotificationID, "sequenceID", event.SequenceID, "delay", delay)
+
+		select {
+		case <-ctx.Done():
+			logger.Warn("context canceled while sending notification",
+				"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+			break
+		case <-time.After(delay):
+			delay *= 2
+			logger.Debug("retrying notification",
+				"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+		}
+	}
+
+	if err != nil {
+		logger.Error("error sending notification; retries exceeded", "error", err,
+			"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+		// TODO: If we were able to send this one then we are not likely to be able to send any
+		//  of the others so perhaps we should purge our queue, or enter a longer backoff period.
+	} else {
+		logger.Info("notification sent",
+			"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+	}
+
+	completionChannel <- &SubscriptionJobComplete{
+		subscriptionID: subscriptionID,
+		notificationID: event.NotificationID,
+		sequenceID:     event.SequenceID,
+	}
+}

--- a/internal/service/common/notifier/notifier.go
+++ b/internal/service/common/notifier/notifier.go
@@ -1,0 +1,294 @@
+package notifier
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/google/uuid"
+)
+
+// Notification defines a generic notification object.  The payload should support JSON marshaling.
+type Notification struct {
+	NotificationID uuid.UUID
+	SequenceID     int
+	Payload        any
+}
+
+// SubscriptionInfo defines a generic subscription object.  The intent is to abstract away the differences between the
+// alarm and resource server subscription models.
+type SubscriptionInfo struct {
+	SubscriptionID uuid.UUID
+	Callback       string
+	Filter         *string
+	EventCursor    int
+}
+
+// NotificationProvider must be implemented by a domain specific model implementor so that the notifier can manage
+// notifications on its behalf.
+type NotificationProvider interface {
+	GetNotifications(ctx context.Context) ([]Notification, error)
+	DeleteNotification(ctx context.Context, notificationID uuid.UUID) error
+}
+
+// SubscriptionProvider must be implemented by a domain specific model implementor so that the notifier can manage
+// subscriptions on its behalf.
+type SubscriptionProvider interface {
+	GetSubscriptions(ctx context.Context) ([]SubscriptionInfo, error)
+	Matches(subscription *SubscriptionInfo, notification *Notification) bool
+	UpdateSubscription(ctx context.Context, subscription *SubscriptionInfo) error
+}
+
+// SubscriptionEvent defines the information sent to the notifier when a subscription is added/removed
+type SubscriptionEvent struct {
+	// Removed defines whether the subscription has been removed or added
+	Removed bool
+	// Subscription is the subscription being added/removed
+	Subscription *SubscriptionInfo
+}
+
+// SubscriptionEventHandler is an interfaces which defines the operations required to be supported by a component that
+// is prepared to handle subscription events.
+type SubscriptionEventHandler interface {
+	SubscriptionEvent(event *SubscriptionEvent)
+}
+
+// Notifier represents the data required by the notification process
+type Notifier struct {
+	// notificationChannel is used to receive notifications about new events from the collector
+	notificationChannel chan *Notification
+	// subscriptionChannel is used to receive notifications about new/deleted subscriptions
+	subscriptionChannel chan *SubscriptionEvent
+	// subscriptionJobCompleteChannel is used to be notified by a worker that it has completed
+	// handling a notification.
+	subscriptionJobCompleteChannel chan *SubscriptionJobComplete
+	// workers is the list of workers started to service subscriptions.  It is mapped by
+	// subscription uuid value.
+	workers              map[uuid.UUID]*SubscriptionWorker
+	NotificationProvider NotificationProvider
+	SubscriptionProvider SubscriptionProvider
+}
+
+// NewNotifier creates a new instance of a Notifier
+func NewNotifier(subscriptionProvider SubscriptionProvider, notificationProvider NotificationProvider) *Notifier {
+	eventChannel := make(chan *Notification, 10)
+	subscriptionChannel := make(chan *SubscriptionEvent, 10)
+	subscriberJobCompleteChannel := make(chan *SubscriptionJobComplete, 10)
+	return &Notifier{
+		SubscriptionProvider:           subscriptionProvider,
+		NotificationProvider:           notificationProvider,
+		notificationChannel:            eventChannel,
+		subscriptionChannel:            subscriptionChannel,
+		subscriptionJobCompleteChannel: subscriberJobCompleteChannel,
+		workers:                        make(map[uuid.UUID]*SubscriptionWorker),
+	}
+}
+
+// Run executes the notifier main loop to respond to changes to the database contents
+func (n *Notifier) Run(ctx context.Context) error {
+	if err := n.init(ctx); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case e := <-n.subscriptionJobCompleteChannel:
+			if err := n.handleSubscriptionJobCompleteEvent(ctx, e); err != nil {
+				slog.Error("failed to handle subscription job complete event", "error", err)
+			}
+		case e := <-n.notificationChannel:
+			if err := n.handleNotification(ctx, e); err != nil {
+				slog.Error("failed to handle notification",
+					"NotificationID", e.NotificationID, "sequenceID", e.SequenceID, "error", err)
+			}
+		case e := <-n.subscriptionChannel:
+			if err := n.handleSubscriptionEvent(ctx, e); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			n.shutdownWorkers()
+			slog.Info("context terminated; notifier exiting")
+			return nil
+		}
+	}
+}
+
+// shutdownWorkers shuts down each worker
+func (n *Notifier) shutdownWorkers() {
+	for _, worker := range n.workers {
+		worker.Shutdown()
+	}
+}
+
+// init runs the onetime initialization steps for the notifier
+func (n *Notifier) init(ctx context.Context) error {
+	slog.Info("initializing notifier")
+	if err := n.loadSubscriptions(ctx); err != nil {
+		return fmt.Errorf("failed to load subscriptions: %w", err)
+	}
+	if err := n.loadEvents(ctx); err != nil {
+		return fmt.Errorf("failed to load events: %w", err)
+	}
+	return nil
+}
+
+// loadEvents loads the current set of notifications from the database
+func (n *Notifier) loadEvents(ctx context.Context) error {
+	slog.Info("loading events")
+
+	notifications, err := n.NotificationProvider.GetNotifications(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get notifications: %w", err)
+	}
+
+	// Sort them by sequence id to ensure we process them in order
+	sort.Slice(notifications, func(i, j int) bool {
+		return notifications[i].SequenceID < notifications[j].SequenceID
+	})
+
+	// Dispatch each event to the workers
+	for _, notification := range notifications {
+		if err := n.handleNotification(ctx, &notification); err != nil {
+			return fmt.Errorf("failed to handle notification: %w", err)
+		}
+	}
+
+	slog.Info("loaded events", "count", len(notifications))
+	return nil
+}
+
+// loadSubscriptions loads the current set of subscriptions from the database
+func (n *Notifier) loadSubscriptions(ctx context.Context) error {
+	slog.Info("loading subscriptions")
+
+	subscriptions, err := n.SubscriptionProvider.GetSubscriptions(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get subscriptions: %w", err)
+	}
+
+	for _, s := range subscriptions {
+		subscriptionID := s.SubscriptionID
+		n.workers[subscriptionID], err = NewSubscriptionWorker(ctx, n.subscriptionJobCompleteChannel, &s)
+		if err != nil {
+			return fmt.Errorf("failed to create subscription worker: %w", err)
+		}
+
+		n.workers[subscriptionID].Run()
+	}
+
+	slog.Info("subscriptions loaded", "count", len(n.workers))
+
+	return nil
+}
+
+// Notify should be used to signal that a database change has occurred
+func (n *Notifier) Notify(event *Notification) {
+	n.notificationChannel <- event
+}
+
+// handleNotification handles an incoming notification
+func (n *Notifier) handleNotification(ctx context.Context, event *Notification) error {
+	slog.Info("handling notification", "NotificationID", event.NotificationID, "sequenceID", event.SequenceID)
+
+	count := 0
+	for _, worker := range n.workers {
+		if n.SubscriptionProvider.Matches(worker.subscription, event) {
+			worker.NewNotification(event)
+			count++
+		}
+	}
+
+	if count == 0 {
+		// No subscriptions matched just delete the event
+		slog.Debug("no matching subscriptions; deleting event",
+			"NotificationID", event.NotificationID, "sequenceID", event.SequenceID)
+		if err := n.NotificationProvider.DeleteNotification(ctx, event.NotificationID); err != nil {
+			return fmt.Errorf("failed to delete notification: %w", err)
+		}
+		return nil
+	}
+
+	slog.Info("notification dispatched",
+		"NotificationID", event.NotificationID, "sequenceID", event.SequenceID,
+		"subscribers", count)
+
+	return nil
+}
+
+// SubscriptionEvent should be used to signal that a change to a subscription has occurred
+func (n *Notifier) SubscriptionEvent(event *SubscriptionEvent) {
+	n.subscriptionChannel <- event
+}
+
+// handleSubscriptionEvent handles an incoming subscription change event
+func (n *Notifier) handleSubscriptionEvent(ctx context.Context, event *SubscriptionEvent) error {
+	subscriptionID := event.Subscription.SubscriptionID
+	slog.Info("handling subscription event", "removed", event.Removed, "subscription", event.Subscription)
+
+	if event.Removed {
+		// The subscription has been removed.  Cleanup any associated data.
+		worker, found := n.workers[subscriptionID]
+		if !found {
+			slog.Debug("subscription worker not found", "subscriptionID", subscriptionID)
+			return nil
+		}
+
+		// shutdown the worker.  This will cause it to release all of its pending work which will lead to cleaning up
+		// any data events that it was holding.
+		worker.Shutdown()
+		delete(n.workers, event.Subscription.SubscriptionID)
+	} else {
+		worker, err := NewSubscriptionWorker(ctx, n.subscriptionJobCompleteChannel, event.Subscription)
+		if err != nil {
+			return fmt.Errorf("failed to create subscription worker: %w", err)
+		}
+
+		n.workers[subscriptionID] = worker
+		go worker.Run()
+	}
+
+	slog.Info("subscription event handled", "workers", len(n.workers))
+
+	return nil
+}
+
+// handleSubscriptionJobCompleteEvent handles a job completion event, removes the subscriber from the event job,
+func (n *Notifier) handleSubscriptionJobCompleteEvent(ctx context.Context, event *SubscriptionJobComplete) error {
+	slog.Debug("handling subscription job complete event",
+		"NotificationID", event.notificationID, "subscriptionID", event.subscriptionID)
+
+	// Lookup the subscription/worker for this event
+	if worker, found := n.workers[event.subscriptionID]; found {
+		// Update the subscriptions event cursor.
+		subscription := worker.subscription
+		subscription.EventCursor = event.sequenceID
+		if err := n.SubscriptionProvider.UpdateSubscription(ctx, subscription); err != nil {
+			return fmt.Errorf("failed to update subscription: %w", err)
+		}
+	} else {
+		// Likely has been deleted and this is a race condition
+		slog.Debug("subscription worker not found", "subscriptionID", event.subscriptionID)
+		// continue to check for other matching subscriptions for this event
+	}
+
+	done := true
+	for _, worker := range n.workers {
+		if worker.subscription.EventCursor < event.sequenceID {
+			done = false
+			break
+		}
+	}
+
+	if done {
+		// This event has been consumed by all subscriptions
+		slog.Debug("notification sent to all subscribers; deleting",
+			"NotificationID", event.notificationID, "sequenceID", event.sequenceID)
+
+		if err := n.NotificationProvider.DeleteNotification(ctx, event.notificationID); err != nil {
+			return fmt.Errorf("failed to delete completed notification: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/common/notifier/notifier_worker.go
+++ b/internal/service/common/notifier/notifier_worker.go
@@ -1,0 +1,237 @@
+package notifier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+)
+
+// maxRetries defines the number of attempts made on each notification
+const maxRetries = 5
+
+// retryDelay defines the amount of time between each successive notification attempt
+const retryDelay = 10 * time.Second // TODO: increase
+
+// SubscriptionJob is the event sent to the subscription worker to have it process the data change event
+type SubscriptionJob struct {
+	notification *Notification
+}
+
+// SubscriptionJobComplete is the event sent from the subscription worker to the notifier to report that it has
+// successfully sent a notification for the data change event
+type SubscriptionJobComplete struct {
+	subscriptionID uuid.UUID
+	notificationID uuid.UUID
+	sequenceID     int
+}
+
+// SubscriptionWorker is a placeholder which represents a go routine created to monitor events for a subscription
+type SubscriptionWorker struct {
+	// subscription is the subscription being monitored for events
+	subscription *SubscriptionInfo
+	// workChannel is the channel to be used to sent work to the worker
+	workChannel chan *SubscriptionJob
+	// completionChannel is the channel to be used to report back to the notifier when an event is complete
+	completionChannel chan *SubscriptionJobComplete
+	// ctx is the context passed to the go routine.  If the subscription is canceled or the server is stopping the
+	// context will be canceled
+	ctx context.Context
+	// cancel is the CancelFunc associated to the worker context.
+	cancel context.CancelFunc
+	// events represents the list of work to be done by the worker
+	events []*Notification
+	// currentEvent is the event currently being processed
+	currentEvent *Notification
+	// currentEventDone signals back to the worker that the current event has been processed
+	currentEventDone chan *SubscriptionJobComplete
+	// client is used to communicate to the subscriber
+	client *http.Client
+	// logger is used to add info to each log produced by the worker
+	logger *slog.Logger
+}
+
+// NewSubscriptionWorker creates a new subscription worker object to service a specific subscription
+func NewSubscriptionWorker(ctx context.Context, completionChannel chan *SubscriptionJobComplete, subscription *SubscriptionInfo) (*SubscriptionWorker, error) {
+	// Create a client for this subscription.
+	// TODO: fill in the oauth attributes from the SMO config passed to the server
+	client, err := utils.SetupOAuthClient(ctx, utils.OAuthClientConfig{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup oauth client: %w", err)
+	}
+
+	// Set up a custom logger to include the subscription info so it doesn't need to be repeated
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     slog.LevelDebug, // TODO: set log level from server args
+	}))
+	logger = logger.With("subscription", subscription.SubscriptionID)
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	return &SubscriptionWorker{
+		subscription:      subscription,
+		workChannel:       make(chan *SubscriptionJob, 1),
+		completionChannel: completionChannel,
+		cancel:            cancel,
+		ctx:               workerCtx,
+		currentEventDone:  make(chan *SubscriptionJobComplete, 1),
+		client:            client,
+		logger:            logger,
+	}, nil
+}
+
+// NewNotification sends a data change event to a subscription worker
+func (w *SubscriptionWorker) NewNotification(notification *Notification) {
+	w.workChannel <- &SubscriptionJob{notification: notification}
+}
+
+// Shutdown terminates the worker and releases any pending events
+func (w *SubscriptionWorker) Shutdown() {
+	w.cancel()
+}
+
+// releaseEvents releases all pending events back to the notifier
+func (w *SubscriptionWorker) releaseEvents() {
+	for _, event := range w.events {
+		w.completionChannel <- &SubscriptionJobComplete{
+			subscriptionID: w.subscription.SubscriptionID,
+			notificationID: event.NotificationID,
+			sequenceID:     event.SequenceID,
+		}
+	}
+}
+
+// Run executes that main loop for the worker handling events as they arrive.
+func (w *SubscriptionWorker) Run() {
+	w.logger.Info("subscription worker started")
+
+	for {
+		select {
+		case e := <-w.currentEventDone:
+			w.handleCurrentEventCompletion(e)
+		case event := <-w.workChannel:
+			w.handleSubscriptionJob(w.ctx, event)
+		case <-w.ctx.Done():
+			w.releaseEvents()
+			w.logger.Info("subscription worker shutting down")
+			return
+		}
+	}
+}
+
+// handleCurrentEventCompletion handles the end of processing the current event.
+func (w *SubscriptionWorker) handleCurrentEventCompletion(e *SubscriptionJobComplete) {
+	w.currentEvent = nil
+	// forward to the notifier so that it can release the event
+	w.completionChannel <- e
+	// handle the next event
+	w.processNextEvent(w.ctx)
+}
+
+// handleSubscriptionJob receives a new subscription job and queues it for processing
+func (w *SubscriptionWorker) handleSubscriptionJob(ctx context.Context, job *SubscriptionJob) {
+	// Queue it
+	w.events = append(w.events, job.notification)
+	w.logger.Info("data change event job received",
+		"notificationID", job.notification.NotificationID,
+		"sequenceID", job.notification.SequenceID)
+
+	if w.currentEvent == nil {
+		w.currentEvent = job.notification
+		go w.processEvent(ctx, w.currentEvent)
+	}
+}
+
+// sendNotification sends the inventory change notification to the subscriber
+func (w *SubscriptionWorker) sendNotification(ctx context.Context, notification *Notification) error {
+	body, err := json.Marshal(notification.Payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal notification payload: %w", err)
+	}
+
+	buffer := bytes.NewBuffer(body)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, w.subscription.Callback, buffer)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	response, err := w.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("failed to send notification: %w", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("notification failed: %v", response.StatusCode)
+	}
+
+	return nil
+}
+
+// processEvent attempts to send a notification to the subscriber.  It does so until it succeeds or the maximum
+// number of retries has been reached.  When it completes or timeout it sends a job completion event and signals back
+// to the worker that this current event is complete
+func (w *SubscriptionWorker) processEvent(ctx context.Context, event *Notification) {
+	w.logger.Info("processing data change event",
+		"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+
+	var err error = nil
+	for i := 0; i < maxRetries; i++ {
+		err = w.sendNotification(ctx, event)
+		if err == nil {
+			break
+		}
+
+		w.logger.Warn("failed to send notification", "error", err,
+			"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+
+		select {
+		case <-ctx.Done():
+			w.logger.Warn("context canceled while sending notification",
+				"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+			break
+		case <-time.After(retryDelay):
+			w.logger.Debug("retrying notification",
+				"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+		}
+	}
+
+	if err != nil {
+		w.logger.Error("error sending notification; retries exceeded", "error", err,
+			"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+		// TODO: If we were able to send this one then we are not likely to be able to send any
+		//  of the others so perhaps we should purge our queue, or enter a longer backoff period.
+	} else {
+		w.logger.Info("notification sent",
+			"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+	}
+
+	w.currentEventDone <- &SubscriptionJobComplete{
+		subscriptionID: w.subscription.SubscriptionID,
+		notificationID: event.NotificationID,
+		sequenceID:     event.SequenceID,
+	}
+}
+
+// processNextEvent looks for the next event to be processed.
+func (w *SubscriptionWorker) processNextEvent(ctx context.Context) {
+	if len(w.events) == 0 {
+		// No more events
+		w.logger.Debug("no more events to process")
+		return
+	}
+
+	// Pop the first element off of the list and set it as the current event
+	w.currentEvent, w.events = w.events[0], w.events[1:]
+
+	// Launch a task to send the notification (or retry on failures)
+	go w.processEvent(ctx, w.currentEvent)
+}

--- a/internal/service/resources/api/server.go
+++ b/internal/service/resources/api/server.go
@@ -157,11 +157,15 @@ func (r *ResourceServer) CreateSubscription(ctx context.Context, request api.Cre
 
 	// Validate the subscription
 	if err := r.validateSubscription(request); err != nil {
+		filter := "<null>"
+		if request.Body.Filter != nil {
+			filter = *request.Body.Filter
+		}
 		return api.CreateSubscription400ApplicationProblemPlusJSONResponse{
 			AdditionalAttributes: &map[string]string{
 				"consumerSubscriptionId": consumerSubscriptionId,
 				"callback":               request.Body.Callback,
-				"filter":                 "",
+				"filter":                 filter,
 			},
 			Detail: err.Error(),
 			Status: http.StatusBadRequest,

--- a/internal/service/resources/collector/collector_acm.go
+++ b/internal/service/resources/collector/collector_acm.go
@@ -314,8 +314,7 @@ func (d *ACMDataSource) convertNodeToResource(from data.Object) (to models.Resou
 		return
 	}
 
-	resourceIDName, err := data.GetString(from,
-		graphql.PropertyNode("resourceID").MapProperty())
+	name, err := data.GetString(from, "name")
 	if err != nil {
 		return
 	}
@@ -355,7 +354,7 @@ func (d *ACMDataSource) convertNodeToResource(from data.Object) (to models.Resou
 	extensions := convertMapAnyToString(extensionsMap)
 
 	// For now continue to generate UUID values based on the string values assigned
-	resourceID := makeUUIDFromName(ResourceUUIDNamespace, d.cloudID, resourceIDName)
+	resourceID := makeUUIDFromName(ResourceUUIDNamespace, d.cloudID, name)
 	resourcePoolID := makeUUIDFromName(ResourcePoolUUIDNamespace, d.cloudID, resourcePoolIdName)
 
 	resourceTypeID := d.makeResourceTypeID(cpu, architecture)
@@ -370,7 +369,7 @@ func (d *ACMDataSource) convertNodeToResource(from data.Object) (to models.Resou
 		Tags:           nil,
 		DataSourceID:   d.dataSourceID,
 		GenerationID:   d.generationID,
-		ExternalID:     resourceIDName,
+		ExternalID:     globalAssetId,
 	}
 
 	return

--- a/internal/service/resources/db/migrations/000001_baseline.up.sql
+++ b/internal/service/resources/db/migrations/000001_baseline.up.sql
@@ -101,6 +101,7 @@ CREATE TABLE IF NOT EXISTS data_change_event
     parent_id      UUID NULL,
     before_state json        NULL,
     after_state json NULL,
+    sequence_id SERIAL,                -- track insertion order rather than rely on timestamp since precision may cause ambiguity
     created_at  TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/internal/service/resources/db/models/data_change_event.go
+++ b/internal/service/resources/db/models/data_change_event.go
@@ -19,6 +19,7 @@ type DataChangeEvent struct {
 	ParentID     *uuid.UUID `db:"parent_id"`
 	BeforeState  *string    `db:"before_state"`
 	AfterState   *string    `db:"after_state"`
+	SequenceID   *int       `db:"sequence_id"`
 	CreatedAt    *time.Time `db:"created_at"`
 }
 
@@ -28,7 +29,7 @@ func (r DataChangeEvent) TableName() string {
 }
 
 // PrimaryKey returns the primary key column associated to this model
-func (r DataChangeEvent) PrimaryKey() string { return "id" }
+func (r DataChangeEvent) PrimaryKey() string { return "data_change_id" }
 
 // OnConflict returns the column or constraint to be used in the UPSERT operation
 func (r DataChangeEvent) OnConflict() string {

--- a/internal/service/resources/db/models/subscription.go
+++ b/internal/service/resources/db/models/subscription.go
@@ -17,8 +17,9 @@ type Subscription struct {
 	ConsumerSubscriptionID *uuid.UUID `db:"consumer_subscription_id"`
 	Filter                 *string    `db:"filter"`
 	Callback               string     `db:"callback"`
-	EventCursor            int        `db:"event_cursor"`
-	CreatedAt              *time.Time `db:"created_at"`
+	// EventCursor holds the SequenceID of the last processed event.  Sequences start at 1 so we initialize this to 0.
+	EventCursor int        `db:"event_cursor"`
+	CreatedAt   *time.Time `db:"created_at"`
 }
 
 // TableName returns the table name associated to this model

--- a/internal/service/resources/db/repo/notifications.go
+++ b/internal/service/resources/db/repo/notifications.go
@@ -1,0 +1,52 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
+	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/models"
+)
+
+// Compile time check for interface compliance
+var _ notifier.NotificationProvider = (*NotificationStorageProvider)(nil)
+
+// NotificationStorageProvider implements the NotificationProvider interface as a means to abstract the concrete
+// notification type out of the Notifier
+type NotificationStorageProvider struct {
+	repository *ResourcesRepository
+}
+
+// NewNotificationStorageProvider creates a new NotificationProvider
+func NewNotificationStorageProvider(repository *ResourcesRepository) notifier.NotificationProvider {
+	return &NotificationStorageProvider{
+		repository: repository,
+	}
+}
+
+// GetNotifications returns the list of notifications persisted to the database
+func (p *NotificationStorageProvider) GetNotifications(ctx context.Context) ([]notifier.Notification, error) {
+	records, err := p.repository.GetDataChangeEvents(ctx)
+	if err != nil {
+		return []notifier.Notification{}, fmt.Errorf("failed to get data change events: %w", err)
+	}
+
+	var notifications []notifier.Notification
+	for _, record := range records {
+		notifications = append(notifications, *models.DataChangeEventToNotification(&record))
+	}
+
+	return notifications, nil
+}
+
+// DeleteNotification deletes a notification.  This should be invoked when the notifier has ensured
+// that the notification has been seen by all subscriptions.
+func (p *NotificationStorageProvider) DeleteNotification(ctx context.Context, notificationID uuid.UUID) error {
+	_, err := p.repository.DeleteDataChangeEvent(ctx, notificationID)
+	if err != nil {
+		return fmt.Errorf("failed to delete notification %s: %w", notificationID, err)
+	}
+	return nil
+}

--- a/internal/service/resources/db/repo/repository.go
+++ b/internal/service/resources/db/repo/repository.go
@@ -48,6 +48,11 @@ func (r *ResourcesRepository) CreateSubscription(ctx context.Context, subscripti
 	return utils.Create[models.Subscription](ctx, r.Db, *subscription)
 }
 
+// UpdateSubscription updates a specific Subscription tuple
+func (r *ResourcesRepository) UpdateSubscription(ctx context.Context, subscription *models.Subscription) (*models.Subscription, error) {
+	return utils.Update[models.Subscription](ctx, r.Db, *subscription.SubscriptionID, *subscription)
+}
+
 // GetResourceTypes retrieves all ResourceType tuples or returns an empty array if no tuples are found
 func (r *ResourcesRepository) GetResourceTypes(ctx context.Context) ([]models.ResourceType, error) {
 	return utils.FindAll[models.ResourceType](ctx, r.Db)
@@ -133,4 +138,20 @@ func (r *ResourcesRepository) CreateDataSource(ctx context.Context, dataSource *
 // UpdateDataSource updates a specific DataSource tuple
 func (r *ResourcesRepository) UpdateDataSource(ctx context.Context, dataSource *models.DataSource) (*models.DataSource, error) {
 	return utils.Update[models.DataSource](ctx, r.Db, *dataSource.DataSourceID, *dataSource)
+}
+
+// CreateDataChangeEvent creates a new DataSource tuple
+func (r *ResourcesRepository) CreateDataChangeEvent(ctx context.Context, dataChangeEvent *models.DataChangeEvent) (*models.DataChangeEvent, error) {
+	return utils.Create[models.DataChangeEvent](ctx, r.Db, *dataChangeEvent)
+}
+
+// DeleteDataChangeEvent deletes a DataChangeEvent tuple.  The caller should ensure that it exists prior to calling this.
+func (r *ResourcesRepository) DeleteDataChangeEvent(ctx context.Context, id uuid.UUID) (int64, error) {
+	expr := psql.Quote(models.DataChangeEvent{}.PrimaryKey()).EQ(psql.Arg(id))
+	return utils.Delete[models.DataChangeEvent](ctx, r.Db, expr)
+}
+
+// GetDataChangeEvents retrieves all DataChangeEvent tuples or returns an empty array if no tuples are found
+func (r *ResourcesRepository) GetDataChangeEvents(ctx context.Context) ([]models.DataChangeEvent, error) {
+	return utils.FindAll[models.DataChangeEvent](ctx, r.Db)
 }

--- a/internal/service/resources/db/repo/subscriptions.go
+++ b/internal/service/resources/db/repo/subscriptions.go
@@ -1,0 +1,71 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/models"
+)
+
+// Compile time check for interface compliance
+var _ notifier.SubscriptionProvider = (*SubscriptionStorageProvider)(nil)
+
+// SubscriptionStorageProvider implements the SubscriptionProvider interface as a means to abstract the concrete
+// subscription type out of the Notifier
+type SubscriptionStorageProvider struct {
+	repository *ResourcesRepository
+}
+
+// NewSubscriptionStorageProvider creates a new SubscriptionProvider
+func NewSubscriptionStorageProvider(repository *ResourcesRepository) notifier.SubscriptionProvider {
+	return &SubscriptionStorageProvider{
+		repository: repository,
+	}
+}
+
+// GetSubscriptions returns the list of subscriptions persisted to the database
+func (p *SubscriptionStorageProvider) GetSubscriptions(ctx context.Context) ([]notifier.SubscriptionInfo, error) {
+	records, err := p.repository.GetSubscriptions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get subscriptions: %w", err)
+	}
+
+	var subscriptions []notifier.SubscriptionInfo
+	for _, result := range records {
+		subscriptions = append(subscriptions, *models.SubscriptionToInfo(&result))
+	}
+
+	return subscriptions, nil
+}
+
+// UpdateSubscription updates the subscription on behalf of the Notifier.  Currently only supports setting the event
+// cursor.
+func (p *SubscriptionStorageProvider) UpdateSubscription(ctx context.Context, subscription *notifier.SubscriptionInfo) error {
+	record, err := p.repository.GetSubscription(ctx, subscription.SubscriptionID)
+	if errors.Is(err, utils.ErrNotFound) {
+		return fmt.Errorf("subscription %s not found", subscription.SubscriptionID)
+	} else if err != nil {
+		return fmt.Errorf("failed to get subscription %s: %w", subscription.SubscriptionID, err)
+	}
+
+	// Only update the event cursor since that's the only piece of data updated by the notifier
+	record.EventCursor = subscription.EventCursor
+
+	_, err = p.repository.UpdateSubscription(ctx, record)
+	if err != nil {
+		return fmt.Errorf("failed to update subscription %s: %w", subscription.SubscriptionID, err)
+	}
+
+	return nil
+}
+
+// Matches determines if an event matches the filter defined for this subscription
+func (p *SubscriptionStorageProvider) Matches(subscription *notifier.SubscriptionInfo, notification *notifier.Notification) bool {
+	// TODO: implement filtering.  Currently not defined in the spec, but a reasonable approach may be to implement
+	//  the same kind of filtering as on the API query parameters although may not make complete sense given that
+	//  different object types have different fields and a filter can only contain 1 description.
+	return true
+}

--- a/internal/service/resources/utils/constants.go
+++ b/internal/service/resources/utils/constants.go
@@ -1,0 +1,4 @@
+package utils
+
+var BaseInventoryURL = "/o2ims-infrastructureInventory/v1"
+var CurrentInventoryVersion = "1.0.0"


### PR DESCRIPTION
This adds support for sending notifications to a subscriber whenever a data change event occurs.  This applies to all the supported inventory object (i.e., resource types, resource pools, resources, and deployment managers).

If the subscriber is not reachable then a number of retries are attempted.  If at the end of the retries the subscriber is still not reachable then the event notification is retired and the notifier moves on to the next event in the list.  This behaviour should likely be changed so that if the subscriber is unreachable for a set period of time then the subscription should be put in an 'offline' state and should ignore new events for some period of time to avoid excess error
logs.   This is left for a future commit.