### PR TITLE
Add ClusterTemplate ID as label in MCL and Agent CRs

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1222,6 +1222,8 @@ spec:
           verbs:
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - apps
@@ -1266,6 +1268,8 @@ spec:
           verbs:
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - config.openshift.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -102,6 +102,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - apps
@@ -146,6 +148,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - config.openshift.io

--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers"
 	"github.com/openshift-kni/oran-o2ims/internal/exit"
+	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/spf13/cobra"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -124,6 +125,7 @@ func init() {
 	utilruntime.Must(openshiftoperatorv1.AddToScheme(scheme))
 	utilruntime.Must(ibguv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(pluginv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(assistedservicev1beta1.AddToScheme(scheme))
 }
 
 // run executes the `start controller-manager` command.

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -100,6 +100,8 @@ func getClusterTemplateRefName(name, version string) string {
 //+kubebuilder:rbac:groups=lcm.openshift.io,resources=imagebasedgroupupgrades,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=lcm.openshift.io,resources=imagebasedgroupupgrades/status,verbs=get
 //+kubebuilder:rbac:groups=hwmgr-plugin.oran.openshift.io,resources=hardwaremanagers,verbs=get;list;watch
+//+kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;patch;update;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;patch;update;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -43,6 +43,7 @@ import (
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 )
 
 func TestControllers(t *testing.T) {
@@ -135,4 +136,6 @@ var _ = BeforeSuite(func() {
 	scheme.AddKnownTypes(openshiftoperatorv1.SchemeGroupVersion, &openshiftoperatorv1.IngressController{})
 	scheme.AddKnownTypes(ibguv1alpha1.SchemeGroupVersion, &ibguv1alpha1.ImageBasedGroupUpgrade{})
 	scheme.AddKnownTypes(pluginv1alpha1.GroupVersion, &pluginv1alpha1.HardwareManager{})
+	scheme.AddKnownTypes(assistedservicev1beta1.GroupVersion, &assistedservicev1beta1.Agent{})
+	scheme.AddKnownTypes(assistedservicev1beta1.GroupVersion, &assistedservicev1beta1.AgentList{})
 })

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -283,6 +283,8 @@ const (
 	OpenshiftVersionLabelName = "openshiftVersion"
 	ClusterIDLabelName        = "clusterID"
 	LocalClusterLabelName     = "local-cluster"
+
+	ClusterTemplateArtifactsLabel = "clustertemplates.o2ims.provisioning.oran.org/templateId"
 )
 
 // Alertmanager values


### PR DESCRIPTION
Description:
- For a ManagedCluster and the corresponding Agent, add the `clustertemplates.o2ims.provisioning.oran.org/templateId` label with a value that points to `spec.TemplateId` of the ClusterTemplate used in the corresponding ProvisioningRequest.
- The above label is only added once a ProvisioningRequest becomes `fulfilled`.
- If the ProvisioningRequest goes through Day2 configuration and its status changes from `fulfilled`, the label is kept.
- The function that adds the labels is run during each reconciliation for which the ProvisioningRequest is `fulfilled` to ensure the label has the correct value, in the case it has been tempered with.
- Add tests.