### PR TITLE
Pgx explicit configs and enable trace capabilities

### DIFF
--- a/internal/service/common/db/postgres.go
+++ b/internal/service/common/db/postgres.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/tracelog"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
@@ -19,12 +21,28 @@ type PgConfig struct {
 
 // NewPgxPool get a concurrency safe pool of connection
 func NewPgxPool(ctx context.Context, cfg PgConfig) (*pgxpool.Pool, error) {
-	// TODO: update config with trace, timeouts etc.
 	poolConfig, err := pgxpool.ParseConfig(fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
 		cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Database))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config: %w", err)
 	}
+
+	// Create the tracer with our custom logger
+	poolConfig.ConnConfig.Tracer = &tracelog.TraceLog{
+		Logger:   customLogger,
+		LogLevel: tracelog.LogLevelDebug,
+	}
+
+	// Connection pool settings
+	poolConfig.MaxConns = 10                                 // Maximum connections in the pool
+	poolConfig.MinConns = 2                                  // Minimum idle connections to maintain
+	poolConfig.MaxConnLifetime = time.Hour                   // Maximum lifetime of a connection
+	poolConfig.MaxConnIdleTime = 30 * time.Minute            // How long a connection can be idle
+	poolConfig.HealthCheckPeriod = time.Minute               // How often to check connection health
+	poolConfig.MaxConnLifetimeJitter = 10 * time.Millisecond // Add jitter to prevent all connections from being closed at same time
+
+	// Connection settings
+	poolConfig.ConnConfig.ConnectTimeout = 2 * time.Minute // Connection timeout
 
 	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {
@@ -51,5 +69,100 @@ func GetPgConfig(username, password, database string) PgConfig {
 		User:     username,
 		Password: password,
 		Database: database,
+	}
+}
+
+var (
+	warnQueryThreshold  = 500 * time.Millisecond // Queries slower than this trigger warnings
+	errorQueryThreshold = 2 * time.Second        // Queries slower than this trigger errors
+	maxLogSQLLength     = 500                    // Maximum number of characters of SQL to log
+)
+
+// customLogger implements a pgx query logger that tracks query performance, truncates long SQL statements, and includes relevant metadata for debugging.
+var customLogger = tracelog.LoggerFunc(func(ctx context.Context, level tracelog.LogLevel, msg string, data map[string]interface{}) {
+	var attrs []slog.Attr
+	attrs = append(attrs, slog.String("event", msg))
+
+	// Handle duration and query performance
+	var logLevel = convertLogLevel(level)
+	if duration, ok := data["time"].(time.Duration); ok {
+		attrs = append(attrs, slog.String("duration", duration.String()))
+
+		switch {
+		case duration >= errorQueryThreshold:
+			logLevel = slog.LevelError
+			attrs = append(attrs, slog.String("performance", "critical"))
+		case duration >= warnQueryThreshold:
+			logLevel = slog.LevelWarn
+			attrs = append(attrs, slog.String("performance", "slow"))
+		}
+	}
+
+	// Handle SQL truncation
+	if sql, ok := data["sql"].(string); ok {
+		if len(sql) > maxLogSQLLength {
+			attrs = append(attrs,
+				slog.String("sql", sql[:maxLogSQLLength]+"..."),
+				slog.Int("sql_truncated_length", len(sql)-maxLogSQLLength),
+			)
+		} else {
+			attrs = append(attrs, slog.String("sql", sql))
+		}
+	}
+
+	// Add common pgx attributes
+	if commandTag, ok := data["commandTag"]; ok {
+		attrs = append(attrs, slog.Any("command_tag", commandTag))
+	}
+	if pid, ok := data["pid"]; ok {
+		attrs = append(attrs, slog.Any("pid", pid))
+	}
+	if name, ok := data["name"].(string); ok {
+		attrs = append(attrs, slog.String("statement_name", name))
+	}
+	if prepared, ok := data["alreadyPrepared"].(bool); ok {
+		attrs = append(attrs, slog.Bool("already_prepared", prepared))
+	}
+	if host, ok := data["host"].(string); ok {
+		attrs = append(attrs, slog.String("host", host))
+	}
+	if port, ok := data["port"].(uint16); ok {
+		attrs = append(attrs, slog.Uint64("port", uint64(port)))
+	}
+	if db, ok := data["database"].(string); ok {
+		attrs = append(attrs, slog.String("database", db))
+	}
+	if table, ok := data["tableName"]; ok {
+		attrs = append(attrs, slog.Any("table_name", table))
+	}
+	if cols, ok := data["columnNames"]; ok {
+		attrs = append(attrs, slog.Any("columns", cols))
+	}
+	if rows, ok := data["rowCount"]; ok {
+		attrs = append(attrs, slog.Any("rows_affected", rows))
+	}
+
+	// Handle errors (this takes precedence over performance warnings)
+	if err, ok := data["err"].(error); ok && err != nil {
+		attrs = append(attrs, slog.String("error", err.Error()))
+		slog.LogAttrs(ctx, slog.LevelError, fmt.Sprintf("Database %s failed", msg), attrs...)
+		return
+	}
+
+	slog.LogAttrs(ctx, logLevel, fmt.Sprintf("Database %s", msg), attrs...)
+})
+
+func convertLogLevel(level tracelog.LogLevel) slog.Level {
+	switch level {
+	case tracelog.LogLevelTrace, tracelog.LogLevelDebug:
+		return slog.LevelDebug
+	case tracelog.LogLevelInfo:
+		return slog.LevelInfo
+	case tracelog.LogLevelWarn:
+		return slog.LevelWarn
+	case tracelog.LogLevelError:
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
 	}
 }

