### PR TITLE
CNF-15570: Add unique constraint to subscriptions

### DIFF
--- a/internal/service/alarms/internal/db/migrations/000005_create_alarm_subscription_info_table.up.sql
+++ b/internal/service/alarms/internal/db/migrations/000005_create_alarm_subscription_info_table.up.sql
@@ -16,7 +16,8 @@ CREATE TABLE IF NOT EXISTS alarm_subscription_info (
     updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP -- Record last update timestamp
 
     -- check does not fail with NULL
-    CONSTRAINT chk_filter CHECK (filter IN ('new', 'change', 'clear', 'acknowledge'))
+    CONSTRAINT chk_filter CHECK (filter IN ('new', 'change', 'clear', 'acknowledge')),
+    CONSTRAINT unique_callback UNIQUE (callback)
 );
 
 -- Function to update the updated_at column on modification

--- a/internal/service/resources/db/migrations/000001_baseline.up.sql
+++ b/internal/service/resources/db/migrations/000001_baseline.up.sql
@@ -112,7 +112,8 @@ CREATE TABLE subscription
     filter                   TEXT,
     callback                 TEXT    NOT NULL,
     event_cursor             INTEGER NOT NULL DEFAULT 0,
-    created_at               TIMESTAMPTZ      DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT unique_callback UNIQUE (callback)
 );
 
 -- Table: cached_alarm_dictionary


### PR DESCRIPTION
The conformance tests expect a 400 status code if a duplicate subscription is requested.  A 409 status code is a more common choice for this type of error condition but since the tests look for a 400 we are sort of bound by that.