### PR TITLE
Fix debug mode handling for re-registration using an annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,15 @@ spec:
 
 Once the hub cluster is set up and the O-Cloud Manager is started, the end user must update the Inventory CR to
 configure the SMO attributes so that the application can register with the SMO. The user must provide the Global
-O-Cloud ID value which is provided by the SMO.
+O-Cloud ID value, which is provided by the SMO. This registration is a one-time operation. Once it succeeds, it will
+not be repeated.
+
+> :exclamation: For development/debug purposes, if repeating the registration is necessary, the following annotation can
+> be applied to the Inventory CR.
+>
+>```bash
+> oc annotate -n oran-o2ims inventories default o2ims.oran.openshift.io/register-on-restart=true
+>```
 
 In a production environment, this requires that an OAuth2 authorization server be available and configured with the
 appropriate client configurations for both the SMO and the O-Cloud Manager. In debug/test environments, the OAuth2

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -69,7 +69,7 @@ func makePod(namespace, serverName string) *corev1.Pod {
 
 var _ = DescribeTable(
 	"Reconciler",
-	func(objs []client.Object, request reconcile.Request, validate func(result ctrl.Result, reconciler Reconciler)) {
+	func(objs []client.Object, request reconcile.Request, validate func(result ctrl.Result, reconciler *Reconciler)) {
 		// Declare the Namespace for the O-RAN O2IMS resource.
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -139,7 +139,7 @@ var _ = DescribeTable(
 		result, err := r.Reconcile(context.TODO(), request)
 		Expect(err).ToNot(HaveOccurred())
 
-		validate(result, *r)
+		validate(result, r)
 	},
 	Entry(
 		"Resource server deployment is updated after edit",
@@ -171,7 +171,7 @@ var _ = DescribeTable(
 				Name:      "oran-o2ims-sample-1",
 			},
 		},
-		func(result ctrl.Result, reconciler Reconciler) {
+		func(result ctrl.Result, reconciler *Reconciler) {
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Minute}))
 
 			// Check that the metadata server deployment exists.
@@ -244,7 +244,7 @@ var _ = DescribeTable(
 				Name:      "oran-o2ims-sample-1",
 			},
 		},
-		func(result ctrl.Result, reconciler Reconciler) {
+		func(result ctrl.Result, reconciler *Reconciler) {
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Minute}))
 
 			// Check the metadata server deployment exists.
@@ -339,7 +339,7 @@ var _ = DescribeTable(
 				Name:      "oran-o2ims-sample-1",
 			},
 		},
-		func(result ctrl.Result, reconciler Reconciler) {
+		func(result ctrl.Result, reconciler *Reconciler) {
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Minute}))
 
 			// Check that the resource server exists.
@@ -417,7 +417,7 @@ var _ = DescribeTable(
 				Name:      "oran-o2ims-sample-1",
 			},
 		},
-		func(result ctrl.Result, reconciler Reconciler) {
+		func(result ctrl.Result, reconciler *Reconciler) {
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Minute}))
 			// Check the metadata server deployment does not exist.
 			resourceDeployment := &appsv1.Deployment{}


### PR DESCRIPTION
The REGISTER_ON_RESTART env variable was meant to force a single registration on every Pod restart, but it was inadvertently causing a registration on every reconcile loop.  It was also noticed that when deploying from a bundle that it is not straightforward to set an env variable as it gets overridden automatically to align with the CSV, therefore, we are changing this to an annotation.