### PR TITLE
CNF-16737: Validate the ClusterInstance defaults ConfigMap against the ClusterInstance CRD schema

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -125,31 +125,31 @@
                             "serve"
                     ]
             },
-                {
-                        "name": "test",
-                        "type": "go",
-                        "request": "launch",
-                        "mode": "test",
-                        "program": "${fileDirname}"
-                },
-                {
-                        "name": "start controller",
-                        "type": "go",
-                        "request": "launch",
-                        "mode": "auto",
-                        "program": "${workspaceFolder}",
-                        "env": {
-                                "KUBECONFIG": "${env:KUBECONFIG}",
-                                "IMAGE": "quay.io/openshift-kni/oran-o2ims-operator:latest",
-                                "HWMGR_PLUGIN_NAMESPACE": "oran-hwmgr-plugin",
-                                "POSTGRES_IMAGE": "registry.redhat.io/rhel9/postgresql-16:9.5-1731610873",
-                                "KUBE_RBAC_PROXY_IMAGE": "quay.io/openshift/origin-kube-rbac-proxy:4.18"
-                        },
-                        "args": [
-                                "start",
-                                "controller-manager",
-                                "--enable-webhooks=false"
-                        ]
-                }
+            {
+                    "name": "test",
+                    "type": "go",
+                    "request": "launch",
+                    "mode": "test",
+                    "program": "${fileDirname}"
+            },
+            {
+                    "name": "start controller",
+                    "type": "go",
+                    "request": "launch",
+                    "mode": "auto",
+                    "program": "${workspaceFolder}",
+                    "env": {
+                            "KUBECONFIG": "${env:KUBECONFIG}",
+                            "IMAGE": "quay.io/openshift-kni/oran-o2ims-operator:latest",
+                            "HWMGR_PLUGIN_NAMESPACE": "oran-hwmgr-plugin",
+                            "POSTGRES_IMAGE": "registry.redhat.io/rhel9/postgresql-16:9.5-1731610873",
+                            "KUBE_RBAC_PROXY_IMAGE": "quay.io/openshift/origin-kube-rbac-proxy:4.18"
+                    },
+                    "args": [
+                            "start",
+                            "controller-manager",
+                            "--enable-webhooks=false"
+                    ]
+            }
         ]
 }

--- a/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -76,10 +76,10 @@ func ExtractMatchingInput(parentSchema []byte, subSchemaKey string) (any, error)
 	return matchingInput, nil
 }
 
-// disallowUnknownFieldsInSchema updates a schema by adding "additionalProperties": false
+// DisallowUnknownFieldsInSchema updates a schema by adding "additionalProperties": false
 // to all objects/arrays that define "properties". This ensures that any unknown fields
 // not defined in the schema will be disallowed during validation.
