### PR TITLE
CNF-15570: Fix issues with notifier

### DIFF
--- a/internal/service/common/notifier/notifier.go
+++ b/internal/service/common/notifier/notifier.go
@@ -179,7 +179,7 @@ func (n *Notifier) loadSubscriptions(ctx context.Context) error {
 			return fmt.Errorf("failed to create subscription worker: %w", err)
 		}
 
-		n.workers[subscriptionID].Run()
+		go n.workers[subscriptionID].Run()
 	}
 
 	slog.Info("subscriptions loaded", "count", len(n.workers))

--- a/internal/service/common/notifier/notifier_worker.go
+++ b/internal/service/common/notifier/notifier_worker.go
@@ -137,15 +137,17 @@ func (w *SubscriptionWorker) handleCurrentEventCompletion(e *SubscriptionJobComp
 
 // handleSubscriptionJob receives a new subscription job and queues it for processing
 func (w *SubscriptionWorker) handleSubscriptionJob(ctx context.Context, job *SubscriptionJob) {
-	// Queue it
-	w.events = append(w.events, job.notification)
 	w.logger.Info("data change event job received",
 		"notificationID", job.notification.NotificationID,
 		"sequenceID", job.notification.SequenceID)
 
 	if w.currentEvent == nil {
+		// Handle it immediately
 		w.currentEvent = job.notification
 		go processEvent(ctx, w.logger, w.client, w.currentEventDone, *w.currentEvent, w.subscription.SubscriptionID, w.subscription.Callback)
+	} else {
+		// Queue it
+		w.events = append(w.events, job.notification)
 	}
 }
 


### PR DESCRIPTION
This addresses two issues with the notifier.

+ On a restart it blocks on running a subscription worker rather than dispatching it to a go routing and continuing.

+ Any events received when idle results in 2 notifications being sent to the subscriber.