### PR TITLE
CNF-17204: Enable Cluster Provisioning with metal3 plugin

### DIFF
--- a/api/hardwaremanagement/v1alpha1/node.go
+++ b/api/hardwaremanagement/v1alpha1/node.go
@@ -40,6 +40,10 @@ type NodeSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hardware Manager Node ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	HwMgrNodeId string `json:"hwMgrNodeId,omitempty"`
 
+	// HwMgrNodeNs is the node namespace from the hardware manager.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hardware Manager Node Namespace",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	HwMgrNodeNs string `json:"hwMgrNodeNs,omitempty"`
+
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	Extensions map[string]string `json:"extensions,omitempty"`
 }

--- a/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
+++ b/bundle/manifests/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
@@ -71,6 +71,9 @@ spec:
                 description: HwMgrNodeId is the node identifier from the hardware
                   manager.
                 type: string
+              hwMgrNodeNs:
+                description: HwMgrNodeNs is the node namespace from the hardware manager.
+                type: string
               hwProfile:
                 description: HwProfile
                 type: string

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1003,6 +1003,11 @@ spec:
         path: hwMgrNodeId
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HwMgrNodeNs is the node namespace from the hardware manager.
+        displayName: Hardware Manager Node Namespace
+        path: hwMgrNodeNs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: HwProfile
         displayName: Hardware Profile
         path: hwProfile

--- a/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
+++ b/config/crd/bases/o2ims-hardwaremanagement.oran.openshift.io_nodes.yaml
@@ -71,6 +71,9 @@ spec:
                 description: HwMgrNodeId is the node identifier from the hardware
                   manager.
                 type: string
+              hwMgrNodeNs:
+                description: HwMgrNodeNs is the node namespace from the hardware manager.
+                type: string
               hwProfile:
                 description: HwProfile
                 type: string

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -400,6 +400,11 @@ spec:
         path: hwMgrNodeId
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HwMgrNodeNs is the node namespace from the hardware manager.
+        displayName: Hardware Manager Node Namespace
+        path: hwMgrNodeNs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: HwProfile
         displayName: Hardware Profile
         path: hwProfile

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -548,6 +548,8 @@ func TestAssignNodeDetails(t *testing.T) {
 					bmcCredentialsName: ptr("bmc-secret"),
 					bootMACAddress:     ptr("AA:BB:CC:DD:EE:FF"),
 					bmcAddress:         ptr("192.168.1.1"),
+					HwMgrNodeId:        "test",
+					HwMgrNodeNs:        "test",
 				},
 			},
 			expected: map[string]any{
@@ -559,6 +561,10 @@ func TestAssignNodeDetails(t *testing.T) {
 							"bmcAddress":     "192.168.1.1",
 							"bmcCredentialsName": map[string]any{
 								"name": "bmc-secret",
+							},
+							"hostRef": map[string]string{
+								"name":      "test",
+								"namespace": "test",
 							},
 						},
 					},

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -48,6 +48,8 @@ const IngressClassName = "openshift-default"
 // IngressPortName defines the name of service port to which our ingress controller directs traffic to
 const IngressPortName = "api"
 
+const Metal3PluginName = "metal3"
+
 // Resource operations
 const (
 	UPDATE = "Update"
@@ -175,6 +177,7 @@ var (
 		{"nodes", "*", "bmcAddress"},
 		{"nodes", "*", "bmcCredentialsName"},
 		{"nodes", "*", "bootMACAddress"},
+		{"nodes", "*", "hostRef"},
 		{"nodes", "*", "nodeNetwork", "interfaces", "*", "macAddress"},
 		// The interface labels are not part of the ClusterInstance.
 		{"nodes", "*", "nodeNetwork", "interfaces", "*", "label"},

--- a/internal/controllers/utils/hardware_utils.go
+++ b/internal/controllers/utils/hardware_utils.go
@@ -17,12 +17,16 @@ import (
 
 	hwv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
-	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	bmhNamespaceLabel = "baremetalhost.metal3.io/namespace"
 )
 
 var (
@@ -108,11 +112,19 @@ func CollectNodeDetails(ctx context.Context, c client.Client,
 			return nil, fmt.Errorf("the Node %s status in namespace %s does not have BMC details",
 				nodeName, nodePool.Namespace)
 		}
+		// Check both node label and Spec.HwMgrNodeNs to ensure compatibility until plugin transitions to Spec.HwMgrNodeNs
+		bmhNs, ok := node.ObjectMeta.Labels[bmhNamespaceLabel]
+		if !ok {
+			bmhNs = node.Spec.HwMgrNodeNs
+		}
+
 		// Store the nodeInfo per group
 		hwNodes[node.Spec.GroupName] = append(hwNodes[node.Spec.GroupName], NodeInfo{
 			BmcAddress:     node.Status.BMC.Address,
 			BmcCredentials: node.Status.BMC.CredentialsName,
 			NodeName:       node.Name,
+			HwMgrNodeId:    node.Spec.HwMgrNodeId,
+			HwMgrNodeNs:    bmhNs,
 			Interfaces:     node.Status.Interfaces,
 		})
 	}
@@ -156,6 +168,60 @@ func CopyBMCSecrets(ctx context.Context, c client.Client, hwNodes map[string][]N
 			}
 		}
 	}
