### PR TITLE
Add env variable to control forced SMO registration

### DIFF
--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -239,11 +239,12 @@ const MinimumProxyLogLevel = 10
 
 // Environment values
 const (
-	ServerImageName         = "IMAGE"
-	KubeRbacProxyImageName  = "KUBE_RBAC_PROXY_IMAGE"
-	PostgresImageName       = "POSTGRES_IMAGE"
-	HwMgrPluginNameSpace    = "HWMGR_PLUGIN_NAMESPACE"
-	InternalServicePortName = "INTERNAL_SERVICE_PORT"
+	ServerImageName           = "IMAGE"
+	KubeRbacProxyImageName    = "KUBE_RBAC_PROXY_IMAGE"
+	PostgresImageName         = "POSTGRES_IMAGE"
+	HwMgrPluginNameSpace      = "HWMGR_PLUGIN_NAMESPACE"
+	InternalServicePortName   = "INTERNAL_SERVICE_PORT"
+	RegisterOnRestartsEnvName = "REGISTER_ON_RESTART"
 )
 
 // ClusterVersionName is the name given to the default ClusterVersion object


### PR DESCRIPTION
Since we only register once with the SMO it may be difficult/annoying for SMO developers to test their functionality.  With the following environment variable set to "true" we will redo the registration any time the Pod is restarted.

e.g., REGISTER_ON_RESTART=true

Any value that resolve to True with Go's strconv.ParseBool() will work.