### PR TITLE
CNF-16246: Add list of cluster resources to node cluster

### DIFF
--- a/internal/service/cluster/api/server.go
+++ b/internal/service/cluster/api/server.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/google/uuid"
+
 	api "github.com/openshift-kni/oran-o2ims/internal/service/cluster/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/repo"
@@ -165,9 +167,26 @@ func (r *ClusterServer) GetNodeClusters(ctx context.Context, request api.GetNode
 		return nil, fmt.Errorf("failed to get node clusters: %w", err)
 	}
 
+	// Retrieve the list of ClusterResourceID values per NodeCluster in one query so that we don't have to look it up
+	// on a per NodeCluster basis.
+	nodeClusterResourceIDs, err := r.Repo.GetNodeClusterResourceIDs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node cluster resource ids: %w", err)
+	}
+
+	// Store them in a map so they are easier to access for the next operation.
+	mapper := make(map[uuid.UUID][]uuid.UUID)
+	for _, entry := range nodeClusterResourceIDs {
+		mapper[entry.NodeClusterID] = entry.ClusterResourceIDs
+	}
+
 	objects := make([]api.NodeCluster, len(records))
 	for i, record := range records {
-		objects[i] = models.NodeClusterToModel(&record)
+		clusterResourceIDs, found := mapper[record.NodeClusterID]
+		if !found {
+			clusterResourceIDs = make([]uuid.UUID, 0)
+		}
+		objects[i] = models.NodeClusterToModel(&record, clusterResourceIDs)
 	}
 
 	return api.GetNodeClusters200JSONResponse(objects), nil
@@ -194,7 +213,17 @@ func (r *ClusterServer) GetNodeCluster(ctx context.Context, request api.GetNodeC
 		}, nil
 	}
 
-	object := models.NodeClusterToModel(record)
+	resources, err := r.Repo.GetNodeClusterResources(ctx, record.NodeClusterID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node cluster resources: %w", err)
+	}
+
+	ids := make([]uuid.UUID, len(resources))
+	for i, resource := range resources {
+		ids[i] = resource.ClusterResourceID
+	}
+
+	object := models.NodeClusterToModel(record, ids)
 	return api.GetNodeCluster200JSONResponse(object), nil
 }
 