+	return nil
+}
+
+func GetPullSecretName(clusterInstance *unstructured.Unstructured) (string, error) {
+	pullSecretName, found, err := unstructured.NestedString(clusterInstance.Object, "spec", "pullSecretRef", "name")
+	if err != nil {
+		return "", fmt.Errorf("error getting pullSecretRef.name: %w", err)
+	}
+	if !found {
+		return "", fmt.Errorf("pullSecretRef.name not found")
+	}
+	return pullSecretName, nil
+}
+
+// CopyPullSecret copies the pull secrets from the cluster template namespace to the bmh namespace.
+func CopyPullSecret(ctx context.Context, c client.Client, ownerObject client.Object, sourceNamespace, pullSecretName string,
+	hwNodes map[string][]NodeInfo) error {
+
+	pullSecret := &corev1.Secret{}
+	exists, err := DoesK8SResourceExist(ctx, c, pullSecretName, sourceNamespace, pullSecret)
+	if err != nil {
+		return fmt.Errorf("failed to check existence of pull secret %q in namespace %q: %w", pullSecretName, sourceNamespace, err)
+	}
+	if !exists {
+		return NewInputError(
+			"pull secret %s expected to exist in the %s namespace, but it is missing",
+			pullSecretName, sourceNamespace)
+	}
+
+	// Extract the namespace from any node (all nodes in the same pool share the same namespace).
+	var targetNamespace string
+	for _, nodes := range hwNodes {
+		if len(nodes) > 0 {
+			targetNamespace = nodes[0].HwMgrNodeNs
+			break
+		}
+	}
+	if targetNamespace == "" {
+		return fmt.Errorf("failed to determine the target namespace for pull secret copy")
+	}
+
+	newSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pullSecretName,
+			Namespace: targetNamespace,
+		},
+		Data: pullSecret.Data,
+		Type: corev1.SecretTypeDockerConfigJson,
+	}
+
+	if err := CreateK8sCR(ctx, c, newSecret, ownerObject, UPDATE); err != nil {
+		return fmt.Errorf("failed to create Kubernetes CR for PullSecret: %w", err)
+	}
+
 	return nil
 }
 
