### PR TITLE
update siteconfig operator namespace to open-cluster-management in the sample CRs

### DIFF
--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/sno-ran-du/clusterinstance-defaults-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/sno-ran-du/clusterinstance-defaults-v1.yaml
@@ -33,7 +33,7 @@ data:
       - 1.pool.ntp.org
     templateRefs:
       - name: ai-cluster-templates-v1
-        namespace: siteconfig-operator
+        namespace: open-cluster-management
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
@@ -73,4 +73,4 @@ data:
                 type: bond
         templateRefs:
           - name: ai-node-templates-v1
-            namespace: siteconfig-operator
+            namespace: open-cluster-management

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v1.yaml
@@ -33,7 +33,7 @@ data:
       - 1.pool.ntp.org
     templateRefs:
       - name: ai-cluster-templates-v1
-        namespace: siteconfig-operator
+        namespace: open-cluster-management
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
@@ -73,4 +73,4 @@ data:
                 type: bond
         templateRefs:
           - name: ai-node-templates-v1
-            namespace: siteconfig-operator
+            namespace: open-cluster-management

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v2.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v2.yaml
@@ -36,7 +36,7 @@ data:
       - 1.pool.ntp.org
     templateRefs:
       - name: ai-cluster-templates-v1
-        namespace: siteconfig-operator
+        namespace: open-cluster-management
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
@@ -76,4 +76,4 @@ data:
                 type: bond
         templateRefs:
           - name: ai-node-templates-v1
-            namespace: siteconfig-operator
+            namespace: open-cluster-management

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v3.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v3.yaml
@@ -36,7 +36,7 @@ data:
       - 1.pool.ntp.org
     templateRefs:
       - name: ai-cluster-templates-v1
-        namespace: siteconfig-operator
+        namespace: open-cluster-management
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
@@ -76,4 +76,4 @@ data:
                 type: bond
         templateRefs:
           - name: ai-node-templates-v1
-            namespace: siteconfig-operator
+            namespace: open-cluster-management

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v4.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v4.yaml
@@ -36,7 +36,7 @@ data:
       - 1.pool.ntp.org
     templateRefs:
       - name: ai-cluster-templates-v1
-        namespace: siteconfig-operator
+        namespace: open-cluster-management
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
@@ -76,4 +76,4 @@ data:
                 type: bond
         templateRefs:
           - name: ai-node-templates-v1
-            namespace: siteconfig-operator
+            namespace: open-cluster-management

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-full-du/clusterinstance-defaults-full-du-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-full-du/clusterinstance-defaults-full-du-v1.yaml
@@ -33,7 +33,7 @@ data:
       - 1.pool.ntp.org
     templateRefs:
       - name: ai-cluster-templates-v1
-        namespace: siteconfig-operator
+        namespace: open-cluster-management
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
@@ -60,4 +60,4 @@ data:
                 type: ethernet
         templateRefs:
           - name: ai-node-templates-v1
-            namespace: siteconfig-operator
+            namespace: open-cluster-management


### PR DESCRIPTION
If the prefered method to enable siteconfig operator is through the command 
`oc patch multiclusterhubs.operator.open-cluster-management.io multiclusterhub -n <ACM_NAMESPACE> --type json --patch '[{"op": "add", "path":"/spec/overrides/components/-", "value": {"name":"siteconfig","enabled": true}}]'`
, then the default namespace of siteconfig operator will be open-cluster-management. 

This PR is to update the namespace to open-cluster-management in the samples in order to avoid confusion. 