### PR TITLE
Include local-cluster as NodeCluster without extra label

### DIFF
--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -338,6 +338,7 @@ func (c *Collector) findDataSource(dataSourceID uuid.UUID) DataSource {
 // handleNodeClusterSyncCompletion handles the end of sync for NodeCluster objects.  It deletes any NodeCluster objects
 // not included in the set of keys received during the sync operation.
 func (c *Collector) handleNodeClusterSyncCompletion(ctx context.Context, ids []any) error {
+	slog.Debug("Handling end of sync for NodeCluster instances", "count", len(ids))
 	records, err := c.repository.GetNodeClustersNotIn(ctx, ids)
 	if err != nil {
 		return fmt.Errorf("failed to get stale node clusters: %w", err)
@@ -375,6 +376,7 @@ func (c *Collector) handleNodeClusterSyncCompletion(ctx context.Context, ids []a
 // handleClusterResourceSyncCompletion handles the end of sync for ClusterResource objects.  It deletes any
 // ClusterResource objects not included in the set of keys received during the sync operation.
 func (c *Collector) handleClusterResourceSyncCompletion(ctx context.Context, ids []any) error {
+	slog.Debug("Handling end of sync for ClusterResource instances", "count", len(ids))
 	records, err := c.repository.GetClusterResourcesNotIn(ctx, ids)
 	if err != nil {
 		return fmt.Errorf("failed to get stale cluster resources: %w", err)

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -479,6 +479,7 @@ func (c *Collector) collectResourcePools(ctx context.Context, dataSource Resourc
 // handleDeploymentManagerSyncCompletion handles the end of sync for DeploymentManager objects.  It deletes any
 // DeploymentManager objects not included in the set of keys received during the sync operation.
 func (c *Collector) handleDeploymentManagerSyncCompletion(ctx context.Context, ids []any) error {
+	slog.Debug("Handling end of sync for DeploymentManager instances", "count", len(ids))
 	records, err := c.repository.GetDeploymentManagersNotIn(ctx, ids)
 	if err != nil {
 		return fmt.Errorf("failed to get stale deployment managers: %w", err)

--- a/internal/service/resources/collector/collector_k8s.go
+++ b/internal/service/resources/collector/collector_k8s.go
@@ -233,13 +233,13 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 		condition := meta.FindStatusCondition(cluster.Status.Conditions, "ManagedClusterConditionAvailable")
 		if condition == nil || condition.Status == metav1.ConditionFalse {
 			// This cluster is not yet available, so filter it out.
-			slog.Warn("Managed cluster is not available; skipping", "cluster", cluster.Name, "condition", condition)
+			slog.Debug("Managed cluster is not available; skipping", "cluster", cluster.Name, "condition", condition)
 			return uuid.Nil, nil
 		}
 
 		if _, found := cluster.Labels[utils.ClusterTemplateArtifactsLabel]; !found {
 			// The provisioning request which is managing the installation of this cluster is not yet fulfilled
-			slog.Warn("Cluster provisioning request is not yet fulfilled; skipping", "cluster", cluster.Name)
+			slog.Debug("Cluster provisioning request is not yet fulfilled; skipping", "cluster", cluster.Name)
 			return uuid.Nil, nil
 		}
 	}


### PR DESCRIPTION
This updates the cluster server so that the local-cluster is included as a NodeCluster object for tracking alarms against it. A DeploymentManager will not be created for it since; at this time, it is not expected that the SMO will need to run workloads on the hub.