### PR TITLE
Remove webhook restriction on templateName and templateVersion updates

### DIFF
--- a/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -379,17 +379,3 @@ func matchesAnyPattern(path []string, patterns [][]string) bool {
 	}
 	return false
 }
-
-// HasFatalProvisioningFailure checks if the ProvisioningRequest
-// has a fatal provisioning failure that cannot be recovered
-// on its own.
-func HasFatalProvisioningFailure(conditions []metav1.Condition) bool {
-	for _, condType := range FatalPRconditionTypes {
-		cond := meta.FindStatusCondition(conditions, string(condType))
-		if cond != nil && cond.Status == metav1.ConditionFalse &&
-			(cond.Reason == string(CRconditionReasons.Failed) || cond.Reason == string(CRconditionReasons.TimedOut)) {
-			return true
-		}
-	}
-	return false
-}

--- a/api/provisioning/v1alpha1/provisioningrequest_webhook.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_webhook.go
@@ -82,25 +82,6 @@ func (v *provisioningRequestValidator) ValidateUpdate(ctx context.Context, oldOb
 		return nil, nil
 	}
 
-	// Check if spec.templateName or spec.templateVersion is changed
-	if oldPr.Spec.TemplateName != newPr.Spec.TemplateName || oldPr.Spec.TemplateVersion != newPr.Spec.TemplateVersion {
-		switch newPr.Status.ProvisioningStatus.ProvisioningPhase {
-		case StatePending, StateProgressing:
-			return nil, fmt.Errorf(
-				"updates to spec.templateName or spec.templateVersion are not allowed if the ProvisioningRequest is %s",
-				newPr.Status.ProvisioningStatus.ProvisioningPhase)
-		case StateFailed:
-			// Check if the ProvisioningRequest has failed with a disallowed error
-			if HasFatalProvisioningFailure(newPr.Status.Conditions) {
-				return nil, fmt.Errorf(
-					"updates to spec.templateName or spec.templateVersion are not allowed " +
-						"because the ProvisioningRequest has failed with a disallowed error")
-			}
-		default:
-			// ProvisioningRequest is fulfilled, allow the change
-		}
-	}
-
 	if err := v.validateCreateOrUpdate(ctx, oldPr, newPr); err != nil {
 		provisioningrequestlog.Error(err, "failed to validate the ProvisioningRequest")
 		return nil, err

--- a/api/provisioning/v1alpha1/provisioningrequest_webhook_test.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_webhook_test.go
@@ -96,96 +96,16 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 				newPr.Spec.TemplateVersion = "v1.0.2"
 			})
 
