### PR TITLE
CNF-15570: Set default 404 handler

### DIFF
--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -126,6 +126,8 @@ func Serve(config *AlarmsServerConfig) error {
 	)
 
 	r := http.NewServeMux()
+	// Register a default handler that replies with 404 so that we can override the response format
+	r.HandleFunc("/", common.NotFoundFunc())
 
 	// This also validates the spec file
 	swagger, err := generated.GetSwagger()

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -115,6 +115,8 @@ func Serve(config *api.ResourceServerConfig) error {
 	)
 
 	router := http.NewServeMux()
+	// Register a default handler that replies with 404 so that we can override the response format
+	router.HandleFunc("/", common.NotFoundFunc())
 
 	// This also validates the spec file
 	swagger, err := generated.GetSwagger()


### PR DESCRIPTION
The default 404 handler on the router generates a text response, but the ORAN spec requires a JSON response.  This adapts the output to be a JSON response with the appropriate content type header.