### PR TITLE
Fix panic when not using client TLS to SMO

### DIFF
--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -390,7 +390,7 @@ func addArgsForSMO(inventory *inventoryv1alpha1.Inventory, args []string) []stri
 				fmt.Sprintf("--oauth-token-url=%s%s", smo.OAuthConfig.URL, smo.OAuthConfig.TokenEndpoint))
 		}
 
-		if smo.TLS.ClientCertificateName != nil {
+		if smo.TLS != nil && smo.TLS.ClientCertificateName != nil {
 			args = append(args,
 				fmt.Sprintf("--tls-client-cert=%s/tls.crt", TLSClientMountPath),
 				fmt.Sprintf("--tls-client-key=%s/tls.key", TLSClientMountPath),


### PR DESCRIPTION
Fixes a panic due to a nil pointer deference when testing against an SMO without using a client TLS certificate for mTLS.