-			Context("when the ProvisioningRequest is fulfilled", func() {
-				It("should allow the change", func() {
-					newPr.Status.ProvisioningStatus.ProvisioningPhase = StateFulfilled
-					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).NotTo(HaveOccurred())
-				})
+			It("should allow the change when the ProvisioningRequest is fulfilled", func() {
+				newPr.Status.ProvisioningStatus.ProvisioningPhase = StateFulfilled
+				_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
+				Expect(err).NotTo(HaveOccurred())
 			})
 
-			Context("when the ProvisioningRequest is progressing or pending", func() {
-				It("should forbid the change if it is progressing", func() {
-					newPr.Status.ProvisioningStatus.ProvisioningPhase = StateProgressing
-					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring(
-						"updates to spec.templateName or spec.templateVersion are not allowed " +
-							"if the ProvisioningRequest is progressing"))
-				})
-
-				It("should forbid the change if it is pending", func() {
-					newPr.Status.ProvisioningStatus.ProvisioningPhase = StatePending
-					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring(
-						"updates to spec.templateName or spec.templateVersion are not allowed " +
-							"if the ProvisioningRequest is pending"))
-				})
-			})
-
-			Context("when the ProvisioningRequest is failed", func() {
-				BeforeEach(func() {
-					newPr.Status.ProvisioningStatus.ProvisioningPhase = StateFailed
-				})
-
-				It("should forbid the change if it fails due to a disallowed error (ClusterProvisioned failed)", func() {
-					newPr.Status.Conditions = append(newPr.Status.Conditions, metav1.Condition{
-						Type:   string(PRconditionTypes.ClusterProvisioned),
-						Status: metav1.ConditionFalse,
-						Reason: string(CRconditionReasons.Failed),
-					})
-					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring(
-						"updates to spec.templateName or spec.templateVersion are not allowed " +
-							"because the ProvisioningRequest has failed with a disallowed error"))
-				})
-
-				It("should forbid the change if it fails due to a disallowed error (HardwareProvisioned TimedOut)", func() {
-					newPr.Status.Conditions = append(newPr.Status.Conditions, metav1.Condition{
-						Type:   string(PRconditionTypes.HardwareProvisioned),
-						Status: metav1.ConditionFalse,
-						Reason: string(CRconditionReasons.TimedOut),
-					})
-					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring(
-						"updates to spec.templateName or spec.templateVersion are not allowed " +
-							"because the ProvisioningRequest has failed with a disallowed error"))
-				})
-
-				It("should allow the change if it failed but not due to a disallowed error (ClusterInstanceRendered failed)", func() {
-					newPr.Status.Conditions = append(newPr.Status.Conditions, metav1.Condition{
-						Type:   string(PRconditionTypes.ClusterInstanceRendered),
-						Status: metav1.ConditionFalse,
-						Reason: string(CRconditionReasons.Failed),
-					})
-					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("should forbid the change if both validation and HardwareProvisioned failed", func() {
-					newPr.Status.Conditions = append(newPr.Status.Conditions,
-						metav1.Condition{
-							Type:   string(PRconditionTypes.Validated),
-							Status: metav1.ConditionFalse,
-							Reason: string(CRconditionReasons.Failed),
-						},
-						metav1.Condition{
-							Type:    string(PRconditionTypes.HardwareProvisioned),
-							Status:  metav1.ConditionFalse,
-							Reason:  string(CRconditionReasons.Failed),
-							Message: "Hardware provisioning failed",
-						},
-					)
-					newPr.Status.ProvisioningStatus.ProvisioningDetails = "Hardware provisioning failed"
-					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring(
-						"updates to spec.templateName or spec.templateVersion are not allowed " +
-							"because the ProvisioningRequest has failed with a disallowed error"))
-				})
+			It("should allow the change when the ProvisioningRequest is failed", func() {
+				newPr.Status.ProvisioningStatus.ProvisioningPhase = StateFailed
+				_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -234,7 +234,7 @@ func (t *provisioningRequestReconcilerTask) run(ctx context.Context) (ctrl.Resul
 func (t *provisioningRequestReconcilerTask) shouldStopReconciliation() bool {
 	if t.object.Status.ObservedGeneration == t.object.Generation &&
 		t.object.Status.ProvisioningStatus.ProvisioningPhase == provisioningv1alpha1.StateFailed &&
-		provisioningv1alpha1.HasFatalProvisioningFailure(t.object.Status.Conditions) {
+		utils.HasFatalProvisioningFailure(t.object.Status.Conditions) {
 		// If the provisioning has failed with a fatal error and no spec changes,
 		// stop reconciliation.
 		return true

--- a/internal/controllers/utils/conditions.go
+++ b/internal/controllers/utils/conditions.go
@@ -189,3 +189,18 @@ func IsClusterZtpDone(cr *provisioningv1alpha1.ProvisioningRequest) bool {
 	}
 	return false
 }
+
+// HasFatalProvisioningFailure checks if the ProvisioningRequest
+// has a fatal provisioning failure that cannot be recovered
+// on its own.
+func HasFatalProvisioningFailure(conditions []metav1.Condition) bool {
+	for _, condType := range provisioningv1alpha1.FatalPRconditionTypes {
+		cond := meta.FindStatusCondition(conditions, string(condType))
+		if cond != nil && cond.Status == metav1.ConditionFalse &&
+			(cond.Reason == string(provisioningv1alpha1.CRconditionReasons.Failed) ||
+				cond.Reason == string(provisioningv1alpha1.CRconditionReasons.TimedOut)) {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -379,17 +379,3 @@ func matchesAnyPattern(path []string, patterns [][]string) bool {
 	}
 	return false
 }
-
-// HasFatalProvisioningFailure checks if the ProvisioningRequest
-// has a fatal provisioning failure that cannot be recovered
-// on its own.
-func HasFatalProvisioningFailure(conditions []metav1.Condition) bool {
-	for _, condType := range FatalPRconditionTypes {
-		cond := meta.FindStatusCondition(conditions, string(condType))
-		if cond != nil && cond.Status == metav1.ConditionFalse &&
-			(cond.Reason == string(CRconditionReasons.Failed) || cond.Reason == string(CRconditionReasons.TimedOut)) {
-			return true
-		}
-	}
-	return false
-}

--- a/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_webhook.go
+++ b/vendor/github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1/provisioningrequest_webhook.go
@@ -82,25 +82,6 @@ func (v *provisioningRequestValidator) ValidateUpdate(ctx context.Context, oldOb
 		return nil, nil
 	}
 
-	// Check if spec.templateName or spec.templateVersion is changed
-	if oldPr.Spec.TemplateName != newPr.Spec.TemplateName || oldPr.Spec.TemplateVersion != newPr.Spec.TemplateVersion {
-		switch newPr.Status.ProvisioningStatus.ProvisioningPhase {
-		case StatePending, StateProgressing:
-			return nil, fmt.Errorf(
-				"updates to spec.templateName or spec.templateVersion are not allowed if the ProvisioningRequest is %s",
-				newPr.Status.ProvisioningStatus.ProvisioningPhase)
-		case StateFailed:
-			// Check if the ProvisioningRequest has failed with a disallowed error
-			if HasFatalProvisioningFailure(newPr.Status.Conditions) {
-				return nil, fmt.Errorf(
-					"updates to spec.templateName or spec.templateVersion are not allowed " +
-						"because the ProvisioningRequest has failed with a disallowed error")
-			}
-		default:
-			// ProvisioningRequest is fulfilled, allow the change
-		}
-	}
-
 	if err := v.validateCreateOrUpdate(ctx, oldPr, newPr); err != nil {
 		provisioningrequestlog.Error(err, "failed to validate the ProvisioningRequest")
 		return nil, err


### PR DESCRIPTION
Remove the restriction since templateName and templateVersion are no longer invariant and we expect user updates to solve issues. 