### PR TITLE
CNF-16193: Templates REST API internal server - GET ALL

### DIFF
--- a/internal/service/artifacts/api/server.go
+++ b/internal/service/artifacts/api/server.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	api "github.com/openshift-kni/oran-o2ims/internal/service/artifacts/api/generated"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ArtifactsServer implements StrictServerInterface. This ensures that we've conformed to the `StrictServerInterface` with a compile-time check
+var _ api.StrictServerInterface = (*ArtifactsServer)(nil)
+
+type ArtifactsServer struct {
+	HubClient client.Client
+}
+
+// Get managed infrastructure templates
+// (GET /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates)
+func (r *ArtifactsServer) GetManagedInfrastructureTemplates(
+	ctx context.Context,
+	request api.GetManagedInfrastructureTemplatesRequestObject) (api.GetManagedInfrastructureTemplatesResponseObject, error) {
+
+	// Get all the ClusterTemplates from the hub cluster.
+	var allClusterTemplates provisioningv1alpha1.ClusterTemplateList
+	err := r.HubClient.List(ctx, &allClusterTemplates)
+	if err != nil {
+		return nil, fmt.Errorf("could not get list of ManagedInfrastructureTemplate across the cluster: %w", err)
+	}
+
+	// Range through the ClusterTemplates and convert them to the ManagedInfrastructureTemplate model.
+	objects := make([]api.ManagedInfrastructureTemplate, 0, len(allClusterTemplates.Items))
+	for _, clusterTemplate := range allClusterTemplates.Items {
+		// Validate and transform the string to UUID.
+		if _, err := uuid.Parse(clusterTemplate.Spec.TemplateID); err != nil {
+			return nil, fmt.Errorf("could not get uuid from ManagedInfrastructureTemplate: %w", err)
+		}
+		uuid := uuid.MustParse(clusterTemplate.Spec.TemplateID)
+		// Obtain the parameter schema in the desired map format.
+		var parameterSchema map[string]interface{}
+		if err := json.Unmarshal(clusterTemplate.Spec.TemplateParameterSchema.Raw, &parameterSchema); err != nil {
+			return nil, fmt.Errorf("could not get parameterSchema from ManagedInfrastructureTemplate: %w", err)
+		}
+		// Convert the current ClusterTemplate to ManagedInfrastructureTemplate.
+		managedInfrastructureTemplate := api.ManagedInfrastructureTemplate{
+			ArtifactResourceId: uuid,
+			Name:               clusterTemplate.Name,
+			Version:            clusterTemplate.Spec.Version,
+			Description:        clusterTemplate.Spec.Description,
+			ParameterSchema:    parameterSchema,
+		}
+		objects = append(objects, managedInfrastructureTemplate)
+	}
+
+	return api.GetManagedInfrastructureTemplates200JSONResponse(objects), nil
+}
+
+// Get managed infrastructure templates
+// (GET /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates/{managedInfrastructureTemplateId})
+func (r *ArtifactsServer) GetManagedInfrastructureTemplate(
+	ctx context.Context, request api.GetManagedInfrastructureTemplateRequestObject) (api.GetManagedInfrastructureTemplateResponseObject, error) {
+
+	// TODO implement me
+	return nil, fmt.Errorf("not implemented")
+}

--- a/internal/service/artifacts/cmd/root.go
+++ b/internal/service/artifacts/cmd/root.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// artifactsRootCmd represents the root command for working artifacts server
+var artifactsRootCmd = &cobra.Command{
+	Use:   "artifacts-server",
+	Short: "All things needed for the artifacts server",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		configureArtifactsLogger()
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Nothing to do. Use sub-commands instead.")
+	},
+}
+
+func GetArtifactsRootCmd() *cobra.Command {
+	return artifactsRootCmd
+}
+
+func configureArtifactsLogger() {
+	l := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level:     slog.LevelDebug,
+		AddSource: true,
+	}))
+	slog.SetDefault(l)
+	slog.Info("Artifacts server global logger configured")
+}

