### PR TITLE
Fix notifier related hangs on shutdown

### DIFF
--- a/internal/service/alarms/api/server.go
+++ b/internal/service/alarms/api/server.go
@@ -148,7 +148,7 @@ func (a *AlarmsServer) CreateSubscription(ctx context.Context, request api.Creat
 	}
 
 	// Signal the notifier to handle this new subscription
-	a.Notifier.SubscriptionEvent(&notifier.SubscriptionEvent{
+	a.Notifier.SubscriptionEvent(ctx, &notifier.SubscriptionEvent{
 		Removed:      false,
 		Subscription: models.ConvertAlertSubToNotificationSub(record),
 	})
@@ -180,7 +180,7 @@ func (a *AlarmsServer) DeleteSubscription(ctx context.Context, request api.Delet
 	}
 
 	// Signal the notifier to handle this subscription change
-	a.Notifier.SubscriptionEvent(&notifier.SubscriptionEvent{
+	a.Notifier.SubscriptionEvent(ctx, &notifier.SubscriptionEvent{
 		Removed:      true,
 		Subscription: models.ConvertAlertSubToNotificationSub(&models.AlarmSubscription{SubscriptionID: request.AlarmSubscriptionId}),
 	})
@@ -538,7 +538,7 @@ func (a *AlarmsServer) AmNotification(ctx context.Context, request api.AmNotific
 		}
 
 		for _, notification := range notifications {
-			a.Notifier.Notify(&notification)
+			a.Notifier.Notify(subCtx, &notification)
 		}
 	}()
 

--- a/internal/service/cluster/api/server.go
+++ b/internal/service/cluster/api/server.go
@@ -345,7 +345,7 @@ func (r *ClusterServer) CreateSubscription(ctx context.Context, request api.Crea
 	}
 
 	// Signal the notifier to handle this new subscription
-	r.SubscriptionEventHandler.SubscriptionEvent(&notifier.SubscriptionEvent{
+	r.SubscriptionEventHandler.SubscriptionEvent(ctx, &notifier.SubscriptionEvent{
 		Removed:      false,
 		Subscription: models.SubscriptionToInfo(result),
 	})
@@ -403,7 +403,7 @@ func (r *ClusterServer) DeleteSubscription(ctx context.Context, request api.Dele
 	}
 
 	// Signal the notifier to handle this subscription change
-	r.SubscriptionEventHandler.SubscriptionEvent(&notifier.SubscriptionEvent{
+	r.SubscriptionEventHandler.SubscriptionEvent(ctx, &notifier.SubscriptionEvent{
 		Removed: true,
 		Subscription: models.SubscriptionToInfo(&models2.Subscription{
 			SubscriptionID: &request.SubscriptionId,

--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -39,7 +39,7 @@ type DataSource interface {
 }
 
 type NotificationHandler interface {
-	Notify(event *notifier.Notification)
+	Notify(ctx context.Context, event *notifier.Notification)
 }
 
 // Collector defines the attributes required by the collector implementation.
@@ -201,7 +201,7 @@ func (c *Collector) collectClusterResources(ctx context.Context, dataSource Data
 		}
 
 		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(models.DataChangeEventToNotification(dataChangeEvent))
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 		}
 	}
 
@@ -227,7 +227,7 @@ func (c *Collector) collectClusterResources(ctx context.Context, dataSource Data
 		}
 
 		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(models.DataChangeEventToNotification(dataChangeEvent))
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 		}
 	}
 
@@ -268,7 +268,7 @@ func (c *Collector) collectNodeClusters(ctx context.Context, dataSource DataSour
 		}
 
 		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(models.DataChangeEventToNotification(dataChangeEvent))
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 		}
 	}
 
@@ -284,7 +284,7 @@ func (c *Collector) collectNodeClusters(ctx context.Context, dataSource DataSour
 		}
 
 		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(models.DataChangeEventToNotification(dataChangeEvent))
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 		}
 	}
 

--- a/internal/service/resources/api/server.go
+++ b/internal/service/resources/api/server.go
@@ -199,7 +199,7 @@ func (r *ResourceServer) CreateSubscription(ctx context.Context, request api.Cre
 	}
 
 	// Signal the notifier to handle this new subscription
-	r.SubscriptionEventHandler.SubscriptionEvent(&notifier.SubscriptionEvent{
+	r.SubscriptionEventHandler.SubscriptionEvent(ctx, &notifier.SubscriptionEvent{
 		Removed:      false,
 		Subscription: models.SubscriptionToInfo(result),
 	})
@@ -257,7 +257,7 @@ func (r *ResourceServer) DeleteSubscription(ctx context.Context, request api.Del
 	}
 
 	// Signal the notifier to handle this subscription change
-	r.SubscriptionEventHandler.SubscriptionEvent(&notifier.SubscriptionEvent{
+	r.SubscriptionEventHandler.SubscriptionEvent(ctx, &notifier.SubscriptionEvent{
 		Removed: true,
 		Subscription: models.SubscriptionToInfo(&models2.Subscription{
 			SubscriptionID: &request.SubscriptionId,

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -33,7 +33,7 @@ type DataSource interface {
 }
 
 type NotificationHandler interface {
-	Notify(event *notifier.Notification)
+	Notify(ctx context.Context, event *notifier.Notification)
 }
 
 // Collector defines the attributes required by the collector implementation.
@@ -195,7 +195,7 @@ func (c *Collector) collectResources(ctx context.Context, dataSource DataSource,
 		}
 
 		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(models.DataChangeEventToNotification(dataChangeEvent))
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 		}
 	}
 
@@ -211,7 +211,7 @@ func (c *Collector) collectResources(ctx context.Context, dataSource DataSource,
 		}
 
 		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(models.DataChangeEventToNotification(dataChangeEvent))
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 		}
 	}
 
@@ -240,7 +240,7 @@ func (c *Collector) collectResourcePools(ctx context.Context, dataSource DataSou
 		}
 
 		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(models.DataChangeEventToNotification(dataChangeEvent))
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 		}
 	}
 
@@ -269,7 +269,7 @@ func (c *Collector) collectDeploymentManagers(ctx context.Context, dataSource Da
 		}
 
 		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(models.DataChangeEventToNotification(dataChangeEvent))
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 		}
 	}
 


### PR DESCRIPTION
The input channels to the notifier for subscription or notification events assume that the write to the channel will always succeed.  Since we used buffered channels, and we know that there are use cases where many events may be in-flight simultaneously, it is conceivable that the notifier back-pressures back to the source of the events.  If this happens, then the event source blocks until the channel becomes available to receive a new message.

If this condition is present while the process is shut down, then the source go routine will hang waiting to send to the channel(s).  By incorporating the channel write into a select that also considers the state of the context; then we are able to abort a blocked send if the source go routine is canceled.