### PR TITLE
CNF-15570: Set RBAC rules for test client

### DIFF
--- a/config/testing/client-service-account-rbac.yaml
+++ b/config/testing/client-service-account-rbac.yaml
@@ -10,11 +10,9 @@ metadata:
   name: oran-o2ims-test-client-role
 rules:
 - nonResourceURLs:
-  - /o2ims-infrastructureInventory/v1
-  - /o2ims-infrastructureInventory/v1/*
+  - /o2ims-infrastructureInventory/*
   - /o2ims-infrastructureInventory/api_versions
-  - /o2ims-infrastructureMonitoring/v1
-  - /o2ims-infrastructureMonitoring/v1/*
+  - /o2ims-infrastructureMonitoring/*
   - /o2ims-infrastructureMonitoring/api_versions
   verbs:
   - get
@@ -24,6 +22,12 @@ rules:
   verbs:
   - get
   - create
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions/*
+  - /o2ims-infrastructureInventory/v1/subscriptions/*
+  verbs:
+  - get
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This adjusts the test client RBAC rules so additional operations are supported by the test client.  These are necessary to pass the conformance tests.