-func disallowUnknownFieldsInSchema(schema map[string]any) {
+func DisallowUnknownFieldsInSchema(schema map[string]any) {
 	// Check if the current schema level has "properties" defined
 	if properties, hasProperties := schema["properties"]; hasProperties {
 		// If "additionalProperties" is not already set, add it with the value false
@@ -91,7 +91,7 @@ func disallowUnknownFieldsInSchema(schema map[string]any) {
 		if propsMap, ok := properties.(map[string]any); ok {
 			for _, propValue := range propsMap {
 				if propSchema, ok := propValue.(map[string]any); ok {
-					disallowUnknownFieldsInSchema(propSchema)
+					DisallowUnknownFieldsInSchema(propSchema)
 				}
 			}
 		}
@@ -100,7 +100,7 @@ func disallowUnknownFieldsInSchema(schema map[string]any) {
 	// Recurse into each property defined under "items"
 	if items, hasItems := schema["items"]; hasItems {
 		if itemSchema, ok := items.(map[string]any); ok {
-			disallowUnknownFieldsInSchema(itemSchema)
+			DisallowUnknownFieldsInSchema(itemSchema)
 		}
 	}
 
@@ -201,7 +201,7 @@ func (r *ProvisioningRequest) ValidateClusterInstanceInputMatchesSchema(
 			"failed to extract %s subschema: %s", TemplateParamClusterInstance, err.Error())
 	}
 	// Any unknown fields not defined in the schema will be disallowed
-	disallowUnknownFieldsInSchema(clusterInstanceSubSchema)
+	DisallowUnknownFieldsInSchema(clusterInstanceSubSchema)
 
 	// Get the matching input for ClusterInstanceParameters
 	clusterInstanceMatchingInput, err := ExtractMatchingInput(

--- a/api/provisioning/v1alpha1/provisioningrquest_validation_test.go
+++ b/api/provisioning/v1alpha1/provisioningrquest_validation_test.go
@@ -116,7 +116,7 @@ required:
 type: object
 `
 
-var _ = Describe("disallowUnknownFieldsInSchema", func() {
+var _ = Describe("DisallowUnknownFieldsInSchema", func() {
 	var schemaMap map[string]any
 
 	BeforeEach(func() {
@@ -232,7 +232,7 @@ required:
 type: object
 `
 		// Call the function
-		disallowUnknownFieldsInSchema(schemaMap)
+		DisallowUnknownFieldsInSchema(schemaMap)
 
 		var expectedSchema map[string]any
 		err := yaml.Unmarshal([]byte(expected), &expectedSchema)

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1252,6 +1252,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - apps
           resources:
           - deployments

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -120,6 +120,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	golang.org/x/sync v0.11.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.6
+	k8s.io/apiextensions-apiserver v0.31.2
 	k8s.io/apimachinery v0.31.6
 	k8s.io/apiserver v0.31.6
 	k8s.io/client-go v12.0.0+incompatible
@@ -166,7 +167,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gorm.io/gorm v1.24.5 // indirect
-	k8s.io/apiextensions-apiserver v0.31.2 // indirect
 	k8s.io/component-base v0.31.6 // indirect
 	k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect

--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -48,6 +48,7 @@ import (
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/spf13/cobra"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
@@ -135,6 +136,7 @@ func init() {
 	utilruntime.Must(ibguv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(pluginv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(assistedservicev1beta1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 }
 
 // run executes the `start controller-manager` command.

--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -84,6 +84,7 @@ func requeueWithCustomInterval(interval time.Duration) ctrl.Result {
 	return ctrl.Result{RequeueAfter: interval}
 }
 
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=o2ims.provisioning.oran.org,resources=clustertemplates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=o2ims.provisioning.oran.org,resources=clustertemplates/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=o2ims.provisioning.oran.org,resources=clustertemplates/finalizers,verbs=update
@@ -307,6 +308,10 @@ func validateConfigmapReference[T any](
 
 	if templateDataKey == utils.ClusterInstanceTemplateDefaultsConfigmapKey {
 		if err = utils.ValidateDefaultInterfaces(data); err != nil {
+			return utils.NewInputError("failed to validate the default ConfigMap: %w", err)
+		}
+
+		if err = utils.ValidateConfigmapSchemaAgainstClusterInstanceCRD(ctx, c, data); err != nil {
 			return utils.NewInputError("failed to validate the default ConfigMap: %w", err)
 		}
 	}

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -42,6 +42,8 @@ var _ = Describe("policyManagement", func() {
 
 	BeforeEach(func() {
 		// Define the needed resources.
+		clusterInstanceCRD, err := utils.BuildTestClusterInstanceCRD(utils.TestClusterInstanceSpecOk)
+		Expect(err).ToNot(HaveOccurred())
 		crs := []client.Object{
 			// Cluster Template Namespace.
 			&corev1.Namespace{
@@ -91,7 +93,7 @@ templateRefs:
 - name: "ai-cluster-templates-v1"
   namespace: "siteconfig-operator"
 nodes:
-- hostname: "node1"
+- hostName: "node1"
   nodeNetwork:
     interfaces:
     - name: eno1
@@ -158,6 +160,8 @@ defaultHugepagesSize: "1G"`,
 					Namespace: ctNamespace,
 				},
 			},
+			// ClusterInstance CRD.
+			clusterInstanceCRD,
 			// Provisioning Requests.
 			&provisioningv1alpha1.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -199,6 +203,7 @@ defaultHugepagesSize: "1G"`,
 		}
 
 		c = getFakeClientFromObjects(crs...)
+
 		// Reconcile the ClusterTemplate.
 		CTReconciler = &ClusterTemplateReconciler{
 			Client: c,
@@ -212,7 +217,7 @@ defaultHugepagesSize: "1G"`,
 			},
 		}
 
-		_, err := CTReconciler.Reconcile(ctx, req)
+		_, err = CTReconciler.Reconcile(ctx, req)
 		Expect(err).ToNot(HaveOccurred())
 
 		CRReconciler = &ProvisioningRequestReconciler{

--- a/internal/controllers/provisioningrequest_resourcecreation.go
+++ b/internal/controllers/provisioningrequest_resourcecreation.go
@@ -129,6 +129,10 @@ func (t *provisioningRequestReconcilerTask) createExtraManifestsConfigMap(
 func (t *provisioningRequestReconcilerTask) createClusterInstanceNamespace(
 	ctx context.Context, clusterName string) error {
 
+	if clusterName == "" {
+		return fmt.Errorf("spec.clusterName cannot be empty")
+	}
+
 	// Create the namespace.
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -28,6 +28,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
@@ -142,4 +143,5 @@ var _ = BeforeSuite(func() {
 	scheme.AddKnownTypes(pluginv1alpha1.GroupVersion, &pluginv1alpha1.HardwareManager{})
 	scheme.AddKnownTypes(assistedservicev1beta1.GroupVersion, &assistedservicev1beta1.Agent{})
 	scheme.AddKnownTypes(assistedservicev1beta1.GroupVersion, &assistedservicev1beta1.AgentList{})
+	scheme.AddKnownTypes(apiextensionsv1.SchemeGroupVersion, &apiextensionsv1.CustomResourceDefinition{})
 })

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -148,6 +148,7 @@ const (
 	ClusterInstanceTemplateName                 = "ClusterInstance"
 	ClusterInstanceTemplatePath                 = "controllers/clusterinstance-template.yaml"
 	ClusterInstanceTemplateDefaultsConfigmapKey = "clusterinstance-defaults"
+	ClusterInstanceCrdName                      = "clusterinstances"
 )
 
 var (

--- a/internal/controllers/utils/test_common.go
+++ b/internal/controllers/utils/test_common.go
@@ -1,0 +1,167 @@
+package utils
+
+import (
+	"fmt"
+
+	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
+)
+
+const TestClusterInstanceSpecOk = `
+group: siteconfig.open-cluster-management.io
+scope: Namespaced
+versions:
+- name: v1alpha1
+  schema:
+    openAPIV3Schema:
+      description: ClusterInstance is the Schema for the clusterinstances API
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            additionalNTPSources:
+              items:
+                type: string
+              type: array
+            apiVIPs:
+              items:
+                type: string
+              maxItems: 2
+              type: array
+            baseDomain:
+              type: string
+            clusterImageSetNameRef:
+              type: string
+            pullSecretRef:
+              properties:
+                name:
+                  type: string
+              type: object
+              x-kubernetes-map-type: atomic
+            nodes:
+              items:
+                properties:
+                  hostName:
+                    type: string
+                  templateRefs:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                    type: array
+                  nodeNetwork:
+                    properties:
+                      interfaces:
+                        items:
+                          properties:
+                            macAddress:
+                              type: string
+                            name:
+                              type: string
+                        type: array
+                    type: object
+              type: array
+            templateRefs:
+              items:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+              type: array
+          type: object
+          required:
+          - baseDomain
+          - clusterName
+      type: object
+  served: true
+  storage: true
+`
+const TestClusterInstanceSpecNoVersions = `
+group: siteconfig.open-cluster-management.io
+scope: Namespaced
+openAPIV3Schema:
+  description: ClusterInstance is the Schema for the clusterinstances API
+  properties:
+  apiVersion:
+    type: string
+  kind:
+    type: string
+  metadata:
+    type: object
+  spec:
+    properties:
+      additionalNTPSources:
+        items:
+          type: string
+        type: array
+      baseDomain:
+        type: string
+    type: object
+    required:
+    - baseDomain
+served: true
+storage: true
+`
+const TestClusterInstanceSpecServedFalse = `
+group: siteconfig.open-cluster-management.io
+scope: Namespaced
+versions:
+- name: v1alpha1
+  served: false
+  storage: true
+`
+
+const TestClusterInstancePropertiesRequiredRemoval = `
+properties:
+  apiVIPs:
+    items:
+      type: string
+    maxItems: 2
+    type: array
+  baseDomain:
+    type: string
+  clusterImageSetNameRef:
+    type: string
+  machineNetwork:
+    items:
+      properties:
+        cidr:
+          type: string
+      required:
+      - cidr
+      type: object
+    type: array
+type: object
+required:
+- baseDomain
+- clusterName
+`
+
+func BuildTestClusterInstanceCRD(clusterInstanceSpecStr string) (*unstructured.Unstructured, error) {
+	clusterInstanceCrd := &unstructured.Unstructured{}
+	clusterInstanceCrd.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+	clusterInstanceCrd.SetName(fmt.Sprintf("%s.%s", ClusterInstanceCrdName, siteconfig.Group))
+
+	var clusterInstanceSpecIntf map[string]interface{}
+	err := yaml.Unmarshal([]byte(clusterInstanceSpecStr), &clusterInstanceSpecIntf)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling error: %w", err)
+	}
+	clusterInstanceCrd.Object["spec"] = clusterInstanceSpecIntf
+
+	return clusterInstanceCrd, nil
+}

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -76,10 +76,10 @@ func ExtractMatchingInput(parentSchema []byte, subSchemaKey string) (any, error)
 	return matchingInput, nil
 }
 
-// disallowUnknownFieldsInSchema updates a schema by adding "additionalProperties": false
+// DisallowUnknownFieldsInSchema updates a schema by adding "additionalProperties": false
 // to all objects/arrays that define "properties". This ensures that any unknown fields
 // not defined in the schema will be disallowed during validation.
-func disallowUnknownFieldsInSchema(schema map[string]any) {
+func DisallowUnknownFieldsInSchema(schema map[string]any) {
 	// Check if the current schema level has "properties" defined
 	if properties, hasProperties := schema["properties"]; hasProperties {
 		// If "additionalProperties" is not already set, add it with the value false
@@ -91,7 +91,7 @@ func disallowUnknownFieldsInSchema(schema map[string]any) {
 		if propsMap, ok := properties.(map[string]any); ok {
 			for _, propValue := range propsMap {
 				if propSchema, ok := propValue.(map[string]any); ok {
-					disallowUnknownFieldsInSchema(propSchema)
+					DisallowUnknownFieldsInSchema(propSchema)
 				}
 			}
 		}
@@ -100,7 +100,7 @@ func disallowUnknownFieldsInSchema(schema map[string]any) {
 	// Recurse into each property defined under "items"
 	if items, hasItems := schema["items"]; hasItems {
 		if itemSchema, ok := items.(map[string]any); ok {
-			disallowUnknownFieldsInSchema(itemSchema)
+			DisallowUnknownFieldsInSchema(itemSchema)
 		}
 	}
 
@@ -201,7 +201,7 @@ func (r *ProvisioningRequest) ValidateClusterInstanceInputMatchesSchema(
 			"failed to extract %s subschema: %s", TemplateParamClusterInstance, err.Error())
 	}
 	// Any unknown fields not defined in the schema will be disallowed
-	disallowUnknownFieldsInSchema(clusterInstanceSubSchema)
+	DisallowUnknownFieldsInSchema(clusterInstanceSubSchema)
 
 	// Get the matching input for ClusterInstanceParameters
 	clusterInstanceMatchingInput, err := ExtractMatchingInput(


### PR DESCRIPTION
Steps:
- obtain the ClusterInstance CRD and get the schema for the CRD version that is stored and served
- from the schema obtained above, remove all the `required` properties since the ClusterInstance default ConfigMap will probably not contain all the required configuration.
- from the ClusterInstance default ConfigMap, remove the `label` property for each node interface as that is not part of the ClusterInstance schema, but a mechanism used by the O-Cloud Manager for provisioning
- validate the ConfigMap content against the CRD schema using the existing `ValidateJsonAgainstJsonSchema`  function

Updated existing unit tests and added more for the extra functionality.