### PR TITLE
fix cluster server assertion error

### DIFF
--- a/internal/service/cluster/collector/collector_alarms.go
+++ b/internal/service/cluster/collector/collector_alarms.go
@@ -101,11 +101,12 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 
 		alarmDictionaryIDString := (*nodeClusterType.Extensions)[utils.ClusterAlarmDictionaryIDExtension]
 		if alarmDictionaryIDString != nil {
-			_, err := uuid.Parse(alarmDictionaryIDString.(string))
+			id, err := uuid.Parse(alarmDictionaryIDString.(string))
 			if err != nil {
 				slog.Error("error parsing alarm dictionary ID", "NodeClusterType ID", nodeClusterType.NodeClusterTypeID, "error", err)
 				continue
 			}
+			(*nodeClusterType.Extensions)[utils.ClusterAlarmDictionaryIDExtension] = id
 
 			filteredNodeClusterTypes = append(filteredNodeClusterTypes, nodeClusterType)
 		}


### PR DESCRIPTION
{"time":"2025-02-07T14:59:31.862941086Z","level":"ERROR","source":{"function":"github.com/openshift-kni/oran-o2ims/internal/service/cluster/collector.(*AlarmsDataSource).buildAlarmDictionaryIDToAlarmDefinitions","file":"/workspace/internal/service/cluster/collector/collector_alarms.go","line":292},"msg":"no alarm dictionary ID found for node cluster type","NodeClusterType ID":"14ec7a85-8304-5455-a597-0770e46dcb20"}
{"time":"2025-02-07T14:59:31.863104628Z","level":"ERROR","source":{"function":"github.com/openshift-kni/oran-o2ims/internal/service/cluster/collector.(*AlarmsDataSource).makeAlarmDictionaries","file":"/workspace/internal/service/cluster/collector/collector_alarms.go","line":393},"msg":"no alarm dictionary ID found for node cluster type","NodeClusterType ID":"14ec7a85-8304-5455-a597-0770e46dcb20"}
{"time":"2025-02-07T14:59:31.863230911Z","level":"WARN","source":{"function":"github.com/openshift-kni/oran-o2ims/internal/service/cluster/collector.(*Collector).execute","file":"/workspace/internal/service/cluster/collector/collector.go","line":175},"msg":"failed to collect data from data source","source":"Alarms","error":"failed to sync alarm dictionaries: no alarm dictionaries were processed"}