--- a/internal/service/common/utils/repository.go
+++ b/internal/service/common/utils/repository.go
@@ -212,13 +212,11 @@ func ExecuteCollectExactlyOneRow[T db.Model](ctx context.Context, db DBQuery, sq
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
 
-	slog.Debug("record found", "table", record.TableName())
 	return &record, nil
 }
 
 // ExecuteCollectRows executes a query and collects result using pgx.CollectRows.
 func ExecuteCollectRows[T db.Model](ctx context.Context, db DBQuery, sql string, args []any) ([]T, error) {
-	var record T
 	var err error
 
 	// Run query
@@ -228,6 +226,5 @@ func ExecuteCollectRows[T db.Model](ctx context.Context, db DBQuery, sql string,
 		return []T{}, fmt.Errorf("failed to execute query: %w", err)
 	}
 
-	slog.Debug("records found", "table", record.TableName(), "count", len(records))
 	return records, nil
 }

--- a/vendor/github.com/jackc/pgx/v5/tracelog/tracelog.go
+++ b/vendor/github.com/jackc/pgx/v5/tracelog/tracelog.go
@@ -1,0 +1,368 @@
+// Package tracelog provides a tracer that acts as a traditional logger.
+package tracelog
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// LogLevel represents the pgx logging level. See LogLevel* constants for
+// possible values.
+type LogLevel int
+
+// The values for log levels are chosen such that the zero value means that no
+// log level was specified.
+const (
+	LogLevelTrace = LogLevel(6)
+	LogLevelDebug = LogLevel(5)
+	LogLevelInfo  = LogLevel(4)
+	LogLevelWarn  = LogLevel(3)
+	LogLevelError = LogLevel(2)
+	LogLevelNone  = LogLevel(1)
+)
+
+func (ll LogLevel) String() string {
+	switch ll {
+	case LogLevelTrace:
+		return "trace"
+	case LogLevelDebug:
+		return "debug"
+	case LogLevelInfo:
+		return "info"
+	case LogLevelWarn:
+		return "warn"
+	case LogLevelError:
+		return "error"
+	case LogLevelNone:
+		return "none"
+	default:
+		return fmt.Sprintf("invalid level %d", ll)
+	}
+}
+
+// Logger is the interface used to get log output from pgx.
+type Logger interface {
+	// Log a message at the given level with data key/value pairs. data may be nil.
+	Log(ctx context.Context, level LogLevel, msg string, data map[string]any)
+}
+
+// LoggerFunc is a wrapper around a function to satisfy the pgx.Logger interface
+type LoggerFunc func(ctx context.Context, level LogLevel, msg string, data map[string]interface{})
+
+// Log delegates the logging request to the wrapped function
+func (f LoggerFunc) Log(ctx context.Context, level LogLevel, msg string, data map[string]interface{}) {
+	f(ctx, level, msg, data)
+}
+
+// LogLevelFromString converts log level string to constant
+//
+// Valid levels:
+//
+//	trace
+//	debug
+//	info
+//	warn
+//	error
+//	none
+func LogLevelFromString(s string) (LogLevel, error) {
+	switch s {
+	case "trace":
+		return LogLevelTrace, nil
+	case "debug":
+		return LogLevelDebug, nil
+	case "info":
+		return LogLevelInfo, nil
+	case "warn":
+		return LogLevelWarn, nil
+	case "error":
+		return LogLevelError, nil
+	case "none":
+		return LogLevelNone, nil
+	default:
+		return 0, errors.New("invalid log level")
+	}
+}
+
+func logQueryArgs(args []any) []any {
+	logArgs := make([]any, 0, len(args))
+
+	for _, a := range args {
+		switch v := a.(type) {
+		case []byte:
+			if len(v) < 64 {
+				a = hex.EncodeToString(v)
+			} else {
+				a = fmt.Sprintf("%x (truncated %d bytes)", v[:64], len(v)-64)
+			}
+		case string:
+			if len(v) > 64 {
+				var l int = 0
+				for w := 0; l < 64; l += w {
+					_, w = utf8.DecodeRuneInString(v[l:])
+				}
+				if len(v) > l {
+					a = fmt.Sprintf("%s (truncated %d bytes)", v[:l], len(v)-l)
+				}
+			}
+		}
+		logArgs = append(logArgs, a)
+	}
+
+	return logArgs
+}
+
+// TraceLogConfig holds the configuration for key names
+type TraceLogConfig struct {
+	TimeKey string
+}
+
+// DefaultTraceLogConfig returns the default configuration for TraceLog
+func DefaultTraceLogConfig() *TraceLogConfig {
+	return &TraceLogConfig{
+		TimeKey: "time",
+	}
+}
+
+// TraceLog implements pgx.QueryTracer, pgx.BatchTracer, pgx.ConnectTracer, and pgx.CopyFromTracer. Logger and LogLevel
+// are required. Config will be automatically initialized on first use if nil.
+type TraceLog struct {
+	Logger   Logger
+	LogLevel LogLevel
+
+	Config           *TraceLogConfig
+	ensureConfigOnce sync.Once
+}
+
+// ensureConfig initializes the Config field with default values if it is nil.
+func (tl *TraceLog) ensureConfig() {
+	tl.ensureConfigOnce.Do(
+		func() {
+			if tl.Config == nil {
+				tl.Config = DefaultTraceLogConfig()
+			}
+		},
+	)
+}
+
+type ctxKey int
+
+const (
+	_ ctxKey = iota
+	tracelogQueryCtxKey
+	tracelogBatchCtxKey
+	tracelogCopyFromCtxKey
+	tracelogConnectCtxKey
+	tracelogPrepareCtxKey
+)
+
+type traceQueryData struct {
+	startTime time.Time
+	sql       string
+	args      []any
+}
+
+func (tl *TraceLog) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	return context.WithValue(ctx, tracelogQueryCtxKey, &traceQueryData{
+		startTime: time.Now(),
+		sql:       data.SQL,
+		args:      data.Args,
+	})
+}
+
+func (tl *TraceLog) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryEndData) {
+	tl.ensureConfig()
+	queryData := ctx.Value(tracelogQueryCtxKey).(*traceQueryData)
+
+	endTime := time.Now()
+	interval := endTime.Sub(queryData.startTime)
+
+	if data.Err != nil {
+		if tl.shouldLog(LogLevelError) {
+			tl.log(ctx, conn, LogLevelError, "Query", map[string]any{"sql": queryData.sql, "args": logQueryArgs(queryData.args), "err": data.Err, tl.Config.TimeKey: interval})
+		}
+		return
+	}
+
+	if tl.shouldLog(LogLevelInfo) {
+		tl.log(ctx, conn, LogLevelInfo, "Query", map[string]any{"sql": queryData.sql, "args": logQueryArgs(queryData.args), tl.Config.TimeKey: interval, "commandTag": data.CommandTag.String()})
+	}
+}
+
+type traceBatchData struct {
+	startTime time.Time
+}
+
+func (tl *TraceLog) TraceBatchStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchStartData) context.Context {
+	return context.WithValue(ctx, tracelogBatchCtxKey, &traceBatchData{
+		startTime: time.Now(),
+	})
+}
+
+func (tl *TraceLog) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchQueryData) {
+	if data.Err != nil {
+		if tl.shouldLog(LogLevelError) {
+			tl.log(ctx, conn, LogLevelError, "BatchQuery", map[string]any{"sql": data.SQL, "args": logQueryArgs(data.Args), "err": data.Err})
+		}
+		return
+	}
+
+	if tl.shouldLog(LogLevelInfo) {
+		tl.log(ctx, conn, LogLevelInfo, "BatchQuery", map[string]any{"sql": data.SQL, "args": logQueryArgs(data.Args), "commandTag": data.CommandTag.String()})
+	}
+}
+
+func (tl *TraceLog) TraceBatchEnd(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchEndData) {
+	tl.ensureConfig()
+	queryData := ctx.Value(tracelogBatchCtxKey).(*traceBatchData)
+
+	endTime := time.Now()
+	interval := endTime.Sub(queryData.startTime)
+
+	if data.Err != nil {
+		if tl.shouldLog(LogLevelError) {
+			tl.log(ctx, conn, LogLevelError, "BatchClose", map[string]any{"err": data.Err, tl.Config.TimeKey: interval})
+		}
+		return
+	}
+
+	if tl.shouldLog(LogLevelInfo) {
+		tl.log(ctx, conn, LogLevelInfo, "BatchClose", map[string]any{tl.Config.TimeKey: interval})
+	}
+}
+
+type traceCopyFromData struct {
+	startTime   time.Time
+	TableName   pgx.Identifier
+	ColumnNames []string
+}
+
+func (tl *TraceLog) TraceCopyFromStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceCopyFromStartData) context.Context {
+	return context.WithValue(ctx, tracelogCopyFromCtxKey, &traceCopyFromData{
+		startTime:   time.Now(),
+		TableName:   data.TableName,
+		ColumnNames: data.ColumnNames,
+	})
+}
+
+func (tl *TraceLog) TraceCopyFromEnd(ctx context.Context, conn *pgx.Conn, data pgx.TraceCopyFromEndData) {
+	tl.ensureConfig()
+	copyFromData := ctx.Value(tracelogCopyFromCtxKey).(*traceCopyFromData)
+
+	endTime := time.Now()
+	interval := endTime.Sub(copyFromData.startTime)
+
+	if data.Err != nil {
+		if tl.shouldLog(LogLevelError) {
+			tl.log(ctx, conn, LogLevelError, "CopyFrom", map[string]any{"tableName": copyFromData.TableName, "columnNames": copyFromData.ColumnNames, "err": data.Err, tl.Config.TimeKey: interval})
+		}
+		return
+	}
+
+	if tl.shouldLog(LogLevelInfo) {
+		tl.log(ctx, conn, LogLevelInfo, "CopyFrom", map[string]any{"tableName": copyFromData.TableName, "columnNames": copyFromData.ColumnNames, "err": data.Err, tl.Config.TimeKey: interval, "rowCount": data.CommandTag.RowsAffected()})
+	}
+}
+
+type traceConnectData struct {
+	startTime  time.Time
+	connConfig *pgx.ConnConfig
+}
+
+func (tl *TraceLog) TraceConnectStart(ctx context.Context, data pgx.TraceConnectStartData) context.Context {
+	return context.WithValue(ctx, tracelogConnectCtxKey, &traceConnectData{
+		startTime:  time.Now(),
+		connConfig: data.ConnConfig,
+	})
+}
+
+func (tl *TraceLog) TraceConnectEnd(ctx context.Context, data pgx.TraceConnectEndData) {
+	tl.ensureConfig()
+	connectData := ctx.Value(tracelogConnectCtxKey).(*traceConnectData)
+
+	endTime := time.Now()
+	interval := endTime.Sub(connectData.startTime)
+
+	if data.Err != nil {
+		if tl.shouldLog(LogLevelError) {
+			tl.Logger.Log(ctx, LogLevelError, "Connect", map[string]any{
+				"host":            connectData.connConfig.Host,
+				"port":            connectData.connConfig.Port,
+				"database":        connectData.connConfig.Database,
+				tl.Config.TimeKey: interval,
+				"err":             data.Err,
+			})
+		}
+		return
+	}
+
+	if data.Conn != nil {
+		if tl.shouldLog(LogLevelInfo) {
+			tl.log(ctx, data.Conn, LogLevelInfo, "Connect", map[string]any{
+				"host":            connectData.connConfig.Host,
+				"port":            connectData.connConfig.Port,
+				"database":        connectData.connConfig.Database,
+				tl.Config.TimeKey: interval,
+			})
+		}
+	}
+}
+
+type tracePrepareData struct {
+	startTime time.Time
+	name      string
+	sql       string
+}
+
+func (tl *TraceLog) TracePrepareStart(ctx context.Context, _ *pgx.Conn, data pgx.TracePrepareStartData) context.Context {
+	return context.WithValue(ctx, tracelogPrepareCtxKey, &tracePrepareData{
+		startTime: time.Now(),
+		name:      data.Name,
+		sql:       data.SQL,
+	})
+}
+
+func (tl *TraceLog) TracePrepareEnd(ctx context.Context, conn *pgx.Conn, data pgx.TracePrepareEndData) {
+	tl.ensureConfig()
+	prepareData := ctx.Value(tracelogPrepareCtxKey).(*tracePrepareData)
+
+	endTime := time.Now()
+	interval := endTime.Sub(prepareData.startTime)
+
+	if data.Err != nil {
+		if tl.shouldLog(LogLevelError) {
+			tl.log(ctx, conn, LogLevelError, "Prepare", map[string]any{"name": prepareData.name, "sql": prepareData.sql, "err": data.Err, tl.Config.TimeKey: interval})
+		}
+		return
+	}
+
+	if tl.shouldLog(LogLevelInfo) {
+		tl.log(ctx, conn, LogLevelInfo, "Prepare", map[string]any{"name": prepareData.name, "sql": prepareData.sql, tl.Config.TimeKey: interval, "alreadyPrepared": data.AlreadyPrepared})
+	}
+}
+
+func (tl *TraceLog) shouldLog(lvl LogLevel) bool {
+	return tl.LogLevel >= lvl
+}
+
+func (tl *TraceLog) log(ctx context.Context, conn *pgx.Conn, lvl LogLevel, msg string, data map[string]any) {
+	if data == nil {
+		data = map[string]any{}
+	}
+
+	pgConn := conn.PgConn()
+	if pgConn != nil {
+		pid := pgConn.PID()
+		if pid != 0 {
+			data["pid"] = pid
+		}
+	}
+
+	tl.Logger.Log(ctx, lvl, msg, data)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,6 +188,7 @@ github.com/jackc/pgx/v5/pgproto3
 github.com/jackc/pgx/v5/pgtype
 github.com/jackc/pgx/v5/pgxpool
 github.com/jackc/pgx/v5/stdlib
+github.com/jackc/pgx/v5/tracelog
 # github.com/jackc/puddle/v2 v2.2.2
 ## explicit; go 1.19
 github.com/jackc/puddle/v2


### PR DESCRIPTION
- Pgx config is now explicit with additionally keep at least two connection alive 
- Enable pgx capability to get important debug info and capture any possible performance issues during DB interaction

e.g 
```
{"time":"2025-01-21T18:21:48.795474022Z","level":"INFO","source":{"function":"github.com/openshift-kni/oran-o2ims/internal/service/common/db.init.func1","file":"/workspace/internal/service/common/db/postgres.go","line":152},
"msg":"Database Query",
"event":"Query",
"duration":"26.711377ms",
"sql":"INSERT INTO alarm_definition (\"alarm_name\", \"alarm_last_change\", \"alarm_description\", \"proposed_repair_actions\", \"alarm_additional_fields\", \"alarm_dictionary_id\", \"severity\")\nVALUES ($1, $2, $3, $4, $5, $6, $7), ($8, $9, $10, $11, $12, $13, $14), ($15, $16, $17, $18, $19, $20, $21), ($22, $23, $24, $25, $26, $27, $28), ($29, $30, $31, $32, $33, $34, $35), ($36, $37, $38, $39, $40, $41, $42), ($43, $44, $45, $46, $47, $48, $49), ($50, $51, $52, $53, $54, $55, $56), ($57, $58, $59, $60, $61, $62, ...",
"sql_truncated_length":8968,"command_tag":
"INSERT 0 195",
"pid":269}
``` 