### PR TITLE
CNF-16482: Sample and docs updates for ProvisioningRequest

### DIFF
--- a/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -169,6 +169,7 @@ type ProvisioningRequestStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:scope=Cluster,shortName=oranpr
+//+kubebuilder:printcolumn:name="DisplayName",type="string",JSONPath=".spec.name"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="ProvisionPhase",type="string",JSONPath=".status.provisioningStatus.provisioningPhase"
 //+kubebuilder:printcolumn:name="ProvisionDetails",type="string",JSONPath=".status.provisioningStatus.provisioningDetails"

--- a/bundle/manifests/o2ims.provisioning.oran.org_provisioningrequests.yaml
+++ b/bundle/manifests/o2ims.provisioning.oran.org_provisioningrequests.yaml
@@ -17,6 +17,9 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: DisplayName
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -433,11 +433,11 @@ metadata:
               "app.kubernetes.io/name": "provisioningrequest",
               "app.kubernetes.io/part-of": "oran-o2ims"
             },
-            "name": "provisioningrequest-sample"
+            "name": "123e4567-e89b-12d3-a456-426614174000"
           },
           "spec": {
             "description": "Provisioning request for setting up a Single Node OpenShift (SNO) in the test environment.",
-            "name": "TestEnv-SNO-Provisioning",
+            "name": "TestEnv-SNO-Provisioning-site-sno-du-1",
             "templateName": "clustertemplate-sample",
             "templateParameters": {
               "clusterInstanceParameters": {

--- a/config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml
+++ b/config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml
@@ -17,6 +17,9 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: DisplayName
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/samples/v1alpha1_provisioningrequest.yaml
+++ b/config/samples/v1alpha1_provisioningrequest.yaml
@@ -7,9 +7,9 @@ metadata:
     app.kubernetes.io/part-of: oran-o2ims
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: oran-o2ims
-  name: provisioningrequest-sample
+  name: 123e4567-e89b-12d3-a456-426614174000
 spec:
-  name: "TestEnv-SNO-Provisioning"
+  name: "TestEnv-SNO-Provisioning-site-sno-du-1"
   description: "Provisioning request for setting up a Single Node OpenShift (SNO) in the test environment."
   templateName: clustertemplate-sample
   templateVersion: v1.0.0

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -53,7 +53,7 @@ kind: ProvisioningRequest
 metadata:
   finalizers:
     - provisioningrequest.o2ims.provisioning.oran.org/finalizer
-  name: sno-ran-du-1
+  name: 123e4567-e89b-12d3-a456-426614174000
 spec:
   description: Provisioning request for basic SNO with sample ACM policies
   name: Dev-main-SNO-Provisioning-sno-ran-du-1
@@ -79,7 +79,7 @@ kind: ProvisioningRequest
 metadata:
   finalizers:
     - provisioningrequest.o2ims.provisioning.oran.org/finalizer
-  name: sno-ran-du-1
+  name: 123e4567-e89b-12d3-a456-426614174000
 spec:
   description: Provisioning request for basic SNO with sample ACM policies
   name: Dev-main-SNO-Provisioning-sno-ran-du-1
@@ -116,7 +116,7 @@ kind: ProvisioningRequest
 metadata:
   finalizers:
     - provisioningrequest.o2ims.provisioning.oran.org/finalizer
-  name: sno-ran-du-1
+  name: 123e4567-e89b-12d3-a456-426614174000
 spec:
   description: Provisioning request for basic SNO with sample ACM policies
   name: Dev-main-SNO-Provisioning-sno-ran-du-1

--- a/docs/cluster-provisioning.md
+++ b/docs/cluster-provisioning.md
@@ -16,10 +16,16 @@ The operator leverages several key components to achieve this:
 
 Ensure the following operators are installed on the hub cluster:
 
-- Advanced Cluster Management (ACM)
+- Advanced Cluster Management (ACM) v2.12+
 - Red Hat OpenShift GitOps Operator
-- SiteConfig Operator
 - ORAN Hardware Manager Plugin
+- SiteConfig Operator
+
+  Enable it in ACM by running the following command:
+
+  ```console
+  oc patch multiclusterhubs.operator.open-cluster-management.io multiclusterhub -n <ACM_NAMESPACE> --type json --patch '[{"op": "add", "path":"/spec/overrides/components/-", "value": {"name":"siteconfig","enabled": true}}]'
+  ```
 
 ### Git Respository Setup
 
@@ -76,6 +82,8 @@ status:
 ## ProvisioningRequest CR
 
 A cluster-scoped CR managed by the O-Cloud Manager, providing all neccessary parameters for provisioning a cluster. An example of ProvisioningRequest can be found [here](../config/samples/v1alpha1_provisioningrequest.yaml).
+
+The `metadata.name` of a ProvisioningRequest CR must be a valid UUID. Any attempt to create a ProvisioningRequest with an invalid `metadata.name` will be rejected by the webhook.
 
 The [CRD](../config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml)'s `spec` fields include:
 
@@ -359,9 +367,9 @@ data:
 Deleting the ProvisioningRequest CR initiates the deletion of a provisioned cluster. O-Cloud manager sets the ProvisioningState to `deleting`, ensuring that all dependent resources are fully cleaned up before completing the deletion.
 
 ```console
-oc get oranpr sno1
-NAME      AGE   PROVISIONSTATE   PROVISIONDETAILS
-sno1      71m   deleting         Deletion is in progress
+oc get oranpr 123e4567-e89b-12d3-a456-426614174000
+NAME                                   DISPLAYNAME       AGE     PROVISIONPHASE   PROVISIONDETAILS
+123e4567-e89b-12d3-a456-426614174000   sno1-request      71m     deleting         Deletion is in progress
 ```
 
 ## Monitoring Process

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -169,6 +169,7 @@ type ProvisioningRequestStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:scope=Cluster,shortName=oranpr
+//+kubebuilder:printcolumn:name="DisplayName",type="string",JSONPath=".spec.name"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="ProvisionPhase",type="string",JSONPath=".status.provisioningStatus.provisioningPhase"
 //+kubebuilder:printcolumn:name="ProvisionDetails",type="string",JSONPath=".status.provisioningStatus.provisioningDetails"


### PR DESCRIPTION
Updates:
- Added `spec.name` in the `oc get oranpr` output to improve human readablity, as metadata.name is now a UUID.
```
✗ oc get oranpr
NAME                                   DISPLAYNAME       AGE     PROVISIONPHASE   PROVISIONDETAILS
a1478db9-651f-4d30-96d6-8af13481d778   cnfdf20-request   2d20h   fulfilled        Provisioning request has completed successfully
```
- Updated the sample and docs to reflect the recent change requiring  `metadata.name` to be a valid UUID for ProvReq