### PR TITLE
 CNF-14946: CNF-14947: retrieve all probableCauses of current set of alarms or one probableCause for a given ID

### DIFF
--- a/internal/service/alarms/api/server.go
+++ b/internal/service/alarms/api/server.go
@@ -494,14 +494,14 @@ func (a *AlarmsServer) UpdateAlarmServiceConfiguration(ctx context.Context, requ
 
 // GetProbableCauses list all the relevant probableCauses based on alarms that are currently in the events table
 func (a *AlarmsServer) GetProbableCauses(ctx context.Context, _ api.GetProbableCausesRequestObject) (api.GetProbableCausesResponseObject, error) {
-	defs, err := a.AlarmsRepository.GetAllAlarmDefForProbableCause(ctx)
+	defs, err := a.AlarmsRepository.GetAllAlarmDefinitionForProbableCause(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get alarm definitions for probableCauses: %w", err)
 	}
 
 	pcs := make([]api.ProbableCause, 0, len(defs))
 	for _, def := range defs {
-		pcs = append(pcs, models.ConvertDefToPC(def))
+		pcs = append(pcs, models.ConvertAlarmDefinitionToProbableCause(def))
 	}
 
 	slog.Info("Successfully retrieved probableCauses of current events", "count", len(pcs))
@@ -510,7 +510,7 @@ func (a *AlarmsServer) GetProbableCauses(ctx context.Context, _ api.GetProbableC
 
 // GetProbableCause retrieve a probable cause of alarm with UUID
 func (a *AlarmsServer) GetProbableCause(ctx context.Context, request api.GetProbableCauseRequestObject) (api.GetProbableCauseResponseObject, error) {
-	alarmDefs, err := a.AlarmsRepository.GetAlarmDefForProbableCause(ctx, request.ProbableCauseId)
+	alarmDefs, err := a.AlarmsRepository.GetAlarmDefinitionForProbableCause(ctx, request.ProbableCauseId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get alarm definition for probableCause: %w", err)
 	}
@@ -526,7 +526,7 @@ func (a *AlarmsServer) GetProbableCause(ctx context.Context, request api.GetProb
 	}
 
 	slog.Info("Successfully retrieved probable cause", "id", request.ProbableCauseId)
-	return api.GetProbableCause200JSONResponse(models.ConvertDefToPC(alarmDefs[0])), nil
+	return api.GetProbableCause200JSONResponse(models.ConvertAlarmDefinitionToProbableCause(alarmDefs[0])), nil
 }
 
 // AmNotification handles an API request coming from AlertManager with CaaS alerts. This api is used internally.

--- a/internal/service/alarms/internal/db/models/converters.go
+++ b/internal/service/alarms/internal/db/models/converters.go
@@ -137,3 +137,12 @@ func ConvertAlertSubToNotificationSub(as *AlarmSubscription) *notifier.Subscript
 	}
 	return &info
 }
+
+// ConvertDefToPC probableCause is subset of alarm definition
+func ConvertDefToPC(def AlarmDefinition) api.ProbableCause {
+	return api.ProbableCause{
+		Description:     def.AlarmDescription,
+		Name:            def.AlarmName,
+		ProbableCauseId: def.ProbableCauseID,
+	}
+}

--- a/internal/service/alarms/internal/db/models/converters.go
+++ b/internal/service/alarms/internal/db/models/converters.go
@@ -138,8 +138,8 @@ func ConvertAlertSubToNotificationSub(as *AlarmSubscription) *notifier.Subscript
 	return &info
 }
 
-// ConvertDefToPC probableCause is subset of alarm definition
-func ConvertDefToPC(def AlarmDefinition) api.ProbableCause {
+// ConvertAlarmDefinitionToProbableCause probableCause is subset of alarm definition
+func ConvertAlarmDefinitionToProbableCause(def AlarmDefinition) api.ProbableCause {
 	return api.ProbableCause{
 		Description:     def.AlarmDescription,
 		Name:            def.AlarmName,

--- a/internal/service/alarms/internal/db/repo/alarms_repository.go
+++ b/internal/service/alarms/internal/db/repo/alarms_repository.go
@@ -441,8 +441,8 @@ func (ar *AlarmsRepository) GetMaxAlarmSeq(ctx context.Context) (int64, error) {
 	return maxSeq, nil
 }
 
-// GetAlarmDefForProbableCause extract the PC details from alarms def for a given probableCauseID
-func (ar *AlarmsRepository) GetAlarmDefForProbableCause(ctx context.Context, probableCauseID uuid.UUID) ([]models.AlarmDefinition, error) {
+// GetAlarmDefinitionForProbableCause extract the probableCause details (name, description) from alarms definition for a given probableCauseID
+func (ar *AlarmsRepository) GetAlarmDefinitionForProbableCause(ctx context.Context, probableCauseID uuid.UUID) ([]models.AlarmDefinition, error) {
 	m := models.AlarmDefinition{}
 	dbTags := utils.GetAllDBTagsFromStruct(m)
 
@@ -467,8 +467,8 @@ func (ar *AlarmsRepository) GetAlarmDefForProbableCause(ctx context.Context, pro
 	return rows, nil
 }
 
-// GetAllAlarmDefForProbableCause get all the possible probable cause from current list of alarms and then retrieve info (name, description) for them from alarms def table
-func (ar *AlarmsRepository) GetAllAlarmDefForProbableCause(ctx context.Context) ([]models.AlarmDefinition, error) {
+// GetAllAlarmDefinitionForProbableCause get all the possible probable cause from current list of alarms and then retrieve info (name, description) for them from alarms definition table
+func (ar *AlarmsRepository) GetAllAlarmDefinitionForProbableCause(ctx context.Context) ([]models.AlarmDefinition, error) {
 	aEvent := models.AlarmEventRecord{}
 	dbTags := utils.GetAllDBTagsFromStruct(aEvent)
 


### PR DESCRIPTION
Implements the two probableCause APIs.
- Look for rows in events table and extract out the ProbableCause for each and list them all. ("get all")
- Find a specific probableCause with a given ID.  ("get one")