### PR TITLE
Fix selector number handling

### DIFF
--- a/internal/search/selector_evaluator.go
+++ b/internal/search/selector_evaluator.go
@@ -236,6 +236,9 @@ func (e *SelectorEvaluator) evaluateEq(value any, args []any) (result bool,
 	case int:
 		arg := arg.(int)
 		result = value == arg
+	case float64:
+		arg := arg.(float64)
+		result = value == arg
 	default:
 		err = fmt.Errorf(
 			"the 'eq' operator supports attributes containing strings, numbers, "+
@@ -267,6 +270,9 @@ func (e *SelectorEvaluator) evaluateGt(value any, args []any) (result bool,
 	case int:
 		arg := arg.(int)
 		result = value > arg
+	case float64:
+		arg := arg.(float64)
+		result = value > arg
 	default:
 		err = fmt.Errorf(
 			"the 'gt' operator supports attributes containing strings, numbers, "+
@@ -297,6 +303,9 @@ func (e *SelectorEvaluator) evaluateGte(value any, args []any) (result bool,
 		result = strings.Compare(value, arg) >= 0
 	case int:
 		arg := arg.(int)
+		result = value >= arg
+	case float64:
+		arg := arg.(float64)
 		result = value >= arg
 	default:
 		err = fmt.Errorf(
@@ -345,6 +354,9 @@ func (e *SelectorEvaluator) evaluateLt(value any, args []any) (result bool,
 	case int:
 		arg := arg.(int)
 		result = value < arg
+	case float64:
+		arg := arg.(float64)
+		result = value < arg
 	default:
 		err = fmt.Errorf(
 			"the 'lt' operator supports attributes containing strings, numbers, "+
@@ -375,6 +387,9 @@ func (e *SelectorEvaluator) evaluateLte(value any, args []any) (result bool,
 		result = strings.Compare(value, arg) <= 0
 	case int:
 		arg := arg.(int)
+		result = value <= arg
+	case float64:
+		arg := arg.(float64)
 		result = value <= arg
 	default:
 		err = fmt.Errorf(
@@ -432,6 +447,9 @@ func (e *SelectorEvaluator) evaluateNeq(value any, args []any) (result bool,
 	case int:
 		arg := arg.(int)
 		result = value != arg
+	case float64:
+		arg := arg.(float64)
+		result = value != arg
 	default:
 		err = fmt.Errorf(
 			"the 'neq' operator supports attributes containing strings, numbers, "+
@@ -465,6 +483,8 @@ func (e *SelectorEvaluator) convertArgs(value any, args []any) (result []any, er
 		result, err = e.convertStrings(args)
 	case int:
 		result, err = e.convertInts(args)
+	case float64:
+		result, err = e.convertFloats(args)
 	default:
 		err = fmt.Errorf(
 			"don't know how to convert values to type %T",
@@ -482,6 +502,8 @@ func (e *SelectorEvaluator) convertStrings(args []any) (result []any, err error)
 			converted[i] = arg
 		case int:
 			converted[i] = strconv.Itoa(arg)
+		case float64:
+			converted[i] = strconv.FormatFloat(arg, 'f', -1, 64)
 		default:
 			err = fmt.Errorf(
 				"don't know how to convert value of type %T to string",
@@ -506,6 +528,35 @@ func (e *SelectorEvaluator) convertInts(args []any) (result []any, err error) {
 			}
 			converted[i] = value
 		case int:
+			converted[i] = arg
+		case float64:
+			converted[i] = int(arg)
+		default:
+			err = fmt.Errorf(
+				"don't know how to convert value of type %T to integer",
+				arg,
+			)
+			return
+		}
+	}
+	result = converted
+	return
+}
+
+func (e *SelectorEvaluator) convertFloats(args []any) (result []any, err error) {
+	converted := make([]any, len(args))
+	for i, arg := range args {
+		switch arg := arg.(type) {
+		case string:
+			var value float64
+			value, err = strconv.ParseFloat(arg, 64)
+			if err != nil {
+				return
+			}
+			converted[i] = value
+		case int:
+			converted[i] = float64(arg)
+		case float64:
 			converted[i] = arg
 		default:
 			err = fmt.Errorf(

--- a/internal/search/selector_evaluator_test.go
+++ b/internal/search/selector_evaluator_test.go
@@ -155,6 +155,32 @@ var _ = Describe("Selector evaluator", func() {
 			false,
 		),
 		Entry(
+			"Eq float64 is true",
+			"(eq,MyField,123)",
+			func() any {
+				type MyObject struct {
+					MyField float64
+				}
+				return MyObject{
+					MyField: 123,
+				}
+			},
+			true,
+		),
+		Entry(
+			"Eq float64 is false",
+			"(eq,MyField,123)",
+			func() any {
+				type MyObject struct {
+					MyField float64
+				}
+				return MyObject{
+					MyField: 456,
+				}
+			},
+			false,
+		),
+		Entry(
 			"Cont is true",
 			"(cont,MyField,my)",
 			func() any {
@@ -259,6 +285,19 @@ var _ = Describe("Selector evaluator", func() {
 			false,
 		),
 		Entry(
+			"Gte float64 is false",
+			"(gte,MyField,456)",
+			func() any {
+				type MyObject struct {
+					MyField float64
+				}
+				return MyObject{
+					MyField: 123,
+				}
+			},
+			false,
+		),
+		Entry(
 			"Gte same string is true",
 			"(gte,MyField,a)",
 			func() any {
@@ -277,6 +316,19 @@ var _ = Describe("Selector evaluator", func() {
 			func() any {
 				type MyObject struct {
 					MyField int
+				}
+				return MyObject{
+					MyField: 123,
+				}
+			},
+			true,
+		),
+		Entry(
+			"Gte same float64 is true",
+			"(gte,MyField,123)",
+			func() any {
+				type MyObject struct {
+					MyField float64
 				}
 				return MyObject{
 					MyField: 123,
@@ -363,6 +415,45 @@ var _ = Describe("Selector evaluator", func() {
 			false,
 		),
 		Entry(
+			"Lt float64 is true",
+			"(lt,MyField,456)",
+			func() any {
+				type MyObject struct {
+					MyField float64
+				}
+				return MyObject{
+					MyField: 123,
+				}
+			},
+			true,
+		),
+		Entry(
+			"Lt float64 is false",
+			"(lt,MyField,123)",
+			func() any {
+				type MyObject struct {
+					MyField float64
+				}
+				return MyObject{
+					MyField: 456,
+				}
+			},
+			false,
+		),
+		Entry(
+			"Lt same float64 is false",
+			"(lt,MyField,123)",
+			func() any {
+				type MyObject struct {
+					MyField float64
+				}
+				return MyObject{
+					MyField: 123,
+				}
+			},
+			false,
+		),
+		Entry(
 			"Lte string is true",
 			"(lte,MyField,b)",
 			func() any {
@@ -433,6 +524,45 @@ var _ = Describe("Selector evaluator", func() {
 			func() any {
 				type MyObject struct {
 					MyField int
+				}
+				return MyObject{
+					MyField: 123,
+				}
+			},
+			true,
+		),
+		Entry(
+			"Lte float64 is true",
+			"(lte,MyField,456)",
+			func() any {
+				type MyObject struct {
+					MyField float64
+				}
+				return MyObject{
+					MyField: 123,
+				}
+			},
+			true,
+		),
+		Entry(
+			"Lte float64 is false",
+			"(lte,MyField,123)",
+			func() any {
+				type MyObject struct {
+					MyField float64
+				}
+				return MyObject{
+					MyField: 456,
+				}
+			},
+			false,
+		),
+		Entry(
+			"Lte same float64 is true",
+			"(lte,MyField,123)",
+			func() any {
+				type MyObject struct {
+					MyField float64
 				}
 				return MyObject{
 					MyField: 123,
@@ -615,6 +745,32 @@ var _ = Describe("Selector evaluator", func() {
 			func() any {
 				type MyObject struct {
 					MyField int
+				}
+				return MyObject{
+					MyField: 123,
+				}
+			},
+			false,
+		),
+		Entry(
+			"Neq float64 is true",
+			"(neq,MyField,123)",
+			func() any {
+				type MyObject struct {
+					MyField float64
+				}
+				return MyObject{
+					MyField: 456,
+				}
+			},
+			true,
+		),
+		Entry(
+			"Neq float64 is false",
+			"(neq,MyField,123)",
+			func() any {
+				type MyObject struct {
+					MyField float64
 				}
 				return MyObject{
 					MyField: 123,

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -141,7 +141,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 		AddSource: true,
 		Level:     slog.LevelDebug,
 	}))
-	filterAdapter, err := common.NewFilterAdapter(logger, swagger)
+	filterAdapter, err := common.NewFilterAdapter(logger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -88,7 +88,7 @@ func Serve() error {
 	}))
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters.
-	filterAdapter, err := common.NewFilterAdapter(logger, swagger)
+	filterAdapter, err := common.NewFilterAdapter(logger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -146,7 +146,7 @@ func Serve(config *api.ClusterServerConfig) error {
 	}))
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters
-	filterAdapter, err := common.NewFilterAdapter(logger, swagger)
+	filterAdapter, err := common.NewFilterAdapter(logger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}

--- a/internal/service/common/api/filtering_test.go
+++ b/internal/service/common/api/filtering_test.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const testFilterParams = "filter=(eq,name,hello)%3b(eq,value,1)"
+
+var _ = Describe("ResponseFilter", func() {
+	var (
+		recorder *httptest.ResponseRecorder
+		req      *http.Request
+		handler  http.Handler
+		adapter  *FilterAdapter
+		next     http.HandlerFunc
+	)
+
+	type object struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	BeforeEach(func() {
+		recorder = httptest.NewRecorder()
+		req = httptest.NewRequest(http.MethodGet, "/some-endpoint", nil)
+		logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+		var err error
+		adapter, err = NewFilterAdapter(logger)
+		Expect(err).NotTo(HaveOccurred())
+
+		list := []object{{Name: "hello", Value: 1}, {Name: "world", Value: 10}}
+		body, err := json.Marshal(list)
+		Expect(err).NotTo(HaveOccurred())
+
+		next = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}
+		handler = ResponseFilter(adapter)(next)
+	})
+
+	It("should process the list request and respond correctly", func() {
+		req.URL.RawQuery = testFilterParams
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		var list []object
+		err := json.Unmarshal(recorder.Body.Bytes(), &list)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list).To(HaveLen(1))
+		Expect(list[0].Name).To(Equal("hello"))
+		Expect(list[0].Value).To(Equal(1))
+	})
+
+	It("should not process the filter if an error is returned", func() {
+		list := []object{{Name: "hello", Value: 1}, {Name: "world", Value: 10}}
+		body, err := json.Marshal(list)
+		Expect(err).NotTo(HaveOccurred())
+		next = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write(body)
+		}
+		handler = ResponseFilter(adapter)(next)
+
+		req.URL.RawQuery = testFilterParams
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+		err = json.Unmarshal(recorder.Body.Bytes(), &list)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list).To(HaveLen(2))
+	})
+
+	It("should not process the filter on a get request", func() {
+		record := object{Name: "hello", Value: 1}
+		body, err := json.Marshal(record)
+		Expect(err).NotTo(HaveOccurred())
+		next = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}
+		handler = ResponseFilter(adapter)(next)
+
+		req.URL.RawQuery = testFilterParams
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		err = json.Unmarshal(recorder.Body.Bytes(), &record)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(record.Name).To(Equal("hello"))
+	})
+
+	It("should process the list request without a filter", func() {
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		var list []object
+		err := json.Unmarshal(recorder.Body.Bytes(), &list)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list).To(HaveLen(2))
+	})
+
+	It("should return an empty list if the filtering excludes all list items", func() {
+		req.URL.RawQuery = "filter=(eq,name,foo)%3b(eq,value,10)"
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		var list []object
+		err := json.Unmarshal(recorder.Body.Bytes(), &list)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list).To(HaveLen(0))
+	})
+
+	It("should return bad request on invalid query", func() {
+		// Bad ';' ... needs to be encoded
+		req.URL.RawQuery = "filter=(eq,name,foo);(eq,value,10)"
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("should return bad request on invalid filter", func() {
+		req.URL.RawQuery = "filter=(xxx,name,foo)"
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("should return bad request on unknown field name", func() {
+		req.URL.RawQuery = "filter=(eq,unknown,foo)"
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("should return bad request on type mismatch", func() {
+		req.URL.RawQuery = "filter=(eq,value,foo)"
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("should return internal server error on flush failure", func() {
+		next = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`invalid json`))
+		}
+		handler = ResponseFilter(adapter)(next)
+
+		req.URL.RawQuery = "filter=(eq,name,foo)"
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusInternalServerError))
+	})
+})

--- a/internal/service/common/api/suite_test.go
+++ b/internal/service/common/api/suite_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package api
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common/API")
+}

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -85,7 +85,7 @@ func Serve(config *api.ProvisioningServerConfig) error {
 	}))
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters.
-	filterAdapter, err := common.NewFilterAdapter(logger, swagger)
+	filterAdapter, err := common.NewFilterAdapter(logger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -164,7 +164,7 @@ func Serve(config *api.ResourceServerConfig) error {
 	}))
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters
-	filterAdapter, err := common.NewFilterAdapter(logger, swagger)
+	filterAdapter, err := common.NewFilterAdapter(logger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}


### PR DESCRIPTION
The response from the http handler needs to be marshaled to a map of interface{} values so that it can be handled by the selector code.  The JSON decoder treats any numeric value as a float64, therefore, we need to change the selector evaluator to handle float64.

This wasn't needed in the original PoC implementation because the actual object type was passed to the selector rather than a map of interface{} values.  We cannot do that in this case because we only have the HTTP ResponseWriter with the marshaled output rather than the actual object type.

The behavior of the JSON marshaler is described here:

https://github.com/square/go-jose/pull/352