### PR TITLE
CNF-16478: Add OIDC validation at front-end proxies

### DIFF
--- a/api/inventory/v1alpha1/inventory_types.go
+++ b/api/inventory/v1alpha1/inventory_types.go
@@ -42,6 +42,17 @@ type OAuthConfig struct {
 	// authorize our requests
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OAuth Scopes",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Scopes []string `json:"scopes"`
+	// UsernameClaim represents the claim contained within the OAuth JWT token which holds the username
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OAuth Username Claim",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	//+kubebuilder:default=preferred_username
+	UsernameClaim string `json:"usernameClaim"`
+	// GroupsClaim represents the claim contained within the OAuth JWT token which holds the list of groups/roles. This
+	// must be a list/array and not a space separated list of names.  It must also be a top level attribute rather than
+	// a nested field in the JSON structure of the JWT object.
+	//    i.e., {"roles": ["a", "b"]} rather than {"realm": {"roles": ["a", "b"}}.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OAuth Groups Claim",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	//+kubebuilder:default=groups
+	GroupsClaim string `json:"groupsClaim"`
 }
 
 // TLSConfig defines the TLS specific attributes specific to the SMO and OAuth servers

--- a/bundle/manifests/o2ims.oran.openshift.io_inventories.yaml
+++ b/bundle/manifests/o2ims.oran.openshift.io_inventories.yaml
@@ -178,6 +178,14 @@ spec:
                           ClientSecretName represents the name of a secret (in the current namespace) which contains the client-id and
                           client-secret values used by the OAuth client.
                         type: string
