### PR TITLE
Update IMS endpoint in O-Cloud registration

### DIFF
--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -628,7 +628,7 @@ func (t *reconcilerTask) registerWithSmo(ctx context.Context) error {
 	data := utils.AvailableNotification{
 		GlobalCloudId: *t.object.Spec.CloudID,
 		OCloudId:      t.object.Status.ClusterID,
-		ImsEndpoint:   fmt.Sprintf("https://%s/o2ims-infrastructureInventory/v1", t.object.Status.IngressHost),
+		ImsEndpoint:   fmt.Sprintf("https://%s", t.object.Status.IngressHost),
 	}
 
 	body, err := json.Marshal(data)


### PR DESCRIPTION
The IMS endpoint points directly to the inventory API endpoints, but since we now support other API endpoints, this needs to be updated to be more generic.