### PR TITLE
Changes to hardware CRs

### DIFF
--- a/api/hardwaremanagement/v1alpha1/hardwaretemplate_types.go
+++ b/api/hardwaremanagement/v1alpha1/hardwaretemplate_types.go
@@ -26,8 +26,11 @@ type NodePoolData struct {
 	Role string `json:"role"`
 	// +kubebuilder:validation:MinLength=1
 	HwProfile string `json:"hwProfile"`
-	// +kubebuilder:validation:MinLength=1
-	ResourcePoolId string `json:"resourcePoolId"`
+	// ResourcePoolId is the identifier for the Resource Pool in the hardware manager instance.
+	// +optional
+	ResourcePoolId string `json:"resourcePoolId,omitempty"`
+	// +optional
+	ResourceSelector string `json:"resourceSelector,omitempty"`
 }
 
 // HardwareTemplateSpec defines the desired state of HardwareTemplate

--- a/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -24,6 +24,7 @@ type LocationSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Location",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Location string `json:"location,omitempty"`
 	// Site
+	// +kubebuilder:validation:Required
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Site",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Site string `json:"site"`
 }

--- a/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_hardwaretemplates.yaml
+++ b/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_hardwaretemplates.yaml
@@ -83,7 +83,10 @@ spec:
                       minLength: 1
                       type: string
                     resourcePoolId:
-                      minLength: 1
+                      description: ResourcePoolId is the identifier for the Resource
+                        Pool in the hardware manager instance.
+                      type: string
+                    resourceSelector:
                       type: string
                     role:
                       enum:
@@ -93,7 +96,6 @@ spec:
                   required:
                   - hwProfile
                   - name
-                  - resourcePoolId
                   - role
                   type: object
                 minItems: 1

--- a/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
+++ b/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
@@ -82,7 +82,10 @@ spec:
                           minLength: 1
                           type: string
                         resourcePoolId:
-                          minLength: 1
+                          description: ResourcePoolId is the identifier for the Resource
+                            Pool in the hardware manager instance.
+                          type: string
+                        resourceSelector:
                           type: string
                         role:
                           enum:
@@ -92,7 +95,6 @@ spec:
                       required:
                       - hwProfile
                       - name
-                      - resourcePoolId
                       - role
                       type: object
                     size:

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -22,13 +22,14 @@ metadata:
               {
                 "hwProfile": "profile-spr-single-processor-64G",
                 "name": "controller",
-                "resourcePoolID": "master-pool",
+                "resourcePoolId": "master-pool",
+                "resourceSelector": "selector-here",
                 "role": "master"
               },
               {
                 "hwProfile": "profile-spr-dual-processor-128G",
                 "name": "worker",
-                "resourcePoolID": "worker-pool",
+                "resourcePoolId": "worker-pool",
                 "role": "worker"
               }
             ]

--- a/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_hardwaretemplates.yaml
+++ b/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_hardwaretemplates.yaml
@@ -83,7 +83,10 @@ spec:
                       minLength: 1
                       type: string
                     resourcePoolId:
-                      minLength: 1
+                      description: ResourcePoolId is the identifier for the Resource
+                        Pool in the hardware manager instance.
+                      type: string
+                    resourceSelector:
                       type: string
                     role:
                       enum:
@@ -93,7 +96,6 @@ spec:
                   required:
                   - hwProfile
                   - name
-                  - resourcePoolId
                   - role
                   type: object
                 minItems: 1

--- a/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
+++ b/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodepools.yaml
@@ -82,7 +82,10 @@ spec:
                           minLength: 1
                           type: string
                         resourcePoolId:
-                          minLength: 1
+                          description: ResourcePoolId is the identifier for the Resource
+                            Pool in the hardware manager instance.
+                          type: string
+                        resourceSelector:
                           type: string
                         role:
                           enum:
@@ -92,7 +95,6 @@ spec:
                       required:
                       - hwProfile
                       - name
-                      - resourcePoolId
                       - role
                       type: object
                     size:

--- a/config/samples/v1alpha1_hardwaretemplate.yaml
+++ b/config/samples/v1alpha1_hardwaretemplate.yaml
@@ -14,11 +14,12 @@ spec:
     - name: controller
       role: master
       hwProfile: profile-spr-single-processor-64G
