### PR TITLE
Remove disable-auto-import annotation after the installation is complete

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -147,7 +147,8 @@
                         },
                         "args": [
                                 "start",
-                                "controller-manager"
+                                "controller-manager",
+                                "--enable-webhooks=false"
                         ]
                 }
         ]

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -184,8 +184,8 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx contex
 	}
 
 	// Remove the disable-auto-import annotation for the managed cluster
-	// if the cluster provisioning is in progress.
-	if utils.IsClusterProvisionInProgress(t.object) {
+	// if the cluster provisioning is completed.
+	if utils.IsClusterProvisionCompleted(t.object) {
 		return t.removeDisableAutoImportAnnotation(ctx, clusterInstance)
 	}
 

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -15,7 +15,6 @@ import (
 	hwv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"github.com/openshift/assisted-service/api/v1beta1"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -2303,7 +2302,7 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
                     `,
 					),
 				},
-				Interfaces: []*v1beta1.Interface{
+				Interfaces: []*assistedservicev1beta1.Interface{
 					{Name: "eno1", MacAddress: "00:00:00:01:20:30"},
 					{Name: "eth0", MacAddress: "02:00:00:80:12:14"},
 					{Name: "eth1", MacAddress: "02:00:00:80:12:15"},


### PR DESCRIPTION
The disable-auto-import annotation is added to the ManagedCluster when it is created and removed once installation starts to prevent a race condition, as implemented in [PR #546](https://github.com/openshift-kni/oran-o2ims/pull/546). However, it turns out that removing the annotation at this stage is too early. At that point, the cluster has only just started installation and the race condition may still occur. This updates to remove the annotation only after the cluster installation has been completed.