### PR TITLE
CNF-16400: CNF-16401: Artifacts server api_versions and GET one

### DIFF
--- a/internal/service/artifacts/api/openapi.yaml
+++ b/internal/service/artifacts/api/openapi.yaml
@@ -39,6 +39,64 @@ tags:
 
 paths:
 
+  /o2ims-infrastructureArtifacts/api_versions:
+    get:
+      operationId: getAllVersions
+      summary: Get API versions
+      description: |
+        Returns the complete list of API versions implemented by the service.
+      tags:
+      - metadata
+      responses:
+        '200':
+          description: |
+            Successfully obtained the complete list of versions.
+          content:
+            application/json:
+              schema:
+                $ref: "../../common/api/openapi.yaml#/components/schemas/APIVersions"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '500':
+          description: Internal server error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+
+  /o2ims-infrastructureArtifacts/v1/api_versions:
+    get:
+      operationId: getMinorVersions
+      summary: Get minor API versions
+      description: |
+        Returns the list of minor API versions implemented for this major version of the API.
+      tags:
+      - metadata
+      responses:
+        '200':
+          description: |
+            Success
+          content:
+            application/json:
+              schema:
+                $ref: "../../common/api/openapi.yaml#/components/schemas/APIVersions"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '500':
+          description: Internal server error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+
   /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates:
     get:
       operationId: getManagedInfrastructureTemplates
@@ -123,7 +181,7 @@ components:
       required: true
       schema:
         type: string
-      example: fa242779-dfef-414e-b2b1-3b75d6f6b65d
+      example: name.version
 
   schemas:
     ManagedInfrastructureTemplate:

