### PR TITLE
Resource server: add secrets to clusterrole and expose error

### DIFF
--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -986,6 +986,19 @@ func (t *reconcilerTask) createResourceServerClusterRole(ctx context.Context) er
 			},
 			{
 				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"secrets",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+			{
+				APIGroups: []string{
 					"internal.open-cluster-management.io",
 				},
 				Resources: []string{

--- a/internal/service/resources/collector/collector_k8s.go
+++ b/internal/service/resources/collector/collector_k8s.go
@@ -199,7 +199,7 @@ func (d *K8SDataSource) convertManagedClusterToDeploymentManager(ctx context.Con
 
 	extensions, err := d.getDeploymentManagerExtensions(ctx, cluster.Name)
 	if err != nil {
-		return models.DeploymentManager{}, fmt.Errorf("failed to get extensions for cluster %s", cluster.Name)
+		return models.DeploymentManager{}, fmt.Errorf("failed to get extensions for cluster %s: %w", cluster.Name, err)
 	}
 
 	to := models.DeploymentManager{


### PR DESCRIPTION
Description:
- Add `secrets` to the resource-server clusterrole
- Expose errors coming from getting managed clusters