### PR TITLE
Move first fetch all operation inside sync routine

### DIFF
--- a/internal/service/alarms/internal/infrastructure/clusterserver.go
+++ b/internal/service/alarms/internal/infrastructure/clusterserver.go
@@ -217,25 +217,29 @@ func (r *ClusterServer) GetAlarmDefinitionID(nodeClusterTypeID uuid.UUID, name, 
 	return alarmDefinitionID, nil
 }
 
-// ReSync starts a resync for the cluster server
-func (r *ClusterServer) ReSync(ctx context.Context) {
-	slog.Info("Starting resync for ClusterServer")
+// Sync starts the sync process for the cluster server objects
+func (r *ClusterServer) Sync(ctx context.Context) {
+	slog.Info("Starting sync process for cluster server objects")
 
 	go func() {
+		// First fetch of all objects
+		if err := r.FetchAll(ctx); err != nil {
+			slog.Error("Failed to run initial sync for cluster server objects", "error", err)
+		}
+
 		for {
 			select {
 			case <-ctx.Done():
-				slog.Info("Stopping resync for ClusterServer")
+				slog.Info("Stopping sync process for cluster server objects")
 				return
 			case <-time.After(resyncInterval):
-				slog.Info("Resyncing ClusterServer")
+				slog.Info("Syncing ClusterServer objects")
 				if err := r.FetchAll(ctx); err != nil {
-					slog.Error("Failed to resync ClusterServer", "error", err)
+					slog.Error("Failed to sync cluster server objects", "error", err)
 				}
 			}
 		}
 	}()
-
 }
 
 // getNodeClusters lists all node clusters

--- a/internal/service/alarms/internal/infrastructure/infrastructure.go
+++ b/internal/service/alarms/internal/infrastructure/infrastructure.go
@@ -22,7 +22,8 @@ type Client interface {
 	GetObjectTypeID(objectID uuid.UUID) (uuid.UUID, error)
 	GetAlarmDefinitionID(ObjectTypeID uuid.UUID, name, severity string) (uuid.UUID, error)
 
-	ReSync(ctx context.Context)
+	// Sync starts a background process to populate and keep up-to-date a local cache with data from the infrastructure servers
+	Sync(ctx context.Context)
 }
 
 // Infrastructure represents the infrastructure clients
@@ -48,11 +49,7 @@ func Init(ctx context.Context) (*Infrastructure, error) {
 			return nil, fmt.Errorf("failed to setup %s: %w", server.Name(), err)
 		}
 
-		if err := server.FetchAll(ctx); err != nil {
-			return nil, fmt.Errorf("failed to fetch all data for %s: %w", server.Name(), err)
-		}
-
-		server.ReSync(ctx)
+		server.Sync(ctx)
 	}
 
 	return &Infrastructure{Clients: clients}, nil


### PR DESCRIPTION
This prevents the alarm server to restart when the cluster server is not yet up