### PR TITLE
CNF-17204: Enable Cluster Provisioning with the Metal3 plugin

### DIFF
--- a/api/hardwaremanagement/v1alpha1/node.go
+++ b/api/hardwaremanagement/v1alpha1/node.go
@@ -40,6 +40,10 @@ type NodeSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hardware Manager Node ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	HwMgrNodeId string `json:"hwMgrNodeId,omitempty"`
 
+	// HwMgrNodeNs is the node namespace from the hardware manager.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hardware Manager Node Namespace",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	HwMgrNodeNs string `json:"hwMgrNodeNs,omitempty"`
+
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	Extensions map[string]string `json:"extensions,omitempty"`
 }

--- a/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
+++ b/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
@@ -71,6 +71,9 @@ spec:
                 description: HwMgrNodeId is the node identifier from the hardware
                   manager.
                 type: string
+              hwMgrNodeNs:
+                description: HwMgrNodeNs is the node namespace from the hardware manager.
+                type: string
               hwProfile:
                 description: HwProfile
                 type: string

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1003,6 +1003,11 @@ spec:
         path: hwMgrNodeId
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HwMgrNodeNs is the node namespace from the hardware manager.
+        displayName: Hardware Manager Node Namespace
+        path: hwMgrNodeNs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: HwProfile
         displayName: Hardware Profile
         path: hwProfile

--- a/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
+++ b/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
@@ -71,6 +71,9 @@ spec:
                 description: HwMgrNodeId is the node identifier from the hardware
                   manager.
                 type: string
+              hwMgrNodeNs:
+                description: HwMgrNodeNs is the node namespace from the hardware manager.
+                type: string
               hwProfile:
                 description: HwProfile
                 type: string

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -400,6 +400,11 @@ spec:
         path: hwMgrNodeId
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HwMgrNodeNs is the node namespace from the hardware manager.
+        displayName: Hardware Manager Node Namespace
+        path: hwMgrNodeNs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: HwProfile
         displayName: Hardware Profile
         path: hwProfile

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -48,6 +48,8 @@ const IngressClassName = "openshift-default"
 // IngressPortName defines the name of service port to which our ingress controller directs traffic to
 const IngressPortName = "api"
 
+const Metal3PluginName = "metal3"
+
 // Resource operations
 const (
 	UPDATE = "Update"
@@ -175,6 +177,7 @@ var (
 		{"nodes", "*", "bmcAddress"},
 		{"nodes", "*", "bmcCredentialsName"},
 		{"nodes", "*", "bootMACAddress"},
+		{"nodes", "*", "hostRef"},
 		{"nodes", "*", "nodeNetwork", "interfaces", "*", "macAddress"},
 		// The interface labels are not part of the ClusterInstance.
 		{"nodes", "*", "nodeNetwork", "interfaces", "*", "label"},

--- a/internal/controllers/utils/types.go
+++ b/internal/controllers/utils/types.go
@@ -110,5 +110,7 @@ type NodeInfo struct {
 	BmcAddress     string
 	BmcCredentials string
 	NodeName       string
+	HwMgrNodeId    string
+	HwMgrNodeNs    string
 	Interfaces     []*hwv1alpha1.Interface
 }

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node.go
@@ -40,6 +40,10 @@ type NodeSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hardware Manager Node ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	HwMgrNodeId string `json:"hwMgrNodeId,omitempty"`
 
+	// HwMgrNodeNs is the node namespace from the hardware manager.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hardware Manager Node Namespace",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	HwMgrNodeNs string `json:"hwMgrNodeNs,omitempty"`
+
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	Extensions map[string]string `json:"extensions,omitempty"`
 }


### PR DESCRIPTION
This pull request introduces support for cluster provisioning with the Metal3 plugin by leveraging the newly added hostRef field in the Cluster instance object. The hostRef field enables the creation of Bare Metal Hosts (BMH) and other node-level installation resources (such as InfraEnv and NMStateConfig) within the BMH namespace.

As a result of this change, the pull secret must now be available in the BMH namespace. The current logic that copies the pull secret from the template namespace to the cluster namespace will be deprecated.

Additionally, this update introduces a new field in the Node object. The plugin will utilize this new field to determine and return the BMH namespace. For backward compatibility, the IMS will check for the existing node label before transitioning to the new Spec.HwMgrNodeNs field.

Note: This pull request will be updated to import the SiteConfig from ACM 2.13 once the HostRef support is back-ported.

This PR is no longer needed if [PR](https://github.com/openshift-kni/oran-o2ims/pull/625) gets merged.