--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -19,7 +19,9 @@ import (
 const pollingDelay = 10 * time.Minute
 
 // clusterNameExtension represents a mandatory extension that data sources must add to ClusterResource objects to
-// identify their parent NodeCluster.
+// identify their parent NodeCluster.  The term "mandatory" here doesn't refer to the definition of the spec; only that
+// internally we rely on it being present to find the node cluster ID value using its name value. We actually delete
+// this extension and do not expose it to the API.
 const clusterNameExtension = "clusterName"
 
 // DataSource represents the operations required to be supported by any objects implementing a
@@ -209,6 +211,9 @@ func (c *Collector) collectClusterResources(ctx context.Context, dataSource Data
 		if resource.Extensions != nil {
 			clusterName := (*resource.Extensions)[clusterNameExtension].(string)
 			resource.NodeClusterID = clusterNameToID[clusterName]
+			// The name extension was added for the sole purpose of allowing us to find the matching cluster ID value
+			// since it is not possible for the data source to do this directly.  Removing it since it is not required
+			// by the spec and seems redundant since the full NodeCluster can be retrieved with the ID value.
 			delete(*resource.Extensions, clusterNameExtension)
 		}
 

--- a/internal/service/cluster/collector/collector_k8s.go
+++ b/internal/service/cluster/collector/collector_k8s.go
@@ -205,6 +205,7 @@ func (d *K8SDataSource) convertAgentToClusterResource(agent *v1beta1.Agent) mode
 	resourceTypeID := d.makeClusterResourceTypeID(architecture, strconv.FormatInt(cores, 10))
 
 	extensions := map[string]interface{}{
+		clusterNameExtension: agent.Spec.ClusterDeploymentName.Name,
 		"cpu": map[string]string{
 			"cores":        strconv.FormatInt(cores, 10),
 			"architecture": architecture,
@@ -222,6 +223,7 @@ func (d *K8SDataSource) convertAgentToClusterResource(agent *v1beta1.Agent) mode
 		// TODO: add more info for disks, nics, etc...
 	}
 
+	// NodeClusterID is filled in by the caller since it has to convert the cluster name to an id.
 	return models.ClusterResource{
 		ClusterResourceID:     resourceID,
 		ClusterResourceTypeID: resourceTypeID,

--- a/internal/service/cluster/db/migrations/000001_baseline.up.sql
+++ b/internal/service/cluster/db/migrations/000001_baseline.up.sql
@@ -35,37 +35,6 @@ CREATE TABLE subscription
     CONSTRAINT unique_callback UNIQUE (callback)
 );
 
--- Table: cluster_resource_type
-CREATE TABLE IF NOT EXISTS cluster_resource_type
-(
-    cluster_resource_type_id UUID PRIMARY KEY,
-    name                     VARCHAR(255) NOT NULL,
-    description              TEXT         NOT NULL,
-    extensions               json         NULL,
-    data_source_id           UUID         NOT NULL,
-    generation_id            INTEGER      NOT NULL DEFAULT 0,
-    created_at               TIMESTAMPTZ           DEFAULT CURRENT_TIMESTAMP, -- TBD; tracks when first imported
-    FOREIGN KEY (data_source_id) REFERENCES data_source (data_source_id)      -- Manual cascade required for events
-);
-
--- Table: cluster_resource
-CREATE TABLE IF NOT EXISTS cluster_resource
-(
-    cluster_resource_id      UUID PRIMARY KEY,
-    cluster_resource_type_id UUID,
-    name                     VARCHAR(255) NOT NULL,
-    description              TEXT         NOT NULL,
-    extensions               json         NULL,
-    artifact_resource_ids    UUID[]       NULL,
-    resource_id              UUID         NOT NULL,
-    data_source_id           UUID         NOT NULL,
-    generation_id            INTEGER      NOT NULL DEFAULT 0,
-    external_id              VARCHAR(255) NOT NULL,                           -- FQDN of resource in downstream data source (e.g., id=XXX)
-    created_at               TIMESTAMPTZ           DEFAULT CURRENT_TIMESTAMP, -- TBD; tracks when first imported
-    FOREIGN KEY (cluster_resource_type_id) REFERENCES cluster_resource_type (cluster_resource_type_id),
-    FOREIGN KEY (data_source_id) REFERENCES data_source (data_source_id)      -- Manual cascade required for events
-);
-
 -- Table: node_cluster_type
 CREATE TABLE IF NOT EXISTS node_cluster_type
 (
@@ -95,8 +64,41 @@ CREATE TABLE IF NOT EXISTS node_cluster
     generation_id                    INTEGER      NOT NULL DEFAULT 0,
     external_id                      VARCHAR(255) NOT NULL,                           -- FQDN of resource in downstream data source (e.g., id=XXX)
     created_at                       TIMESTAMPTZ           DEFAULT CURRENT_TIMESTAMP, -- TBD; tracks when first imported
-    FOREIGN KEY (node_cluster_type_id) REFERENCES node_cluster_type (node_cluster_type_id),
+    FOREIGN KEY (node_cluster_type_id) REFERENCES node_cluster_type (node_cluster_type_id),-- Manual cascade required for events
     FOREIGN KEY (data_source_id) REFERENCES data_source (data_source_id)              -- Manual cascade required for events
+);
+
+-- Table: cluster_resource_type
+CREATE TABLE IF NOT EXISTS cluster_resource_type
+(
+    cluster_resource_type_id UUID PRIMARY KEY,
+    name                     VARCHAR(255) NOT NULL,
+    description              TEXT         NOT NULL,
+    extensions               json         NULL,
+    data_source_id           UUID         NOT NULL,
+    generation_id            INTEGER      NOT NULL DEFAULT 0,
+    created_at               TIMESTAMPTZ           DEFAULT CURRENT_TIMESTAMP, -- TBD; tracks when first imported
+    FOREIGN KEY (data_source_id) REFERENCES data_source (data_source_id)      -- Manual cascade required for events
+);
+
+-- Table: cluster_resource
+CREATE TABLE IF NOT EXISTS cluster_resource
+(
+    cluster_resource_id      UUID PRIMARY KEY,
+    cluster_resource_type_id UUID,
+    name                     VARCHAR(255) NOT NULL,
+    node_cluster_id          UUID         NOT NULL,
+    description              TEXT         NOT NULL,
+    extensions               json         NULL,
+    artifact_resource_ids    UUID[]       NULL,
+    resource_id              UUID         NOT NULL,
+    data_source_id           UUID         NOT NULL,
+    generation_id            INTEGER      NOT NULL DEFAULT 0,
+    external_id              VARCHAR(255) NOT NULL,                           -- FQDN of resource in downstream data source (e.g., id=XXX)
+    created_at               TIMESTAMPTZ           DEFAULT CURRENT_TIMESTAMP, -- TBD; tracks when first imported
+    FOREIGN KEY (node_cluster_id) REFERENCES node_cluster (node_cluster_id),-- Manual cascade required for events
+    FOREIGN KEY (cluster_resource_type_id) REFERENCES cluster_resource_type (cluster_resource_type_id),-- Manual cascade required for events
+    FOREIGN KEY (data_source_id) REFERENCES data_source (data_source_id)      -- Manual cascade required for events
 );
 
 -- Table: cached_alarm_dictionary

--- a/internal/service/cluster/db/models/cluster_resource.go
+++ b/internal/service/cluster/db/models/cluster_resource.go
@@ -16,6 +16,7 @@ type ClusterResource struct {
 	ClusterResourceID     uuid.UUID               `db:"cluster_resource_id"` // Non-nil because we always set this from named values
 	ClusterResourceTypeID uuid.UUID               `db:"cluster_resource_type_id"`
 	Name                  string                  `db:"name"`
+	NodeClusterID         uuid.UUID               `db:"node_cluster_id"`
 	Description           string                  `db:"description"`
 	Extensions            *map[string]interface{} `db:"extensions"`
 	ArtifactResourceIDs   *[]uuid.UUID            `db:"artifact_resource_ids"`
@@ -36,3 +37,21 @@ func (r ClusterResource) PrimaryKey() string { return "cluster_resource_id" }
 
 // OnConflict returns the column or constraint to be used in the UPSERT operation
 func (r ClusterResource) OnConflict() string { return "" }
+
+// ClusterResourceIDs represents the data returned in a customized query to return the list of ClusterResource ID values
+// associated to each NodeCluster
+type ClusterResourceIDs struct {
+	NodeClusterID      uuid.UUID   `db:"node_cluster_id"`
+	ClusterResourceIDs []uuid.UUID `db:"cluster_resource_ids"`
+}
+
+// TableName returns the table name associated to this model
+func (r ClusterResourceIDs) TableName() string {
+	return "cluster_resource"
+}
+
+// PrimaryKey returns the primary key column associated to this model
+func (r ClusterResourceIDs) PrimaryKey() string { return "cluster_resource_id" }
+
+// OnConflict returns the column or constraint to be used in the UPSERT operation
+func (r ClusterResourceIDs) OnConflict() string { return "" }

--- a/internal/service/cluster/db/models/converters.go
+++ b/internal/service/cluster/db/models/converters.go
@@ -50,8 +50,9 @@ func NodeClusterToModel(record *NodeCluster, clusterResourceIDs []uuid.UUID) gen
 		Name:                           record.Name,
 	}
 
-	if clusterResourceIDs != nil {
-		object.ClusterResourceIds = clusterResourceIDs
+	object.ClusterResourceIds = clusterResourceIDs
+	if clusterResourceIDs == nil {
+		object.ClusterResourceIds = []uuid.UUID{}
 	}
 
 	return object

--- a/internal/service/cluster/db/models/converters.go
+++ b/internal/service/cluster/db/models/converters.go
@@ -37,19 +37,24 @@ func ClusterResourceTypeToModel(record *ClusterResourceType) generated.ClusterRe
 }
 
 // NodeClusterToModel converts a DB tuple to an API model
-func NodeClusterToModel(record *NodeCluster) generated.NodeCluster {
-	return generated.NodeCluster{
+func NodeClusterToModel(record *NodeCluster, clusterResourceIDs []uuid.UUID) generated.NodeCluster {
+	object := generated.NodeCluster{
 		NodeClusterId:                  record.NodeClusterID,
 		NodeClusterTypeId:              record.NodeClusterTypeID,
 		ArtifactResourceId:             record.ArtifactResourceID,
 		ClientNodeClusterId:            record.ClientNodeClusterID,
 		ClusterDistributionDescription: record.ClusterDistributionDescription,
 		ClusterResourceGroups:          record.ClusterResourceGroups,
-		ClusterResourceIds:             []uuid.UUID{}, // TODO: caller should pass in this list
 		Description:                    record.Description,
 		Extensions:                     record.Extensions,
 		Name:                           record.Name,
 	}
+
+	if clusterResourceIDs != nil {
+		object.ClusterResourceIds = clusterResourceIDs
+	}
+
+	return object
 }
 
 // NodeClusterTypeToModel converts a DB tuple to an API model


### PR DESCRIPTION
This adds the ability to return the list of cluster resource id values as part of an API query for node cluster(s).  These values are not persisted to the database, but are queried on an as-needed basis in response to an API query.