### PR TITLE
CNF-16482: Validate metadata name as UUID and refactor to use CustomValidator

### DIFF
--- a/api/provisioning/go.mod
+++ b/api/provisioning/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift-kni/oran-o2ims/api/provisioning
 go 1.22.0
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/r3labs/diff/v3 v3.0.1
@@ -33,7 +34,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -222,7 +222,7 @@ func (r *ProvisioningRequest) ValidateClusterInstanceInputMatchesSchema(
 	if err != nil {
 		return nil, fmt.Errorf(
 			"spec.templateParameters.%s does not match the schema defined in ClusterTemplate (%s) spec.templateParameterSchema.%s: %w",
-			TemplateParamClusterInstance, TemplateParamClusterInstance, clusterTemplate.Name, err)
+			TemplateParamClusterInstance, clusterTemplate.Name, TemplateParamClusterInstance, err)
 	}
 
 	return clusterInstanceMatchingInput, nil

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -222,7 +222,7 @@ func (r *ProvisioningRequest) ValidateClusterInstanceInputMatchesSchema(
 	if err != nil {
 		return nil, fmt.Errorf(
 			"spec.templateParameters.%s does not match the schema defined in ClusterTemplate (%s) spec.templateParameterSchema.%s: %w",
-			TemplateParamClusterInstance, TemplateParamClusterInstance, clusterTemplate.Name, err)
+			TemplateParamClusterInstance, clusterTemplate.Name, TemplateParamClusterInstance, err)
 	}
 
 	return clusterInstanceMatchingInput, nil


### PR DESCRIPTION
Updates:
 - Add validation for metadata name in the webhook to reject creation if its name is not a valid UUID. This aligns with the ProvisioningRequest REST API. 
 - Refactor to use `webhook.CustomValidator` instead of `webhook.Validator` as the latter is deprecated. 