### PR TITLE
Fix panic on shutdown

### DIFF
--- a/internal/service/common/async/store.go
+++ b/internal/service/common/async/store.go
@@ -150,6 +150,7 @@ func (c *ReflectorStore) Receive(ctx context.Context, handler AsyncEventHandler)
 		case <-ctx.Done():
 			slog.Info("stopping store adapter; context canceled")
 			close(c.ready)
+			return
 		case <-c.ready:
 			c.handleOperations(ctx, handler)
 		}


### PR DESCRIPTION
Fixes a panic caused by not breaking out of main loop which leads to closing an already closed channel on shutdown.