### PR TITLE
CNF-16194: Add filtering to the artifacts server

### DIFF
--- a/internal/service/artifacts/api/server.go
+++ b/internal/service/artifacts/api/server.go
@@ -47,7 +47,7 @@ func (r *ArtifactsServer) GetManagedInfrastructureTemplates(
 		// Convert the current ClusterTemplate to ManagedInfrastructureTemplate.
 		managedInfrastructureTemplate := api.ManagedInfrastructureTemplate{
 			ArtifactResourceId: uuid,
-			Name:               clusterTemplate.Name,
+			Name:               clusterTemplate.Spec.Name,
 			Version:            clusterTemplate.Spec.Version,
 			Description:        clusterTemplate.Spec.Description,
 			ParameterSchema:    parameterSchema,


### PR DESCRIPTION
Description:
- Add a ResponseFilter to the artifacts server to enable filtering on GET requests.
- Map the managedInfrastructureTemplate Name to Cluster Template Spec.Name instead of Metadata.Name.
- Example curl:
```console
curl \
  -X 'GET' \
  'http://127.0.0.1:8000/o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates?filter=(eq,version,v4-17-3-1)%3b(eq,name,sno-ran-du)' \
  -H 'accept: application/json' | jq
```