### PR TITLE
Fix lookup of hwmgr plugin namespace

### DIFF
--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -1567,7 +1567,7 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (u
 		},
 		{
 			Name:  utils.HwMgrPluginNameSpace,
-			Value: os.Getenv(utils.HwMgrPluginNameSpace),
+			Value: utils.GetHwMgrPluginNS(),
 		},
 	}...)
 

--- a/internal/service/resources/collector/collector_hwmgr.go
+++ b/internal/service/resources/collector/collector_hwmgr.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 
 	"github.com/google/uuid"
 	inventoryclient "github.com/openshift-kni/oran-hwmgr-plugin/pkg/inventory-client/generated"
@@ -73,7 +72,7 @@ func NewHwMgrDataSource(name string, cloudID, globalCloudID uuid.UUID) (DataSour
 func setupInventoryClient(name string) (*inventoryclient.ClientWithResponses, error) {
 	slog.Info("Creating inventory API client", "name", name)
 
-	url := fmt.Sprintf("https://oran-hwmgr-plugin-controller-manager.%s.svc.cluster.local:6443", os.Getenv(utils.HwMgrPluginNameSpace))
+	url := fmt.Sprintf("https://oran-hwmgr-plugin-controller-manager.%s.svc.cluster.local:6443", utils.GetHwMgrPluginNS())
 
 	// Set up transport
 	tr, err := utils.GetDefaultBackendTransport()


### PR DESCRIPTION
This ensures that the default hwmgr plugin namespace is used even if the env variable is not set.