### PR TITLE
Remove transition from failed to progressing

### DIFF
--- a/api/provisioning/v1alpha1/conditions.go
+++ b/api/provisioning/v1alpha1/conditions.go
@@ -71,3 +71,15 @@ var CRconditionReasons = struct {
 	TimedOut:        "TimedOut",
 	Unknown:         "Unknown",
 }
+
+// FatalPRconditionTypes is a list of ProvisioningRequest conditions
+// that are fatal and cannot be recovered on their own.
+var FatalPRconditionTypes = []ConditionType{
+	PRconditionTypes.HardwareProvisioned,
+	PRconditionTypes.HardwareNodeConfigApplied,
+	PRconditionTypes.HardwareConfigured,
+	PRconditionTypes.ClusterInstanceProcessed,
+	PRconditionTypes.ClusterProvisioned,
+	PRconditionTypes.ConfigurationApplied,
+	PRconditionTypes.UpgradeCompleted,
+}

--- a/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -350,3 +350,17 @@ func matchesAnyPattern(path []string, patterns [][]string) bool {
 	}
 	return false
 }
+
+// HasFatalProvisioningFailure checks if the ProvisioningRequest
+// has a fatal provisioning failure that cannot be recovered
+// on its own.
+func HasFatalProvisioningFailure(conditions []metav1.Condition) bool {
+	for _, condType := range FatalPRconditionTypes {
+		cond := meta.FindStatusCondition(conditions, string(condType))
+		if cond != nil && cond.Status == metav1.ConditionFalse &&
+			(cond.Reason == string(CRconditionReasons.Failed) || cond.Reason == string(CRconditionReasons.TimedOut)) {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/conditions.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/conditions.go
@@ -71,3 +71,15 @@ var CRconditionReasons = struct {
 	TimedOut:        "TimedOut",
 	Unknown:         "Unknown",
 }
+
+// FatalPRconditionTypes is a list of ProvisioningRequest conditions
+// that are fatal and cannot be recovered on their own.
+var FatalPRconditionTypes = []ConditionType{
+	PRconditionTypes.HardwareProvisioned,
+	PRconditionTypes.HardwareNodeConfigApplied,
+	PRconditionTypes.HardwareConfigured,
+	PRconditionTypes.ClusterInstanceProcessed,
+	PRconditionTypes.ClusterProvisioned,
+	PRconditionTypes.ConfigurationApplied,
+	PRconditionTypes.UpgradeCompleted,
+}

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -350,3 +350,17 @@ func matchesAnyPattern(path []string, patterns [][]string) bool {
 	}
 	return false
 }
+
+// HasFatalProvisioningFailure checks if the ProvisioningRequest
+// has a fatal provisioning failure that cannot be recovered
+// on its own.
+func HasFatalProvisioningFailure(conditions []metav1.Condition) bool {
+	for _, condType := range FatalPRconditionTypes {
+		cond := meta.FindStatusCondition(conditions, string(condType))
+		if cond != nil && cond.Status == metav1.ConditionFalse &&
+			(cond.Reason == string(CRconditionReasons.Failed) || cond.Reason == string(CRconditionReasons.TimedOut)) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Updates:
- Removed the transition from failed to progressing. The system cannot autonomously recover from fatal errors. It requires either a PR update or delete/recreate to get rid of the error.
- Moved the preparation steps into a separate function to reduce the complexity of `run` function.