### PR TITLE
Fix the end of sync query when not data is present

### DIFF
--- a/internal/service/cluster/db/repo/repository.go
+++ b/internal/service/cluster/db/repo/repository.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/dialect/psql"
 
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/models"
@@ -36,7 +37,10 @@ func (r *ClusterRepository) GetNodeClusters(ctx context.Context) ([]models.NodeC
 // GetNodeClustersNotIn returns the list of NodeCluster records not matching the list of keys provided, or an empty list
 // if none exist; otherwise an error
 func (r *ClusterRepository) GetNodeClustersNotIn(ctx context.Context, keys []any) ([]models.NodeCluster, error) {
-	e := psql.Quote(models.NodeCluster{}.PrimaryKey()).NotIn(psql.Arg(keys...))
+	var e bob.Expression = nil
+	if len(keys) > 0 {
+		e = psql.Quote(models.NodeCluster{}.PrimaryKey()).NotIn(psql.Arg(keys...))
+	}
 	return utils.Search[models.NodeCluster](ctx, r.Db, e)
 }
 
@@ -110,7 +114,10 @@ func (r *ClusterRepository) GetClusterResources(ctx context.Context) ([]models.C
 // GetClusterResourcesNotIn returns the list of ClusterResource records not matching the list of keys provided, or an
 // empty list if none exist; otherwise an error
 func (r *ClusterRepository) GetClusterResourcesNotIn(ctx context.Context, keys []any) ([]models.ClusterResource, error) {
-	e := psql.Quote(models.ClusterResource{}.PrimaryKey()).NotIn(psql.Arg(keys...))
+	var e bob.Expression = nil
+	if len(keys) > 0 {
+		e = psql.Quote(models.ClusterResource{}.PrimaryKey()).NotIn(psql.Arg(keys...))
+	}
 	return utils.Search[models.ClusterResource](ctx, r.Db, e)
 }
 

--- a/internal/service/resources/db/repo/repository.go
+++ b/internal/service/resources/db/repo/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/dialect/psql"
 
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/repo"
@@ -24,7 +25,10 @@ func (r *ResourcesRepository) GetDeploymentManagers(ctx context.Context) ([]mode
 // GetDeploymentManagersNotIn returns the list of DeploymentManager records not matching the list of keys provided, or
 // an empty list if none exist; otherwise an error
 func (r *ResourcesRepository) GetDeploymentManagersNotIn(ctx context.Context, keys []any) ([]models.DeploymentManager, error) {
-	e := psql.Quote(models.DeploymentManager{}.PrimaryKey()).NotIn(psql.Arg(keys...))
+	var e bob.Expression = nil
+	if len(keys) > 0 {
+		e = psql.Quote(models.DeploymentManager{}.PrimaryKey()).NotIn(psql.Arg(keys...))
+	}
 	return utils.Search[models.DeploymentManager](ctx, r.Db, e)
 }
 


### PR DESCRIPTION
When the resync ends and no data exists in the k8s API for some resource then the "NotIn" clause on the database query throws an error since the list passed to it is empty.  If no data exists in the API server then we simply want to delete ALL records therefore we don't need to supply a where clause.