### PR TITLE
Fix notifier deadlock on new events

### DIFF
--- a/internal/service/common/notifier/notifier.go
+++ b/internal/service/common/notifier/notifier.go
@@ -12,7 +12,12 @@ import (
 )
 
 // DefaultBufferedChannelSize defines the default size for buffered channels used across the notifier.
-const DefaultBufferedChannelSize = 10
+const DefaultBufferedChannelSize = 100
+
+// CompletionChannelSize defines the buffer size of the completion channel.  We keep this small to ensure that we don't
+// process a large number of notifications without first updating the subscription cursor so workers will block until
+// completions are processed before sending more notifications.
+const CompletionChannelSize = 1
 
 // Notification defines a generic notification object.  The payload should support JSON marshaling.
 type Notification struct {
@@ -84,7 +89,7 @@ func NewNotifier(subscriptionProvider SubscriptionProvider, notificationProvider
 	oauthConfig *utils.OAuthClientConfig) *Notifier {
 	eventChannel := make(chan *Notification, DefaultBufferedChannelSize)
 	subscriptionChannel := make(chan *SubscriptionEvent, DefaultBufferedChannelSize)
-	subscriberJobCompleteChannel := make(chan *SubscriptionJobComplete, DefaultBufferedChannelSize)
+	subscriberJobCompleteChannel := make(chan *SubscriptionJobComplete, CompletionChannelSize)
 	return &Notifier{
 		oauthConfig:                    oauthConfig,
 		subscriptionProvider:           subscriptionProvider,

--- a/internal/service/common/notifier/notifier_worker.go
+++ b/internal/service/common/notifier/notifier_worker.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -19,11 +20,6 @@ const maxRetries = 5
 // retryDelay defines the amount of time between each successive notification attempt
 const retryDelay = 10 * time.Second // TODO: increase
 
-// SubscriptionJob is the event sent to the subscription worker to have it process the data change event
-type SubscriptionJob struct {
-	notification *Notification
-}
-
 // SubscriptionJobComplete is the event sent from the subscription worker to the notifier to report that it has
 // successfully sent a notification for the data change event
 type SubscriptionJobComplete struct {
@@ -32,12 +28,12 @@ type SubscriptionJobComplete struct {
 	sequenceID     int
 }
 
-// SubscriptionWorker is a placeholder which represents a go routine created to monitor events for a subscription
+// SubscriptionWorker is a placeholder that represents a go routine created to monitor events for a subscription
 type SubscriptionWorker struct {
 	// subscription is the subscription being monitored for events
 	subscription *SubscriptionInfo
-	// workChannel is the channel to be used to sent work to the worker
-	workChannel chan *SubscriptionJob
+	// workChannel is the channel used to send work to the worker
+	workChannel chan struct{}
 	// subscriptionJobCompleteChannel is the channel to be used to report back to the notifier when an event is complete
 	subscriptionJobCompleteChannel chan *SubscriptionJobComplete
 	// ctx is the context passed to the go routine.  If the subscription is canceled or the server is stopping the
@@ -45,10 +41,10 @@ type SubscriptionWorker struct {
 	ctx context.Context
 	// cancel is the CancelFunc associated to the worker context.
 	cancel context.CancelFunc
-	// events represents the list of work to be done by the worker
-	events []*Notification
-	// currentEvent is the event currently being processed
-	currentEvent *Notification
+	// workQueue represents the list of work to be done by the worker
+	workQueue []*Notification
+	// workMutex protects the workQueue from concurrent changes
+	workMutex sync.Mutex
 	// currentEventDone signals back to the worker that the current event has been processed
 	currentEventDone chan *SubscriptionJobComplete
 	// client is used to communicate to the subscriber
@@ -76,7 +72,7 @@ func NewSubscriptionWorker(ctx context.Context, oauthConfig *utils.OAuthClientCo
 	workerCtx, cancel := context.WithCancel(ctx)
 	return &SubscriptionWorker{
 		subscription:                   subscription,
-		workChannel:                    make(chan *SubscriptionJob, 1),
+		workChannel:                    make(chan struct{}, 1),
 		subscriptionJobCompleteChannel: subscriptionJobCompleteChannel,
 		cancel:                         cancel,
 		ctx:                            workerCtx,
@@ -88,7 +84,15 @@ func NewSubscriptionWorker(ctx context.Context, oauthConfig *utils.OAuthClientCo
 
 // NewNotification sends a data change event to a subscription worker
 func (w *SubscriptionWorker) NewNotification(notification *Notification) {
-	w.workChannel <- &SubscriptionJob{notification: notification}
+	w.workMutex.Lock()
+	defer w.workMutex.Unlock()
+	w.workQueue = append(w.workQueue, notification)
+	w.logger.Debug("notification enqueued to work queue", "size", len(w.workQueue))
+	if len(w.workQueue) == 1 {
+		// If this is the first entry in the queue, then kick the worker to process its queue; otherwise, let it finish
+		// processing the queue before kicking it again.
+		w.workChannel <- struct{}{}
+	}
 }
 
 // Shutdown terminates the worker and releases any pending events
@@ -96,13 +100,13 @@ func (w *SubscriptionWorker) Shutdown() {
 	w.cancel()
 }
 
-// releaseEvents releases all pending events back to the notifier
-func (w *SubscriptionWorker) releaseEvents() {
-	for _, event := range w.events {
+// releaseNotifications releases all pending notifications back to the notifier
+func (w *SubscriptionWorker) releaseNotifications() {
+	for _, notification := range w.workQueue {
 		w.subscriptionJobCompleteChannel <- &SubscriptionJobComplete{
 			subscriptionID: w.subscription.SubscriptionID,
-			notificationID: event.NotificationID,
-			sequenceID:     event.SequenceID,
+			notificationID: notification.NotificationID,
+			sequenceID:     notification.SequenceID,
 		}
 	}
 }
@@ -115,52 +119,41 @@ func (w *SubscriptionWorker) Run() {
 		select {
 		case e := <-w.currentEventDone:
 			w.handleCurrentEventCompletion(e)
-		case event := <-w.workChannel:
-			w.handleSubscriptionJob(w.ctx, event)
+		case <-w.workChannel:
+			w.workMutex.Lock()
+			w.processNextEvent(w.ctx, w.workQueue[0])
+			w.workMutex.Unlock()
 		case <-w.ctx.Done():
-			w.releaseEvents()
+			w.releaseNotifications()
 			w.logger.Info("subscription worker shutting down")
 			return
 		}
 	}
 }
 
-// handleCurrentEventCompletion handles the end of processing the current event.
+// handleCurrentEventCompletion handles the end of the current event and looks for another event to process.
 func (w *SubscriptionWorker) handleCurrentEventCompletion(e *SubscriptionJobComplete) {
-	w.currentEvent = nil
-	// forward to the notifier so that it can release the event
+	// Forward to the notifier so that it can release it. This may block if the notifier is busy handling other
+	// completion jobs or new notifications.
 	w.subscriptionJobCompleteChannel <- e
-	// handle the next event
-	w.processNextEvent(w.ctx)
-}
 
-// handleSubscriptionJob receives a new subscription job and queues it for processing
-func (w *SubscriptionWorker) handleSubscriptionJob(ctx context.Context, job *SubscriptionJob) {
-	w.logger.Info("data change event job received",
-		"notificationID", job.notification.NotificationID,
-		"sequenceID", job.notification.SequenceID)
+	// dequeue the completed event and handle the next event
+	w.workMutex.Lock()
+	defer w.workMutex.Unlock()
+	w.workQueue = w.workQueue[1:]
 
-	if w.currentEvent == nil {
-		// Handle it immediately
-		w.currentEvent = job.notification
-		go processEvent(ctx, w.logger, w.client, w.currentEventDone, *w.currentEvent, w.subscription.SubscriptionID, w.subscription.Callback)
-	} else {
-		// Queue it
-		w.events = append(w.events, job.notification)
-	}
-}
-
-// processNextEvent looks for the next event to be processed.
-func (w *SubscriptionWorker) processNextEvent(ctx context.Context) {
-	if len(w.events) == 0 {
+	if len(w.workQueue) == 0 {
 		// No more events
 		w.logger.Debug("no more events to process")
 		return
 	}
+	w.logger.Debug("dequeued notification from work queue", "size", len(w.workQueue))
 
-	// Pop the first element off of the list and set it as the current event
-	w.currentEvent, w.events = w.events[0], w.events[1:]
+	w.processNextEvent(w.ctx, w.workQueue[0])
+}
 
+// processNextEvent looks for the next event to be processed.
+func (w *SubscriptionWorker) processNextEvent(ctx context.Context, nextEvent *Notification) {
 	// Launch a task to send the notification (or retry on failures)
-	go processEvent(ctx, w.logger, w.client, w.currentEventDone, *w.currentEvent, w.subscription.SubscriptionID, w.subscription.Callback)
+	go processEvent(ctx, w.logger, w.client, w.currentEventDone, *nextEvent, w.subscription.SubscriptionID, w.subscription.Callback)
 }


### PR DESCRIPTION
The design of the notifier and notifier worker interactions was flawed in that it allowed the possibility of a deadlock whenever both the worker's work channel and notifier's completion channel buffers were full.  The notifier cannot send new work to the worker, and the worker gets stuck waiting for the notifier to acknowledge receipt of the completion event.

This is being mitigated by having the notifier enqueue work onto the worker's work queue directly, and only signaling the work channel upon adding the first event onto the queue.  The worker will independently process the queue and report completion down to the notifier.  This should eliminate the possibility that the completion channel fills up and the worker blocking indefinitely.