### PR TITLE
Loosen HTTP status code checks

### DIFF
--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -617,7 +617,7 @@ func (t *reconcilerTask) registerWithSmo(ctx context.Context) error {
 		return fmt.Errorf("failed to send registration request to '%s': %s", url, err.Error())
 	}
 
-	if result.StatusCode != http.StatusOK {
+	if result.StatusCode > http.StatusNoContent {
 		return fmt.Errorf("registration request failed to '%s', HTTP code=%s", url, result.Status)
 	}
 

--- a/internal/service/common/notifier/event.go
+++ b/internal/service/common/notifier/event.go
@@ -40,7 +40,7 @@ func sendNotification(ctx context.Context, client *http.Client, url string, even
 		}
 	}(response.Body)
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode > http.StatusNoContent {
 		return fmt.Errorf("notification failed: %v", response.StatusCode)
 	}
 


### PR DESCRIPTION
In anticipation of inconsistencies between success return codes on the SMO API endpoints, and since we don't look for any response bodies, we are going to accept anything between 200 and 204 inclusively.