### PR TITLE
Fix side effects from duplicates

### DIFF
--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -345,6 +345,11 @@ func (c *Collector) handleNodeClusterSyncCompletion(ctx context.Context, ids []a
 
 	count := 0
 	for _, record := range records {
+		// Handle the NodeCluster deletion, but first delete all subtending ClusterResources
+		if err := c.deleteRelatedClusterResources(ctx, record); err != nil {
+			return err
+		}
+
 		dataChangeEvent, err := utils.DeleteObjectWithChangeEvent(ctx, c.repository.Db, record, record.NodeClusterID, nil, func(object interface{}) any {
 			r, _ := object.(models.NodeCluster)
 			return models.NodeClusterToModel(&r, nil, commonapi.NewDefaultFieldOptions())


### PR DESCRIPTION
* Delete cluster resources on stale node cluster
    
    At the end of init, the reflectors will report which NodeClusters
    currently exist on the system.  We use that as a trigger to delete stale
    NodeCluster objects, but when we do so, we don't first try to delete any
    related ClusterResource objects.  That leads to a DB constraint
    violation because of the FK relationship.
    
* Fix panic on duplicate node clusters in DB
    
    We never expect that there will be multiple NodeCluster objects in the
    database with the same name.  When we query for NodeCluster objects with
    a specific name, we are returned an error indicating that multiple rows
    were found when only one was expected.  This error is not handled, and
    we dereference a nil pointer.
