### PR TITLE
Intercept and convert plain text errors to JSON

### DIFF
--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -124,9 +124,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 		},
 	)
 
-	r := http.NewServeMux()
-	// Register a default handler that replies with 404 so that we can override the response format
-	r.HandleFunc("/", common.NotFoundFunc())
+	r := common.NewErrorJsonifier(http.NewServeMux())
 
 	// This also validates the spec file
 	swagger, err := generated.GetSwagger()

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -61,9 +61,7 @@ func Serve() error {
 		},
 	)
 
-	router := http.NewServeMux()
-	// Register a default handler that replies with 404 so that we can override the response format.
-	router.HandleFunc("/", common.NotFoundFunc())
+	router := common.NewErrorJsonifier(http.NewServeMux())
 
 	// This also validates the spec file
 	swagger, err := generated.GetSwagger()

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -114,9 +114,7 @@ func Serve(config *api.ClusterServerConfig) error {
 		},
 	)
 
-	router := http.NewServeMux()
-	// Register a default handler that replies with 404 so that we can override the response format
-	router.HandleFunc("/", common.NotFoundFunc())
+	router := common.NewErrorJsonifier(http.NewServeMux())
 
 	// Create a new logger to be passed to things that need a logger
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{

--- a/internal/service/common/api/errors.go
+++ b/internal/service/common/api/errors.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api/generated"
+)
+
+// interceptor defines an implementation of a workaround for a limitation of the http.ServeMux.
+// http.ServeMux does not allow customizing the error handlers to write JSON formatted responses
+// instead of plain text.  To meet our interface requirements, we need to respond with JSON
+// formatted error responses in all cases.
+//
+// see: https://github.com/golang/go/issues/65648
+type interceptor struct {
+	original    http.ResponseWriter
+	statusCode  int
+	intercepted bool
+}
+
+// Header returns the headers stored in the underlying original ResponseWriter
+func (e *interceptor) Header() http.Header {
+	return e.original.Header()
+}
+
+// WriteHeader sets the status code and determines if a plain text header has already been set.  If
+// so, then the header is overwritten to an application/problem+json header with the expectation
+// that when the Write method is called with the actual error text that it will be reformatted to
+// the expected JSON response.
+func (e *interceptor) WriteHeader(statusCode int) {
+	if strings.Contains(e.original.Header().Get("Content-Type"), "text/plain") {
+		e.original.Header().Set("Content-Type", "application/problem+json; charset=utf-8")
+		e.intercepted = true
+	}
+	e.statusCode = statusCode
+	e.original.WriteHeader(statusCode)
+}
+
+// Write determines whether the data to be written should be passed through directly the underlying
+// buffer or if it needs to be converted to JSON first based on what that of header was written
+// previously using the WriteHeader method.
+func (e *interceptor) Write(data []byte) (int, error) {
+	var out []byte
+	if e.intercepted {
+		out, _ = json.Marshal(common.ProblemDetails{
+			Detail: strings.TrimSpace(string(data)),
+			Status: e.statusCode,
+		})
+	} else {
+		out = data
+	}
+	return e.original.Write(out) //nolint:wrapcheck
+}
+
+// ErrorJsonifier wraps a http.ServeMux so that we can override plain text error responses to JSON
+type ErrorJsonifier struct {
+	mux *http.ServeMux
+}
+
+// NewErrorJsonifier creates a new instance of an ErrorJsonifier
+func NewErrorJsonifier(router *http.ServeMux) *ErrorJsonifier {
+	return &ErrorJsonifier{mux: router}
+}
+
+// HandleFunc calls the HandleFunc method on the original http.ServeMux
+func (e *ErrorJsonifier) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	e.mux.HandleFunc(pattern, handler)
+}
+
+// ServeHTTP calls the ServeHTTP method on the original http.ServeMux by substituting the
+// ResponseWriter with an implementation that can intercept plain text error responses and convert
+// them to JSON.
+func (e *ErrorJsonifier) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	e.mux.ServeHTTP(&interceptor{
+		original: writer,
+	}, request)
+}

--- a/internal/service/common/api/middleware.go
+++ b/internal/service/common/api/middleware.go
@@ -101,15 +101,3 @@ func GetOranRespErrFunc() func(w http.ResponseWriter, r *http.Request, err error
 		problemDetails(w, string(out), http.StatusInternalServerError)
 	}
 }
-
-// NotFoundFunc is used to override the default 404 response which is a text only reply so that we can respond with the
-// required JSON body.
-func NotFoundFunc() func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		out, _ := json.Marshal(common.ProblemDetails{
-			Detail: fmt.Sprintf("Path '%s' not found", r.RequestURI),
-			Status: http.StatusNotFound,
-		})
-		problemDetails(w, string(out), http.StatusNotFound)
-	}
-}

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -58,9 +58,7 @@ func Serve(config *api.ProvisioningServerConfig) error {
 		},
 	)
 
-	router := http.NewServeMux()
-	// Register a default handler that replies with 404 so that we can override the response format.
-	router.HandleFunc("/", common.NotFoundFunc())
+	router := common.NewErrorJsonifier(http.NewServeMux())
 
 	// This also validates the spec file
 	swagger, err := generated.GetSwagger()

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -136,9 +136,7 @@ func Serve(config *api.ResourceServerConfig) error {
 		},
 	)
 
-	router := http.NewServeMux()
-	// Register a default handler that replies with 404 so that we can override the response format
-	router.HandleFunc("/", common.NotFoundFunc())
+	router := common.NewErrorJsonifier(http.NewServeMux())
 
 	// Create a new logger to be passed to things that need a logger
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{


### PR DESCRIPTION
This implements a workaround for a limitation of the http.ServeMux to convert plain text error responses to JSON.  The limitation is that it does not provide a means to specify whether error responses should be in plain text or JSON format.  The issue is discussed here [1].

The 'solution' is to wrap the ServeMux so that we supply a custom ResponseWriter that is capable of intercepting "text/plain" errors and re-format them to "application/problem+json" to comply with the ORAN interface specifications.

The previous approach attempted to better handle this scenario for a 404 error using a default "/" path, but overlooked that 405 errors are never returned as long as the "/" path is in the mux.

[1] https://github.com/golang/go/issues/65648