### PR TITLE
Define and package function-specific RBAC roles

### DIFF
--- a/bundle/manifests/oran-o2ims-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/oran-o2ims-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,16 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      role: reader-role
+  - matchLabels:
+      role: subscriber-role
+  - matchLabels:
+      role: maintainer-role
+  - matchLabels:
+      role: provisioner-role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: oran-o2ims-admin-role
+rules: null

--- a/bundle/manifests/oran-o2ims-maintainer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/oran-o2ims-maintainer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    role: maintainer-role
+  name: oran-o2ims-maintainer-role
+rules:
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarms/*
+  verbs:
+  - patch
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmServiceConfiguration
+  verbs:
+  - get
+  - patch
+  - update

--- a/bundle/manifests/oran-o2ims-provisioner-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/oran-o2ims-provisioner-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    role: provisioner-role
+  name: oran-o2ims-provisioner-role
+rules:
+- nonResourceURLs:
+  - /o2ims-infrastructureArtifacts/*
+  - /o2ims-infrastructureArtifacts/api_versions
+  - /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates
+  - /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates/*
+  - /o2ims-infrastructureProvisioning/*
+  - /o2ims-infrastructureProvisioning/api_versions
+  verbs:
+  - get
+- nonResourceURLs:
+  - /o2ims-infrastructureProvisioning/v1/provisioningRequests
+  verbs:
+  - get
+  - create
+- nonResourceURLs:
+  - /o2ims-infrastructureProvisioning/v1/provisioningRequests/*
+  verbs:
+  - get
+  - delete
+- nonResourceURLs:
+  - /o2ims-infrastructureProvisioning/v1/provisioningRequests/*
+  verbs:
+  - update

--- a/bundle/manifests/oran-o2ims-reader-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/oran-o2ims-reader-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    role: reader-role
+  name: oran-o2ims-reader-role
+rules:
+- nonResourceURLs:
+  - /o2ims-infrastructureInventory/*
+  - /o2ims-infrastructureInventory/api_versions
+  - /o2ims-infrastructureMonitoring/*
+  - /o2ims-infrastructureMonitoring/api_versions
+  - /o2ims-infrastructureCluster/*
+  - /o2ims-infrastructureCluster/api_versions
+  - /o2ims-infrastructureArtifacts/*
+  - /o2ims-infrastructureArtifacts/api_versions
+  - /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates
+  - /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates/*
+  - /o2ims-infrastructureProvisioning/*
+  - /o2ims-infrastructureProvisioning/api_versions
+  verbs:
+  - get
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions
+  - /o2ims-infrastructureInventory/v1/subscriptions
+  - /o2ims-infrastructureCluster/v1/subscriptions
+  - /o2ims-infrastructureProvisioning/v1/provisioningRequests
+  verbs:
+  - get
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions/*
+  - /o2ims-infrastructureInventory/v1/subscriptions/*
+  - /o2ims-infrastructureCluster/v1/subscriptions/*
+  - /o2ims-infrastructureProvisioning/v1/provisioningRequests/*
+  verbs:
+  - get
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmServiceConfiguration
+  verbs:
+  - get

--- a/bundle/manifests/oran-o2ims-subscriber-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/oran-o2ims-subscriber-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    role: subscriber-role
+  name: oran-o2ims-subscriber-role
+rules:
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions
+  - /o2ims-infrastructureInventory/v1/subscriptions
+  - /o2ims-infrastructureCluster/v1/subscriptions
+  verbs:
+  - get
+  - create
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions/*
+  - /o2ims-infrastructureInventory/v1/subscriptions/*
+  - /o2ims-infrastructureCluster/v1/subscriptions/*
+  verbs:
+  - get
+  - delete

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,14 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+# Pre-canned roles to allow binding to users that require specific access to our API endpoints
+- oran_o2ims_user_roles.yaml
+# Pre-canned roles to allow binding to users that require specific access to our CRs
+# (uncomment these lines to have RBAC roles created to test access to our CRs... similar ones
+#  get created if testing with `make bundle-run`, therefore they are unneeded by default)
+#- o2ims.oran.openshift.io_inventories_editor_role.yaml
+#- o2ims.oran.openshift.io_inventories_viewer_role.yaml
+#- o2ims.provisioning.oran.org_clustertemplate_editor_role.yaml
+#- o2ims.provisioning.oran.org_clustertemplate_viewer_role.yaml
+#- o2ims.provisioning.oran.org_provisioningrequest_editor_role.yaml
+#- o2ims.provisioning.oran.org_provisioningrequest_viewer_role.yaml

--- a/config/rbac/o2ims.oran.openshift.io_inventories_editor_role.yaml
+++ b/config/rbac/o2ims.oran.openshift.io_inventories_editor_role.yaml
@@ -1,20 +1,20 @@
-# permissions for end users to edit provisioningrequests.
+# permissions for end users to edit Inventory CR.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: provisioningrequest-editor-role
+    app.kubernetes.io/instance: inventory-editor-role
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: oran-o2ims
     app.kubernetes.io/part-of: oran-o2ims
     app.kubernetes.io/managed-by: kustomize
-  name: provisioningrequest-editor-role
+  name: inventory-editor-role
 rules:
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.oran.openshift.io
   resources:
-  - provisioningrequests
+  - inventories
   verbs:
   - create
   - delete
@@ -24,8 +24,8 @@ rules:
   - update
   - watch
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.oran.openshift.io
   resources:
-  - provisioningrequests/status
+  - inventories/status
   verbs:
   - get

--- a/config/rbac/o2ims.oran.openshift.io_inventories_viewer_role.yaml
+++ b/config/rbac/o2ims.oran.openshift.io_inventories_viewer_role.yaml
@@ -1,27 +1,27 @@
-# permissions for end users to view clustertemplates.
+# permissions for end users to view Inventory CR.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: clustertemplate-viewer-role
+    app.kubernetes.io/instance: inventory-viewer-role
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: oran-o2ims
     app.kubernetes.io/part-of: oran-o2ims
     app.kubernetes.io/managed-by: kustomize
-  name: clustertemplate-viewer-role
+  name: inventory-viewer-role
 rules:
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.oran.openshift.io
   resources:
-  - clustertemplates
+  - inventories
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.oran.openshift.io
   resources:
-  - clustertemplates/status
+  - inventories/status
   verbs:
   - get

--- a/config/rbac/o2ims.provisioning.oran.org_clustertemplate_editor_role.yaml
+++ b/config/rbac/o2ims.provisioning.oran.org_clustertemplate_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: clustertemplate-editor-role
 rules:
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.provisioning.oran.org
   resources:
   - clustertemplates
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.provisioning.oran.org
   resources:
   - clustertemplates/status
   verbs:

--- a/config/rbac/o2ims.provisioning.oran.org_clustertemplate_viewer_role.yaml
+++ b/config/rbac/o2ims.provisioning.oran.org_clustertemplate_viewer_role.yaml
@@ -1,27 +1,27 @@
-# permissions for end users to view provisioningrequests.
+# permissions for end users to view clustertemplates.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: provisioningrequest-viewer-role
+    app.kubernetes.io/instance: clustertemplate-viewer-role
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: oran-o2ims
     app.kubernetes.io/part-of: oran-o2ims
     app.kubernetes.io/managed-by: kustomize
-  name: provisioningrequest-viewer-role
+  name: clustertemplate-viewer-role
 rules:
 - apiGroups:
   - oran.openshift.io
   resources:
-  - provisioningrequests
+  - clustertemplates
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.provisioning.oran.org
   resources:
-  - provisioningrequests/status
+  - clustertemplates/status
   verbs:
   - get

--- a/config/rbac/o2ims.provisioning.oran.org_provisioningrequest_editor_role.yaml
+++ b/config/rbac/o2ims.provisioning.oran.org_provisioningrequest_editor_role.yaml
@@ -1,27 +1,31 @@
-# permissions for end users to view orano2ims.
+# permissions for end users to edit provisioningrequests.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: orano2ims-viewer-role
+    app.kubernetes.io/instance: provisioningrequest-editor-role
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: oran-o2ims
     app.kubernetes.io/part-of: oran-o2ims
     app.kubernetes.io/managed-by: kustomize
-  name: orano2ims-viewer-role
+  name: provisioningrequest-editor-role
 rules:
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.provisioning.oran.org
   resources:
-  - orano2ims
+  - provisioningrequests
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.provisioning.oran.org
   resources:
-  - orano2ims/status
+  - provisioningrequests/status
   verbs:
   - get

--- a/config/rbac/o2ims.provisioning.oran.org_provisioningrequest_viewer_role.yaml
+++ b/config/rbac/o2ims.provisioning.oran.org_provisioningrequest_viewer_role.yaml
@@ -1,31 +1,27 @@
-# permissions for end users to edit orano2ims.
+# permissions for end users to view provisioningrequests.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: orano2ims-editor-role
+    app.kubernetes.io/instance: provisioningrequest-viewer-role
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: oran-o2ims
     app.kubernetes.io/part-of: oran-o2ims
     app.kubernetes.io/managed-by: kustomize
-  name: orano2ims-editor-role
+  name: provisioningrequest-viewer-role
 rules:
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.provisioning.oran.org
   resources:
-  - orano2ims
+  - provisioningrequests
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
-  - oran.openshift.io
+  - o2ims.provisioning.oran.org
   resources:
-  - orano2ims/status
+  - provisioningrequests/status
   verbs:
   - get

--- a/config/rbac/oran_o2ims_user_roles.yaml
+++ b/config/rbac/oran_o2ims_user_roles.yaml
@@ -1,0 +1,126 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: reader-role
+  labels:
+    role: reader-role
+rules:
+- nonResourceURLs:
+  - /o2ims-infrastructureInventory/*
+  - /o2ims-infrastructureInventory/api_versions
+  - /o2ims-infrastructureMonitoring/*
+  - /o2ims-infrastructureMonitoring/api_versions
+  - /o2ims-infrastructureCluster/*
+  - /o2ims-infrastructureCluster/api_versions
+  - /o2ims-infrastructureArtifacts/*
+  - /o2ims-infrastructureArtifacts/api_versions
+  - /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates
+  - /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates/*
+  - /o2ims-infrastructureProvisioning/*
+  - /o2ims-infrastructureProvisioning/api_versions
+  verbs:
+  - get
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions
+  - /o2ims-infrastructureInventory/v1/subscriptions
+  - /o2ims-infrastructureCluster/v1/subscriptions
+  - /o2ims-infrastructureProvisioning/v1/provisioningRequests
+  verbs:
+  - get
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions/*
+  - /o2ims-infrastructureInventory/v1/subscriptions/*
+  - /o2ims-infrastructureCluster/v1/subscriptions/*
+  - /o2ims-infrastructureProvisioning/v1/provisioningRequests/*
+  verbs:
+  - get
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmServiceConfiguration
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: maintainer-role
+  labels:
+    role: maintainer-role
+rules:
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarms/*
+  verbs:
+  - patch
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmServiceConfiguration
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: subscriber-role
+  labels:
+    role: subscriber-role
+rules:
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions
+  - /o2ims-infrastructureInventory/v1/subscriptions
+  - /o2ims-infrastructureCluster/v1/subscriptions
+  verbs:
+  - get
+  - create
+- nonResourceURLs:
+  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions/*
+  - /o2ims-infrastructureInventory/v1/subscriptions/*
+  - /o2ims-infrastructureCluster/v1/subscriptions/*
+  verbs:
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: provisioner-role
+  labels:
+    role: provisioner-role
+rules:
+- nonResourceURLs:
+  - /o2ims-infrastructureArtifacts/*
+  - /o2ims-infrastructureArtifacts/api_versions
+  - /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates
+  - /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates/*
+  - /o2ims-infrastructureProvisioning/*
+  - /o2ims-infrastructureProvisioning/api_versions
+  verbs:
+  - get
+- nonResourceURLs:
+  - /o2ims-infrastructureProvisioning/v1/provisioningRequests
+  verbs:
+  - get
+  - create
+- nonResourceURLs:
+  - /o2ims-infrastructureProvisioning/v1/provisioningRequests/*
+  verbs:
+  - get
+  - delete
+- nonResourceURLs:
+  - /o2ims-infrastructureProvisioning/v1/provisioningRequests/*
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: admin-role
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      role: reader-role
+  - matchLabels:
+      role: subscriber-role
+  - matchLabels:
+      role: maintainer-role
+  - matchLabels:
+      role: provisioner-role

--- a/config/testing/client-service-account-rbac.yaml
+++ b/config/testing/client-service-account-rbac.yaml
@@ -5,64 +5,13 @@ metadata:
   namespace: oran-o2ims
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: oran-o2ims-test-client-role
-rules:
-- nonResourceURLs:
-  - /o2ims-infrastructureInventory/*
-  - /o2ims-infrastructureInventory/api_versions
-  - /o2ims-infrastructureMonitoring/*
-  - /o2ims-infrastructureMonitoring/api_versions
-  - /o2ims-infrastructureCluster/*
-  - /o2ims-infrastructureCluster/api_versions
-  - /o2ims-infrastructureArtifacts/*
-  - /o2ims-infrastructureArtifacts/api_versions
-  - /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates
-  - /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates/*
-  - /o2ims-infrastructureProvisioning/*
-  - /o2ims-infrastructureProvisioning/api_versions
-  verbs:
-  - get
-- nonResourceURLs:
-  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions
-  - /o2ims-infrastructureInventory/v1/subscriptions
-  - /o2ims-infrastructureCluster/v1/subscriptions
-  - /o2ims-infrastructureProvisioning/v1/provisioningRequests
-  verbs:
-  - get
-  - create
-- nonResourceURLs:
-  - /o2ims-infrastructureMonitoring/v1/alarmSubscriptions/*
-  - /o2ims-infrastructureInventory/v1/subscriptions/*
-  - /o2ims-infrastructureCluster/v1/subscriptions/*
-  - /o2ims-infrastructureProvisioning/v1/provisioningRequests/*
-  verbs:
-  - get
-  - delete
-- nonResourceURLs:
-  - /o2ims-infrastructureProvisioning/v1/provisioningRequests/*
-  verbs:
-  - update
-- nonResourceURLs:
-    - /o2ims-infrastructureMonitoring/v1/alarms/*
-  verbs:
-    - patch
-- nonResourceURLs:
-    - /o2ims-infrastructureMonitoring/v1/alarmServiceConfiguration
-  verbs:
-    - get
-    - patch
-    - update
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: oran-o2ims-test-client-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: oran-o2ims-test-client-role
+  name: oran-o2ims-admin-role
 subjects:
   - kind: ServiceAccount
     name: test-client


### PR DESCRIPTION
Defines function-specific RBAC roles for users of the O2IMS API and CRs. These roles can later be assigned to users or groups via ClusterRoleBindings.

The roles are defined for the following functions:

O2IMS API access:

+ reader: read-only access to all API endpoints
+ subscriber: read/write access to all subscription API endpoints
+ maintainer: read/write access to alarms and alarm configuration
+ provisioner: read/write access to templates and provisioning requests
+ admin: read/write access to all API endpoints

O2IMS CR access:
(note: these are mostly for developer testing since similar ones get
 automatically created when our operator bundle is installed and run.)

+ editor: read/write access to corresponding CR
+ viewer: read-only access to corresponding CR