### PR TITLE
Add extra labels on the Agent CRs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -130,7 +130,9 @@
                         "env": {
                                 "KUBECONFIG": "${env:KUBECONFIG}",
                                 "IMAGE": "quay.io/openshift-kni/oran-o2ims-operator:latest",
-                                "HWMGR_PLUGIN_NAMESPACE": "oran-hwmgr-plugin"
+                                "HWMGR_PLUGIN_NAMESPACE": "oran-hwmgr-plugin",
+                                "POSTGRES_IMAGE": "registry.redhat.io/rhel9/postgresql-16:9.5-1731610873",
+                                "KUBE_RBAC_PROXY_IMAGE": "quay.io/openshift/origin-kube-rbac-proxy:4.18"
                         },
                         "args": [
                                 "start",

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/assisted-service/api/v1beta1"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 
 	ibguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
@@ -16,6 +15,7 @@ import (
 	hwv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift/assisted-service/api/v1beta1"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -2002,8 +2002,8 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			}
 			Expect(c.Create(ctx, agent)).To(Succeed())
 
-			networkConfig := &v1beta1.NMStateConfigSpec{
-				NetConfig: v1beta1.NetConfig{
+			networkConfig := &assistedservicev1beta1.NMStateConfigSpec{
+				NetConfig: assistedservicev1beta1.NetConfig{
 					Raw: []byte(
 						`
       dns-resolver:

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -83,6 +83,9 @@ func getFakeClientFromObjects(objs ...client.Object) client.WithWatch {
 		WithStatusSubresource(&policiesv1.Policy{}).
 		WithStatusSubresource(&clusterv1.ManagedCluster{}).
 		WithStatusSubresource(&pluginv1alpha1.HardwareManager{}).
+		WithIndex(&hwv1alpha1.Node{}, "spec.nodePool", func(obj client.Object) []string {
+			return []string{obj.(*hwv1alpha1.Node).Spec.NodePool}
+		}).
 		Build()
 }
 
@@ -128,6 +131,7 @@ var _ = BeforeSuite(func() {
 	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &hwv1alpha1.HardwareTemplate{})
 	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &hwv1alpha1.NodePool{})
 	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &hwv1alpha1.Node{})
+	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &hwv1alpha1.NodeList{})
 	scheme.AddKnownTypes(policiesv1.SchemeGroupVersion, &policiesv1.Policy{})
 	scheme.AddKnownTypes(policiesv1.SchemeGroupVersion, &policiesv1.PolicyList{})
 	scheme.AddKnownTypes(clusterv1.SchemeGroupVersion, &clusterv1.ManagedCluster{})

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -287,6 +287,8 @@ const (
 	LocalClusterLabelName     = "local-cluster"
 
 	ClusterTemplateArtifactsLabel = "clustertemplates.o2ims.provisioning.oran.org/templateId"
+	HardwareManagerIdLabel        = "hardwaremanagers.hwmgr-plugin.oran.openshift.io/hwMgrId"
+	HardwareManagerNodeIdLabel    = "hardwaremanagers.hwmgr-plugin.oran.openshift.io/hwMgrNodeId"
 )
 
 // AlarmDefinitionSeverityField severity field within additional fields of alarm definition


### PR DESCRIPTION
Description:
- add the following labels on the Agent CRs to enable the resource server:
`hardwaremanagers.hwmgr-plugin.oran.openshift.io/hwMgrId`
`hardwaremanagers.hwmgr-plugin.oran.openshift.io/hwMgrNodeId`