--- a/internal/service/artifacts/cmd/serve.go
+++ b/internal/service/artifacts/cmd/serve.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"log/slog"
+	"os"
+
+	artifacts "github.com/openshift-kni/oran-o2ims/internal/service/artifacts"
+	"github.com/spf13/cobra"
+)
+
+// artifactsServer represents start command for the artifacts server
+var artifactsServer = &cobra.Command{
+	Use:   "serve",
+	Short: "Start artifacts server",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := artifacts.Serve(); err != nil {
+			slog.Error("failed to start artifacts server", "err", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	artifactsRootCmd.AddCommand(artifactsServer)
+}

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -1,0 +1,121 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/openshift-kni/oran-o2ims/internal/service/artifacts/api"
+	"github.com/openshift-kni/oran-o2ims/internal/service/artifacts/api/generated"
+	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
+)
+
+// Resource server config values
+const (
+	host         = "127.0.0.1"
+	port         = "8000"
+	readTimeout  = 5 * time.Second
+	writeTimeout = 10 * time.Second
+	idleTimeout  = 120 * time.Second
+)
+
+// Serve start artifacts server
+func Serve() error {
+	slog.Info("Starting artifacts server")
+	// Channel for shutdown signals
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		sig := <-shutdown
+		slog.Info("Shutdown signal received", "signal", sig)
+		cancel()
+	}()
+
+	// Get client for hub
+	hubClient, err := k8s.NewClientForHub()
+	if err != nil {
+		return fmt.Errorf("error creating client for hub: %w", err)
+	}
+
+	// Init server
+	// Create the handler
+	server := api.ArtifactsServer{
+		HubClient: hubClient,
+	}
+
+	serverStrictHandler := generated.NewStrictHandlerWithOptions(&server, nil,
+		generated.StrictHTTPServerOptions{
+			RequestErrorHandlerFunc:  common.GetOranReqErrFunc(),
+			ResponseErrorHandlerFunc: common.GetOranRespErrFunc(),
+		},
+	)
+
+	router := http.NewServeMux()
+	// Register a default handler that replies with 404 so that we can override the response format.
+	router.HandleFunc("/", common.NotFoundFunc())
+
+	// This also validates the spec file
+	swagger, err := generated.GetSwagger()
+	if err != nil {
+		return fmt.Errorf("failed to get swagger: %w", err)
+	}
+
+	opt := generated.StdHTTPServerOptions{
+		BaseRouter: router,
+		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here
+			common.OpenAPIValidation(swagger),
+			common.LogDuration(),
+		},
+		ErrorHandlerFunc: common.GetOranReqErrFunc(),
+	}
+
+	// Register the handler
+	generated.HandlerWithOptions(serverStrictHandler, opt)
+
+	// Server config
+	srv := &http.Server{
+		Handler:      router,
+		Addr:         net.JoinHostPort(host, port),
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
+		IdleTimeout:  idleTimeout,
+		ErrorLog: slog.NewLogLogger(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			AddSource: true,
+		}), slog.LevelError),
+	}
+
+	// Channel to listen for errors coming from the listener.
+	serverErrors := make(chan error, 1)
+
+	// Start server
+	go func() {
+		slog.Info(fmt.Sprintf("Listening on %s", srv.Addr))
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErrors <- err
+		}
+	}()
+
+	// Blocking select
+	select {
+	case err := <-serverErrors:
+		return fmt.Errorf("error starting server: %w", err)
+	case <-ctx.Done():
+		slog.Info("Shutting down server")
+		if err := common.GracefulShutdown(srv); err != nil {
+			return fmt.Errorf("error shutting down server: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/common/clients/k8s/k8s.go
+++ b/internal/service/common/clients/k8s/k8s.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients"
@@ -52,6 +53,7 @@ func GetSchemeForHub() *runtime.Scheme {
 	utilruntime.Must(clusterv1beta2.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(agentv1beta1.AddToScheme(scheme))
+	utilruntime.Must(provisioningv1alpha1.AddToScheme(scheme))
 
 	return scheme
 }

--- a/internal/service/resources/api/server.go
+++ b/internal/service/resources/api/server.go
@@ -19,7 +19,7 @@ import (
 	utils2 "github.com/openshift-kni/oran-o2ims/internal/service/resources/utils"
 )
 
-// AlarmsServer implements StrictServerInterface. This ensures that we've conformed to the `StrictServerInterface` with a compile-time check
+// ResourceServer implements StrictServerInterface. This ensures that we've conformed to the `StrictServerInterface` with a compile-time check
 var _ api.StrictServerInterface = (*ResourceServer)(nil)
 
 // ResourceServerConfig defines the configuration attributes for the resource server

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	alarmscmd "github.com/openshift-kni/oran-o2ims/internal/service/alarms/cmd"
+	artifactscmd "github.com/openshift-kni/oran-o2ims/internal/service/artifacts/cmd"
 	clustercmd "github.com/openshift-kni/oran-o2ims/internal/service/cluster/cmd"
 	inventorycmd "github.com/openshift-kni/oran-o2ims/internal/service/resources/cmd"
 
@@ -44,6 +45,7 @@ func main() {
 		AddCommand(alarmscmd.GetAlarmRootCmd).        // TODO: all server should have same root to share init info
 		AddCommand(clustercmd.GetClusterRootCmd).     // TODO: all server should have same root to share init info
 		AddCommand(inventorycmd.GetResourcesRootCmd). // TODO: all server should have same root to share init info
+		AddCommand(artifactscmd.GetArtifactsRootCmd). // TODO: all server should have same root to share init info
 		Build()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())


### PR DESCRIPTION
Description:
- Implement the artifacts server and the code for getting all the `ClusterTemplates` from a hub cluster
- The ClusterTemplates are converted to the `ManagedInfrastructureTemplate` format by following the rules:
```
clustertemplate.name                    -> managedInfrastructureTemplate.name
clustertemplate.version                 -> managedInfrastructureTemplate.version
clustertemplate.description             -> managedInfrastructureTemplate.description 
clustertemplate.templateParameterSchema	-> managedInfrastructureTemplate.parameterSchema
clustertemplate.templateId              -> managedInfrastructureTemplate.artifactResourceId
```
- For local runs (the only supported method so far):
```console
./bin/oran-o2ims artifacts-server serve
curl http://127.0.0.1:8000/o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates | jq
```
- Authentication has not been implemented yet.
- Filtering & running as a pod will be addressed in a future PR.