-      resourcePoolID: master-pool
+      resourcePoolId: master-pool
+      resourceSelector: "selector-here"
     - name: worker
       role: worker
       hwProfile: profile-spr-dual-processor-128G
-      resourcePoolID: worker-pool
+      resourcePoolId: worker-pool
   extensions:
     resourceTypeId: ResourceGroup~2.1.1
 status:

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/hardwaretemplate_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/hardwaretemplate_types.go
@@ -26,8 +26,11 @@ type NodePoolData struct {
 	Role string `json:"role"`
 	// +kubebuilder:validation:MinLength=1
 	HwProfile string `json:"hwProfile"`
-	// +kubebuilder:validation:MinLength=1
-	ResourcePoolId string `json:"resourcePoolId"`
+	// ResourcePoolId is the identifier for the Resource Pool in the hardware manager instance.
+	// +optional
+	ResourcePoolId string `json:"resourcePoolId,omitempty"`
+	// +optional
+	ResourceSelector string `json:"resourceSelector,omitempty"`
 }
 
 // HardwareTemplateSpec defines the desired state of HardwareTemplate

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node_pools.go
@@ -24,6 +24,7 @@ type LocationSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Location",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Location string `json:"location,omitempty"`
 	// Site
+	// +kubebuilder:validation:Required
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Site",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Site string `json:"site"`
 }


### PR DESCRIPTION
Description:
- Add optional `resourceSelector` field to the `NodePoolData` structure used both in the `HardwareTemplate `CR and in the `NodePool` CR
- Make the `ResourcePoolId` field of the `NodePoolData` structure optional

Examples:
```console

# HARDWARE TEMPLATE:
apiVersion: o2ims-hardwaremanagement.oran.openshift.io/v1alpha1
kind: HardwareTemplate
metadata:
  name: du-template-v1
  namespace: oran-o2ims
spec:
  bootInterfaceLabel: bootable-interface
  extensions:
    resourceTypeId: Resource-Group
  hardwareProvisioningTimeout: 60m
  hwMgrId: loopback-1
  nodePoolData:
  - hwProfile: profile-1-v1
    name: master
    resourcePoolId: master
    resourceSelector: test              <<<<   New field
    role: master
  - hwProfile: profile-2-v1
    name: worker
    resourcePoolId: worker-pool
    role: worker
status:
  conditions:
  - lastTransitionTime: "2025-01-21T22:43:52Z"
    message: Validated
    reason: Completed
    status: "True"
    type: Validation

# NODE POOL:
apiVersion: o2ims-hardwaremanagement.oran.openshift.io/v1alpha1
kind: NodePool
metadata:
  annotations:
    bootInterfaceLabel: bootable-interface
  finalizers:
  - oran-hwmgr-plugin/nodepool-finalizer
  generation: 5
  labels:
    provisioningrequest.o2ims.provisioning.oran.org/name: sno-du-1
  name: sno-du-1
  namespace: oran-hwmgr-plugin
  ownerReferences:
  - apiVersion: o2ims.provisioning.oran.org/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: ProvisioningRequest
    name: sno-du-1
    uid: b6420e2d-2616-46db-95f4-5febd1f7c14f
spec:
  cloudID: sno-du-1
  extensions:
    resourceTypeId: Resource-Group
  hwMgrId: loopback-1
  nodeGroup:
  - nodePoolData:
      hwProfile: profile-1-v1
      name: master
      resourcePoolId: master
      resourceSelector: test         <<<<   New field passed down from the ProvisioningRequest
      role: master
    size: 1
  - nodePoolData:
      hwProfile: profile-2-v1
      name: worker
      resourcePoolId: worker-pool
      role: worker
    size: 0
  site: local-west-12345            <<<<   Passed down from the ProvisioningRequest's spec.templateParameters.oCloudSiteId
status:
  conditions:
  - lastTransitionTime: "2025-01-21T22:44:12Z"
    message: Created
    reason: Completed
    status: "True"
    type: Provisioned
  - lastTransitionTime: "2025-01-21T22:44:12Z"
    message: Configuration has been applied successfully
    reason: ConfigurationApplied
    status: "True"
    type: Configured
  hwMgrPlugin:
    observedGeneration: 5
  properties:
    nodeNames:
    - f597ad99-60d7-4537-8251-6e8c5b7b15c2
```