### PR TITLE
Handle alarm_change_time only on trigger for all operations

### DIFF
--- a/internal/service/alarms/api/server.go
+++ b/internal/service/alarms/api/server.go
@@ -315,7 +315,6 @@ func (a *AlarmsServer) PatchAlarm(ctx context.Context, request api.PatchAlarmReq
 		record.PerceivedSeverity = perceivedSeverity
 		currentTime := time.Now()
 		record.AlarmClearedTime = &currentTime
-		record.AlarmChangedTime = &currentTime
 	}
 
 	// Patch alarmAcknowledged
@@ -350,7 +349,6 @@ func (a *AlarmsServer) PatchAlarm(ctx context.Context, request api.PatchAlarmReq
 		record.AlarmAcknowledged = alarmAcknowledged
 		currentTime := time.Now()
 		record.AlarmAcknowledgedTime = &currentTime
-		record.AlarmChangedTime = &currentTime
 	}
 
 	// Update the Alarm Event Record


### PR DESCRIPTION
This addresses the following:

- When alarm is cleared, the changed time is equal to the cleared time to properly show that the record was updated due to this and not give the impression that a subsequent change was made.

- When an acknowledged alarm is resolved, the change time is not updated.

- Handle alarm_change_time column only in the trigger. Remove setting this on the API.

- Have a consistent behavior. When an alarm is created, the changed time is equal to the raised time. When it is resolved, the change time is equal to the cleared time. When it is acknowledged, the change time is equal to the change time. Any other updates have CURRENT_TIMESTAMP set by the trigger