### PR TITLE
CNF-16275: Support pending status for ProvisioningRequest

### DIFF
--- a/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -112,6 +112,12 @@ type PolicyDetails struct {
 type ProvisioningPhase string
 
 const (
+	// StatePending indicates that the provisioning process is either waiting to start
+	// or is preparing to apply new changes. This state is set when the ProvisioningRequest
+	// is observed with new spec changes, during validation and resource preparation,
+	// before the actual provisioning begins.
+	StatePending ProvisioningPhase = "pending"
+
 	// StateProgressing means the provisioning process is currently in progress.
 	// It could be in progress during hardware provisioning, cluster installation, or cluster configuration.
 	StateProgressing ProvisioningPhase = "progressing"
@@ -138,7 +144,7 @@ type ProvisionedResources struct {
 
 type ProvisioningStatus struct {
 	// The current state of the provisioning process.
-	// +kubebuilder:validation:Enum=progressing;fulfilled;failed;deleting
+	// +kubebuilder:validation:Enum=pending;progressing;fulfilled;failed;deleting
 	ProvisioningPhase ProvisioningPhase `json:"provisioningPhase,omitempty"`
 
 	// The details about the current state of the provisioning process.
@@ -164,6 +170,9 @@ type ProvisioningRequestStatus struct {
 	Extensions Extensions `json:"extensions,omitempty"`
 
 	ProvisioningStatus ProvisioningStatus `json:"provisioningStatus,omitempty"`
+
+	// ObservedGeneration is the most recent generation observed by the controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/bundle/manifests/o2ims.provisioning.oran.org_provisioningrequests.yaml
+++ b/bundle/manifests/o2ims.provisioning.oran.org_provisioningrequests.yaml
@@ -231,6 +231,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
               provisioningStatus:
                 properties:
                   provisionedResources:
@@ -249,6 +254,7 @@ spec:
                   provisioningPhase:
                     description: The current state of the provisioning process.
                     enum:
+                    - pending
                     - progressing
                     - fulfilled
                     - failed

--- a/config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml
+++ b/config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml
@@ -231,6 +231,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
               provisioningStatus:
                 properties:
                   provisionedResources:
@@ -249,6 +254,7 @@ spec:
                   provisioningPhase:
                     description: The current state of the provisioning process.
                     enum:
+                    - pending
                     - progressing
                     - fulfilled
                     - failed

--- a/internal/controllers/utils/conditions.go
+++ b/internal/controllers/utils/conditions.go
@@ -28,6 +28,13 @@ func SetStatusCondition(
 	)
 }
 
+// SetProvisioningStatePending updates the provisioning state to pending with detailed message
+func SetProvisioningStatePending(cr *provisioningv1alpha1.ProvisioningRequest, message string) {
+	cr.Status.ProvisioningStatus.ProvisioningPhase = provisioningv1alpha1.StatePending
+	cr.Status.ProvisioningStatus.ProvisioningDetails = message
+	cr.Status.ProvisioningStatus.UpdateTime = metav1.Now()
+}
+
 // SetProvisioningStateInProgress updates the provisioning state to progressing with detailed message
 func SetProvisioningStateInProgress(cr *provisioningv1alpha1.ProvisioningRequest, message string) {
 	cr.Status.ProvisioningStatus.ProvisioningPhase = provisioningv1alpha1.StateProgressing

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -26,6 +26,7 @@ import (
 	ibguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
 
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	openshiftv1 "github.com/openshift/api/config/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -50,6 +51,11 @@ var (
 )
 
 func UpdateK8sCRStatus(ctx context.Context, c client.Client, object client.Object) error {
+	cr, ok := object.(*provisioningv1alpha1.ProvisioningRequest)
+	if ok {
+		cr.Status.ObservedGeneration = cr.Generation
+	}
+
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := c.Status().Update(ctx, object); err != nil {
 			return fmt.Errorf("failed to update status: %w", err)

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -112,6 +112,12 @@ type PolicyDetails struct {
 type ProvisioningPhase string
 
 const (
+	// StatePending indicates that the provisioning process is either waiting to start
+	// or is preparing to apply new changes. This state is set when the ProvisioningRequest
+	// is observed with new spec changes, during validation and resource preparation,
+	// before the actual provisioning begins.
+	StatePending ProvisioningPhase = "pending"
+
 	// StateProgressing means the provisioning process is currently in progress.
 	// It could be in progress during hardware provisioning, cluster installation, or cluster configuration.
 	StateProgressing ProvisioningPhase = "progressing"
@@ -138,7 +144,7 @@ type ProvisionedResources struct {
 
 type ProvisioningStatus struct {
 	// The current state of the provisioning process.
-	// +kubebuilder:validation:Enum=progressing;fulfilled;failed;deleting
+	// +kubebuilder:validation:Enum=pending;progressing;fulfilled;failed;deleting
 	ProvisioningPhase ProvisioningPhase `json:"provisioningPhase,omitempty"`
 
 	// The details about the current state of the provisioning process.
@@ -164,6 +170,9 @@ type ProvisioningRequestStatus struct {
 	Extensions Extensions `json:"extensions,omitempty"`
 
 	ProvisioningStatus ProvisioningStatus `json:"provisioningStatus,omitempty"`
+
+	// ObservedGeneration is the most recent generation observed by the controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true


### PR DESCRIPTION
Introduced a new overall provisioning status `Pending`, which represents the CR validation and resource preparation phase. This status is set only when there are spec changes to the ProvisioningRequest. Any failed validation, resource rendering or generation result in the provisioning status to `Failed` which is same with current behavior.

`status.observedGeneration` has been introduced to differentiate whether the controller's reconcile was triggered by spec  changes or for other factors(watched resources or periodic requeues). It reflects the most recent generation observed by the controller and is updated to match metadata.generation during status updates to acknowledge the new generation.


The Pending status transition is quick. Tested the following scenarios:
- Invalid CR validation (pending -> failed)
- Successful provisioning (pending -> progressing -> fulfilled)
- Updates with invalid values during cluster installation (pending -> progressing -> pending -> progressing -> fulfilled -> failed)
- Day 2 updates after successful provisioning (fulfilled -> pending -> progressing -> fulfilled)