### PR TITLE
Temporarily remove limits for the O2IMS deployment

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1615,9 +1615,6 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
-                  limits:
-                    cpu: 500m
-                    memory: 256Mi
                   requests:
                     cpu: 10m
                     memory: 64Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -117,9 +117,7 @@ spec:
         # TODO(user): Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
-          limits:
-            cpu: 500m
-            memory: 256Mi
+          # No CPU and memory limits for now.
           requests:
             cpu: 10m
             memory: 64Mi


### PR DESCRIPTION
Remove the limits for the O2IMS Deployment for now, to avoid OOMKilled situations.
The limits should be added back once their values are established.