### PR TITLE
Remove fulfilled check for hwTemplate changes

### DIFF
--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -389,12 +389,9 @@ func (t *provisioningRequestReconcilerTask) checkExistingNodePool(ctx context.Co
 	}
 
 	if exist {
-		changed, err := utils.CompareHardwareTemplateWithNodePool(hwTemplate, nodePool)
+		_, err := utils.CompareHardwareTemplateWithNodePool(hwTemplate, nodePool)
 		if err != nil {
 			return utils.NewInputError("%w", err)
-		}
-		if changed && !utils.IsProvisioningStateFulfilled(t.object) {
-			return utils.NewInputError("hardware template changes are not allowed until the cluster provisioning is fulfilled")
 		}
 	}
 


### PR DESCRIPTION
Since the `Pending` status was introduced (which is the initial status for a new generation), it’s impossible for this fulfilled check to pass during hardware template updates. Given that webhook validation has been added to reject updates to the referenced template if it’s not fulfilled, we should be able to safely remove this obsolete check. 