### PR TITLE
Fix kustomize layering for debug mode

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1513,6 +1513,29 @@ spec:
                 control-plane: controller-manager
             spec:
               containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: quay.io/openshift/origin-kube-rbac-proxy:4.18
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               - command:
                 - /usr/bin/oran-o2ims
                 - start
@@ -1567,29 +1590,6 @@ spec:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert
                   readOnly: true
-              - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=0
-                image: quay.io/openshift/origin-kube-rbac-proxy:4.18
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 5m
-                    memory: 64Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: oran-o2ims-controller-manager

--- a/config/debug/disable-health-probes.yaml
+++ b/config/debug/disable-health-probes.yaml
@@ -1,4 +1,4 @@
--   path: /spec/template/spec/containers/1/livenessProbe
-    op: remove
--   path: /spec/template/spec/containers/1/readinessProbe
-    op: remove
+- path: /spec/template/spec/containers/1/livenessProbe
+  op: remove
+- path: /spec/template/spec/containers/1/readinessProbe
+  op: remove

--- a/config/debug/disable-leader-election.yaml
+++ b/config/debug/disable-leader-election.yaml
@@ -1,8 +1,8 @@
--   path: /spec/template/spec/containers/1/command
-    op: replace
-    value:
-        - /usr/bin/oran-o2ims
-        - start
-        - controller-manager
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+- path: /spec/template/spec/containers/1/command
+  op: replace
+  value:
+  - /usr/bin/oran-o2ims
+  - start
+  - controller-manager
+  - --health-probe-bind-address=:8081
+  - --metrics-bind-address=127.0.0.1:8080

--- a/config/debug/manager_config_patch.yaml
+++ b/config/debug/manager_config_patch.yaml
@@ -1,6 +1,6 @@
-- path: /spec/template/spec/volumes
+- path: /spec/template/spec/volumes/0
   op: add
   value:
-  - name: postgres-debug-passwords
+    name: postgres-debug-passwords
     secret:
       secretName: postgres-debug-passwords

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -33,7 +33,10 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- path: manager_webhook_patch.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: manager_webhook_patch.yaml
 
 # We use Openshift Service CA injection instead of cert-manager by default. To use cert-manager,
 # uncomment the annotation cert-manager.io/inject-ca-from in the following patch.

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,23 +1,19 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        ports:
-        - containerPort: 9443
-          name: webhook-server
-          protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: oran-o2ims-webhook-server-cert
+- path: /spec/template/spec/volumes/0
+  op: add
+  value:
+    name: cert
+    secret:
+      defaultMode: 420
+      secretName: oran-o2ims-webhook-server-cert
+- path: /spec/template/spec/containers/1/ports/0
+  op: add
+  value:
+    containerPort: 9443
+    name: webhook-server
+    protocol: TCP
+- path: /spec/template/spec/containers/1/volumeMounts/0
+  op: add
+  value:
+    mountPath: /tmp/k8s-webhook-server/serving-certs
+    name: cert
+    readOnly: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -119,5 +119,8 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        ports: [ ]
+        volumeMounts: [ ]
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      volumes: [ ]


### PR DESCRIPTION
The introduction of the webhook validation affected the ability to build with DEBUG=yes so this commit re-arranges how the lists are defined and patched to work around the issue.