+                      groupsClaim:
+                        default: groups
+                        description: |-
+                          GroupsClaim represents the claim contained within the OAuth JWT token which holds the list of groups/roles. This
+                          must be a list/array and not a space separated list of names.  It must also be a top level attribute rather than
+                          a nested field in the JSON structure of the JWT object.
+                             i.e., {"roles": ["a", "b"]} rather than {"realm": {"roles": ["a", "b"}}.
+                        type: string
                       scopes:
                         description: |-
                           Scopes represents the OAuth scope values to request when acquiring a token.  Typically, this should be set to
@@ -195,11 +203,18 @@ spec:
                         description: URL represents the base URL of the authorization
                           server. (e.g., https://keycloak.example.com/realms/oran)
                         type: string
+                      usernameClaim:
+                        default: preferred_username
+                        description: UsernameClaim represents the claim contained
+                          within the OAuth JWT token which holds the username
+                        type: string
                     required:
                     - clientSecretName
+                    - groupsClaim
                     - scopes
                     - tokenEndpoint
                     - url
+                    - usernameClaim
                     type: object
                   registrationEndpoint:
                     description: RegistrationEndpoint represents the API endpoint

--- a/bundle/manifests/oran-o2ims-admin-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/oran-o2ims-admin-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: oran-o2ims-admin-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-admin-role
+subjects:
+- kind: Group
+  name: o2ims-admin

--- a/bundle/manifests/oran-o2ims-maintainer-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/oran-o2ims-maintainer-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: oran-o2ims-maintainer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-maintainer-role
+subjects:
+- kind: Group
+  name: o2ims-maintainer

--- a/bundle/manifests/oran-o2ims-provisioner-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/oran-o2ims-provisioner-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: oran-o2ims-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-provisioner-role
+subjects:
+- kind: Group
+  name: o2ims-provisioner

--- a/bundle/manifests/oran-o2ims-reader-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/oran-o2ims-reader-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: oran-o2ims-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-reader-role
+subjects:
+- kind: Group
+  name: o2ims-reader

--- a/bundle/manifests/oran-o2ims-subscriber-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/oran-o2ims-subscriber-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: oran-o2ims-subscriber-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-subscriber-role
+subjects:
+- kind: Group
+  name: o2ims-subscriber

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -167,6 +167,7 @@ metadata:
             "smo": {
               "oauth": {
                 "clientSecretName": "oauth-client-secrets",
+                "groupsClaim": "roles",
                 "scopes": [
                   "openid",
                   "profile",
@@ -174,7 +175,8 @@ metadata:
                   "smo-audience"
                 ],
                 "tokenEndpoint": "/protocol/openid-connect/token",
-                "url": "https://oauth.example.com:8443/realms/oran"
+                "url": "https://oauth.example.com:8443/realms/oran",
+                "usernameClaim": "preferred_username"
               },
               "registrationEndpoint": "/smo/v1/registration",
               "tls": {
@@ -865,6 +867,15 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: |-
+          GroupsClaim represents the claim contained within the OAuth JWT token which holds the list of groups/roles. This
+          must be a list/array and not a space separated list of names.  It must also be a top level attribute rather than
+          a nested field in the JSON structure of the JWT object.
+             i.e., {"roles": ["a", "b"]} rather than {"realm": {"roles": ["a", "b"}}.
+        displayName: OAuth Groups Claim
+        path: smo.oauth.groupsClaim
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
           Scopes represents the OAuth scope values to request when acquiring a token.  Typically, this should be set to
           "openid" in addition to any other scopes that the SMO specifically requires (e.g., "roles", "groups", etc...) to
           authorize our requests
@@ -883,6 +894,12 @@ spec:
           https://keycloak.example.com/realms/oran)
         displayName: OAuth URL
         path: smo.oauth.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: UsernameClaim represents the claim contained within the OAuth
+          JWT token which holds the username
+        displayName: OAuth Username Claim
+        path: smo.oauth.usernameClaim
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: RegistrationEndpoint represents the API endpoint used to register

--- a/config/crd/bases/o2ims.oran.openshift.io_inventories.yaml
+++ b/config/crd/bases/o2ims.oran.openshift.io_inventories.yaml
@@ -178,6 +178,14 @@ spec:
                           ClientSecretName represents the name of a secret (in the current namespace) which contains the client-id and
                           client-secret values used by the OAuth client.
                         type: string
+                      groupsClaim:
+                        default: groups
+                        description: |-
+                          GroupsClaim represents the claim contained within the OAuth JWT token which holds the list of groups/roles. This
+                          must be a list/array and not a space separated list of names.  It must also be a top level attribute rather than
+                          a nested field in the JSON structure of the JWT object.
+                             i.e., {"roles": ["a", "b"]} rather than {"realm": {"roles": ["a", "b"}}.
+                        type: string
                       scopes:
                         description: |-
                           Scopes represents the OAuth scope values to request when acquiring a token.  Typically, this should be set to
@@ -195,11 +203,18 @@ spec:
                         description: URL represents the base URL of the authorization
                           server. (e.g., https://keycloak.example.com/realms/oran)
                         type: string
+                      usernameClaim:
+                        default: preferred_username
+                        description: UsernameClaim represents the claim contained
+                          within the OAuth JWT token which holds the username
+                        type: string
                     required:
                     - clientSecretName
+                    - groupsClaim
                     - scopes
                     - tokenEndpoint
                     - url
+                    - usernameClaim
                     type: object
                   registrationEndpoint:
                     description: RegistrationEndpoint represents the API endpoint

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -269,6 +269,15 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: |-
+          GroupsClaim represents the claim contained within the OAuth JWT token which holds the list of groups/roles. This
+          must be a list/array and not a space separated list of names.  It must also be a top level attribute rather than
+          a nested field in the JSON structure of the JWT object.
+             i.e., {"roles": ["a", "b"]} rather than {"realm": {"roles": ["a", "b"}}.
+        displayName: OAuth Groups Claim
+        path: smo.oauth.groupsClaim
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
           Scopes represents the OAuth scope values to request when acquiring a token.  Typically, this should be set to
           "openid" in addition to any other scopes that the SMO specifically requires (e.g., "roles", "groups", etc...) to
           authorize our requests
@@ -287,6 +296,12 @@ spec:
           https://keycloak.example.com/realms/oran)
         displayName: OAuth URL
         path: smo.oauth.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: UsernameClaim represents the claim contained within the OAuth
+          JWT token which holds the username
+        displayName: OAuth Username Claim
+        path: smo.oauth.usernameClaim
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: RegistrationEndpoint represents the API endpoint used to register

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -18,6 +18,8 @@ resources:
 - auth_proxy_client_clusterrole.yaml
 # Pre-canned roles to allow binding to users that require specific access to our API endpoints
 - oran_o2ims_user_roles.yaml
+# Pre-canned role bindings that map to groups names that can be used as OAuth "roles" on the authorization server.
+- oran_o2ims_oauth_role_bindings.yaml
 # Pre-canned roles to allow binding to users that require specific access to our CRs
 # (uncomment these lines to have RBAC roles created to test access to our CRs... similar ones
 #  get created if testing with `make bundle-run`, therefore they are unneeded by default)

--- a/config/rbac/oran_o2ims_oauth_role_bindings.yaml
+++ b/config/rbac/oran_o2ims_oauth_role_bindings.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-reader-role
+subjects:
+- kind: Group
+  name: o2ims-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: maintainer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-maintainer-role
+subjects:
+- kind: Group
+  name: o2ims-maintainer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: subscriber-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-subscriber-role
+subjects:
+- kind: Group
+  name: o2ims-subscriber
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-provisioner-role
+subjects:
+- kind: Group
+  name: o2ims-provisioner
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-admin-role
+subjects:
+- kind: Group
+  name: o2ims-admin

--- a/config/samples/v1alpha1_inventory.yaml
+++ b/config/samples/v1alpha1_inventory.yaml
@@ -23,6 +23,8 @@ spec:
         - profile
         - roles
         - smo-audience
+      usernameClaim: preferred_username
+      groupsClaim: roles
     tls:
       clientCertificateName: o2ims-client-tls-certificate
   caBundleName: o2ims-custom-ca-certs

--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -234,7 +234,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 		return
 	}
 
-	err = t.createService(ctx, utils.InventoryDatabaseServerName, utils.DatabaseServicePort, utils.DatabaseTargetPort)
+	err = t.createService(ctx, utils.InventoryDatabaseServerName, utils.DatabaseServicePort, utils.DatabaseTargetPort, 0, "")
 	if err != nil {
 		t.logger.ErrorContext(
 			ctx,

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -233,7 +233,7 @@ var _ = DescribeTable(
 			err = reconciler.Client.Get(
 				context.TODO(),
 				types.NamespacedName{
-					Name:      utils.InventoryIngressName,
+					Name:      utils.IngressName,
 					Namespace: utils.InventoryNamespace,
 				},
 				ingress)

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -30,8 +30,14 @@ const (
 	InventoryProvisioningServerName = InventoryProvisioning + serverSuffix
 )
 
-// InventoryIngressName the name of our Ingress controller instance
-const InventoryIngressName = "api"
+// IngressName defines the name of our ingress controller
+const IngressName = "oran-o2ims-ingress"
+
+// IngressClassName defines the ingress controller class to be used
+const IngressClassName = "openshift-default"
+
+// IngressPortName defines the name of service port to which our ingress controller directs traffic to
+const IngressPortName = "api"
 
 // Resource operations
 const (
@@ -204,16 +210,22 @@ const (
 
 // POD Container Names
 const (
-	MigrationContainerName = "migration"
-	RbacContainerName      = "rbac"
-	ServerContainerName    = "server"
+	MigrationContainerName    = "migration"
+	RbacContainerName         = "rbac"
+	ServerContainerName       = "server"
+	InternalRbacContainerName = "internal-rbac"
 )
 
 // POD Port Values
 const (
-	DefaultServicePort   = 8000
-	DefaultTargetPort    = "https"
-	DefaultContainerPort = 8000
+	DefaultServicePort       = 8000
+	DefaultServiceTargetPort = "https"
+	DefaultContainerPort     = 8000
+	DefaultProxyPort         = 8443
+
+	InternalServicePort       = 9000
+	InternalServiceTargetPort = "internal-https"
+	InternalProxyPort         = 6443
 
 	DatabaseServicePort = 5432
 	DatabaseTargetPort  = "database"
@@ -221,10 +233,11 @@ const (
 
 // Environment values
 const (
-	ServerImageName        = "IMAGE"
-	KubeRbacProxyImageName = "KUBE_RBAC_PROXY_IMAGE"
-	PostgresImageName      = "POSTGRES_IMAGE"
-	HwMgrPluginNameSpace   = "HWMGR_PLUGIN_NAMESPACE"
+	ServerImageName         = "IMAGE"
+	KubeRbacProxyImageName  = "KUBE_RBAC_PROXY_IMAGE"
+	PostgresImageName       = "POSTGRES_IMAGE"
+	HwMgrPluginNameSpace    = "HWMGR_PLUGIN_NAMESPACE"
+	InternalServicePortName = "INTERNAL_SERVICE_PORT"
 )
 
 // ClusterVersionName is the name given to the default ClusterVersion object

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -231,6 +231,12 @@ const (
 	DatabaseTargetPort  = "database"
 )
 
+// MinimumProxyTLSVersion defines the minimum value we accept for incoming TLS connections to the proxies
+const MinimumProxyTLSVersion = "VersionTLS12"
+
+// MinimumProxyLogLevel defines the minimum log-level set on the proxies
+const MinimumProxyLogLevel = 10
+
 // Environment values
 const (
 	ServerImageName         = "IMAGE"

--- a/internal/controllers/utils/types.go
+++ b/internal/controllers/utils/types.go
@@ -60,6 +60,7 @@ var InventoryConditionReasons = struct {
 	SmoRegistrationSuccessful         InventoryConditionReason
 	SmoRegistrationFailed             InventoryConditionReason
 	SmoNotConfigured                  InventoryConditionReason
+	OAuthClientIDNotConfigured        InventoryConditionReason
 }{
 	DatabaseDeploymentFailed:          "DatabaseDeploymentFailed",
 	DeploymentsReady:                  "AllDeploymentsReady",
@@ -69,6 +70,7 @@ var InventoryConditionReasons = struct {
 	SmoRegistrationSuccessful:         "SmoRegistrationSuccessful",
 	SmoRegistrationFailed:             "SmoRegistrationFailed",
 	SmoNotConfigured:                  "SmoNotConfigured",
+	OAuthClientIDNotConfigured:        "OAuthClientIDNotConfigured",
 }
 
 var MapAvailableDeploymentNameConditionType = map[string]InventoryConditionType{

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1/inventory_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1/inventory_types.go
@@ -42,6 +42,17 @@ type OAuthConfig struct {
 	// authorize our requests
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OAuth Scopes",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Scopes []string `json:"scopes"`
+	// UsernameClaim represents the claim contained within the OAuth JWT token which holds the username
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OAuth Username Claim",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	//+kubebuilder:default=preferred_username
+	UsernameClaim string `json:"usernameClaim"`
+	// GroupsClaim represents the claim contained within the OAuth JWT token which holds the list of groups/roles. This
+	// must be a list/array and not a space separated list of names.  It must also be a top level attribute rather than
+	// a nested field in the JSON structure of the JWT object.
+	//    i.e., {"roles": ["a", "b"]} rather than {"realm": {"roles": ["a", "b"}}.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OAuth Groups Claim",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	//+kubebuilder:default=groups
+	GroupsClaim string `json:"groupsClaim"`
 }
 
 // TLSConfig defines the TLS specific attributes specific to the SMO and OAuth servers


### PR DESCRIPTION
This configures the front-end kube-rbac-proxy instances to accept OIDC OAuth tokens rather than Kubernetes tokens.  Incoming tokens are verified by first validating their signature against the certificate downloaded from the configured OAuth server.  If the signature is
 valid, then the user's roles are extracted from the token and used to
map to the Kubernetes RBAC roles to authorize the request.

Since our servers do inter-server communication and since they do not have OAuth tokens to exchange between themselves (not should they) we create separate kube-rbac-proxy instances that use the Kubernetes token validation to authorize their exchanges.

Therefore, any internal communications go through the "internal" proxy, and any public communications (e.g,. coming from the ingress controller) go through the "public" proxy.