### PR TITLE
CNF-16245: Add edge driven cluster updates with Reflector

### DIFF
--- a/internal/service/alarms/internal/alertmanager/alertmanager_test.go
+++ b/internal/service/alarms/internal/alertmanager/alertmanager_test.go
@@ -21,9 +21,9 @@ var _ = Describe("Alertmanager", func() {
 		var (
 			ctx    context.Context
 			scheme *runtime.Scheme
-			c      client.Client
+			c      client.WithWatch
 
-			temp func() (client.Client, error)
+			temp func() (client.WithWatch, error)
 		)
 
 		BeforeEach(func() {
@@ -31,7 +31,7 @@ var _ = Describe("Alertmanager", func() {
 			_ = corev1.AddToScheme(scheme)
 
 			temp = getHubClient
-			getHubClient = func() (client.Client, error) {
+			getHubClient = func() (client.WithWatch, error) {
 				return c, nil
 			}
 

--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/repo"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/async"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
 	models2 "github.com/openshift-kni/oran-o2ims/internal/service/common/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
@@ -24,20 +26,32 @@ const pollingDelay = 10 * time.Minute
 // this extension and do not expose it to the API.
 const clusterNameExtension = "clusterName"
 
+// asyncEventBufferSize defines the number of buffered entries in the async handleWatchEvent channel
+const asyncEventBufferSize = 10
+
 // DataSource represents the operations required to be supported by any objects implementing a
 // data collection backend.
 type DataSource interface {
 	Name() string
-	SetID(uuid.UUID)
-	SetGenerationID(value int)
+	GetID() uuid.UUID
+	Init(dataSourceID uuid.UUID, generationID int, asyncEventChannel chan<- *async.AsyncChangeEvent)
 	GetGenerationID() int
 	IncrGenerationID() int
-	GetNodeClusters(ctx context.Context) ([]models.NodeCluster, error)
-	GetClusterResources(ctx context.Context, clusters []models.NodeCluster) ([]models.ClusterResource, error)
+}
+
+// ClusterDataSource defines an interface of a data source capable of getting handling Cluster resources.
+type ClusterDataSource interface {
+	DataSource
 	MakeNodeClusterType(resource *models.NodeCluster) (*models.NodeClusterType, error)
 	MakeClusterResourceType(resource *models.ClusterResource) (*models.ClusterResourceType, error)
 }
 
+// WatchableDataSource defines an interface of a data source capable of watching for async events.
+type WatchableDataSource interface {
+	Watch(ctx context.Context) error
+}
+
+// NotificationHandler defines an interface over which notifications are published.
 type NotificationHandler interface {
 	Notify(ctx context.Context, event *notifier.Notification)
 }
@@ -47,6 +61,7 @@ type Collector struct {
 	notificationHandler NotificationHandler
 	repository          *repo.ClusterRepository
 	dataSources         []DataSource
+	asyncChangeEvents   chan *async.AsyncChangeEvent
 }
 
 // NewCollector creates a new collector instance
@@ -55,6 +70,7 @@ func NewCollector(repo *repo.ClusterRepository, notificationHandler Notification
 		repository:          repo,
 		notificationHandler: notificationHandler,
 		dataSources:         dataSources,
+		asyncChangeEvents:   make(chan *async.AsyncChangeEvent, asyncEventBufferSize),
 	}
 }
 
@@ -67,10 +83,17 @@ func (c *Collector) Run(ctx context.Context) error {
 	// Run the initial data collection
 	c.execute(ctx)
 
+	// Start listening for async events
+	if err := c.watchForChanges(ctx); err != nil {
+		return fmt.Errorf("failed to start watchers: %w", err)
+	}
+
 	for {
 		select {
-		// TODO: Add hook for new data sources from watch events
-		// TODO: Add hook for kick to run collection based on watch events on individual data sources
+		case event := <-c.asyncChangeEvents:
+			if err := c.handleAsyncEvent(ctx, event); err != nil {
+				slog.Error("failed to handle async change", "handleWatchEvent", event, "error", err)
+			}
 		case <-time.After(pollingDelay):
 			c.execute(ctx)
 		case <-ctx.Done():
@@ -110,15 +133,31 @@ func (c *Collector) initDataSource(ctx context.Context, dataSource DataSource) e
 			return fmt.Errorf("failed to create new data source %q: %w", name, err)
 		}
 
-		dataSource.SetID(*result.DataSourceID)
+		dataSource.Init(*result.DataSourceID, 0, c.asyncChangeEvents)
 		slog.Info("created new data source", "name", name, "uuid", *result.DataSourceID)
 	case err != nil:
 		return fmt.Errorf("failed to get data source %q: %w", name, err)
 	default:
-		dataSource.SetID(*record.DataSourceID)
-		dataSource.SetGenerationID(record.GenerationID)
+		dataSource.Init(*record.DataSourceID, record.GenerationID, c.asyncChangeEvents)
 		slog.Info("restored data source",
 			"name", name, "uuid", record.DataSourceID, "generation", record.GenerationID)
+	}
+
+	return nil
+}
+
+// watchForChanges starts a watch listener for each data source.  Data is reported by via the channel provided to
+// each data source.
+func (c *Collector) watchForChanges(ctx context.Context) error {
+	for _, d := range c.dataSources {
+		if _, ok := d.(WatchableDataSource); !ok {
+			continue
+		}
+
+		if err := d.(WatchableDataSource).Watch(ctx); err != nil {
+			slog.Error("failed to watch for changes", "source", d.Name(), "error", err)
+			return fmt.Errorf("failed to watch for changes: %w", err)
+		}
 	}
 	return nil
 }
@@ -128,6 +167,8 @@ func (c *Collector) initDataSource(ctx context.Context, dataSource DataSource) e
 func (c *Collector) execute(ctx context.Context) {
 	slog.Debug("collector loop running", "sources", len(c.dataSources))
 	for _, d := range c.dataSources {
+		// TODO: only run this loop for alarm data sources
+
 		d.IncrGenerationID()
 		slog.Debug("collecting data from data source", "source", d.Name(), "generationID", d.GetGenerationID())
 		if err := c.executeOneDataSource(ctx, d); err != nil {
@@ -141,54 +182,32 @@ func (c *Collector) execute(ctx context.Context) {
 
 // executeOneDataSource runs a single iteration of the main loop for a specific data source instance.
 func (c *Collector) executeOneDataSource(ctx context.Context, dataSource DataSource) (err error) {
-	// Get the list of node cluster for this data source
-	pools, err := c.collectNodeClusters(ctx, dataSource)
-	if err != nil {
-		return fmt.Errorf("failed to collect node clusters: %w", err)
-	}
+	// TODO: Add code to retrieve alarm dictionaries
 
-	// Get the list of cluster resources for this data source
-	_, err = c.collectClusterResources(ctx, dataSource, pools)
+	// Persist data source info
+	id := dataSource.GetID()
+	_, err = c.repository.UpdateDataSource(ctx, &models2.DataSource{
+		DataSourceID: &id,
+		Name:         dataSource.Name(),
+		GenerationID: dataSource.GetGenerationID(),
+	})
 	if err != nil {
-		return fmt.Errorf("failed to collect cluster resources: %w", err)
+		return fmt.Errorf("failed to update data source %q: %w", dataSource.Name(), err)
 	}
 
 	// TODO: purge stale record
 
-	// TODO: persist data source info
-
 	return nil
 }
 
-// collectClusterResources collects ClusterResource objects from the data source, persists them to
-// the database, and signals any change events to the notification processor.
-func (c *Collector) collectClusterResources(ctx context.Context, dataSource DataSource,
-	clusters []models.NodeCluster) ([]models.ClusterResource, error) {
-	slog.Debug("collecting cluster resources and types", "source", dataSource.Name())
-
-	resources, err := dataSource.GetClusterResources(ctx, clusters)
+// persistClusterResource persists a ClusterResource to the database.  This may be an add or an update.
+func (c *Collector) persistClusterResource(ctx context.Context, dataSource ClusterDataSource, resource models.ClusterResource, seen map[uuid.UUID]bool) error {
+	resourceType, err := dataSource.MakeClusterResourceType(&resource)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cluster resources: %w", err)
+		return fmt.Errorf("failed to make cluster resource type from '%v': %w", resource, err)
 	}
 
-	// Build a mapping from name to id for clusters so that we can more easily access id values
-	clusterNameToID := make(map[string]uuid.UUID)
-	for _, cluster := range clusters {
-		clusterNameToID[cluster.Name] = cluster.NodeClusterID
-	}
-
-	// Loop over the set of cluster resources and create the associated cluster resource types.
-	seen := make(map[uuid.UUID]bool)
-	for _, resource := range resources {
-		resourceType, err := dataSource.MakeClusterResourceType(&resource)
-		if err != nil {
-			return nil, fmt.Errorf("failed to make cluster resource type from '%v': %w", resource, err)
-		}
-
-		if seen[resourceType.ClusterResourceTypeID] {
-			// We have already seen this one so skip
-			continue
-		}
+	if !seen[resourceType.ClusterResourceTypeID] {
 		seen[resourceType.ClusterResourceTypeID] = true
 
 		dataChangeEvent, err := utils.PersistObjectWithChangeEvent(
@@ -197,7 +216,7 @@ func (c *Collector) collectClusterResources(ctx context.Context, dataSource Data
 				return models.ClusterResourceTypeToModel(&record)
 			})
 		if err != nil {
-			return nil, fmt.Errorf("failed to persist cluster resource type': %w", err)
+			return fmt.Errorf("failed to persist cluster resource type': %w", err)
 		}
 
 		if dataChangeEvent != nil {
@@ -205,66 +224,38 @@ func (c *Collector) collectClusterResources(ctx context.Context, dataSource Data
 		}
 	}
 
-	// Loop over the set of cluster resources and insert (or update) as needed
-	for _, resource := range resources {
-		// Set the cluster ID since the data source doesn't have access to this info
-		if resource.Extensions != nil {
-			clusterName := (*resource.Extensions)[clusterNameExtension].(string)
-			resource.NodeClusterID = clusterNameToID[clusterName]
-			// The name extension was added for the sole purpose of allowing us to find the matching cluster ID value
-			// since it is not possible for the data source to do this directly.  Removing it since it is not required
-			// by the spec and seems redundant since the full NodeCluster can be retrieved with the ID value.
-			delete(*resource.Extensions, clusterNameExtension)
-		}
-
-		dataChangeEvent, err := utils.PersistObjectWithChangeEvent(
-			ctx, c.repository.Db, resource, resource.ClusterResourceID, nil, func(object interface{}) any {
-				record, _ := object.(models.ClusterResource)
-				return models.ClusterResourceToModel(&record)
-			})
-		if err != nil {
-			return nil, fmt.Errorf("failed to persist cluster resource: %w", err)
-		}
-
-		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
-		}
+	dataChangeEvent, err := utils.PersistObjectWithChangeEvent(
+		ctx, c.repository.Db, resource, resource.ClusterResourceID, nil, func(object interface{}) any {
+			record, _ := object.(models.ClusterResource)
+			return models.ClusterResourceToModel(&record)
+		})
+	if err != nil {
+		return fmt.Errorf("failed to persist cluster resource: %w", err)
 	}
 
-	return resources, nil
+	if dataChangeEvent != nil {
+		c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
+	}
+
+	return nil
 }
 
-// collectNodeClusters collects NodeCluster objects from the data source, persists them to
-// the database, and signals any change events to the notification processor.
-func (c *Collector) collectNodeClusters(ctx context.Context, dataSource DataSource) ([]models.NodeCluster, error) {
-	slog.Debug("collecting node clusters and types", "source", dataSource.Name())
-
-	clusters, err := dataSource.GetNodeClusters(ctx)
+// persistNodeCluster persists a NodeCluster to the database.  This may be an add or an update.
+func (c *Collector) persistNodeCluster(ctx context.Context, dataSource ClusterDataSource, cluster models.NodeCluster, seen map[uuid.UUID]bool) error {
+	resourceType, err := dataSource.MakeNodeClusterType(&cluster)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get node clsuters: %w", err)
+		return fmt.Errorf("failed to make node cluster type from '%s': %w", cluster.Name, err)
 	}
 
-	// Loop over the set of resources and create the associated resource types.
-	seen := make(map[uuid.UUID]bool)
-	for _, cluster := range clusters {
-		resourceType, err := dataSource.MakeNodeClusterType(&cluster)
-		if err != nil {
-			return nil, fmt.Errorf("failed to make node cluster type from '%v': %w", cluster, err)
-		}
-
-		if seen[resourceType.NodeClusterTypeID] {
-			// We have already seen this one so skip
-			continue
-		}
+	if !seen[resourceType.NodeClusterTypeID] {
 		seen[resourceType.NodeClusterTypeID] = true
-
 		dataChangeEvent, err := utils.PersistObjectWithChangeEvent(
 			ctx, c.repository.Db, *resourceType, resourceType.NodeClusterTypeID, nil, func(object interface{}) any {
 				record, _ := object.(models.NodeClusterType)
 				return models.NodeClusterTypeToModel(&record)
 			})
 		if err != nil {
-			return nil, fmt.Errorf("failed to persist node cluster type': %w", err)
+			return fmt.Errorf("failed to persist node cluster type': %w", err)
 		}
 
 		if dataChangeEvent != nil {
@@ -272,21 +263,249 @@ func (c *Collector) collectNodeClusters(ctx context.Context, dataSource DataSour
 		}
 	}
 
-	// Loop over the set of node cluster and insert (or update) as needed
-	for _, cluster := range clusters {
-		dataChangeEvent, err := utils.PersistObjectWithChangeEvent(
-			ctx, c.repository.Db, cluster, cluster.NodeClusterID, nil, func(object interface{}) any {
+	dataChangeEvent, err := utils.PersistObjectWithChangeEvent(
+		ctx, c.repository.Db, cluster, cluster.NodeClusterID, nil, func(object interface{}) any {
+			record, _ := object.(models.NodeCluster)
+			return models.NodeClusterToModel(&record, nil)
+		})
+	if err != nil {
+		return fmt.Errorf("failed to persist node cluster: %w", err)
+	}
+
+	if dataChangeEvent != nil {
+		c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
+	}
+
+	return nil
+}
+
+// findDataSource looks up the data source by ID value.  It returns nil if no matching data source was found.
+func (c *Collector) findDataSource(dataSourceID uuid.UUID) DataSource {
+	for _, dataSource := range c.dataSources {
+		if dataSource.GetID() == dataSourceID {
+			return dataSource
+		}
+	}
+	return nil
+}
+
+// handleNodeClusterSyncCompletion handles the end of sync for NodeCluster objects.  It deletes any NodeCluster objects
+// not included in the set of keys received during the sync operation.
+func (c *Collector) handleNodeClusterSyncCompletion(ctx context.Context, ids []any) error {
+	records, err := c.repository.GetNodeClustersNotIn(ctx, ids)
+	if err != nil {
+		return fmt.Errorf("failed to get stale node clusters: %w", err)
+	}
+
+	count := 0
+	for _, record := range records {
+		dataChangeEvent, err := utils.DeleteObjectWithChangeEvent(ctx, c.repository.Db, record, record.NodeClusterID, nil, func(object interface{}) any {
+			r, _ := object.(models.NodeCluster)
+			return models.NodeClusterToModel(&r, nil)
+		})
+
+		if err != nil {
+			return fmt.Errorf("failed to delete stale node cluster: %w", err)
+		}
+
+		if dataChangeEvent != nil {
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
+			count++
+		}
+	}
+
+	if count > 0 {
+		slog.Info("Deleted stale node cluster records", "count", count)
+	}
+
+	return nil
+}
+
+// handleClusterResourceSyncCompletion handles the end of sync for ClusterResource objects.  It deletes any
+// ClusterResource objects not included in the set of keys received during the sync operation.
+func (c *Collector) handleClusterResourceSyncCompletion(ctx context.Context, ids []any) error {
+	records, err := c.repository.GetClusterResourcesNotIn(ctx, ids)
+	if err != nil {
+		return fmt.Errorf("failed to get stale cluster resources: %w", err)
+	}
+
+	count := 0
+	for _, record := range records {
+		dataChangeEvent, err := utils.DeleteObjectWithChangeEvent(ctx, c.repository.Db, record, record.NodeClusterID, nil, func(object interface{}) any {
+			r, _ := object.(models.ClusterResource)
+			return models.ClusterResourceToModel(&r)
+		})
+
+		if err != nil {
+			return fmt.Errorf("failed to delete stale cluster resource: %w", err)
+		}
+
+		if dataChangeEvent != nil {
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
+			count++
+		}
+	}
+
+	if count > 0 {
+		slog.Info("Deleted stale cluster resource records", "count", count)
+	}
+
+	return nil
+}
+
+// handleSyncCompletion handles the case of a data source watcher that has discovered that it is
+// out of date with the data on the API server.  In response to that, it has re-listed all objects to
+// get back to a synchronized state before processing new change events.  This function is being
+// invoked to inform us that all data has been received and that any objects in the database that
+// are not part of the set of keys received can be deleted.
+func (c *Collector) handleSyncCompletion(ctx context.Context, objectType db.Model, keys []uuid.UUID) error {
+	ids := make([]any, len(keys))
+	for i, key := range keys {
+		ids[i] = key
+	}
+
+	switch obj := objectType.(type) {
+	case models.NodeCluster:
+		return c.handleNodeClusterSyncCompletion(ctx, ids)
+	case models.ClusterResource:
+		return c.handleClusterResourceSyncCompletion(ctx, ids)
+	default:
+		return fmt.Errorf("unsupported sync completion type for '%T'", obj)
+	}
+}
+
+// handleAsyncEvent receives and processes an async event received from a data source.
+func (c *Collector) handleAsyncEvent(ctx context.Context, event *async.AsyncChangeEvent) error {
+	s := c.findDataSource(event.DataSourceID)
+	if s == nil {
+		return fmt.Errorf("data source '%s' not found", event.DataSourceID)
+	}
+
+	dataSource, ok := s.(ClusterDataSource)
+	if !ok {
+		return fmt.Errorf("data source '%s' is not a ClusterDataSource", event.DataSourceID)
+	}
+
+	if event.EventType == async.SyncComplete {
+		// The watch is expired (e.g., the ResourceVersion is too old).  We need to re-sync and start again.
+		return c.handleSyncCompletion(ctx, event.Object, event.Keys)
+	}
+
+	switch value := event.Object.(type) {
+	case models.NodeCluster:
+		return c.handleAsyncNodeClusterEvent(ctx, dataSource, value, event.EventType == async.Deleted)
+	case models.ClusterResource:
+		return c.handleAsyncClusterResourceEvent(ctx, dataSource, value, event.EventType == async.Deleted)
+	default:
+		return fmt.Errorf("unknown object type '%T'", event.Object)
+	}
+}
+
+// deleteRelatedClusterResources deletes all related ClusterResource objects prior to deleting a NodeCluster object.
+// This is done explicitly rather than via a cascade action in the database so that we can send the inventory
+// notifications for each of the deleted ClusterResource instances.
+func (c *Collector) deleteRelatedClusterResources(ctx context.Context, nodeCluster models.NodeCluster) error {
+	resources, err := c.repository.GetNodeClusterResources(ctx, nodeCluster.NodeClusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster resources for node_cluster_id %s: %w", nodeCluster.NodeClusterID, err)
+	}
+
+	slog.Debug("deleting related cluster resources", "node_cluster_id", nodeCluster.NodeClusterID, "count", len(resources))
+
+	for _, resource := range resources {
+		dataChangeEvent, err := utils.DeleteObjectWithChangeEvent(
+			ctx, c.repository.Db, resource, resource.ClusterResourceID, &nodeCluster.NodeClusterID, func(object interface{}) any {
+				record, _ := object.(models.ClusterResource)
+				return models.ClusterResourceToModel(&record)
+			})
+
+		if err != nil {
+			return fmt.Errorf("failed to delete cluster resource '%s': %w", resource.ClusterResourceID, err)
+		}
+
+		if dataChangeEvent != nil {
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
+		}
+	}
+
+	return nil
+}
+
+// handleAsyncNodeClusterEvent handles an async handleWatchEvent received for a NodeCluster object.
+func (c *Collector) handleAsyncNodeClusterEvent(ctx context.Context, dataSource ClusterDataSource, nodeCluster models.NodeCluster, deleted bool) error {
+	if deleted {
+		// Handle the NodeCluster deletion, but first delete all subtending ClusterResources
+		if err := c.deleteRelatedClusterResources(ctx, nodeCluster); err != nil {
+			return err
+		}
+
+		dataChangeEvent, err := utils.DeleteObjectWithChangeEvent(
+			ctx, c.repository.Db, nodeCluster, nodeCluster.NodeClusterID, nil, func(object interface{}) any {
 				record, _ := object.(models.NodeCluster)
 				return models.NodeClusterToModel(&record, nil)
 			})
+
 		if err != nil {
-			return nil, fmt.Errorf("failed to persist node cluster: %w", err)
+			return fmt.Errorf("failed to delete node cluster '%s'': %w", nodeCluster.NodeClusterID, err)
 		}
 
 		if dataChangeEvent != nil {
 			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 		}
+
+		return nil
 	}
 
-	return clusters, nil
+	err := c.persistNodeCluster(ctx, dataSource, nodeCluster, map[uuid.UUID]bool{})
+	if err != nil {
+		return fmt.Errorf("failed to update node cluster '%s'': %w", nodeCluster.NodeClusterID, err)
+	}
+
+	return err
+}
+
+// handleAsyncClusterResourceEvent handles an async handleWatchEvent received for a ClusterResource object.
+func (c *Collector) handleAsyncClusterResourceEvent(ctx context.Context, dataSource ClusterDataSource, clusterResource models.ClusterResource, deleted bool) error {
+	// The ClusterResource object has a link to its parent object via the NodeClusterID attribute, but unfortunately, that
+	// piece of data does not appear in the backing data, so we need to augment it ourselves.
+	if clusterResource.Extensions != nil {
+		clusterName := (*clusterResource.Extensions)[clusterNameExtension].(string)
+		nodeCluster, err := c.repository.GetNodeClusterByName(ctx, clusterName)
+		if errors.Is(err, utils.ErrNotFound) {
+			slog.Warn("no node cluster found", "name", clusterName)
+			// This is likely a race condition in which we are processing a cluster resource object for which the cluster
+			// has already been deleted or is not yet present.
+			return nil
+		}
+		clusterResource.NodeClusterID = nodeCluster.NodeClusterID
+		// The name extension was added for the sole purpose of allowing us to find the matching cluster ID value
+		// since it is not possible for the data source to do this directly.  Removing it since it is not required
+		// by the spec and seems redundant since the full NodeCluster can be retrieved with the ID value.
+		delete(*clusterResource.Extensions, clusterNameExtension)
+	}
+
+	if deleted {
+		dataChangeEvent, err := utils.DeleteObjectWithChangeEvent(
+			ctx, c.repository.Db, clusterResource, clusterResource.ClusterResourceID, nil, func(object interface{}) any {
+				record, _ := object.(models.NodeCluster)
+				return models.NodeClusterToModel(&record, nil)
+			})
+
+		if err != nil {
+			return fmt.Errorf("failed to delete cluster resource '%s'': %w", clusterResource.ResourceID, err)
+		}
+
+		if dataChangeEvent != nil {
+			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
+		}
+
+		return nil
+	}
+
+	err := c.persistClusterResource(ctx, dataSource, clusterResource, map[uuid.UUID]bool{})
+	if err != nil {
+		return fmt.Errorf("failed to update cluster resource '%s'': %w", clusterResource.ResourceID, err)
+	}
+
+	return nil
 }

--- a/internal/service/common/async/store.go
+++ b/internal/service/common/async/store.go
@@ -1,0 +1,216 @@
+package async
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
+)
+
+// AsyncEventType defines the types of async events that are supported between the Collector and Reflector.
+type AsyncEventType int
+
+const (
+	// Updated indicates that the object is inserted or updated
+	Updated AsyncEventType = iota
+	// Deleted indicates that the object is deleted
+	Deleted
+	// SyncComplete indicates that the Reflector has re-listed all objects from the API server
+	SyncComplete
+)
+
+// AsyncChangeEvent defines the data received by a data source to signal that an async handleWatchEvent has been received for a
+// given object type.
+type AsyncChangeEvent struct {
+	DataSourceID uuid.UUID
+	EventType    AsyncEventType
+	Object       db.Model
+	Keys         []uuid.UUID
+}
+
+// AsyncEventHandler is intended to be implemented by the Collector so that it can receive data from the Reflector via
+// the Store interface.
+type AsyncEventHandler interface {
+	// HandleSyncComplete is used to indicate that the full list of objects has been received.  Any stale objects should now
+	// be deleted.
+	HandleSyncComplete(ctx context.Context, objectType runtime.Object, keys []uuid.UUID) error
+	// HandleAsyncEvent is used to pass objects received from the Reflector to the Collector
+	HandleAsyncEvent(ctx context.Context, obj interface{}, eventType AsyncEventType) (uuid.UUID, error)
+}
+
+// operation defines an internal structure used to pass information around about pending operations.
+type operation struct {
+	eventType AsyncEventType
+	// objects is used to store the subject(s) of the operation.  If eventType is Updated or Deleted,
+	// then this slice will contain only a single element.  If eventType is SyncComplete, then it
+	// may contain 0 or more elements.
+	objects []interface{}
+}
+
+// ReflectorStore defines an adaptation layer between a Reflector and our Collector.  This is an alternative to using an
+// Informer which eliminates the need for caching objects in memory.  On a system engineered to capacity, this can save
+// us hundreds of MB of memory.
+type ReflectorStore struct {
+	// ObjectType is an instance of the object type monitored by the Reflector.
+	ObjectType runtime.Object
+	// hasSynced indicates whether the initial sync has completed (i.e., whether Replace has been called)
+	hasSynced bool
+	// queue stores the pending operations received from the Reflector
+	queue []operation
+	// mutex protects the shared instance variables from concurrency issues
+	mutex sync.Mutex
+	// ready is used to signal that a new operation has been received from the Reflector
+	ready chan struct{}
+}
+
+// NewReflectorStore creates a new ReflectorStore
+func NewReflectorStore(objectType runtime.Object) *ReflectorStore {
+	return &ReflectorStore{
+		ObjectType: objectType,
+		queue:      []operation{},
+		ready:      make(chan struct{}, 1),
+	}
+}
+
+// enqueue adds an operation to the queue and signals the receiver if it is the first operation
+// enqueued to the queue.
+func (c *ReflectorStore) enqueue(operation operation) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.queue = append(c.queue, operation)
+	if operation.eventType == SyncComplete {
+		c.hasSynced = true
+	}
+	if len(c.queue) == 1 {
+		c.ready <- struct{}{}
+	}
+}
+
+// handleOperations processes the operations that have been enqueued by the Store interface.
+func (c *ReflectorStore) handleOperations(ctx context.Context, handler AsyncEventHandler) {
+	c.mutex.Lock()
+	// Move the operations into a local variable so that we minimize how long we hold the lock to
+	// avoid blocking the Reflector
+	operations := c.queue
+	c.queue = make([]operation, 0)
+	c.mutex.Unlock()
+
+	for _, o := range operations {
+		switch o.eventType {
+		case Updated, Deleted:
+			_, err := handler.HandleAsyncEvent(ctx, o.objects[0], o.eventType)
+			if err != nil {
+				slog.Warn("Failed to handle event", "event", o.eventType, "error", err)
+			}
+		case SyncComplete:
+			var keys []uuid.UUID
+			for _, obj := range o.objects {
+				key, err := handler.HandleAsyncEvent(ctx, obj, Updated)
+				if err != nil {
+					slog.Warn("Failed to handle event", "error", err)
+					continue
+				}
+				keys = append(keys, key)
+			}
+			err := handler.HandleSyncComplete(ctx, c.ObjectType, keys)
+			if err != nil {
+				slog.Warn("Failed to handle sync completion", "error", err)
+			}
+		}
+	}
+}
+
+// Receive waits for new operations to be enqueued to the work queue and then invokes the handler
+// to process each pending operation.  This method does not return unless the context is canceled.
+func (c *ReflectorStore) Receive(ctx context.Context, handler AsyncEventHandler) {
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("stopping store adapter; context canceled")
+		case <-c.ready:
+			c.handleOperations(ctx, handler)
+		}
+	}
+}
+
+// HasSynced is used to determine whether the initial sync operation has completed, which means the initial set of
+// objects has been retrieved from the API server.
+func (c *ReflectorStore) HasSynced() bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.hasSynced
+}
+
+// Add handles a new object being added.
+func (c *ReflectorStore) Add(obj interface{}) error {
+	c.enqueue(operation{
+		eventType: Updated,
+		objects:   []interface{}{obj},
+	})
+	return nil
+}
+
+// Update handles an update to an object.
+func (c *ReflectorStore) Update(obj interface{}) error {
+	c.enqueue(operation{
+		eventType: Updated,
+		objects:   []interface{}{obj},
+	})
+	return nil
+}
+
+// Delete handles a deleted object
+func (c *ReflectorStore) Delete(obj interface{}) error {
+	c.enqueue(operation{
+		eventType: Deleted,
+		objects:   []interface{}{obj},
+	})
+	return nil
+}
+
+// List is not supported.  We only need this interface to accept incoming data via Add, Update, Delete, and Replace.
+func (c *ReflectorStore) List() []interface{} {
+	// The Reflector does not use this method so it is not required.
+	panic("not supported")
+}
+
+// ListKeys is not supported.  We only need this interface to accept incoming data via Add, Update, Delete, and Replace.
+func (c *ReflectorStore) ListKeys() []string {
+	// The Reflector does not use this method so it is not required.
+	panic("not supported")
+}
+
+// Get is not supported.  We only need this interface to accept incoming data via Add, Update, Delete, and Replace.
+func (c *ReflectorStore) Get(_ interface{}) (item interface{}, exists bool, err error) {
+	// The Reflector does not use this method so it is not required.
+	panic("not supported")
+}
+
+// GetByKey is not supported.  We only need this interface to accept incoming data via Add, Update, Delete, and Replace.
+func (c *ReflectorStore) GetByKey(_ string) (item interface{}, exists bool, err error) {
+	// The Reflector does not use this method so it is not required.
+	panic("not supported")
+}
+
+// Replace indicates that the underlying Reflector needed to re-list all data from the API server.
+func (c *ReflectorStore) Replace(items []interface{}, resourceVersion string) error {
+	slog.Info("Replace called", "type", fmt.Sprintf("%T", c.ObjectType),
+		"items", len(items), "resourceVersion", resourceVersion)
+	c.enqueue(operation{
+		eventType: SyncComplete,
+		objects:   items,
+	})
+	return nil
+}
+
+// Resync indicates that a resync operation has occurred.  We do not use this interface.
+func (c *ReflectorStore) Resync() error {
+	// We don't have resync enabled, so this should not be called.
+	slog.Info("Resync called")
+	return nil
+}

--- a/internal/service/common/clients/k8s/k8s.go
+++ b/internal/service/common/clients/k8s/k8s.go
@@ -30,13 +30,13 @@ const (
 )
 
 // NewClientForHub creates a new client for the hub cluster
-func NewClientForHub() (client.Client, error) {
+func NewClientForHub() (client.WithWatch, error) {
 	conf, err := config.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config: %w", err)
 	}
 
-	c, err := client.New(conf, client.Options{Scheme: GetSchemeForHub()})
+	c, err := client.NewWithWatch(conf, client.Options{Scheme: GetSchemeForHub()})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}

--- a/internal/service/common/db/models/data_source.go
+++ b/internal/service/common/db/models/data_source.go
@@ -26,7 +26,7 @@ func (r DataSource) TableName() string {
 }
 
 // PrimaryKey returns the primary key column associated to this model
-func (r DataSource) PrimaryKey() string { return "id" }
+func (r DataSource) PrimaryKey() string { return "data_source_id" }
 
 // OnConflict returns the column or constraint to be used in the UPSERT operation
 func (r DataSource) OnConflict() string {

--- a/internal/service/resources/collector/collector_acm.go
+++ b/internal/service/resources/collector/collector_acm.go
@@ -10,9 +10,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/itchyny/gojq"
 	"github.com/thoas/go-funk"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	v1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
@@ -20,12 +17,13 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/graphql"
 	"github.com/openshift-kni/oran-o2ims/internal/jq"
 	"github.com/openshift-kni/oran-o2ims/internal/service"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/async"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/models"
 )
 
 // Interface compile enforcement
-var _ DataSource = (*ACMDataSource)(nil)
+var _ ResourceDataSource = (*ACMDataSource)(nil)
 
 // ACMDataSource defines an instance of a data source collector that interacts with the ACM search-api
 type ACMDataSource struct {
@@ -34,7 +32,7 @@ type ACMDataSource struct {
 	globalCloudID       uuid.UUID
 	extensions          []string
 	jqTool              *jq.Tool
-	hubClient           client.Client
+	hubClient           client.WithWatch
 	resourceFetcher     *service.ResourceFetcher
 	resourcePoolFetcher *service.ResourcePoolFetcher
 	generationID        int
@@ -57,7 +55,7 @@ const graphqlQuery = `query ($input: [SearchInput]) {
 			}`
 
 // NewACMDataSource creates a new instance of an ACM data source collector whose purpose is to collect data from the
-// ACM search API to be included in the resource, resource pool, resource type, and deployment manager tables.
+// ACM search API to be included in the resource, resource pool, and resource type tables.
 func NewACMDataSource(cloudID, globalCloudID uuid.UUID, backendURL string, extensions []string) (DataSource, error) {
 	// TODO: this needs to be refactored so that the token is re-read if a 401 error is returned so that we can
 	//   refresh it automatically.
@@ -149,9 +147,16 @@ func (d *ACMDataSource) Name() string {
 	return "ACM"
 }
 
-// SetID sets the unique identifier for this data source
-func (d *ACMDataSource) SetID(uuid uuid.UUID) {
+// GetID returns the data source ID for this data source
+func (d *ACMDataSource) GetID() uuid.UUID {
+	return d.dataSourceID
+}
+
+// Init initializes the data source with its configuration data; including the ID, the GenerationID, and its extension
+// values if provided.
+func (d *ACMDataSource) Init(uuid uuid.UUID, generationID int, asyncEventChannel chan<- *async.AsyncChangeEvent) {
 	d.dataSourceID = uuid
+	d.generationID = generationID
 }
 
 // SetGenerationID sets the current generation id for this data source.  This value is expected to
@@ -266,28 +271,6 @@ func (d *ACMDataSource) GetResourcePools(ctx context.Context) ([]models.Resource
 			// a single bad object.
 		} else {
 			results = append(results, result)
-		}
-	}
-
-	return results, nil
-}
-
-// GetDeploymentManagers returns the list of deployment managers for this data source
-func (d *ACMDataSource) GetDeploymentManagers(ctx context.Context) ([]models.DeploymentManager, error) {
-	var clusters v1.ManagedClusterList
-	err := d.hubClient.List(ctx, &clusters)
-	if err != nil {
-		return []models.DeploymentManager{}, fmt.Errorf("failed to list clusters: %w", err)
-	}
-
-	var results []models.DeploymentManager
-	for _, cluster := range clusters.Items {
-		if dm, err := d.convertManagedClusterToDeploymentManager(ctx, cluster); err != nil {
-			slog.Warn("failed to convert managed cluster to deployment manager", "cluster", cluster, "error", err)
-			// Continue on conversion failures so that we don't exclude valid data just because of
-			// a single bad object.
-		} else {
-			results = append(results, dm)
 		}
 	}
 
@@ -445,113 +428,4 @@ func (d *ACMDataSource) convertClusterToResourcePool(from data.Object) (to model
 	}
 
 	return
-}
-
-// makeCapacityInfo creates a map of strings of capacity attributes for the cluster
-func (d *ACMDataSource) makeCapacityInfo(cluster v1.ManagedCluster) map[string]string {
-	results := make(map[string]string)
-	tags := []string{"cpu", "ephemeral-storage", "hugepages-1Gi", "hugepages-2Mi", "memory", "pods"}
-	for _, tag := range tags {
-		if value, found := cluster.Status.Allocatable[v1.ResourceName(tag)]; found {
-			results[tag] = value.String()
-		}
-	}
-	return results
-}
-
-// getClusterClientConfig retrieves the cluster client config for the specified cluster.
-func (d *ACMDataSource) getClusterClientConfig(ctx context.Context, clusterName string) (*clientcmdapi.Config, error) {
-	// Fetch the kubeconfig for this cluster
-	kubeConfig, err := k8s.GetClusterKubeConfigFromSecret(ctx, d.hubClient, clusterName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cluster kubeconfig: %w", err)
-	}
-
-	config, err := clientcmd.Load(kubeConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal cluster config: %w", err)
-	}
-
-	return config, nil
-}
-
-// getDeploymentManagerExtensions builds the extensions required for the deployment manager
-func (d *ACMDataSource) getDeploymentManagerExtensions(ctx context.Context, clusterName string) (map[string]interface{}, error) {
-	// Fetch the kubeconfig for this cluster and provide the info as extensions to the returned object. This
-	// is anticipated as a temporary measure since eventually SMO will require accessing the API using an OAuth token
-	// acquired from an OAuth server.
-	config, err := d.getClusterClientConfig(ctx, clusterName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cluster config: %w", err)
-	}
-
-	var caData, url string
-	if cluster, found := config.Clusters[clusterName]; found {
-		caData = string(cluster.CertificateAuthorityData)
-		url = cluster.Server
-	}
-
-	var adminUser, adminCert, adminKey string
-	if authInfo, found := config.AuthInfos["admin"]; found {
-		adminUser = "admin"
-		adminCert = string(authInfo.ClientCertificateData)
-		adminKey = string(authInfo.ClientKeyData)
-	}
-
-	return map[string]interface{}{
-		"profileName": "k8s",
-		"profileData": map[string]interface{}{
-			"admin_client_cert":    adminCert,
-			"admin_client_key":     adminKey,
-			"admin_user":           adminUser,
-			"cluster_ca_cert":      caData,
-			"cluster_api_endpoint": url,
-		},
-	}, nil
-}
-
-// convertManagedClusterToDeploymentManager converts a ManagedCluster to a DeploymentManager object
-func (d *ACMDataSource) convertManagedClusterToDeploymentManager(ctx context.Context, cluster v1.ManagedCluster) (models.DeploymentManager, error) {
-	clusterID, found := cluster.Labels["clusterID"]
-	if !found {
-		return models.DeploymentManager{}, fmt.Errorf("clusterID label not found in cluster %s", cluster.Name)
-	}
-	deploymentManagerID, err := uuid.Parse(clusterID)
-	if err != nil {
-		return models.DeploymentManager{}, fmt.Errorf("failed to parse from clusterID '%s' from %s", clusterID, cluster.Name)
-	}
-
-	url := ""
-	for _, clientConfig := range cluster.Spec.ManagedClusterClientConfigs {
-		if clientConfig.URL != "" {
-			url = clientConfig.URL
-			break
-		}
-	}
-
-	if url == "" {
-		return models.DeploymentManager{}, fmt.Errorf("failed to find URL for cluster %s", cluster.Name)
-	}
-
-	extensions, err := d.getDeploymentManagerExtensions(ctx, cluster.Name)
-	if err != nil {
-		return models.DeploymentManager{}, fmt.Errorf("failed to get extensions for cluster %s", cluster.Name)
-	}
-
-	to := models.DeploymentManager{
-		DeploymentManagerID: deploymentManagerID,
-		Name:                cluster.Name,
-		Description:         cluster.Name,
-		OCloudID:            d.cloudID,
-		URL:                 url,
-		Locations:           []string{}, // TODO: populate with locations from all pools
-		Capabilities:        nil,
-		CapacityInfo:        d.makeCapacityInfo(cluster),
-		Extensions:          &extensions,
-		DataSourceID:        d.dataSourceID,
-		GenerationID:        d.generationID,
-		ExternalID:          "",
-	}
-
-	return to, nil
 }

--- a/internal/service/resources/collector/collector_k8s.go
+++ b/internal/service/resources/collector/collector_k8s.go
@@ -1,0 +1,326 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	v1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/async"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
+	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/models"
+)
+
+const clusterReflectorName = "cluster-reflector"
+
+// Interface compile enforcement
+var _ DeploymentManagerDataSource = (*K8SDataSource)(nil)
+
+// K8SDataSource defines an instance of a data source collector that interacts with the ACM search-api
+type K8SDataSource struct {
+	dataSourceID      uuid.UUID
+	cloudID           uuid.UUID
+	globalCloudID     uuid.UUID
+	hubClient         client.WithWatch
+	generationID      int
+	AsyncChangeEvents chan<- *async.AsyncChangeEvent
+}
+
+// NewK8SDataSource creates a new instance of an ACM data source collector whose purpose is to collect data from the
+// ACM search API to be included in the resource, resource pool, resource type, and deployment manager tables.
+func NewK8SDataSource(cloudID, globalCloudID uuid.UUID) (DataSource, error) {
+	// Create a k8s client for the hub to be able to retrieve managed cluster info
+	hubClient, err := k8s.NewClientForHub()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create k8s client for hub: %w", err)
+	}
+
+	return &K8SDataSource{
+		generationID:  0,
+		cloudID:       cloudID,
+		globalCloudID: globalCloudID,
+		hubClient:     hubClient,
+	}, nil
+}
+
+// Name returns the name of this data source
+func (d *K8SDataSource) Name() string {
+	return "K8S"
+}
+
+// GetID returns the data source ID for this data source
+func (d *K8SDataSource) GetID() uuid.UUID {
+	return d.dataSourceID
+}
+
+// Init initializes the data source with its configuration data; including the ID, the GenerationID, and its extension
+// values if provided.
+func (d *K8SDataSource) Init(uuid uuid.UUID, generationID int, asyncEventChannel chan<- *async.AsyncChangeEvent) {
+	d.dataSourceID = uuid
+	d.generationID = generationID
+	d.AsyncChangeEvents = asyncEventChannel
+}
+
+// SetGenerationID sets the current generation id for this data source.  This value is expected to
+// be restored from persistent storage at initialization time.
+func (d *K8SDataSource) SetGenerationID(value int) {
+	d.generationID = value
+}
+
+// GetGenerationID retrieves the current generation id for this data source.
+func (d *K8SDataSource) GetGenerationID() int {
+	return d.generationID
+}
+
+// IncrGenerationID increments the current generation id for this data source.
+func (d *K8SDataSource) IncrGenerationID() int {
+	d.generationID++
+	return d.generationID
+}
+
+// GetDeploymentManagers returns the list of deployment managers for this data source
+func (d *K8SDataSource) GetDeploymentManagers(ctx context.Context) ([]models.DeploymentManager, error) {
+	var clusters v1.ManagedClusterList
+	err := d.hubClient.List(ctx, &clusters)
+	if err != nil {
+		return []models.DeploymentManager{}, fmt.Errorf("failed to list clusters: %w", err)
+	}
+
+	var results []models.DeploymentManager
+	for _, cluster := range clusters.Items {
+		if dm, err := d.convertManagedClusterToDeploymentManager(ctx, &cluster); err != nil {
+			slog.Warn("failed to convert managed cluster to deployment manager", "cluster", cluster, "error", err)
+			// Continue on conversion failures so that we don't exclude valid data just because of
+			// a single bad object.
+		} else {
+			results = append(results, dm)
+		}
+	}
+
+	return results, nil
+}
+
+// makeCapacityInfo creates a map of strings of capacity attributes for the cluster
+func (d *K8SDataSource) makeCapacityInfo(cluster *v1.ManagedCluster) map[string]string {
+	results := make(map[string]string)
+	tags := []string{"cpu", "ephemeral-storage", "hugepages-1Gi", "hugepages-2Mi", "memory", "pods"}
+	for _, tag := range tags {
+		if value, found := cluster.Status.Allocatable[v1.ResourceName(tag)]; found {
+			results[tag] = value.String()
+		}
+	}
+	return results
+}
+
+// getClusterClientConfig retrieves the cluster client config for the specified cluster.
+func (d *K8SDataSource) getClusterClientConfig(ctx context.Context, clusterName string) (*clientcmdapi.Config, error) {
+	// Fetch the kubeconfig for this cluster
+	kubeConfig, err := k8s.GetClusterKubeConfigFromSecret(ctx, d.hubClient, clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster kubeconfig: %w", err)
+	}
+
+	config, err := clientcmd.Load(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cluster config: %w", err)
+	}
+
+	return config, nil
+}
+
+// getDeploymentManagerExtensions builds the extensions required for the deployment manager
+func (d *K8SDataSource) getDeploymentManagerExtensions(ctx context.Context, clusterName string) (map[string]interface{}, error) {
+	// Fetch the kubeconfig for this cluster and provide the info as extensions to the returned object. This
+	// is anticipated as a temporary measure since eventually SMO will require accessing the API using an OAuth token
+	// acquired from an OAuth server.
+	config, err := d.getClusterClientConfig(ctx, clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster config: %w", err)
+	}
+
+	var caData, url string
+	if cluster, found := config.Clusters[clusterName]; found {
+		caData = string(cluster.CertificateAuthorityData)
+		url = cluster.Server
+	}
+
+	var adminUser, adminCert, adminKey string
+	if authInfo, found := config.AuthInfos["admin"]; found {
+		adminUser = "admin"
+		adminCert = string(authInfo.ClientCertificateData)
+		adminKey = string(authInfo.ClientKeyData)
+	}
+
+	return map[string]interface{}{
+		"profileName": "k8s",
+		"profileData": map[string]interface{}{
+			"admin_client_cert":    adminCert,
+			"admin_client_key":     adminKey,
+			"admin_user":           adminUser,
+			"cluster_ca_cert":      caData,
+			"cluster_api_endpoint": url,
+		},
+	}, nil
+}
+
+// convertManagedClusterToDeploymentManager converts a ManagedCluster to a DeploymentManager object
+func (d *K8SDataSource) convertManagedClusterToDeploymentManager(ctx context.Context, cluster *v1.ManagedCluster) (models.DeploymentManager, error) {
+	clusterID, found := cluster.Labels["clusterID"]
+	if !found {
+		return models.DeploymentManager{}, fmt.Errorf("clusterID label not found in cluster %s", cluster.Name)
+	}
+	deploymentManagerID, err := uuid.Parse(clusterID)
+	if err != nil {
+		return models.DeploymentManager{}, fmt.Errorf("failed to parse from clusterID '%s' from %s", clusterID, cluster.Name)
+	}
+
+	url := ""
+	for _, clientConfig := range cluster.Spec.ManagedClusterClientConfigs {
+		if clientConfig.URL != "" {
+			url = clientConfig.URL
+			break
+		}
+	}
+
+	if url == "" {
+		return models.DeploymentManager{}, fmt.Errorf("failed to find URL for cluster %s", cluster.Name)
+	}
+
+	extensions, err := d.getDeploymentManagerExtensions(ctx, cluster.Name)
+	if err != nil {
+		return models.DeploymentManager{}, fmt.Errorf("failed to get extensions for cluster %s", cluster.Name)
+	}
+
+	to := models.DeploymentManager{
+		DeploymentManagerID: deploymentManagerID,
+		Name:                cluster.Name,
+		Description:         cluster.Name,
+		OCloudID:            d.cloudID,
+		URL:                 url,
+		Locations:           []string{}, // TODO: populate with locations from all pools
+		Capabilities:        nil,
+		CapacityInfo:        d.makeCapacityInfo(cluster),
+		Extensions:          &extensions,
+		DataSourceID:        d.dataSourceID,
+		GenerationID:        d.generationID,
+		ExternalID:          "",
+	}
+
+	return to, nil
+}
+
+// handleClusterWatchEvent handles an async event received from the managed cluster watcher
+func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1.ManagedCluster, eventType async.AsyncEventType) (uuid.UUID, error) {
+	slog.Debug("handleWatchEvent received for managed cluster", "agent", cluster.Name, "type", eventType)
+
+	record, err := d.convertManagedClusterToDeploymentManager(ctx, cluster)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to convert managed cluster to node cluster: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		slog.Info("context cancelled while writing to async event channel; aborting")
+		return uuid.Nil, fmt.Errorf("context cancelled; aborting")
+	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
+		DataSourceID: d.dataSourceID,
+		EventType:    eventType,
+		Object:       record}:
+		return record.DeploymentManagerID, nil
+	}
+}
+
+// HandleAsyncEvent handles an add/update/delete to an object received by from the Reflector.
+func (d *K8SDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
+	slog.Debug("handleWatchEvent received for store adapter", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	switch value := obj.(type) {
+	case *v1.ManagedCluster:
+		return d.handleClusterWatchEvent(ctx, value, eventType)
+	default:
+		// We are only watching for specific event types so this should happen.
+		slog.Warn("Unknown object type", "type", fmt.Sprintf("%T", obj))
+		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
+	}
+}
+
+// HandleSyncComplete handles the end of a sync operation by sending an event down to the Collector.
+func (d *K8SDataSource) HandleSyncComplete(ctx context.Context, objectType runtime.Object, keys []uuid.UUID) error {
+	var object db.Model
+	switch objectType.(type) {
+	case *v1.ManagedCluster:
+		object = models.DeploymentManager{}
+	default:
+		// This should never happen since we watch for specific types
+		slog.Warn("Unknown object type", "type", fmt.Sprintf("%T", objectType))
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		slog.Info("context cancelled while writing to async event channel; aborting")
+		return fmt.Errorf("context cancelled; aborting")
+	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
+		DataSourceID: d.dataSourceID,
+		EventType:    async.SyncComplete,
+		Object:       object,
+		Keys:         keys}:
+		return nil
+	}
+}
+
+// Watch starts a watcher for each of the resources supported by this data source.
+// The watch is dispatched to a go routine.  If the context is canceled, then the watchers are stopped.
+func (d *K8SDataSource) Watch(ctx context.Context) error {
+
+	// The Reflector package uses a channel to signal stop events rather than a context, so use this go routine to
+	// bridge the two worlds.
+	stopCh := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		slog.Info("context canceled; stopping reflectors")
+		close(stopCh)
+	}()
+
+	// Create a Reflector to watch ManagedCluster objects
+	lister := cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			var managedClusterList v1.ManagedClusterList
+			err := d.hubClient.List(ctx, &managedClusterList, &client.ListOptions{Raw: &options})
+			if err != nil {
+				return nil, fmt.Errorf("error listing managed clusters: %w", err)
+			}
+			return &managedClusterList, nil
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			var managedClusterList v1.ManagedClusterList
+			w, err := d.hubClient.Watch(ctx, &managedClusterList, &client.ListOptions{Raw: &options})
+			if err != nil {
+				return nil, fmt.Errorf("error watching managed clusters: %w", err)
+			}
+			return w, nil
+		},
+		DisableChunking: false,
+	}
+
+	store := async.NewReflectorStore(&v1.ManagedCluster{})
+	reflector := cache.NewNamedReflector(clusterReflectorName, &lister, &v1.ManagedCluster{}, store, time.Duration(0))
+	slog.Info("starting cluster reflector")
+	go reflector.Run(stopCh)
+
+	// Start monitoring the store to process incoming events
+	slog.Info("starting to receive from cluster reflector store")
+	go store.Receive(ctx, d)
+
+	return nil
+}

--- a/internal/service/resources/db/repo/repository.go
+++ b/internal/service/resources/db/repo/repository.go
@@ -21,6 +21,13 @@ func (r *ResourcesRepository) GetDeploymentManagers(ctx context.Context) ([]mode
 	return utils.FindAll[models.DeploymentManager](ctx, r.Db)
 }
 
+// GetDeploymentManagersNotIn returns the list of DeploymentManager records not matching the list of keys provided, or
+// an empty list if none exist; otherwise an error
+func (r *ResourcesRepository) GetDeploymentManagersNotIn(ctx context.Context, keys []any) ([]models.DeploymentManager, error) {
+	e := psql.Quote(models.DeploymentManager{}.PrimaryKey()).NotIn(psql.Arg(keys...))
+	return utils.Search[models.DeploymentManager](ctx, r.Db, e)
+}
+
 // GetDeploymentManager retrieves a specific DeploymentManager tuple or returns ErrNotFound if not found
 func (r *ResourcesRepository) GetDeploymentManager(ctx context.Context, id uuid.UUID) (*models.DeploymentManager, error) {
 	return utils.Find[models.DeploymentManager](ctx, r.Db, id)

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -100,6 +100,10 @@ func Serve(config *api.ResourceServerConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to create ACM data source: %w", err)
 	}
+	k8s, err := collector.NewK8SDataSource(cloudID, globalCloudID)
+	if err != nil {
+		return fmt.Errorf("failed to create K8S data source: %w", err)
+	}
 
 	// Create the notifier with our resource-specific subscription and notification providers.
 	notificationsProvider := repo2.NewNotificationStorageProvider(commonRepository)
@@ -108,7 +112,7 @@ func Serve(config *api.ResourceServerConfig) error {
 	resourceNotifier := notifier.NewNotifier(subscriptionsProvider, notificationsProvider, clientFactory)
 
 	// Create the collector
-	resourceCollector := collector.NewCollector(repository, resourceNotifier, []collector.DataSource{acm})
+	resourceCollector := collector.NewCollector(repository, resourceNotifier, []collector.DataSource{k8s, acm})
 
 	// Init server
 	// Create the handler


### PR DESCRIPTION
This adds the ability to watch for changes to ManagedCluster and Agent objects so that we can dynamically update our persistent storage rather than have to poll at fixed intervals.  The watch is implemented using a Reflector and supplying an adapter layer that receives cache update events and feeds them to the Collector which then updates our storage and emits async notification events to subscribers as needed.