### PR TITLE
Refactor client provider to use authType

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/openshift-kni/oran-hwmgr-plugin v0.0.0-20250228171929-433e46166247
 	github.com/openshift-kni/oran-hwmgr-plugin/api/hwmgr-plugin v0.0.0-20250125003258-ee379f966a62
 	github.com/openshift-kni/oran-hwmgr-plugin/pkg/inventory-client v0.0.0-20250125003258-ee379f966a62
+	github.com/openshift-kni/oran-o2ims/api/common v0.0.0-00010101000000-000000000000
 	github.com/openshift-kni/oran-o2ims/api/hardwaremanagement v0.0.0-20250124152543-be560cbe2609
 	github.com/openshift-kni/oran-o2ims/api/inventory v0.0.0-00010101000000-000000000000
 	github.com/openshift-kni/oran-o2ims/api/provisioning v0.0.0-00010101000000-000000000000
@@ -129,7 +130,6 @@ require (
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/openshift-kni/oran-o2ims/api/common v0.0.0-00010101000000-000000000000 // indirect
 	github.com/openshift/assisted-service/models v0.0.0 // indirect
 	github.com/openshift/hive/apis v0.0.0-20240306163002-9c5806a63531 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -32,6 +32,7 @@ import (
 
 	ibguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
 
+	commonapi "github.com/openshift-kni/oran-o2ims/api/common"
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	openshiftv1 "github.com/openshift/api/config/v1"
@@ -1088,4 +1089,14 @@ func GenerateSecretName(nodeMap map[string]interface{}, provisioningRequest stri
 	}
 	secretName := ExtractBeforeDot(strings.ToLower(nodeHostnameInterface.(string))) + "-bmc-secret"
 	return secretName, nil
+}
+
+func DetermineAuthType(callback string) commonapi.AuthType {
+	// At this time, only the OAuth and ServiceAccount authTypes are supported
+	// Set authType to OAuth
+	authType := commonapi.OAuth
+	if strings.Contains(callback, "svc.cluster.local") {
+		authType = commonapi.ServiceAccount
+	}
+	return authType
 }

--- a/internal/service/common/api/utils.go
+++ b/internal/service/common/api/utils.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 )
 
@@ -31,7 +32,8 @@ func ValidateCallbackURL(ctx context.Context, c notifier.ClientProvider, callbac
 	}
 
 	// A new client is created every time since the user may request a baseclient or oauthclient which we figure out at runtime
-	client, err := c.NewClient(ctx, callback)
+	authType := utils.DetermineAuthType(callback)
+	client, err := c.NewClient(ctx, authType)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}

--- a/internal/service/common/api/utils_test.go
+++ b/internal/service/common/api/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	commonapi "github.com/openshift-kni/oran-o2ims/api/common"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -122,6 +123,6 @@ type stubClientProvider struct {
 	client *http.Client
 }
 
-func (s *stubClientProvider) NewClient(ctx context.Context, callback string) (*http.Client, error) {
+func (s *stubClientProvider) NewClient(ctx context.Context, authType commonapi.AuthType) (*http.Client, error) {
 	return s.client, nil
 }

--- a/internal/service/common/notifier/notifier_worker.go
+++ b/internal/service/common/notifier/notifier_worker.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
 // maxRetries defines the number of attempts made on each notification
@@ -61,7 +62,8 @@ type SubscriptionWorker struct {
 func NewSubscriptionWorker(ctx context.Context, clientProvider ClientProvider, subscriptionJobCompleteChannel chan *SubscriptionJobComplete,
 	subscription *SubscriptionInfo) (*SubscriptionWorker, error) {
 	// Create a client for this subscription.
-	client, err := clientProvider.NewClient(ctx, subscription.Callback)
+	authType := utils.DetermineAuthType(subscription.Callback)
+	client, err := clientProvider.NewClient(ctx, authType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup client: %w", err)
 	}

--- a/internal/service/common/notifier/provider.go
+++ b/internal/service/common/notifier/provider.go
@@ -11,12 +11,12 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
 	"k8s.io/client-go/transport"
 
+	commonapi "github.com/openshift-kni/oran-o2ims/api/common"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
@@ -30,7 +30,7 @@ type ClientFactory struct {
 // ClientProvider defines the interface which any client factory must implement.  This exists for
 // future unit test purposes so that the ClientFactory can be swapped out as needed.
 type ClientProvider interface {
-	NewClient(ctx context.Context, callbackURL string) (*http.Client, error)
+	NewClient(ctx context.Context, authType commonapi.AuthType) (*http.Client, error)
 }
 
 // NewClientFactory creates a new factory
@@ -65,8 +65,8 @@ func (f *ClientFactory) newOAuthClient(ctx context.Context) (*http.Client, error
 // service URL that contains "svc.cluster.local" then a Client will be created that uses the
 // supplied service account token file; otherwise, it is assumed that the URL points to a public
 // endpoint that requires the OAuth credentials.
-func (f *ClientFactory) NewClient(ctx context.Context, callback string) (*http.Client, error) {
-	if strings.Contains(callback, "svc.cluster.local") {
+func (f *ClientFactory) NewClient(ctx context.Context, authType commonapi.AuthType) (*http.Client, error) {
+	if authType == commonapi.ServiceAccount {
 		return f.newClusterClient(ctx)
 	}
 	return f.newOAuthClient(ctx)


### PR DESCRIPTION
# Summary

This PR refactors the client provider to use `authType` when serving new clients from the ClientFactory.

/cc @alegacy @browsell 