### PR TITLE
CNF-16247: Add support for in-cluster subscription endpoints

### DIFF
--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -261,7 +261,8 @@ func startSubscriptionNotifier(ctx context.Context, config api.AlarmsServerConfi
 
 	notificationsProvider := notifier_provider.NewNotificationStorageProvider(a.AlarmsRepository)
 	subscriptionsProvider := notifier_provider.NewSubscriptionStorageProvider(a.AlarmsRepository)
-	newNotifier := notifier.NewNotifier(subscriptionsProvider, notificationsProvider, oauthConfig)
+	clientFactory := notifier.NewClientFactory(oauthConfig, utils.DefaultBackendTokenFile)
+	newNotifier := notifier.NewNotifier(subscriptionsProvider, notificationsProvider, clientFactory)
 
 	a.NotificationProvider = notificationsProvider
 	a.Notifier = newNotifier

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -93,7 +93,8 @@ func Serve(config *api.ClusterServerConfig) error {
 	// Create the notifier with our resource specific subscription and notification providers.
 	notificationsProvider := repo2.NewNotificationStorageProvider(commonRepository)
 	subscriptionsProvider := repo2.NewSubscriptionStorageProvider(commonRepository)
-	clusterNotifier := notifier.NewNotifier(subscriptionsProvider, notificationsProvider, oauthConfig)
+	clientFactory := notifier.NewClientFactory(oauthConfig, utils.DefaultBackendTokenFile)
+	clusterNotifier := notifier.NewNotifier(subscriptionsProvider, notificationsProvider, clientFactory)
 
 	// Create the collector
 	clusterCollector := collector.NewCollector(repository, clusterNotifier, []collector.DataSource{k8s})

--- a/internal/service/common/notifier/notifier_worker.go
+++ b/internal/service/common/notifier/notifier_worker.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
-	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
 // maxRetries defines the number of attempts made on each notification
@@ -54,12 +52,12 @@ type SubscriptionWorker struct {
 }
 
 // NewSubscriptionWorker creates a new subscription worker object to service a specific subscription
-func NewSubscriptionWorker(ctx context.Context, oauthConfig *utils.OAuthClientConfig, subscriptionJobCompleteChannel chan *SubscriptionJobComplete,
+func NewSubscriptionWorker(ctx context.Context, clientProvider ClientProvider, subscriptionJobCompleteChannel chan *SubscriptionJobComplete,
 	subscription *SubscriptionInfo) (*SubscriptionWorker, error) {
 	// Create a client for this subscription.
-	client, err := utils.SetupOAuthClient(ctx, oauthConfig)
+	client, err := clientProvider.NewClient(ctx, subscription.Callback)
 	if err != nil {
-		return nil, fmt.Errorf("failed to setup oauth client: %w", err)
+		return nil, fmt.Errorf("failed to setup client: %w", err)
 	}
 
 	// Set up a custom logger to include the subscription info so it doesn't need to be repeated

--- a/internal/service/common/notifier/provider.go
+++ b/internal/service/common/notifier/provider.go
@@ -1,0 +1,67 @@
+package notifier
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"k8s.io/client-go/transport"
+
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+)
+
+// ClientFactory is a utility used to abstract building an HTTP client based on the type of callback
+// URL supplied.
+type ClientFactory struct {
+	oauthConfig      *utils.OAuthClientConfig
+	serviceTokenFile string
+}
+
+// ClientProvider defines the interface which any client factory must implement.  This exists for
+// future unit test purposes so that the ClientFactory can be swapped out as needed.
+type ClientProvider interface {
+	NewClient(ctx context.Context, callbackURL string) (*http.Client, error)
+}
+
+// NewClientFactory creates a new factory
+func NewClientFactory(oauthConfig *utils.OAuthClientConfig, serviceTokenFile string) ClientProvider {
+	return &ClientFactory{
+		oauthConfig:      oauthConfig,
+		serviceTokenFile: serviceTokenFile,
+	}
+}
+
+func (f *ClientFactory) newClusterClient(ctx context.Context) (*http.Client, error) {
+	tlsConfig, _ := utils.GetDefaultTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12})
+	baseClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+		Timeout: 30 * time.Second,
+	}
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, baseClient)
+	return oauth2.NewClient(ctx, transport.NewCachedFileTokenSource(f.serviceTokenFile)), nil
+}
+
+func (f *ClientFactory) newOAuthClient(ctx context.Context) (*http.Client, error) {
+	client, err := utils.SetupOAuthClient(ctx, f.oauthConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup oauth client")
+	}
+	return client, nil
+}
+
+// NewClient creates a new Client based on the callback URL provided.  If the callback URL is a local
+// service URL that contains "svc.cluster.local" then a Client will be created that uses the
+// supplied service account token file; otherwise, it is assumed that the URL points to a public
+// endpoint that requires the OAuth credentials.
+func (f *ClientFactory) NewClient(ctx context.Context, callback string) (*http.Client, error) {
+	if strings.Contains(callback, "svc.cluster.local") {
+		return f.newClusterClient(ctx)
+	}
+	return f.newOAuthClient(ctx)
+}

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -104,7 +104,8 @@ func Serve(config *api.ResourceServerConfig) error {
 	// Create the notifier with our resource specific subscription and notification providers.
 	notificationsProvider := repo2.NewNotificationStorageProvider(commonRepository)
 	subscriptionsProvider := repo2.NewSubscriptionStorageProvider(commonRepository)
-	resourceNotifier := notifier.NewNotifier(subscriptionsProvider, notificationsProvider, oauthConfig)
+	clientFactory := notifier.NewClientFactory(oauthConfig, utils.DefaultBackendTokenFile)
+	resourceNotifier := notifier.NewNotifier(subscriptionsProvider, notificationsProvider, clientFactory)
 
 	// Create the collector
 	resourceCollector := collector.NewCollector(repository, resourceNotifier, []collector.DataSource{acm})


### PR DESCRIPTION
This adds the ability to re-use our subscription mechanism between services rather than solely supporting OAuth public endpoints (e.g., SMO).  The type of client created is based on the callback URL provided in the subscription.  If it contains "svc.cluster.local" then it is assumed to be in-cluster and uses the service account token rather than an OAuth token.