### PR TITLE
Fix provisioning status for hw configuration

### DIFF
--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -179,6 +179,12 @@ defaultHugepagesSize: "1G"`,
 							Status: metav1.ConditionTrue,
 						},
 					},
+					Extensions: provisioningv1alpha1.Extensions{
+						NodePoolRef: &provisioningv1alpha1.NodePoolRef{
+							Name:      "cluster-1",
+							Namespace: utils.UnitTestHwmgrNamespace,
+						},
+					},
 				},
 			},
 			// Managed clusters
@@ -231,15 +237,19 @@ defaultHugepagesSize: "1G"`,
 				NodeGroup: []hwv1alpha1.NodeGroup{
 					{
 						NodePoolData: hwv1alpha1.NodePoolData{
-							Name:      "controller",
-							HwProfile: "profile-spr-single-processor-64G",
+							Name:           "controller",
+							Role:           "master",
+							HwProfile:      "profile-spr-single-processor-64G",
+							ResourcePoolId: "xyz",
 						},
 						Size: 1,
 					},
 					{
 						NodePoolData: hwv1alpha1.NodePoolData{
-							Name:      "worker",
-							HwProfile: "profile-spr-dual-processor-128G",
+							Name:           "worker",
+							Role:           "worker",
+							HwProfile:      "profile-spr-dual-processor-128G",
+							ResourcePoolId: "xyz",
 						},
 						Size: 0,
 					},
@@ -2092,15 +2102,19 @@ var _ = Describe("addPostProvisioningLabels", func() {
 				NodeGroup: []hwv1alpha1.NodeGroup{
 					{
 						NodePoolData: hwv1alpha1.NodePoolData{
-							Name:      "controller",
-							HwProfile: "profile-spr-single-processor-64G",
+							Name:           "controller",
+							Role:           "master",
+							HwProfile:      "profile-spr-single-processor-64G",
+							ResourcePoolId: "xyz",
 						},
 						Size: 1,
 					},
 					{
 						NodePoolData: hwv1alpha1.NodePoolData{
-							Name:      "worker",
-							HwProfile: "profile-spr-dual-processor-128G",
+							Name:           "worker",
+							Role:           "worker",
+							HwProfile:      "profile-spr-dual-processor-128G",
+							ResourcePoolId: "xyz",
 						},
 						Size: 0,
 					},

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -436,6 +436,15 @@ var _ = Describe("waitForNodePoolProvision", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: crName,
 			},
+			Status: provisioningv1alpha1.ProvisioningRequestStatus{
+				Extensions: provisioningv1alpha1.Extensions{
+					NodePoolRef: &provisioningv1alpha1.NodePoolRef{
+						Name:                           crName,
+						Namespace:                      ctNamespace,
+						HardwareProvisioningCheckStart: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
 		}
 
 		// Define the node pool.
@@ -553,6 +562,10 @@ var _ = Describe("waitForNodePoolProvision", func() {
 	})
 
 	It("returns timeout when NodePool configuring timed out", func() {
+		// Set the configuration start time.
+		cr.Status.Extensions.NodePoolRef.HardwareConfiguringCheckStart = &metav1.Time{Time: time.Now()}
+		Expect(c.Status().Update(ctx, cr)).To(Succeed())
+
 		provisionedCondition := metav1.Condition{
 			Type:   "Provisioned",
 			Status: metav1.ConditionTrue,

--- a/internal/controllers/utils/retry.go
+++ b/internal/controllers/utils/retry.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+func isConflictOrRetriableOrNotFound(err error) bool {
+	return isConflictOrRetriable(err) || errors.IsNotFound(err)
+}
+
+func isConflictOrRetriable(err error) bool {
+	return errors.IsConflict(err) || errors.IsInternalError(err) || errors.IsServiceUnavailable(err) || net.IsConnectionRefused(err)
+}
+
+func RetryOnConflictOrRetriable(backoff wait.Backoff, fn func() error) error {
+	// nolint: wrapcheck
+	return retry.OnError(backoff, isConflictOrRetriable, fn)
+}
+
+func RetryOnConflictOrRetriableOrNotFound(backoff wait.Backoff, fn func() error) error {
+	// nolint: wrapcheck
+	return retry.OnError(backoff, isConflictOrRetriableOrNotFound, fn)
+}


### PR DESCRIPTION
Description:
- For cases where the `Configured` condition is not yet present in the NodePool, but hardware configuration updates have occurred, requeue to wait for the NodePool to be processed.
- Set hardware provisioning startTime after the NodePool is created, and hardware configuration startTime after the NodePool is updated. This helps distinguish between cases where no hardware updates were requested and cases where updates were made but the NodePool hasn’t been processed yet (i.e., the Configured condition hasn’t been returned).
- Set the `HardwareProvisioned` and `HardwareConfigured` conditions, along with the `provisioningPhase`, to `“Waiting for NodePool (name) to be processed”` when the Provisioned or Configured condition is not yet present in the NodePool.
- Add retries for some essential resource queries.
- Add unittests for hw configuration.