### PR TITLE
Add api version endpoints for alarm server

### DIFF
--- a/internal/service/alarms/api/openapi.yaml
+++ b/internal/service/alarms/api/openapi.yaml
@@ -27,6 +27,65 @@ tags:
       Internal endpoints. This is tag is also useful generating client code.
 
 paths:
+  /o2ims-infrastructureMonitoring/api_versions:
+    get:
+      operationId: getAllVersions
+      summary: Get API versions
+      description: |
+        Returns the complete list of API versions implemented by the service.
+      tags:
+      - metadata
+      responses:
+        '200':
+          description: |
+            Successfully obtained the complete list of versions.
+          content:
+            application/json:
+              schema:
+                $ref: "../../common/api/openapi.yaml#/components/schemas/APIVersions"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '500':
+          description: Internal server error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+
+  /o2ims-infrastructureMonitoring/v1/api_versions:
+    get:
+      operationId: getMinorVersions
+      summary: Get minor API versions
+      description: |
+        Returns the list of minor API versions implemented for this major version of the API.
+      tags:
+      - metadata
+      responses:
+        '200':
+          description: |
+            Success
+          content:
+            application/json:
+              schema:
+                $ref: "../../common/api/openapi.yaml#/components/schemas/APIVersions"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '500':
+          description: Internal server error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+
+
   /o2ims-infrastructureMonitoring/v1/alarms:
     get:
       operationId: GetAlarms

--- a/internal/service/alarms/internal/alarms_server.go
+++ b/internal/service/alarms/internal/alarms_server.go
@@ -29,6 +29,40 @@ type AlarmsServer struct {
 // AlarmsServer implements StrictServerInterface. This ensures that we've conformed to the `StrictServerInterface` with a compile-time check
 var _ api.StrictServerInterface = (*AlarmsServer)(nil)
 
+// baseURL is the prefix for all of our supported API endpoints
+var baseURL = "/o2ims-infrastructureMonitoring/v1"
+var currentVersion = "1.0.0"
+
+// GetAllVersions receives the API request to this endpoint, executes the request, and responds appropriately
+func (r *AlarmsServer) GetAllVersions(ctx context.Context, request api.GetAllVersionsRequestObject) (api.GetAllVersionsResponseObject, error) {
+	// We currently only support a single version
+	versions := []common.APIVersion{
+		{
+			Version: &currentVersion,
+		},
+	}
+
+	return api.GetAllVersions200JSONResponse(common.APIVersions{
+		ApiVersions: &versions,
+		UriPrefix:   &baseURL,
+	}), nil
+}
+
+// GetMinorVersions receives the API request to this endpoint, executes the request, and responds appropriately
+func (r *AlarmsServer) GetMinorVersions(ctx context.Context, request api.GetMinorVersionsRequestObject) (api.GetMinorVersionsResponseObject, error) {
+	// We currently only support a single version
+	versions := []common.APIVersion{
+		{
+			Version: &currentVersion,
+		},
+	}
+
+	return api.GetMinorVersions200JSONResponse(common.APIVersions{
+		ApiVersions: &versions,
+		UriPrefix:   &baseURL,
+	}), nil
+}
+
 // GetSubscriptions handles an API request to fetch Alarm Subscriptions
 func (a *AlarmsServer) GetSubscriptions(ctx context.Context, _ api.GetSubscriptionsRequestObject) (api.GetSubscriptionsResponseObject, error) {
 	records, err := a.AlarmsRepository.GetAlarmSubscriptions(ctx)


### PR DESCRIPTION
This adds required API endpoints that report API versions to the alarm server endpoints to satisfy API requirements and conformance tests.