--- a/internal/service/artifacts/api/server.go
+++ b/internal/service/artifacts/api/server.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/google/uuid"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	api "github.com/openshift-kni/oran-o2ims/internal/service/artifacts/api/generated"
+	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -21,6 +23,40 @@ type ArtifactsServer struct {
 
 // ArtifactsServer implements StrictServerInterface. This ensures that we've conformed to the `StrictServerInterface` with a compile-time check
 var _ api.StrictServerInterface = (*ArtifactsServer)(nil)
+
+// baseURL is the prefix for all of our supported API endpoints
+var baseURL = "/o2ims-infrastructureArtifacts/v1"
+var currentVersion = "1.0.0"
+
+// GetAllVersions receives the API request to this endpoint, executes the request, and responds appropriately.
+func (a *ArtifactsServer) GetAllVersions(ctx context.Context, request api.GetAllVersionsRequestObject) (api.GetAllVersionsResponseObject, error) {
+	// We currently only support a single version
+	versions := []common.APIVersion{
+		{
+			Version: &currentVersion,
+		},
+	}
+
+	return api.GetAllVersions200JSONResponse(common.APIVersions{
+		ApiVersions: &versions,
+		UriPrefix:   &baseURL,
+	}), nil
+}
+
+// GetMinorVersions receives the API request to this endpoint, executes the request, and responds appropriately.
+func (a *ArtifactsServer) GetMinorVersions(ctx context.Context, request api.GetMinorVersionsRequestObject) (api.GetMinorVersionsResponseObject, error) {
+	// We currently only support a single version
+	versions := []common.APIVersion{
+		{
+			Version: &currentVersion,
+		},
+	}
+
+	return api.GetMinorVersions200JSONResponse(common.APIVersions{
+		ApiVersions: &versions,
+		UriPrefix:   &baseURL,
+	}), nil
+}
 
 // Get managed infrastructure templates
 // (GET /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates)
@@ -38,23 +74,10 @@ func (r *ArtifactsServer) GetManagedInfrastructureTemplates(
 	// Range through the ClusterTemplates and convert them to the ManagedInfrastructureTemplate model.
 	objects := make([]api.ManagedInfrastructureTemplate, 0, len(allClusterTemplates.Items))
 	for _, clusterTemplate := range allClusterTemplates.Items {
-		// Validate and transform the string to UUID.
-		if _, err := uuid.Parse(clusterTemplate.Spec.TemplateID); err != nil {
-			return nil, fmt.Errorf("could not get uuid from ManagedInfrastructureTemplate: %w", err)
-		}
-		uuid := uuid.MustParse(clusterTemplate.Spec.TemplateID)
-		// Obtain the parameter schema in the desired map format.
-		var parameterSchema map[string]interface{}
-		if err := json.Unmarshal(clusterTemplate.Spec.TemplateParameterSchema.Raw, &parameterSchema); err != nil {
-			return nil, fmt.Errorf("could not get parameterSchema from ManagedInfrastructureTemplate: %w", err)
-		}
 		// Convert the current ClusterTemplate to ManagedInfrastructureTemplate.
-		managedInfrastructureTemplate := api.ManagedInfrastructureTemplate{
-			ArtifactResourceId: uuid,
-			Name:               clusterTemplate.Spec.Name,
-			Version:            clusterTemplate.Spec.Version,
-			Description:        clusterTemplate.Spec.Description,
-			ParameterSchema:    parameterSchema,
+		managedInfrastructureTemplate, err := clusterTemplateToManagedInfrastructureTemplate(clusterTemplate)
+		if err != nil {
+			return nil, err
 		}
 		objects = append(objects, managedInfrastructureTemplate)
 	}
@@ -67,6 +90,65 @@ func (r *ArtifactsServer) GetManagedInfrastructureTemplates(
 func (r *ArtifactsServer) GetManagedInfrastructureTemplate(
 	ctx context.Context, request api.GetManagedInfrastructureTemplateRequestObject) (api.GetManagedInfrastructureTemplateResponseObject, error) {
 
-	// TODO implement me
-	return nil, fmt.Errorf("not implemented")
+	// Get the ClusterTemplates with the requested ID.
+	var clusterTemplates provisioningv1alpha1.ClusterTemplateList
+	err := r.HubClient.List(
+		ctx,
+		&clusterTemplates,
+		client.MatchingFields{"metadata.name": request.ManagedInfrastructureTemplateId},
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not list ManagedInfrastructureTemplates across the cluster: %w", err)
+	}
+
+	// There should be just one ClusterTemplate with the requested ID.
+	// We need ManagedInfrastructureTemplateId to match ClusterTemplate metadata.name
+	// which is of format ClusterTemplate <spec.name>.<spec.version>.
+	if len(clusterTemplates.Items) > 1 {
+		return nil, fmt.Errorf(
+			"more than one ManagedInfrastructureTemplate with the requested ID: %s",
+			request.ManagedInfrastructureTemplateId)
+	}
+
+	if len(clusterTemplates.Items) == 0 {
+		return api.GetManagedInfrastructureTemplate404ApplicationProblemPlusJSONResponse(
+			common.ProblemDetails{
+				AdditionalAttributes: &map[string]string{
+					"managedInfrastructureTemplateId": request.ManagedInfrastructureTemplateId,
+				},
+				Detail: "requested ManagedInfrastructureTemplate not found",
+				Status: http.StatusNotFound,
+			}), nil
+	}
+
+	// Convert the ClusterTemplate to the ManagedInfrastructureTemplate format.
+	object, err := clusterTemplateToManagedInfrastructureTemplate(clusterTemplates.Items[0])
+	if err != nil {
+		return nil, err
+	}
+	return api.GetManagedInfrastructureTemplate200JSONResponse(object), nil
+}
+
+func clusterTemplateToManagedInfrastructureTemplate(clusterTemplate provisioningv1alpha1.ClusterTemplate) (
+	api.ManagedInfrastructureTemplate, error) {
+
+	// Validate and transform the string to UUID.
+	if _, err := uuid.Parse(clusterTemplate.Spec.TemplateID); err != nil {
+		return api.ManagedInfrastructureTemplate{}, fmt.Errorf("could not get uuid from ManagedInfrastructureTemplate: %w", err)
+	}
+	uuid := uuid.MustParse(clusterTemplate.Spec.TemplateID)
+	// Obtain the parameter schema in the desired map format.
+	var parameterSchema map[string]interface{}
+	if err := json.Unmarshal(clusterTemplate.Spec.TemplateParameterSchema.Raw, &parameterSchema); err != nil {
+		return api.ManagedInfrastructureTemplate{}, fmt.Errorf("could not get parameterSchema from ManagedInfrastructureTemplate: %w", err)
+	}
+	// Convert the current ClusterTemplate to ManagedInfrastructureTemplate.
+	return api.ManagedInfrastructureTemplate{
+		ArtifactResourceId: uuid,
+		Name:               clusterTemplate.Spec.Name,
+		Version:            clusterTemplate.Spec.Version,
+		Description:        clusterTemplate.Spec.Description,
+		ParameterSchema:    parameterSchema,
+	}, nil
 }


### PR DESCRIPTION
Description:
- add support for getting the API version and minor versions
```console
$ curl -kq https://o2ims.apps.$MY_CLUSTER/o2ims-infrastructureArtifacts/api_versions -H "Authorization: Bearer ${MY_TOKEN}"  | jq
{
  "apiVersions": [
    {
      "version": "1.0.0"
    }
  ],
  "uriPrefix": "/o2ims-infrastructureArtifacts/v1"
}

$ curl -kq https://o2ims.apps.$MY_CLUSTER/o2ims-infrastructureArtifacts/v1/api_versions -H "Authorization: Bearer ${MY_TOKEN}"  | jq
{
  "apiVersions": [
    {
      "version": "1.0.0"
    }
  ],
  "uriPrefix": "/o2ims-infrastructureArtifacts/v1"
}
```

- add support for getting one `ManagedInfrastructureTemplate` by specifying the `ManagedInfrastructureTemplateId` in the request. `ManagedInfrastructureTemplateId` is currently compared to `<clusterTemplateName>.<clusterTemplateVersion>` (equal to ClusterTemplate `metadata.name`) of a ClusterTemplate to determine a match.
```console
$ curl -kq "https://o2ims.apps.$MY_CLUSTER/o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates/sno-ran-du.v4-17-3-1" -H "Authorization: Bearer ${MY_TOKEN}"  | jq

$ curl -kq "https://o2ims.apps.$MY_CLUSTER/o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates/random-name" -H "Authorization: Bearer ${MY_TOKEN}"  | jq
{
  "additionalAttributes": {
    "managedInfrastructureTemplateId": "random-name"
  },
  "detail": "requested ManagedInfrastructureTemplate not found",
  "status": 404
}
```