### PR TITLE
use pg-16 from quay.io

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -142,7 +142,7 @@
                             "KUBECONFIG": "${env:KUBECONFIG}",
                             "IMAGE": "quay.io/openshift-kni/oran-o2ims-operator:latest",
                             "HWMGR_PLUGIN_NAMESPACE": "oran-hwmgr-plugin",
-                            "POSTGRES_IMAGE": "registry.redhat.io/rhel9/postgresql-16:9.5-1731610873"
+                            "POSTGRES_IMAGE": "quay.io/sclorg/postgresql-16-c9s:20250319"
                     },
                     "args": [
                             "start",

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1546,7 +1546,7 @@ spec:
                 - name: IMAGE
                   value: quay.io/openshift-kni/oran-o2ims-operator:4.18.0
                 - name: POSTGRES_IMAGE
-                  value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
+                  value: quay.io/sclorg/postgresql-16-c9s:20250319
                 - name: HWMGR_PLUGIN_NAMESPACE
                   value: oran-hwmgr-plugin
                 - name: OCLOUD_MANAGER_NAMESPACE

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
         - name: IMAGE
           value: controller:latest
         - name: POSTGRES_IMAGE
-          value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
+          value: quay.io/sclorg/postgresql-16-c9s:20250319
         - name: HWMGR_PLUGIN_NAMESPACE
           # A placeholder for the replacement kustomization that will inject the value from the config map
           value: plugin-namespace-placeholder


### PR DESCRIPTION
Replace `PG-16 rhel9` (only available in redhat [registry](https://catalog.redhat.com/software/containers/rhel9/postgresql-16/657b03866783e1b1fb87e142?container-tabs=overview)) with `PG-16 c9s` so that postgres is available without additional pull secrets 


/cc @donpenney 