### PR TITLE
CNF-16217: Add extensions to NodeClusterType

### DIFF
--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -253,6 +253,16 @@ const (
 	DatabaseHostnameEnvVar = "POSTGRES_HOSTNAME"
 )
 
+// NodeCluster/ClusterResource extensions
+const (
+	ClusterModelExtension   = "model"
+	ClusterVersionExtension = "version"
+	ClusterVendorExtension  = "vendor"
+
+	ClusterModelHubCluster     = "hub-cluster"
+	ClusterModelManagedCluster = "managed-cluster"
+)
+
 // Alertmanager values
 const (
 	AlertmanagerObjectName = "alertmanager"


### PR DESCRIPTION
This adds some extensions to the NodeClusterType to better identify what type of NodeCluster the NodeClusterType represents.  These fields will be consumed by the alarm server to define the alarm dictionary for each NodeClusterType.