### PR TITLE
allow trailing slash and middleware refactoring for all servers

### DIFF
--- a/internal/service/common/api/middleware/filtering.go
+++ b/internal/service/common/api/middleware/filtering.go
@@ -1,4 +1,4 @@
-package api
+package middleware
 
 import (
 	"bytes"

--- a/internal/service/common/api/middleware/filtering_test.go
+++ b/internal/service/common/api/middleware/filtering_test.go
@@ -1,4 +1,4 @@
-package api
+package middleware
 
 import (
 	"encoding/json"

--- a/internal/service/common/api/middleware/middleware_suite_test.go
+++ b/internal/service/common/api/middleware/middleware_suite_test.go
@@ -1,0 +1,13 @@
+package middleware_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMiddleware(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Middleware Suite")
+}

--- a/internal/service/common/api/utils.go
+++ b/internal/service/common/api/utils.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
+	"net/http"
 	"net/url"
+	"time"
 )
 
 // ValidateCallbackURL ensures that the URL used in subscription callback meets our requirements
@@ -16,5 +20,20 @@ func ValidateCallbackURL(callback string) error {
 		return fmt.Errorf("invalid callback scheme %q, only https is supported", u.Scheme)
 	}
 
+	return nil
+}
+
+// GracefulShutdown allow graceful shutdown with timeout
+func GracefulShutdown(srv *http.Server) error {
+	// Create shutdown context with 10 second timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Attempt graceful shutdown
+	if err := srv.Shutdown(ctx); err != nil {
+		return fmt.Errorf("failed graceful shutdown: %w", err)
+	}
+
+	slog.Info("Server gracefully stopped")
 	return nil
 }

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -11,9 +11,11 @@ import (
 	"syscall"
 	"time"
 
+	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
+
 	"github.com/getkin/kin-openapi/openapi3"
 
-	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
 	"github.com/openshift-kni/oran-o2ims/internal/service/provisioning/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/provisioning/api/generated"
@@ -71,12 +73,10 @@ func Serve(config *api.ProvisioningServerConfig) error {
 
 	serverStrictHandler := generated.NewStrictHandlerWithOptions(&server, nil,
 		generated.StrictHTTPServerOptions{
-			RequestErrorHandlerFunc:  common.GetOranReqErrFunc(),
-			ResponseErrorHandlerFunc: common.GetOranRespErrFunc(),
+			RequestErrorHandlerFunc:  middleware.GetOranReqErrFunc(),
+			ResponseErrorHandlerFunc: middleware.GetOranRespErrFunc(),
 		},
 	)
-
-	router := common.NewErrorJsonifier(http.NewServeMux())
 
 	// Create a new logger to be passed where a logger is needed.
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
@@ -85,27 +85,34 @@ func Serve(config *api.ProvisioningServerConfig) error {
 	}))
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters.
-	filterAdapter, err := common.NewFilterAdapter(logger)
+	filterAdapter, err := middleware.NewFilterAdapter(logger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}
 
+	baseRouter := http.NewServeMux()
 	opt := generated.StdHTTPServerOptions{
-		BaseRouter: router,
+		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here
-			common.OpenAPIValidation(swagger),
-			common.ResponseFilter(filterAdapter),
-			common.LogDuration(),
+			middleware.OpenAPIValidation(swagger),
+			middleware.ResponseFilter(filterAdapter),
+			middleware.LogDuration(),
 		},
-		ErrorHandlerFunc: common.GetOranReqErrFunc(),
+		ErrorHandlerFunc: middleware.GetOranReqErrFunc(),
 	}
 
 	// Register the handler
 	generated.HandlerWithOptions(serverStrictHandler, opt)
 
 	// Server config
+	// Wrap base router with additional middlewares
+	handler := middleware.ChainHandlers(baseRouter,
+		middleware.ErrorJsonifier(),
+		middleware.TrailingSlashStripper(),
+	)
+
 	srv := &http.Server{
-		Handler:      router,
+		Handler:      handler,
 		Addr:         config.Listener.Address,
 		ReadTimeout:  readTimeout,
 		WriteTimeout: writeTimeout,

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 	repo2 "github.com/openshift-kni/oran-o2ims/internal/service/common/repo"
@@ -150,12 +151,10 @@ func Serve(config *api.ResourceServerConfig) error {
 
 	serverStrictHandler := generated.NewStrictHandlerWithOptions(&server, nil,
 		generated.StrictHTTPServerOptions{
-			RequestErrorHandlerFunc:  common.GetOranReqErrFunc(),
-			ResponseErrorHandlerFunc: common.GetOranRespErrFunc(),
+			RequestErrorHandlerFunc:  middleware.GetOranReqErrFunc(),
+			ResponseErrorHandlerFunc: middleware.GetOranRespErrFunc(),
 		},
 	)
-
-	router := common.NewErrorJsonifier(http.NewServeMux())
 
 	// Create a new logger to be passed to things that need a logger
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
@@ -164,27 +163,34 @@ func Serve(config *api.ResourceServerConfig) error {
 	}))
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters
-	filterAdapter, err := common.NewFilterAdapter(logger)
+	filterAdapter, err := middleware.NewFilterAdapter(logger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}
 
+	baseRouter := http.NewServeMux()
 	opt := generated.StdHTTPServerOptions{
-		BaseRouter: router,
+		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here
-			common.OpenAPIValidation(swagger),
-			common.ResponseFilter(filterAdapter),
-			common.LogDuration(),
+			middleware.OpenAPIValidation(swagger),
+			middleware.ResponseFilter(filterAdapter),
+			middleware.LogDuration(),
 		},
-		ErrorHandlerFunc: common.GetOranReqErrFunc(),
+		ErrorHandlerFunc: middleware.GetOranReqErrFunc(),
 	}
 
 	// Register the handler
 	generated.HandlerWithOptions(serverStrictHandler, opt)
 
 	// Server config
+	// Wrap base router with additional middlewares
+	handler := middleware.ChainHandlers(baseRouter,
+		middleware.ErrorJsonifier(),
+		middleware.TrailingSlashStripper(),
+	)
+
 	srv := &http.Server{
-		Handler:      router,
+		Handler:      handler,
 		Addr:         config.Listener.Address,
 		ReadTimeout:  readTimeout,
 		WriteTimeout: writeTimeout,


### PR DESCRIPTION
Changes applicable for all servers: 

- New middleware to allow for trailing slash. i.e `/alarms` and `/alarms/` are now both valid
- Refactoring existing middleware to align them further.  