### PR TITLE
CNF-16878: Add client certificate binding support (RFC8705)

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,12 @@ regarding the OAuth settings and JWT contents.
    cases, this may require special configuration steps on the Authorization Server to ensure the proper format in the
    JWT tokens.
 
+7. Client certificate binding (i.e., RFC8705) is enabled by default. If the authorization server has inserted a claim
+   into the token which contains the SHA256 fingerprint of the client certificate which requested a token then it will
+   be validated. If the client certificate which is making the request doesn't match the client certificate that
+   requested the token then the request will be rejected. That claim is expected to be `"cnf": {"x5t#S256": "...."}`.
+   This is an exception to the rule described in (6) above. See below for an example.
+
 ### Sample OAuth JWT Token
 
 The following is a sample JWT payload and header. The signature footer has been removed.
@@ -420,7 +426,7 @@ Header:
 }
 ```
 
-Footer:
+Payload:
 
 ```json
 {
@@ -435,9 +441,11 @@ Footer:
         "typ": "Bearer",
         "azp": "smo-client",
         "acr": "1",
-        "scope": "openid roles profile o2ims-audience",
-        "clientHost": "192.168.1.2",
-        "realm_access.roles": [
+        "cnf": {
+                "x5t#S256": "S1ArY2E4qD_l4lCuNhLh501CxjVJmNFJbLI2RRzigDc"
+        },
+        "scope": "openid profile role:o2ims-reader role:o2ims-subscriber role:o2ims-maintainer role:o2ims-provisioner",
+        "resource_access.o2ims-client.roles": [
                 "o2ims-reader",
                 "o2ims-subscriber",
                 "o2ims-maintainer",

--- a/api/inventory/v1alpha1/inventory_types.go
+++ b/api/inventory/v1alpha1/inventory_types.go
@@ -51,8 +51,13 @@ type OAuthConfig struct {
 	// a nested field in the JSON structure of the JWT object.
 	//    i.e., {"roles": ["a", "b"]} rather than {"realm": {"roles": ["a", "b"}}.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OAuth Groups Claim",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
-	//+kubebuilder:default=groups
+	//+kubebuilder:default=roles
 	GroupsClaim string `json:"groupsClaim"`
+	// ClientBindingClaim represents the claim contained within the OAuth JWT token which holds the certificate SHA256
+	// fingerprint.  This is expected to be a CEL mapper expression.  It should only be changed in advanced scenarios.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OAuth Client Binding Claim",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	//+kubebuilder:default="has(claims.cnf) ? claims.cnf['x5t#S256'] : []"
+	ClientBindingClaim string `json:"clientBindingClaim"`
 }
 
 // TLSConfig defines the TLS specific attributes specific to the SMO and OAuth servers

--- a/bundle/manifests/o2ims.oran.openshift.io_inventories.yaml
+++ b/bundle/manifests/o2ims.oran.openshift.io_inventories.yaml
@@ -167,13 +167,19 @@ spec:
                     description: OAuthConfig defines the configurable attributes required
                       to access the OAuth2 authorization server
                     properties:
+                      clientBindingClaim:
+                        default: 'has(claims.cnf) ? claims.cnf[''x5t#S256''] : []'
+                        description: |-
+                          ClientBindingClaim represents the claim contained within the OAuth JWT token which holds the certificate SHA256
+                          fingerprint.  This is expected to be a CEL mapper expression.  It should only be changed in advanced scenarios.
+                        type: string
                       clientSecretName:
                         description: |-
                           ClientSecretName represents the name of a secret (in the current namespace) which contains the client-id and
                           client-secret values used by the OAuth client.
                         type: string
                       groupsClaim:
-                        default: groups
+                        default: roles
                         description: |-
                           GroupsClaim represents the claim contained within the OAuth JWT token which holds the list of groups/roles. This
                           must be a list/array and not a space separated list of names.  It must also be a top level attribute rather than
@@ -203,6 +209,7 @@ spec:
                           within the OAuth JWT token which holds the username
                         type: string
                     required:
+                    - clientBindingClaim
                     - clientSecretName
                     - groupsClaim
                     - scopes

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -885,6 +885,13 @@ spec:
         displayName: SMO OAuth Configuration
         path: smo.oauth
       - description: |-
+          ClientBindingClaim represents the claim contained within the OAuth JWT token which holds the certificate SHA256
+          fingerprint.  This is expected to be a CEL mapper expression.  It should only be changed in advanced scenarios.
+        displayName: OAuth Client Binding Claim
+        path: smo.oauth.clientBindingClaim
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
           ClientSecretName represents the name of a secret (in the current namespace) which contains the client-id and
           client-secret values used by the OAuth client.
         displayName: Client Secret

--- a/config/crd/bases/o2ims.oran.openshift.io_inventories.yaml
+++ b/config/crd/bases/o2ims.oran.openshift.io_inventories.yaml
@@ -167,13 +167,19 @@ spec:
                     description: OAuthConfig defines the configurable attributes required
                       to access the OAuth2 authorization server
                     properties:
+                      clientBindingClaim:
+                        default: 'has(claims.cnf) ? claims.cnf[''x5t#S256''] : []'
+                        description: |-
+                          ClientBindingClaim represents the claim contained within the OAuth JWT token which holds the certificate SHA256
+                          fingerprint.  This is expected to be a CEL mapper expression.  It should only be changed in advanced scenarios.
+                        type: string
                       clientSecretName:
                         description: |-
                           ClientSecretName represents the name of a secret (in the current namespace) which contains the client-id and
                           client-secret values used by the OAuth client.
                         type: string
                       groupsClaim:
-                        default: groups
+                        default: roles
                         description: |-
                           GroupsClaim represents the claim contained within the OAuth JWT token which holds the list of groups/roles. This
                           must be a list/array and not a space separated list of names.  It must also be a top level attribute rather than
@@ -203,6 +209,7 @@ spec:
                           within the OAuth JWT token which holds the username
                         type: string
                     required:
+                    - clientBindingClaim
                     - clientSecretName
                     - groupsClaim
                     - scopes

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -287,6 +287,13 @@ spec:
         displayName: SMO OAuth Configuration
         path: smo.oauth
       - description: |-
+          ClientBindingClaim represents the claim contained within the OAuth JWT token which holds the certificate SHA256
+          fingerprint.  This is expected to be a CEL mapper expression.  It should only be changed in advanced scenarios.
+        displayName: OAuth Client Binding Claim
+        path: smo.oauth.clientBindingClaim
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
           ClientSecretName represents the name of a secret (in the current namespace) which contains the client-id and
           client-secret values used by the OAuth client.
         displayName: Client Secret

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -417,7 +417,8 @@ func addArgsForOAuth(inventory *inventoryv1alpha1.Inventory, args []string) []st
 				fmt.Sprintf("--oauth-issuer-url=%s", smo.OAuthConfig.URL),
 				fmt.Sprintf("--oauth-token-endpoint=%s", smo.OAuthConfig.TokenEndpoint),
 				fmt.Sprintf("--oauth-username-claim=%s", smo.OAuthConfig.UsernameClaim),
-				fmt.Sprintf("--oauth-groups-claim=%s", smo.OAuthConfig.GroupsClaim))
+				fmt.Sprintf("--oauth-groups-claim=%s", smo.OAuthConfig.GroupsClaim),
+				fmt.Sprintf("--oauth-client-binding-claim=%s", smo.OAuthConfig.ClientBindingClaim))
 		}
 
 		if smo.TLS != nil && smo.TLS.ClientCertificateName != nil {

--- a/internal/service/common/auth/auth_rfc8705.go
+++ b/internal/service/common/auth/auth_rfc8705.go
@@ -1,0 +1,165 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+)
+
+// From HAProxy
+const (
+	sslClientDERHeaderKey      = "x-ssl-client-der"
+	sslChainDERHeaderKey       = "x-ssl-client-chain"
+	sslClientVerifiedHeaderKey = "x-ssl-client-verify"
+)
+
+// From RFC9440.  We are always behind an HAProxy, and it doesn't yet support RFC9440 but some day it likely will so
+// this provides a bit of future-proofing.
+const (
+	sslClientCertKey  = "Client-Cert"
+	sslClientChainKey = "Client-Chain"
+)
+
+// Arbitrary key used to insert fingerprint data into the User Info object.  Authenticators are required to select keys
+// that cannot be confused with those used by other authenticators.
+const fingerprintKey = "o2ims.oran.openshift.io/fingerprint"
+
+// getClientCertificate extracts the client certificate from the incoming request headers.  If none is found, an error
+// is returned.
+func getClientCertificate(req *http.Request) ([]byte, bool, error) {
+	// TODO: Handle case of TLS termination directly on the server rather than at the ingress reverse proxy. However,
+	// this is unlikely to become a required use case since we use the ingress proxy to route the request to the
+	// correct microservice.  It is not possible to route the request without first terminating TLS since the connection
+	// is encrypted and the final API endpoint is not known.
+
+	// Check the standard value from RFC9440 first.
+	certString := req.Header.Get(sslClientCertKey)
+	if certString == "" {
+		// If it doesn't exist, then check those used by HA-Proxy
+		verified := req.Header.Get(sslClientVerifiedHeaderKey)
+		if verified != "0" {
+			// No cert was provided, or the cert provided could not be verified and was allowed
+			return nil, false, nil
+		}
+
+		certString = req.Header.Get(sslClientDERHeaderKey)
+		if certString == "" {
+			// This is unexpected
+			slog.Error("No client certificate found, but verification passed", "header", sslClientDERHeaderKey)
+			return nil, false, nil
+		}
+
+		// Remove these so that they are not accidentally referenced or leaked elsewhere
+		req.Header.Del(sslClientVerifiedHeaderKey)
+		req.Header.Del(sslClientDERHeaderKey)
+		req.Header.Del(sslChainDERHeaderKey)
+	} else {
+		// RFC9440 book-ends the certificate data with colons so we need to remove them before proceeding.
+		certString = strings.TrimLeft(strings.TrimRight(certString, ":"), ":")
+
+		// Remove these so that they are not accidentally referenced or leaked elsewhere
+		req.Header.Del(sslClientCertKey)
+		req.Header.Del(sslClientChainKey)
+	}
+
+	// Both HAProxy and RFC9440 use standard Base64 encoding rather than URL-encoded Base64.
+	certBytes, err := base64.StdEncoding.DecodeString(certString)
+	if err != nil {
+		return nil, false, fmt.Errorf("error decoding client certificate: %w", err)
+	}
+
+	return certBytes, true, nil
+}
+
+// getClientCertificateFingerprint extracts the client certificate SHA256 fingerprint from the incoming request headers.
+// If the headers do not include a client certificate or an error occurs while parsing the certificate, then an error is
+// returned.
+func getClientCertificateFingerprint(req *http.Request) (string, bool, error) {
+	certBytes, present, err := getClientCertificate(req)
+	if err != nil {
+		return "", false, err
+	}
+	if !present {
+		return "", false, nil
+	}
+
+	// Parse the decoded values to make sure we have a valid certificate rather than just a
+	// spoofed set of bytes that result in the expected SHA256 checksum.  We trust the proxy
+	// sitting ahead of us in all cases so that shouldn't be an issue, but just in case.
+	cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return "", false, fmt.Errorf("error parsing client certificate: %w", err)
+	}
+
+	fingerprint := sha256.Sum256(cert.Raw)
+	result := base64.URLEncoding.EncodeToString(fingerprint[:])
+	// RFC8705 requires that superfluous whitespace and trailing equals signs be removed.
+	result = strings.TrimSpace(strings.TrimRight(result, "="))
+	return result, true, nil
+}
+
+type withClientVerification struct {
+	authenticator authenticator.Request
+}
+
+// WithClientVerification wraps an existing token-based authenticator.Request so that further verification is performed
+// on the incoming token to verify the ownership of the token.  It assumes that the wrapped authenticator.Request
+// inserts User Info into the request context if it completes successfully.  The security considerations in RFC8705
+// should be observed whenever using this feature.  The main point is that we are trusting the headers in the request
+// to verify that a client certificate's fingerprint matches the one in the incoming token.  If the proxy in front of
+// us is broken or untrustworthy, then it is possible for a client to set its own proxied header values.  This would
+// allow it to fake possession/control of the same client certificate that was used to acquire the certificate and
+// thereby circumvent this control.  We only have a single network deployment type.  We know that we are always behind
+// an OpenShift Ingress Proxy so we trust that it behaves securely and would block any pre-existing certificate related
+// headers from being passed through from a malicious client.
+func WithClientVerification(request authenticator.Request) authenticator.Request {
+	return &withClientVerification{authenticator: request}
+}
+
+func (w *withClientVerification) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	response, ok, err := w.authenticator.AuthenticateRequest(req)
+	if err != nil {
+		return nil, false, err // nolint: wrapcheck
+	}
+	if !ok {
+		return nil, false, nil
+	}
+
+	user := response.User
+	tokenFingerprintValues, ok := user.GetExtra()[fingerprintKey]
+	if !ok {
+		// The authorization server did not add the expected fingerprint claim; therefore, this token wasn't bound to
+		// the client certificate; hence we do not need to do any further validation.  We could theoretically build in
+		// a configuration option that mandates that all tokens must have this claim, but the RFC doesn't mention that
+		// as an expected behavior of the Resource Server so for now we'll just return here.  We can re-evaluate later.
+		return response, true, nil
+	}
+
+	clientFingerprint, present, err := getClientCertificateFingerprint(req)
+	if err != nil {
+		slog.Error("error extracting client certificate fingerprint", "error", err)
+		return nil, false, err
+	}
+
+	if !present {
+		return nil, false, fmt.Errorf("a client certificate is required")
+	}
+
+	if len(tokenFingerprintValues) != 1 {
+		slog.Error("unexpected number of fingerprint values", "values", tokenFingerprintValues)
+		return nil, false, fmt.Errorf("unexpected number of fingerprint values")
+	}
+
+	if tokenFingerprintValues[0] != "" && tokenFingerprintValues[0] != clientFingerprint {
+		slog.Debug("fingerprint values do not match", "client", clientFingerprint, "token", tokenFingerprintValues[0])
+		return nil, false, fmt.Errorf("client certificate fingerprint mismatch")
+	}
+
+	return response, ok, nil
+}

