### PR TITLE
CNF-16177: Implement Alarm Service Configuration endpoints

### DIFF
--- a/config/testing/client-service-account-rbac.yaml
+++ b/config/testing/client-service-account-rbac.yaml
@@ -36,6 +36,12 @@ rules:
     - /o2ims-infrastructureMonitoring/v1/alarms/*
   verbs:
     - patch
+- nonResourceURLs:
+    - /o2ims-infrastructureMonitoring/v1/alarmServiceConfiguration
+  verbs:
+    - get
+    - patch
+    - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/internal/service/alarms/api/openapi.yaml
+++ b/internal/service/alarms/api/openapi.yaml
@@ -18,7 +18,8 @@ servers:
 tags:
   - name: alarms
     description: Alarm management
-  - name: subscriptions
+  - name: service configuration
+  - name: Alarm Service Configuration
     description: Alarm subscription management
   - name: probableCauses
     description: Probable cause information
@@ -204,6 +205,106 @@ paths:
                 $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
         '409':
           description: Conflict.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '500':
+          description: Internal server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+
+  /o2ims-infrastructureMonitoring/v1/alarmServiceConfiguration:
+    get:
+      operationId: GetServiceConfiguration
+      summary: Retrieve the alarm service configuration
+      tags:
+        - service configuration
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlarmServiceConfiguration'
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '500':
+          description: Internal server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+
+    put:
+      operationId: UpdateAlarmServiceConfiguration
+      summary: Modify all fields of the Alarm Service Configuration.
+      tags:
+        - service configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlarmServiceConfiguration'
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlarmServiceConfiguration'
+        '400':
+          description: Bad request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '500':
+          description: Internal server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+
+    patch:
+      operationId: PatchAlarmServiceConfiguration
+      summary: Modify individual fields of the Alarm Service Configuration.
+      tags:
+        - service configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlarmServiceConfiguration'
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlarmServiceConfiguration'
+        '400':
+          description: Bad request.
           content:
             application/problem+json:
               schema:
@@ -575,6 +676,23 @@ components:
           example: false
         perceivedSeverity:
             $ref: '#/components/schemas/PerceivedSeverity'
+
+    AlarmServiceConfiguration:
+      type: object
+      properties:
+        retentionPeriod:
+          type: integer
+          description: | 
+            Number of days for alarm history to be retained.
+            This value has cannot be set lower than 1 (day).
+          example: 30
+        extensions:
+          type: object
+          additionalProperties:
+            type: string
+          description: List of metadata key-value pairs used to associate meaningful metadata to the related alarm service
+      required:
+        - retentionPeriod
 
     AlarmSubscriptionInfo:
       type: object

--- a/internal/service/alarms/internal/db/migrations/000006_create_alarm_service_configuration_table.down.sql
+++ b/internal/service/alarms/internal/db/migrations/000006_create_alarm_service_configuration_table.down.sql
@@ -1,0 +1,8 @@
+-- Drop the trigger that updates updated_at for alarm_service_configuration
+DROP TRIGGER IF EXISTS update_alarm_service_configuration_timestamp ON alarm_service_configuration;
+
+-- Drop the function used by the alarm_service_configuration trigger
+DROP FUNCTION IF EXISTS update_alarm_service_configuration_timestamp;
+
+-- Drop the alarm_service_configuration table
+DROP TABLE IF EXISTS alarm_service_configuration;

--- a/internal/service/alarms/internal/db/migrations/000006_create_alarm_service_configuration_table.up.sql
+++ b/internal/service/alarms/internal/db/migrations/000006_create_alarm_service_configuration_table.up.sql
@@ -1,0 +1,26 @@
+-- Holds information about the alarm service configuration
+CREATE TABLE IF NOT EXISTS alarm_service_configuration (
+    -- O-RAN
+    retention_period INT NOT NULL, -- Number of days for alarm history to be retained.
+    extensions JSONB, -- Additional data for extensibility
+
+    -- Internal
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(), -- Unique identifier for each alarm service configuration
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP, -- Record creation timestamp
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP -- Record last update timestamp
+);
+
+-- Trigger function to update updated_at timestamp for alarm_service_configuration
+CREATE OR REPLACE FUNCTION update_alarm_service_configuration_timestamp()
+    RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to execute update_alarm_service_configuration_timestamp before each update on alarm_service_configuration
+CREATE OR REPLACE TRIGGER update_alarm_service_configuration_timestamp
+    BEFORE UPDATE ON alarm_service_configuration
+    FOR EACH ROW
+    EXECUTE FUNCTION update_alarm_service_configuration_timestamp();

--- a/internal/service/alarms/internal/db/models/alarm_service_configuration.go
+++ b/internal/service/alarms/internal/db/models/alarm_service_configuration.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ServiceConfiguration represents the alarm_service_configuration table in the database
+type ServiceConfiguration struct {
+	ID              uuid.UUID         `db:"id"`
+	RetentionPeriod int               `db:"retention_period"`
+	Extensions      map[string]string `db:"extensions"`
+
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+// TableName returns the name of the table in the database
+func (r ServiceConfiguration) TableName() string {
+	return "alarm_service_configuration"
+}
+
+// PrimaryKey returns the primary key of the table
+func (r ServiceConfiguration) PrimaryKey() string {
+	return "id"
+}
+
+// OnConflict returns the column or constraint to be used in the UPSERT operation
+func (r ServiceConfiguration) OnConflict() string {
+	return ""
+}

--- a/internal/service/alarms/internal/db/models/converters.go
+++ b/internal/service/alarms/internal/db/models/converters.go
@@ -20,6 +20,19 @@ func ConvertAlarmEventRecordModelToApi(aerModel AlarmEventRecord) api.AlarmEvent
 	}
 }
 
+// ConvertServiceConfigurationToAPI converts an ServiceConfiguration DB model to an API model
+func ConvertServiceConfigurationToAPI(config ServiceConfiguration) api.AlarmServiceConfiguration {
+	apiModel := api.AlarmServiceConfiguration{
+		RetentionPeriod: config.RetentionPeriod,
+	}
+
+	if config.Extensions != nil {
+		apiModel.Extensions = &config.Extensions
+	}
+
+	return apiModel
+}
+
 // ConvertSubscriptionModelToApi converts an AlarmSubscription DB model to an API model
 func ConvertSubscriptionModelToApi(subscriptionModel AlarmSubscription) api.AlarmSubscriptionInfo {
 	apiModel := api.AlarmSubscriptionInfo{

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -110,6 +110,13 @@ func Serve(config *AlarmsServerConfig) error {
 		}
 	}
 
+	// Add Alarm Service Configuration to the database
+	serviceConfig, err := alarmRepository.CreateServiceConfiguration(ctx, internal.DefaultRetentionPeriod)
+	if err != nil {
+		return fmt.Errorf("failed to create alarm service configuration: %w", err)
+	}
+	slog.Info("Alarm Service configuration created/found", "retentionPeriod", serviceConfig.RetentionPeriod, "extensions", serviceConfig.Extensions)
+
 	// Init server
 	// Create the handler
 	alarmServer := internal.AlarmsServer{


### PR DESCRIPTION
This implements the alarm service configuration endpoints. The specification defines GET, PUT (only update, not create) and PATCH operations. Therefore, we create a default service configuration at startup. The spec also mentions that the retention period has a minimum value which is not explicitly defined. We assume 10 and 1 as default and minimum retention periods respectively. The values represent days.
