### PR TITLE
Update trust bundle procedure and naming

### DIFF
--- a/api/inventory/v1alpha1/inventory_types.go
+++ b/api/inventory/v1alpha1/inventory_types.go
@@ -145,7 +145,8 @@ type InventorySpec struct {
 	SmoConfig *SmoConfig `json:"smo,omitempty"`
 	// CaBundleName references a config map that contains a set of custom CA certificates to be used when communicating
 	// with any outside entity (e.g., the SMO, the authorization server, etc.) that has its TLS certificate signed by
-	// a non-public CA certificate.
+	// a non-public CA certificate.  The config map is expected to contain a single file called 'ca-bundle.crt'
+	// containing all trusted CA certificates in PEM format.
 	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Custom CA Certificates",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	CaBundleName *string `json:"caBundleName,omitempty"`

--- a/bundle/manifests/o2ims.oran.openshift.io_inventories.yaml
+++ b/bundle/manifests/o2ims.oran.openshift.io_inventories.yaml
@@ -63,7 +63,8 @@ spec:
                 description: |-
                   CaBundleName references a config map that contains a set of custom CA certificates to be used when communicating
                   with any outside entity (e.g., the SMO, the authorization server, etc.) that has its TLS certificate signed by
-                  a non-public CA certificate.
+                  a non-public CA certificate.  The config map is expected to contain a single file called 'ca-bundle.crt'
+                  containing all trusted CA certificates in PEM format.
                 type: string
               cloudID:
                 description: CloudID is the global cloud ID value used to correlate

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -764,7 +764,8 @@ spec:
       - description: |-
           CaBundleName references a config map that contains a set of custom CA certificates to be used when communicating
           with any outside entity (e.g., the SMO, the authorization server, etc.) that has its TLS certificate signed by
-          a non-public CA certificate.
+          a non-public CA certificate.  The config map is expected to contain a single file called 'ca-bundle.crt'
+          containing all trusted CA certificates in PEM format.
         displayName: Custom CA Certificates
         path: caBundleName
         x-descriptors:

--- a/config/crd/bases/o2ims.oran.openshift.io_inventories.yaml
+++ b/config/crd/bases/o2ims.oran.openshift.io_inventories.yaml
@@ -63,7 +63,8 @@ spec:
                 description: |-
                   CaBundleName references a config map that contains a set of custom CA certificates to be used when communicating
                   with any outside entity (e.g., the SMO, the authorization server, etc.) that has its TLS certificate signed by
-                  a non-public CA certificate.
+                  a non-public CA certificate.  The config map is expected to contain a single file called 'ca-bundle.crt'
+                  containing all trusted CA certificates in PEM format.
                 type: string
               cloudID:
                 description: CloudID is the global cloud ID value used to correlate

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -165,7 +165,8 @@ spec:
       - description: |-
           CaBundleName references a config map that contains a set of custom CA certificates to be used when communicating
           with any outside entity (e.g., the SMO, the authorization server, etc.) that has its TLS certificate signed by
-          a non-public CA certificate.
+          a non-public CA certificate.  The config map is expected to contain a single file called 'ca-bundle.crt'
+          containing all trusted CA certificates in PEM format.
         displayName: Custom CA Certificates
         path: caBundleName
         x-descriptors:

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -562,7 +562,7 @@ func (t *reconcilerTask) setupOAuthClient(ctx context.Context) (*http.Client, er
 			return nil, fmt.Errorf("failed to get configmap: %s", err.Error())
 		}
 
-		caBundle, err = utils.GetConfigMapField(cm, "ca-bundle.pem")
+		caBundle, err = utils.GetConfigMapField(cm, utils.CABundleFilename)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get certificate bundle from configmap: %s", err.Error())
 		}

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -305,6 +305,7 @@ const (
 const (
 	TLSClientMountPath = "/secrets/smo/tls"
 	CABundleMountPath  = "/secrets/smo/certs"
+	CABundleFilename   = "ca-bundle.crt"
 )
 
 // SMO OAuth specific environment variables.  These values are stored in environment variables to

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -416,7 +416,7 @@ func addArgsForSMO(inventory *inventoryv1alpha1.Inventory, args []string) []stri
 
 	if inventory.Spec.CaBundleName != nil {
 		args = append(args,
-			fmt.Sprintf("--ca-bundle-file=%s/ca-bundle.pem", CABundleMountPath),
+			fmt.Sprintf("--ca-bundle-file=%s/%s", CABundleMountPath, CABundleFilename),
 		)
 	}
 
@@ -448,7 +448,7 @@ func AddOAuthArgsForProxy(inventory *inventoryv1alpha1.Inventory, clientID strin
 
 		if inventory.Spec.CaBundleName != nil {
 			args = append(args,
-				fmt.Sprintf("--oidc-ca-file=%s/ca-bundle.pem", CABundleMountPath),
+				fmt.Sprintf("--oidc-ca-file=%s/%s", CABundleMountPath, CABundleFilename),
 			)
 		}
 	}

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1/inventory_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1/inventory_types.go
@@ -145,7 +145,8 @@ type InventorySpec struct {
 	SmoConfig *SmoConfig `json:"smo,omitempty"`
 	// CaBundleName references a config map that contains a set of custom CA certificates to be used when communicating
 	// with any outside entity (e.g., the SMO, the authorization server, etc.) that has its TLS certificate signed by
-	// a non-public CA certificate.
+	// a non-public CA certificate.  The config map is expected to contain a single file called 'ca-bundle.crt'
+	// containing all trusted CA certificates in PEM format.
 	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Custom CA Certificates",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	CaBundleName *string `json:"caBundleName,omitempty"`


### PR DESCRIPTION
To better align with how trust bundles are created and used in other parts of the system, the name of the expected file is being changed from ca-bundle.pem to ca-bundle.crt.  OpenShift is inconsistent in how it expects this file to be named in other areas. But, in the injected trust bundle case, and in the cluster proxy case, the file is expected to be ca-bundle.crt so we are aligning to that.

Beware that when providing a set of trusted client CA certificates to the ingress controller, it is expected to be ca-bundle.pem.