--- a/internal/service/common/auth/auth_rfc8705_test.go
+++ b/internal/service/common/auth/auth_rfc8705_test.go
@@ -1,0 +1,166 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/util/cert"
+)
+
+var _ = Describe("WithClientVerification", func() {
+	var request http.Request
+	var tokenAuthenticator authenticator.Request
+	var noopAuthenticator NoopAuthenticator
+	var testCertificate, testStdCertificate string
+	var testFingerprint string
+
+	BeforeEach(func() {
+		pemBytes, _, err := cert.GenerateSelfSignedCertKey("localhost", nil, nil)
+		Expect(err).To(BeNil())
+		var certsBytes []byte
+		for block, rest := pem.Decode(pemBytes); block != nil; block, rest = pem.Decode(rest) {
+			certsBytes = append(certsBytes, block.Bytes...)
+		}
+		testCerts, err := x509.ParseCertificates(certsBytes)
+		Expect(err).To(BeNil())
+		fingerprint := sha256.Sum256(testCerts[0].Raw)
+		testCertificate = base64.StdEncoding.EncodeToString(testCerts[0].Raw)
+		testStdCertificate = ":" + testCertificate + ":"
+		testFingerprint = strings.Trim(base64.URLEncoding.EncodeToString(fingerprint[:]), "=")
+		noopAuthenticator = NoopAuthenticator{
+			Response: &authenticator.Response{
+				User: &user.DefaultInfo{
+					Name:   "test",
+					UID:    "1234",
+					Groups: nil,
+					Extra: map[string][]string{
+						fingerprintKey: {testFingerprint},
+					},
+				},
+			},
+			Ok:    true,
+			Error: nil,
+		}
+		tokenAuthenticator = WithClientVerification(&noopAuthenticator)
+		request = http.Request{Header: http.Header{
+			sslClientCertKey:  []string{testStdCertificate},
+			sslClientChainKey: []string{testStdCertificate},
+		}}
+		Expect(tokenAuthenticator).ToNot(BeNil())
+	})
+
+	It("authorizes a request with RFC9440 compliant headers", func() {
+		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err).To(BeNil())
+		Expect(ok).To(BeTrue())
+		Expect(response.User.GetName()).To(Equal("test"))
+		Expect(request.Header.Get(sslClientCertKey)).To(Equal(""))
+		Expect(request.Header.Get(sslClientChainKey)).To(Equal(""))
+	})
+
+	It("rejects a request with RFC9440 headers without certificate", func() {
+		request.Header.Del(sslClientCertKey)
+		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(Equal("a client certificate is required"))
+		Expect(ok).To(BeFalse())
+		Expect(response).To(BeNil())
+	})
+
+	It("authorizes a request that without a client binding", func() {
+		delete(noopAuthenticator.Response.User.GetExtra(), fingerprintKey)
+		tokenAuthenticator = WithClientVerification(&noopAuthenticator)
+		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err).To(BeNil())
+		Expect(ok).To(BeTrue())
+		Expect(response.User.GetName()).To(Equal("test"))
+	})
+
+	It("rejects a request with RFC9440 headers with invalid certificate encoding", func() {
+		request.Header.Set(sslClientCertKey, "invalid")
+		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err.Error()).To(ContainSubstring("error decoding client certificate"))
+		Expect(ok).To(BeFalse())
+		Expect(response).To(BeNil())
+	})
+
+	It("rejects a request with RFC9440 headers with invalid certificate encoding", func() {
+		cert := []rune(testStdCertificate)
+		cert[2] = 'B'
+		request.Header.Set(sslClientCertKey, string(cert))
+		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(ContainSubstring("error parsing client certificate"))
+		Expect(ok).To(BeFalse())
+		Expect(response).To(BeNil())
+	})
+
+	It("authorizes a request with HAProxy compliant headers", func() {
+		request.Header.Del(sslClientCertKey)
+		request.Header.Del(sslClientChainKey)
+		request.Header.Set(sslClientDERHeaderKey, testCertificate)
+		request.Header.Set(sslClientVerifiedHeaderKey, "0")
+		request.Header.Set(sslChainDERHeaderKey, "test")
+		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err).To(BeNil())
+		Expect(ok).To(BeTrue())
+		Expect(response.User.GetName()).To(Equal("test"))
+		Expect(request.Header.Get(sslClientDERHeaderKey)).To(Equal(""))
+		Expect(request.Header.Get(sslClientVerifiedHeaderKey)).To(Equal(""))
+		Expect(request.Header.Get(sslChainDERHeaderKey)).To(Equal(""))
+	})
+
+	It("rejects a request with HAProxy headers without valid certificate", func() {
+		request.Header.Del(sslClientCertKey)
+		request.Header.Del(sslClientChainKey)
+		request.Header.Set(sslClientDERHeaderKey, testCertificate)
+		request.Header.Set(sslClientVerifiedHeaderKey, "1")
+		request.Header.Set(sslChainDERHeaderKey, "test")
+		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err).ToNot(BeNil())
+		Expect(ok).To(BeFalse())
+		Expect(response).To(BeNil())
+	})
+
+	It("rejects a request with HAProxy headers without certificate", func() {
+		request.Header.Del(sslClientCertKey)
+		request.Header.Del(sslClientChainKey)
+		request.Header.Set(sslClientVerifiedHeaderKey, "0")
+		request.Header.Set(sslChainDERHeaderKey, "test")
+		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err).ToNot(BeNil())
+		Expect(ok).To(BeFalse())
+		Expect(response).To(BeNil())
+	})
+
+	It("reject a request with mismatched fingerprints", func() {
+		noopAuthenticator.Response.User.GetExtra()[fingerprintKey] = []string{"other"}
+		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(Equal("client certificate fingerprint mismatch"))
+		Expect(ok).To(BeFalse())
+		Expect(response).To(BeNil())
+		Expect(request.Header.Get(sslClientCertKey)).To(Equal(""))
+		Expect(request.Header.Get(sslClientChainKey)).To(Equal(""))
+	})
+
+	It("reject a request with multiple fingerprints", func() {
+		noopAuthenticator.Response.User.GetExtra()[fingerprintKey] = []string{"foo", "bar"}
+		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(Equal("unexpected number of fingerprint values"))
+		Expect(ok).To(BeFalse())
+		Expect(response).To(BeNil())
+		Expect(request.Header.Get(sslClientCertKey)).To(Equal(""))
+		Expect(request.Header.Get(sslClientChainKey)).To(Equal(""))
+	})
+
+})

