### PR TITLE
Include hwMgrId value in inventory uuid generation

### DIFF
--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -856,10 +856,10 @@ func GetServiceURL(serverName string) string {
 	return fmt.Sprintf("https://%s.%s.svc.cluster.local:%s", serverName, GetEnvOrDefault(DefaultNamespaceEnvName, DefaultNamespace), os.Getenv(InternalServicePortName))
 }
 
-// MakeUUIDFromName generates a namespaced uuid value from the specified namespace and name values.  The values are
+// MakeUUIDFromNames generates a namespaced uuid value from the specified namespace and name values.  The values are
 // scoped to a `cloudID` to avoid conflicts with other systems.
-func MakeUUIDFromName(namespace string, cloudID uuid.UUID, name string) uuid.UUID {
-	value := fmt.Sprintf("%s/%s", cloudID.String(), name)
+func MakeUUIDFromNames(namespace string, cloudID uuid.UUID, names ...string) uuid.UUID {
+	value := fmt.Sprintf("%s/%s", cloudID.String(), strings.Join(names, "/"))
 	namespaceUUID := uuid.MustParse(namespace)
 	return uuid.NewSHA1(namespaceUUID, []byte(value))
 }

--- a/internal/service/cluster/collector/collector_k8s.go
+++ b/internal/service/cluster/collector/collector_k8s.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/async"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
+	"github.com/openshift-kni/oran-o2ims/internal/service/resources/collector"
 )
 
 // Interface compile enforcement
@@ -104,7 +105,7 @@ func (d *K8SDataSource) makeClusterResourceTypeName(architecture, cores string) 
 // makeClusterResourceTypeID builds a UUID value for this resource type based on its name so that it has
 // a consistent value each time it is created.
 func (d *K8SDataSource) makeClusterResourceTypeID(architecture, cores string) uuid.UUID {
-	return utils.MakeUUIDFromName(ClusterResourceTypeUUIDNamespace, d.cloudID, d.makeClusterResourceTypeName(architecture, cores))
+	return utils.MakeUUIDFromNames(ClusterResourceTypeUUIDNamespace, d.cloudID, d.makeClusterResourceTypeName(architecture, cores))
 }
 
 // MakeClusterResourceType creates an instance of a ResourceType from a Resource object.
@@ -120,7 +121,7 @@ func (d *K8SDataSource) MakeClusterResourceType(resource *models.ClusterResource
 	cores := cpu["cores"]
 
 	resourceTypeName := d.makeClusterResourceTypeName(architecture, cores)
-	resourceTypeID := utils.MakeUUIDFromName(ClusterResourceTypeUUIDNamespace, d.cloudID, resourceTypeName)
+	resourceTypeID := utils.MakeUUIDFromNames(ClusterResourceTypeUUIDNamespace, d.cloudID, resourceTypeName)
 
 	result := models.ClusterResourceType{
 		ClusterResourceTypeID: resourceTypeID,
@@ -147,8 +148,8 @@ func (d *K8SDataSource) MakeNodeClusterType(resource *models.NodeCluster) (*mode
 	clusterType := (*extensions)[utils.ClusterModelExtension].(string)
 
 	resourceTypeName := d.makeNodeClusterTypeName(clusterType, vendor, version)
-	resourceTypeID := utils.MakeUUIDFromName(NodeClusterTypeUUIDNamespace, d.cloudID, resourceTypeName)
-	alarmDictionaryID := utils.MakeUUIDFromName(NodeClusterTypeUUIDNamespace, d.cloudID, fmt.Sprintf("%s-%s", resourceTypeName, "alarms"))
+	resourceTypeID := utils.MakeUUIDFromNames(NodeClusterTypeUUIDNamespace, d.cloudID, resourceTypeName)
+	alarmDictionaryID := utils.MakeUUIDFromNames(NodeClusterTypeUUIDNamespace, d.cloudID, fmt.Sprintf("%s-%s", resourceTypeName, "alarms"))
 
 	// We expect that the standard will eventually evolve to contain more attributes to align more
 	// closely with how ResourceType was defined, but for now we'll add some additional info as
@@ -178,7 +179,7 @@ func (d *K8SDataSource) convertAgentToClusterResource(agent *v1beta1.Agent) (mod
 	// Build a unique UUID value using the namespace and name.  Choosing not to tie ourselves to the agent UUID since
 	// we don't know if/when it can change and how we want to behave if the node gets deleted and re-installed.
 	name := fmt.Sprintf("%s/%s", agent.Namespace, agent.Name)
-	resourceID := utils.MakeUUIDFromName(ClusterResourceUUIDNamespace, d.cloudID, name)
+	resourceID := utils.MakeUUIDFromNames(ClusterResourceUUIDNamespace, d.cloudID, name)
 
 	architecture := agent.Status.Inventory.Cpu.Architecture
 	cores := agent.Status.Inventory.Cpu.Count
@@ -237,7 +238,7 @@ func (d *K8SDataSource) makeNodeClusterTypeName(clusterType, vendor, version str
 // makeClusterResourceTypeID builds a UUID value for this resource type based on its name so that it has
 // a consistent value each time it is created.
 func (d *K8SDataSource) makeNodeClusterTypeID(clusterType, vendor, version string) uuid.UUID {
-	return utils.MakeUUIDFromName(NodeClusterTypeUUIDNamespace, d.cloudID, d.makeNodeClusterTypeName(clusterType, vendor, version))
+	return utils.MakeUUIDFromNames(NodeClusterTypeUUIDNamespace, d.cloudID, d.makeNodeClusterTypeName(clusterType, vendor, version))
 }
 
 // getExtensionsFromLabels converts a label map to an extensions map

--- a/internal/service/resources/collector/collector_hwmgr.go
+++ b/internal/service/resources/collector/collector_hwmgr.go
@@ -48,7 +48,9 @@ const (
 	adminStateExtension       = "adminState"
 	operationalStateExtension = "operationalState"
 	usageStateExtension       = "usageState"
+	powerStateExtension       = "powerState"
 	hwProfileExtension        = "hwProfile"
+	labelsExtension           = "labels"
 )
 
 // NewHwMgrDataSource creates a new instance of an ACM data source collector whose purpose is to collect data from the
@@ -254,7 +256,11 @@ func (d *HwMgrDataSource) convertResource(resource *inventoryclient.ResourceInfo
 	}
 
 	if resource.PowerState != nil {
-		result.Extensions["powerState"] = string(*resource.PowerState)
+		result.Extensions[powerStateExtension] = string(*resource.PowerState)
+	}
+
+	if resource.Labels != nil {
+		result.Extensions[labelsExtension] = *resource.Labels
 	}
 
 	return result


### PR DESCRIPTION
* Link ClusterResource to Resource
    
    This links the ClusterResource object to the Cluster object via the
    ResourceID UUID value.  This depends on labels to be applied to the
    Agent object so that we know which hwMgrID and hwMgrNodeID was used
    to implement the node.   This labels will be provided in a separate
    PR.
    
* Add labels to inventory resource
    
    This adds the "labels" provided by the hardware manager as extensions
    to the inventory resource object.
    
*  Include hwMgrId value in inventory uuid generation
    
    We generate inventory UUID values based on the cloud id and the resource
    name but the resource name does not necessarily have to be unique
    across multiple hardware managers therefore we include the hwMgrId into
    the string used to generate the UUID.
