### PR TITLE
Align with the ClusterInstance validation check introduced in ACM 2.13

### DIFF
--- a/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -27,7 +27,7 @@ const (
 var (
 	// allowedClusterInstanceFields contains path patterns for fields that are allowed to be updated.
 	// The wildcard "*" is used to match any index in a list.
-	allowedClusterInstanceFields = [][]string{
+	AllowedClusterInstanceFields = [][]string{
 		// Cluster-level non-immutable fields
 		{"extraAnnotations"},
 		{"extraLabels"},
@@ -268,7 +268,7 @@ func (r *ProvisioningRequest) GetClusterTemplateRef(ctx context.Context, client 
 // that are considered immutable and should not be modified and a list of fields related
 // to node scaling, indicating nodes that were added or removed.
 func FindClusterInstanceImmutableFieldUpdates(
-	old, new map[string]any, ignoredFields [][]string) ([]string, []string, error) {
+	old, new map[string]any, ignoredFields [][]string, allowedFields [][]string) ([]string, []string, error) {
 
 	diffs, err := diff.Diff(old, new)
 	if err != nil {
@@ -311,7 +311,7 @@ func FindClusterInstanceImmutableFieldUpdates(
 		)
 
 		// Check if the path matches any allowed fields
-		if matchesAnyPattern(diff.Path, allowedClusterInstanceFields) {
+		if matchesAnyPattern(diff.Path, allowedFields) {
 			// Allowed field; skip
 			continue
 		}

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -8,6 +8,8 @@ package controllers
 
 import (
 	"context"
+	"reflect"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -146,14 +149,14 @@ nodes:
 	})
 
 	It("should not contain disable-auto-import annotation for ManagedCluster in the "+
-		"rendered ClusterInstance if cluster provisioning has started", func() {
+		"rendered ClusterInstance if cluster provisioning has completed", func() {
 		// Simulate that the ClusterInstance has started provisioning
 		task.object.Status.Conditions = []metav1.Condition{
 			{
 				Type:    string(provisioningv1alpha1.PRconditionTypes.ClusterProvisioned),
-				Status:  metav1.ConditionFalse,
-				Reason:  string(provisioningv1alpha1.CRconditionReasons.InProgress),
-				Message: "Provisioning cluster",
+				Status:  metav1.ConditionTrue,
+				Reason:  string(provisioningv1alpha1.CRconditionReasons.Completed),
+				Message: "Provisioned cluster",
 			},
 		}
 		renderedClusterInstance, err := task.handleRenderClusterInstance(ctx)
@@ -161,7 +164,7 @@ nodes:
 		Expect(renderedClusterInstance).ToNot(BeNil())
 
 		// Verify the disable-auto-import annotation is not added to the ManagedCluster
-		// when cluster provisioning has started.
+		// when cluster provisioning has completed.
 		Expect(renderedClusterInstance.Spec.ExtraAnnotations).ToNot(HaveKey("ManagedCluster"))
 
 		// Check if status condition was updated correctly
@@ -241,7 +244,389 @@ nodes:
 			Type:    string(provisioningv1alpha1.PRconditionTypes.ClusterInstanceRendered),
 			Status:  metav1.ConditionFalse,
 			Reason:  string(provisioningv1alpha1.CRconditionReasons.Failed),
-			Message: "Failed to render and validate ClusterInstance: detected changes in immutable fields",
+			Message: "Failed to render and validate ClusterInstance: detected disallowed changes in immutable fields",
 		})
 	})
 })
+
+// ptr is a helper function to create pointers
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestExtractNodeDetails(t *testing.T) {
+	tests := []struct {
+		name       string
+		existingCI *unstructured.Unstructured
+		expected   map[string]nodeInfo
+	}{
+		{
+			name: "Valid Input - Extract Node Details",
+			existingCI: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"hostName":       "node1",
+								"bmcAddress":     "192.168.1.1",
+								"bootMACAddress": "AA:BB:CC:DD:EE:FF",
+								"bmcCredentialsName": map[string]any{
+									"name": "bmc-secret",
+								},
+								"nodeNetwork": map[string]any{
+									"interfaces": []any{
+										map[string]any{
+											"name":       "eth0",
+											"macAddress": "00:11:22:33:44:55",
+										},
+										map[string]any{
+											"name":       "eth1",
+											"macAddress": "00:11:22:33:44:66",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]nodeInfo{
+				"node1": {
+					bmcAddress:         ptr("192.168.1.1"),
+					bootMACAddress:     ptr("AA:BB:CC:DD:EE:FF"),
+					bmcCredentialsName: ptr("bmc-secret"),
+					interfaceMACAddress: map[string]string{
+						"eth0": "00:11:22:33:44:55",
+						"eth1": "00:11:22:33:44:66",
+					},
+				},
+			},
+		},
+		{
+			name: "Missing hostName - Should be skipped",
+			existingCI: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"nodes": []any{
+							map[string]any{ // No hostName
+								"bmcAddress": "192.168.1.1",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]nodeInfo{}, // No nodes extracted
+		},
+		{
+			name: "Missing bmcAddress and bootMACAddress",
+			existingCI: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"hostName": "node1",
+								"bmcCredentialsName": map[string]any{
+									"name": "bmc-secret",
+								},
+								"nodeNetwork": map[string]any{
+									"interfaces": []any{
+										map[string]any{
+											"name":       "eth0",
+											"macAddress": "00:11:22:33:44:55",
+										},
+										map[string]any{
+											"name":       "eth1",
+											"macAddress": "00:11:22:33:44:66",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]nodeInfo{
+				"node1": {
+					bmcCredentialsName: ptr("bmc-secret"),
+					interfaceMACAddress: map[string]string{
+						"eth0": "00:11:22:33:44:55",
+						"eth1": "00:11:22:33:44:66",
+					},
+				},
+			},
+		},
+		{
+			name: "Missing bmcCredentialsName or bmcCredentialsName.name",
+			existingCI: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"hostName":           "node1",
+								"bmcCredentialsName": map[string]any{
+									// "name" key is missing
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]nodeInfo{
+				"node1": {},
+			},
+		},
+		{
+			name: "Missing nodeNetwork.interfaces",
+			existingCI: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"hostName":       "node1",
+								"bmcAddress":     "192.168.1.1",
+								"bootMACAddress": "AA:BB:CC:DD:EE:FF",
+								"bmcCredentialsName": map[string]any{
+									"name": "bmc-secret",
+								},
+								"nodeNetwork": map[string]any{
+									// "interfaces" key is missing
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]nodeInfo{
+				"node1": {
+					bmcAddress:         ptr("192.168.1.1"),
+					bootMACAddress:     ptr("AA:BB:CC:DD:EE:FF"),
+					bmcCredentialsName: ptr("bmc-secret"),
+				},
+			},
+		},
+		{
+			name: "Invalid Interface Data (missing name or macAddress)",
+			existingCI: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"hostName": "node1",
+								"nodeNetwork": map[string]any{
+									"interfaces": []any{
+										map[string]any{ // Missing name
+											"macAddress": "00:11:22:33:44:55",
+										},
+										map[string]any{ // Missing macAddress
+											"name": "eth1",
+										},
+										map[string]any{ // Valid entry
+											"name":       "eth2",
+											"macAddress": "00:11:22:33:44:77",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]nodeInfo{
+				"node1": {
+					interfaceMACAddress: map[string]string{
+						"eth2": "00:11:22:33:44:77", // Only the valid entry should be included
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractNodeDetails(tt.existingCI)
+
+			// Compare the extracted result with expected output
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestAssignNodeDetails(t *testing.T) {
+	tests := []struct {
+		name       string
+		renderedCI *unstructured.Unstructured
+		nodesInfo  map[string]nodeInfo
+		expected   map[string]any
+	}{
+		{
+			name: "Valid Input - Assign Node Details",
+			renderedCI: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"hostName": "node1",
+								"nodeNetwork": map[string]any{
+									"interfaces": []any{
+										map[string]any{
+											"name":       "eth0",
+											"macAddress": "old-mac",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nodesInfo: map[string]nodeInfo{
+				"node1": {
+					bmcAddress:         ptr("192.168.1.1"),
+					bootMACAddress:     ptr("AA:BB:CC:DD:EE:FF"),
+					bmcCredentialsName: ptr("bmc-secret"),
+					interfaceMACAddress: map[string]string{
+						"eth0": "00:11:22:33:44:55",
+					},
+				},
+			},
+			expected: map[string]any{
+				"spec": map[string]any{
+					"nodes": []any{
+						map[string]any{
+							"hostName":       "node1",
+							"bmcAddress":     "192.168.1.1",
+							"bootMACAddress": "AA:BB:CC:DD:EE:FF",
+							"bmcCredentialsName": map[string]any{
+								"name": "bmc-secret",
+							},
+							"nodeNetwork": map[string]any{
+								"interfaces": []any{
+									map[string]any{
+										"name":       "eth0",
+										"macAddress": "00:11:22:33:44:55", // Updated MAC
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Missing spec.nodes - Should not panic",
+			renderedCI: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{},
+				},
+			},
+			nodesInfo: map[string]nodeInfo{
+				"node1": {
+					bmcAddress:         ptr("192.168.1.1"),
+					bootMACAddress:     ptr("AA:BB:CC:DD:EE:FF"),
+					bmcCredentialsName: ptr("bmc-secret"),
+					interfaceMACAddress: map[string]string{
+						"eth0": "00:11:22:33:44:55",
+					},
+				},
+			},
+			expected: map[string]any{
+				"spec": map[string]any{}, // No changes
+			},
+		},
+		{
+			name: "Node with missing hostName - Should be skipped",
+			renderedCI: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"nodes": []any{
+							map[string]any{ // No hostName
+								"nodeNetwork": map[string]any{
+									"interfaces": []any{
+										map[string]any{
+											"name":       "eth0",
+											"macAddress": "old-mac",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nodesInfo: map[string]nodeInfo{
+				"node1": {
+					bmcAddress:         ptr("192.168.1.1"),
+					bootMACAddress:     ptr("AA:BB:CC:DD:EE:FF"),
+					bmcCredentialsName: ptr("bmc-secret"),
+					interfaceMACAddress: map[string]string{
+						"eth0": "00:11:22:33:44:55",
+					},
+				},
+			},
+			expected: map[string]any{
+				"spec": map[string]any{
+					"nodes": []any{ // No changes, since hostName is missing
+						map[string]any{
+							"nodeNetwork": map[string]any{
+								"interfaces": []any{
+									map[string]any{
+										"name":       "eth0",
+										"macAddress": "old-mac",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Missing interfacesMACAddress in the nodeInfo",
+			renderedCI: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"hostName": "node1",
+							},
+						},
+					},
+				},
+			},
+			nodesInfo: map[string]nodeInfo{
+				"node1": {
+					bmcCredentialsName: ptr("bmc-secret"),
+					bootMACAddress:     ptr("AA:BB:CC:DD:EE:FF"),
+					bmcAddress:         ptr("192.168.1.1"),
+				},
+			},
+			expected: map[string]any{
+				"spec": map[string]any{
+					"nodes": []any{
+						map[string]any{
+							"hostName":       "node1",
+							"bootMACAddress": "AA:BB:CC:DD:EE:FF",
+							"bmcAddress":     "192.168.1.1",
+							"bmcCredentialsName": map[string]any{
+								"name": "bmc-secret",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assignNodeDetails(tt.renderedCI, tt.nodesInfo)
+
+			// Compare modified renderedCI with expected output
+			if !reflect.DeepEqual(tt.expected, tt.renderedCI.Object) {
+				t.Errorf("expected %v, got %v", tt.expected, tt.renderedCI.Object)
+			}
+		})
+	}
+}

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -727,6 +727,23 @@ var _ = Describe("ProvisioningRequestReconcile", func() {
 			clusterInstance = &siteconfig.ClusterInstance{}
 			clusterInstance.SetName(crName)
 			clusterInstance.SetNamespace(crName)
+			clusterInstance.Spec = siteconfig.ClusterInstanceSpec{
+				Nodes: []siteconfig.NodeSpec{
+					{
+						HostName:           "node-1",
+						BmcAddress:         "192.168.111.1",
+						BmcCredentialsName: siteconfig.BmcCredentialsName{Name: "node-1-bmc-secret"},
+						NodeNetwork: &assistedservicev1beta1.NMStateConfigSpec{
+							Interfaces: []*assistedservicev1beta1.Interface{
+								{
+									Name:       "eno1",
+									MacAddress: "00:00:00:00:00:00",
+								},
+							},
+						},
+					},
+				},
+			}
 			clusterInstance.Status.Conditions = []metav1.Condition{
 				{Type: string(siteconfig.ClusterInstanceValidated), Status: metav1.ConditionTrue},
 				{Type: string(siteconfig.RenderedTemplates), Status: metav1.ConditionTrue},

--- a/internal/controllers/utils/conditions.go
+++ b/internal/controllers/utils/conditions.go
@@ -98,9 +98,7 @@ func IsClusterProvisionPresent(cr *provisioningv1alpha1.ProvisioningRequest) boo
 func IsClusterProvisionInProgress(cr *provisioningv1alpha1.ProvisioningRequest) bool {
 	condition := meta.FindStatusCondition(cr.Status.Conditions,
 		string(provisioningv1alpha1.PRconditionTypes.ClusterProvisioned))
-	return condition != nil &&
-		(condition.Status == metav1.ConditionFalse ||
-			condition.Reason == string(provisioningv1alpha1.CRconditionReasons.InProgress))
+	return condition != nil && condition.Reason == string(provisioningv1alpha1.CRconditionReasons.InProgress)
 }
 
 // IsClusterProvisionCompleted checks if the cluster provision condition status is completed.

--- a/internal/controllers/utils/provision_test.go
+++ b/internal/controllers/utils/provision_test.go
@@ -424,7 +424,8 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 		updatedFields, scalingNodes, err := provisioningv1alpha1.FindClusterInstanceImmutableFieldUpdates(
 			oldClusterInstance.Object["spec"].(map[string]any),
 			newClusterInstance.Object["spec"].(map[string]any),
-			IgnoredClusterInstanceFields)
+			IgnoredClusterInstanceFields,
+			provisioningv1alpha1.AllowedClusterInstanceFields)
 		Expect(err).To(BeNil())
 		Expect(updatedFields).To(BeEmpty())
 		Expect(scalingNodes).To(BeEmpty())
@@ -438,7 +439,8 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 		updatedFields, scalingNodes, err := provisioningv1alpha1.FindClusterInstanceImmutableFieldUpdates(
 			oldClusterInstance.Object["spec"].(map[string]any),
 			newClusterInstance.Object["spec"].(map[string]any),
-			IgnoredClusterInstanceFields)
+			IgnoredClusterInstanceFields,
+			provisioningv1alpha1.AllowedClusterInstanceFields)
 		Expect(err).To(BeNil())
 		Expect(updatedFields).To(ContainElement("baseDomain"))
 		Expect(scalingNodes).To(BeEmpty())
@@ -457,7 +459,8 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 		updatedFields, scalingNodes, err := provisioningv1alpha1.FindClusterInstanceImmutableFieldUpdates(
 			oldClusterInstance.Object["spec"].(map[string]any),
 			newClusterInstance.Object["spec"].(map[string]any),
-			IgnoredClusterInstanceFields)
+			IgnoredClusterInstanceFields,
+			provisioningv1alpha1.AllowedClusterInstanceFields)
 		Expect(err).To(BeNil())
 		Expect(updatedFields).To(ContainElement("clusterName"))
 		Expect(len(updatedFields)).To(Equal(1))
@@ -474,7 +477,8 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 		updatedFields, scalingNodes, err := provisioningv1alpha1.FindClusterInstanceImmutableFieldUpdates(
 			oldClusterInstance.Object["spec"].(map[string]any),
 			newClusterInstance.Object["spec"].(map[string]any),
-			IgnoredClusterInstanceFields)
+			IgnoredClusterInstanceFields,
+			provisioningv1alpha1.AllowedClusterInstanceFields)
 		Expect(err).To(BeNil())
 		Expect(updatedFields).To(ContainElement(
 			"nodes.0.nodeNetwork.config.dns-resolver.config.server.0"))
@@ -499,7 +503,8 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 		updatedFields, scalingNodes, err := provisioningv1alpha1.FindClusterInstanceImmutableFieldUpdates(
 			oldClusterInstance.Object["spec"].(map[string]any),
 			newClusterInstance.Object["spec"].(map[string]any),
-			IgnoredClusterInstanceFields)
+			IgnoredClusterInstanceFields,
+			provisioningv1alpha1.AllowedClusterInstanceFields)
 		Expect(err).To(BeNil())
 		Expect(updatedFields).To(ContainElement(
 			"nodes.0.nodeNetwork.config.dns-resolver.config.server.0"))
@@ -520,7 +525,8 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 		updatedFields, scalingNodes, err := provisioningv1alpha1.FindClusterInstanceImmutableFieldUpdates(
 			oldClusterInstance.Object["spec"].(map[string]any),
 			newClusterInstance.Object["spec"].(map[string]any),
-			IgnoredClusterInstanceFields)
+			IgnoredClusterInstanceFields,
+			provisioningv1alpha1.AllowedClusterInstanceFields)
 		Expect(err).To(BeNil())
 		Expect(updatedFields).To(BeEmpty())
 		Expect(scalingNodes).To(BeEmpty())
@@ -536,7 +542,8 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 		updatedFields, scalingNodes, err := provisioningv1alpha1.FindClusterInstanceImmutableFieldUpdates(
 			oldClusterInstance.Object["spec"].(map[string]any),
 			newClusterInstance.Object["spec"].(map[string]any),
-			IgnoredClusterInstanceFields)
+			IgnoredClusterInstanceFields,
+			provisioningv1alpha1.AllowedClusterInstanceFields)
 		Expect(err).To(BeNil())
 		Expect(updatedFields).To(BeEmpty())
 		Expect(scalingNodes).To(ContainElement("nodes.1"))
@@ -550,7 +557,8 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 		updatedFields, scalingNodes, err := provisioningv1alpha1.FindClusterInstanceImmutableFieldUpdates(
 			oldClusterInstance.Object["spec"].(map[string]any),
 			newClusterInstance.Object["spec"].(map[string]any),
-			IgnoredClusterInstanceFields)
+			IgnoredClusterInstanceFields,
+			provisioningv1alpha1.AllowedClusterInstanceFields)
 		Expect(err).To(BeNil())
 		Expect(updatedFields).To(BeEmpty())
 		Expect(scalingNodes).To(ContainElement("nodes.0"))

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -27,7 +27,7 @@ const (
 var (
 	// allowedClusterInstanceFields contains path patterns for fields that are allowed to be updated.
 	// The wildcard "*" is used to match any index in a list.
-	allowedClusterInstanceFields = [][]string{
+	AllowedClusterInstanceFields = [][]string{
 		// Cluster-level non-immutable fields
 		{"extraAnnotations"},
 		{"extraLabels"},
@@ -268,7 +268,7 @@ func (r *ProvisioningRequest) GetClusterTemplateRef(ctx context.Context, client 
 // that are considered immutable and should not be modified and a list of fields related
 // to node scaling, indicating nodes that were added or removed.
 func FindClusterInstanceImmutableFieldUpdates(
-	old, new map[string]any, ignoredFields [][]string) ([]string, []string, error) {
+	old, new map[string]any, ignoredFields [][]string, allowedFields [][]string) ([]string, []string, error) {
 
 	diffs, err := diff.Diff(old, new)
 	if err != nil {
@@ -311,7 +311,7 @@ func FindClusterInstanceImmutableFieldUpdates(
 		)
 
 		// Check if the path matches any allowed fields
-		if matchesAnyPattern(diff.Path, allowedClusterInstanceFields) {
+		if matchesAnyPattern(diff.Path, allowedFields) {
 			// Allowed field; skip
 			continue
 		}


### PR DESCRIPTION
Siteconfig has introduced validation check in ACM 2.13+ that rejects any spec updates during cluster installation. This update aligns with that validation. 

Updates:
- ProvisioningRequest webhook and controller validation updates have been updated to disallow any updates during installation.
- The defaults set in the ClusterInstance CRD will be applied to the rendered ClusterInstance after dry-run, so run dry-run before checking ClusterInstance changes in the controller. If we start requiring ACM 2.13+, we could remove our post provisioning updates check and instead leverage the validation in the siteconfig.
- To pass the dry-run for the spec updates that caused by IMS:
     - Extract nodeInfo(e.g. bmc and macAddress that were from hw manager) from the existing ClusterInstance and merge it with the rendered ClusterInstance.
     - Remove auto-disable-import annotation from ClusterInstance CR when installation is completed.
 
     