--- a/internal/service/common/auth/middleware.go
+++ b/internal/service/common/auth/middleware.go
@@ -39,6 +39,7 @@ func GetAuthenticator(ctx context.Context, config *utils.CommonServerConfig) (mi
 			ClientID:             config.OAuth.ClientID,
 			UsernameClaim:        config.OAuth.UsernameClaim,
 			GroupsClaim:          config.OAuth.GroupsClaim,
+			ClientBindingClaim:   config.OAuth.ClientBindingClaim,
 			SupportedSigningAlgs: DefaultSigningAlgorithms,
 			Client:               client,
 		}

--- a/internal/service/common/utils/config.go
+++ b/internal/service/common/utils/config.go
@@ -15,13 +15,14 @@ import (
 
 // OAuthConfig defines the attributes used to communicate with the OAuth server
 type OAuthConfig struct {
-	IssuerURL     string
-	TokenEndpoint string
-	ClientID      string `envconfig:"SMO_OAUTH_CLIENT_ID"`
-	ClientSecret  string `envconfig:"SMO_OAUTH_CLIENT_SECRET"`
-	Scopes        []string
-	UsernameClaim string
-	GroupsClaim   string
+	IssuerURL          string
+	TokenEndpoint      string
+	ClientID           string `envconfig:"SMO_OAUTH_CLIENT_ID"`
+	ClientSecret       string `envconfig:"SMO_OAUTH_CLIENT_SECRET"`
+	Scopes             []string
+	UsernameClaim      string
+	GroupsClaim        string
+	ClientBindingClaim string
 }
 
 // TLSConfig defines the attributes used to establish an mTLS session
@@ -48,17 +49,18 @@ type CommonServerConfig struct {
 }
 
 const (
-	ListenerFlagName           = "api-listener-address"
-	OAuthIssuerURLFlagName     = "oauth-issuer-url"     // nolint: gosec
-	OAuthTokenEndpointFlagName = "oauth-token-endpoint" // nolint: gosec
-	OAuthScopesFlagName        = "oauth-scopes"
-	OAuthUsernameClaimFlagName = "oauth-username-claim"
-	OAuthGroupsClaimFlagName   = "oauth-groups-claim"
-	ServerCertFileFlagName     = "tls-server-cert"
-	ServerKeyFileFlagName      = "tls-server-key"
-	ClientCertFileFlagName     = "tls-client-cert"
-	ClientKeyFileFlagName      = "tls-client-key"
-	CABundleFileFlagName       = "ca-bundle-file"
+	ListenerFlagName                = "api-listener-address"
+	OAuthIssuerURLFlagName          = "oauth-issuer-url"     // nolint: gosec
+	OAuthTokenEndpointFlagName      = "oauth-token-endpoint" // nolint: gosec
+	OAuthScopesFlagName             = "oauth-scopes"
+	OAuthUsernameClaimFlagName      = "oauth-username-claim"
+	OAuthGroupsClaimFlagName        = "oauth-groups-claim"
+	OAuthClientBindingClaimFlagName = "oauth-client-binding-claim"
+	ServerCertFileFlagName          = "tls-server-cert"
+	ServerKeyFileFlagName           = "tls-server-key"
+	ClientCertFileFlagName          = "tls-client-cert"
+	ClientKeyFileFlagName           = "tls-client-key"
+	CABundleFileFlagName            = "ca-bundle-file"
 )
 
 // SetCommonServerFlags creates the flag instances for the server
@@ -99,6 +101,12 @@ func SetCommonServerFlags(cmd *cobra.Command, config *CommonServerConfig) error 
 		OAuthGroupsClaimFlagName,
 		"",
 		"OAuth groups claim",
+	)
+	flags.StringVar(
+		&config.OAuth.ClientBindingClaim,
+		OAuthClientBindingClaimFlagName,
+		"",
+		"OAuth client binding claim",
 	)
 	flags.StringVar(
 		&config.TLS.CertFile,

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1/inventory_types.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1/inventory_types.go
@@ -51,8 +51,13 @@ type OAuthConfig struct {
 	// a nested field in the JSON structure of the JWT object.
 	//    i.e., {"roles": ["a", "b"]} rather than {"realm": {"roles": ["a", "b"}}.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OAuth Groups Claim",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
-	//+kubebuilder:default=groups
+	//+kubebuilder:default=roles
 	GroupsClaim string `json:"groupsClaim"`
+	// ClientBindingClaim represents the claim contained within the OAuth JWT token which holds the certificate SHA256
+	// fingerprint.  This is expected to be a CEL mapper expression.  It should only be changed in advanced scenarios.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OAuth Client Binding Claim",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	//+kubebuilder:default="has(claims.cnf) ? claims.cnf['x5t#S256'] : []"
+	ClientBindingClaim string `json:"clientBindingClaim"`
 }
 
 // TLSConfig defines the TLS specific attributes specific to the SMO and OAuth servers


### PR DESCRIPTION
This adds support for client certificate bound access tokens (e.g., RFC8705).  When this feature is enabled on the authorization server each token generated contains an attribute which represents the SHA256 fingerprint of the TLS certificate which was used by the client who requested the token.

When this attribute is added to the token, Resource Servers are supposed to validate that the token is only used by a client presenting that same TLS certificate.  This is verified by comparing the fingerprint contained within the token with the fingerprint of the certificate being used to make the request.

We only support being behind an ingress proxy; therefore, we never expect TLS to be terminated directly on each server for OAuth use cases. For this reason, we only expect to get the client certificate information from the proxy headers rather than from the local TLS stack.  Since we only expect to be behind an HAProxy, we currently only support the client certificate headers added by HAProxy and the proposed standard of RFC9440.