### PR TITLE
Make UUID comparison case insensitive

### DIFF
--- a/internal/search/selector_evaluator.go
+++ b/internal/search/selector_evaluator.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // SelectorEvaluatorBuilder contains the logic and data needed to create filter expression
@@ -226,7 +228,11 @@ func (e *SelectorEvaluator) evaluateEq(value any, args []any) (result bool,
 	switch value := value.(type) {
 	case string:
 		arg := arg.(string)
-		result = value == arg
+		if _, err2 := uuid.Parse(arg); err2 == nil {
+			result = strings.EqualFold(value, arg)
+		} else {
+			result = value == arg
+		}
 	case int:
 		arg := arg.(int)
 		result = value == arg

--- a/internal/search/selector_evaluator_test.go
+++ b/internal/search/selector_evaluator_test.go
@@ -103,6 +103,19 @@ var _ = Describe("Selector evaluator", func() {
 			true,
 		),
 		Entry(
+			"Eq string case insensitive for UUID values",
+			"(eq,MyField,B8F14332-0331-45D9-8C0D-D24C25CC1F2E)",
+			func() any {
+				type MyObject struct {
+					MyField string
+				}
+				return MyObject{
+					MyField: "b8f14332-0331-45d9-8c0d-d24c25cc1f2e",
+				}
+			},
+			true,
+		),
+		Entry(
 			"Eq string is false",
 			"(eq,MyField,yourvalue)",
 			func() any {


### PR DESCRIPTION
The conformance tests pass in a search filter with an upper case UUID value so to pass the test we need to make our comparison case insensitive; at least for the 'eq' case.