@@ -251,17 +317,37 @@ func getInterfaces(nodeMap map[string]interface{}) []map[string]interface{} {
 //
 // Returns:
 // - error: An error if any unexpected structure or data is encountered; otherwise, nil.
-func AssignMacAddress(clusterInput map[string]any, hwInterfacess []*hwv1alpha1.Interface,
-	nodeSpec *siteconfig.NodeSpec) error {
+func AssignMacAddress(clusterInput map[string]any, hwInterfaces []*hwv1alpha1.Interface,
+	nodeSpec map[string]interface{}) error {
 
 	nodesInput, ok := clusterInput["nodes"].([]any)
 	if !ok {
 		return fmt.Errorf("unexpected: invalid nodes slice from the cluster input data")
 	}
-	// Iterate over each interface in the node specification to assign MAC addresses.
+
+	// Extract nodeNetwork.interfaces from nodeSpec
+	interfacesSlice, found, err := unstructured.NestedSlice(nodeSpec, "nodeNetwork", "interfaces")
+	if err != nil {
+		return fmt.Errorf("failed to extract nodeNetwork.interfaces: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("nodeNetwork.interfaces not found in nodeSpec")
+	}
+
 OuterLoop:
-	for i, iface := range nodeSpec.NodeNetwork.Interfaces {
+	for i, ifaceRaw := range interfacesSlice {
+		ifaceMap, ok := ifaceRaw.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected: interface at index %d is not a valid map", i)
+		}
+
+		name, ok := ifaceMap["name"].(string)
+		if !ok {
+			return fmt.Errorf("missing or invalid 'name' in nodeSpec interface at index %d", i)
+		}
+
 		macAddressAssigned := false
+
 		for _, node := range nodesInput {
 			nodeMapInput, ok := node.(map[string]interface{})
 			if !ok {
@@ -280,23 +366,34 @@ OuterLoop:
 			for _, intf := range interfaces {
 				// Check that "label" and "name" keys are present in the interface map.
 				label, labelOk := intf["label"]
-				name, nameOk := intf["name"]
+				ifName, nameOk := intf["name"]
 				if !labelOk || !nameOk {
 					return fmt.Errorf("interface map from the cluster input is missing 'label' or 'name' key")
 				}
-				for _, nodeIface := range hwInterfacess {
-					if nodeIface.Label == label && iface.Name == name {
-						nodeSpec.NodeNetwork.Interfaces[i].MacAddress = nodeIface.MACAddress
+
+				for _, nodeIface := range hwInterfaces {
+					if nodeIface.Label == label && ifName == name {
+						// Assign MAC address
+						ifaceMap["macAddress"] = nodeIface.MACAddress
+						interfacesSlice[i] = ifaceMap
 						macAddressAssigned = true
 						continue OuterLoop
 					}
 				}
 			}
 		}
+
 		if !macAddressAssigned {
-			return fmt.Errorf("mac address not assigned for interface %s, node name %s", iface.Name, nodeSpec.HostName)
+			hostName, _, _ := unstructured.NestedString(nodeSpec, "hostName")
+			return fmt.Errorf("mac address not assigned for interface %s, node name %s", name, hostName)
 		}
 	}
+
+	// Set updated interfaces slice back into nodeSpec
+	if err := unstructured.SetNestedSlice(nodeSpec, interfacesSlice, "nodeNetwork", "interfaces"); err != nil {
+		return fmt.Errorf("failed to update interfaces in nodeSpec: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/controllers/utils/provision.go
+++ b/internal/controllers/utils/provision.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -312,4 +313,22 @@ func GetParentPolicyNameAndNamespace(childPolicyName string) (policyName, policy
 // in the namespace "ztp-<clustertemplate-ns>".
 func IsParentPolicyInZtpClusterTemplateNs(policyNamespace, ctNamespace string) bool {
 	return policyNamespace == fmt.Sprintf("ztp-%s", ctNamespace)
+}
+
+func ConvertToUnstructured(ci siteconfig.ClusterInstance) (*unstructured.Unstructured, error) {
+	objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&ci)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert cluster instance to unstructured: %w", err)
+	}
+	unstructuredObj := &unstructured.Unstructured{Object: objMap}
+	return unstructuredObj, nil
+}
+
+func ConvertFromUnstructured(u *unstructured.Unstructured) (*siteconfig.ClusterInstance, error) {
+	var ci siteconfig.ClusterInstance
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &ci)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert unstructured to ClusterInstance: %w", err)
+	}
+	return &ci, nil
 }

--- a/internal/controllers/utils/types.go
+++ b/internal/controllers/utils/types.go
@@ -110,5 +110,7 @@ type NodeInfo struct {
 	BmcAddress     string
 	BmcCredentials string
 	NodeName       string
+	HwMgrNodeId    string
+	HwMgrNodeNs    string
 	Interfaces     []*hwv1alpha1.Interface
 }

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1/node.go
@@ -40,6 +40,10 @@ type NodeSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hardware Manager Node ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	HwMgrNodeId string `json:"hwMgrNodeId,omitempty"`
 
+	// HwMgrNodeNs is the node namespace from the hardware manager.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hardware Manager Node Namespace",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	HwMgrNodeNs string `json:"hwMgrNodeNs,omitempty"`
+
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	Extensions map[string]string `json:"extensions,omitempty"`
 }


### PR DESCRIPTION
This pull request adds support for cluster provisioning with the Metal3 plugin by utilizing the newly introduced hostRef field in the Cluster instance object. The hostRef field enables the creation of Bare Metal Hosts (BMH) and other node-level installation resources—such as InfraEnv and NMStateConfig—within the BMH namespace. It leverages the unstructured site-config cluster instance to eliminate dependencies on upgrading the siteconfig package.

As a result of this change, the pull secret must now be available in the BMH namespace. The current logic that copies the pull secret from the template namespace to the cluster namespace will be deprecated.

Additionally, this update introduces a new field in the Node object. The plugin will utilize this new field to determine and return the BMH namespace. For backward compatibility, the IMS will check for the existing node label before transitioning to the new Spec.HwMgrNodeNs field.