### PR TITLE
Add validation logic when registering a new HardwarePlugin

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1114,6 +1114,10 @@ spec:
           - get
           - list
         - nonResourceURLs:
+          - /hardware-manager/provisioning/*
+          verbs:
+          - get
+        - nonResourceURLs:
           - /internal/v1/caas-alerts/alertmanager
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,6 +10,10 @@ rules:
   - get
   - list
 - nonResourceURLs:
+  - /hardware-manager/provisioning/*
+  verbs:
+  - get
+- nonResourceURLs:
   - /internal/v1/caas-alerts/alertmanager
   verbs:
   - create

--- a/hwmgr-plugins/controller/hardwareplugin_controller.go
+++ b/hwmgr-plugins/controller/hardwareplugin_controller.go
@@ -10,9 +10,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
 
-	"github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -21,6 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	pluginv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
+	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
 // HardwarePluginReconciler reconciles a HardwarePlugin object
@@ -73,8 +78,8 @@ func (r *HardwarePluginReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	condStatus := metav1.ConditionFalse
 	condMessage := ""
 
-	isValid, err := r.validateHardwarePlugin(ctx, hwplugin)
-
+	var isValid bool
+	isValid, err = r.validateHardwarePlugin(ctx, hwplugin)
 	if err != nil {
 		err = fmt.Errorf("encountered an error while attempting to validate HardwarePlugin (%s): %w", hwplugin.Name, err)
 		condMessage = err.Error()
@@ -99,9 +104,112 @@ func (r *HardwarePluginReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return
 }
 
+// setupOAuthClientConfig constructs an OAuth client configuration from the HardwarePlugin CR.
+func (r *HardwarePluginReconciler) setupOAuthClientConfig(ctx context.Context, hwplugin *pluginv1alpha1.HardwarePlugin) (*sharedutils.OAuthClientConfig, error) {
+	var caBundle string
+	if hwplugin.Spec.CaBundleName != nil {
+		cm, err := sharedutils.GetConfigmap(ctx, r.Client, *hwplugin.Spec.CaBundleName, hwplugin.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get CA Bundle configmap: %w", err)
+		}
+
+		caBundle, err = sharedutils.GetConfigMapField(cm, sharedutils.CABundleFilename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get certificate bundle from configmap: %w", err)
+		}
+	}
+
+	config := sharedutils.OAuthClientConfig{
+		TLSConfig: &sharedutils.TLSConfig{CaBundle: []byte(caBundle)},
+	}
+
+	if hwplugin.Spec.AuthClientConfig.TLSConfig != nil && hwplugin.Spec.AuthClientConfig.TLSConfig.SecretName != nil {
+		secretName := *hwplugin.Spec.AuthClientConfig.TLSConfig.SecretName
+		cert, key, err := sharedutils.GetKeyPairFromSecret(ctx, r.Client, secretName, hwplugin.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get certificate and key from secret: %w", err)
+		}
+
+		config.TLSConfig.ClientCert = sharedutils.NewStaticKeyPairLoader(cert, key)
+	}
+
+	if hwplugin.Spec.AuthClientConfig.OAuthClientConfig != nil {
+		oauthConf := hwplugin.Spec.AuthClientConfig.OAuthClientConfig
+		secret, err := sharedutils.GetSecret(ctx, r.Client, oauthConf.ClientSecretName, hwplugin.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get oauth secret '%s': %w", oauthConf.ClientSecretName, err)
+		}
+
+		clientID, err := sharedutils.GetSecretField(secret, sharedutils.OAuthClientIDField)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get '%s' from oauth secret: %s", sharedutils.OAuthClientIDField, err.Error())
+		}
+
+		clientSecret, err := sharedutils.GetSecretField(secret, sharedutils.OAuthClientSecretField)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get '%s' from oauth secret: %s", sharedutils.OAuthClientSecretField, err.Error())
+		}
+
+		config.OAuthConfig = &sharedutils.OAuthConfig{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			TokenURL:     strings.TrimSuffix(oauthConf.URL, "/") + "/" + strings.TrimPrefix(oauthConf.TokenEndpoint, "/"),
+			Scopes:       oauthConf.Scopes,
+		}
+	}
+
+	// TODO: process hwplugin.Spec.AuthClientConfig.BasicAuthSecret when `Basic` authType is supported
+
+	return &config, nil
+}
+
 // validateHardwarePlugin verifies secure connectivity to the HardwarePlugin's apiRoot using mTLS.
 func (r *HardwarePluginReconciler) validateHardwarePlugin(ctx context.Context, hwplugin *pluginv1alpha1.HardwarePlugin) (bool, error) {
-	// TODO - complete
+
+	if hwplugin.Spec.AuthClientConfig == nil {
+		return false, fmt.Errorf("missing authClientConfig configuration")
+	}
+
+	// Construct OAuth client configuration
+	config, err := r.setupOAuthClientConfig(ctx, hwplugin)
+	if err != nil {
+		return false, fmt.Errorf("failed to setup OAuthClientConfig: %w", err)
+	}
+
+	// build OAuth client information if type is not ServiceAccount
+	cf := notifier.NewClientFactory(config, sharedutils.DefaultBackendTokenFile)
+	httpClient, err := cf.NewClient(ctx, hwplugin.Spec.AuthClientConfig.Type)
+	if err != nil {
+		return false, fmt.Errorf("failed to build client: %w", err)
+	}
+
+	// Validate apiRoot URL
+	apiRoot, err := url.Parse(hwplugin.Spec.ApiRoot)
+	if err != nil {
+		return false, fmt.Errorf("invalid apiRoot URL '%s': %w", hwplugin.Spec.ApiRoot, err)
+	}
+
+	// Build request to validation endpoint url
+	url := fmt.Sprintf("%s%s", apiRoot, sharedutils.HardwarePluginValidationEndpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Send request to HardwarePlugin server
+	// TODO: replace this section with a generated client version from the plugin API spec.
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to send request to '%s': %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > http.StatusNoContent {
+		r.Logger.ErrorContext(ctx, fmt.Sprintf("validation attempt to '%s' failed, HTTP code=%d", url, resp.StatusCode))
+		return false, nil
+	}
+
+	r.Logger.InfoContext(ctx, fmt.Sprintf("validation attempt to '%s' succeeded, HTTP code=%d", url, resp.StatusCode))
 	return true, nil
 }
 

--- a/internal/controllers/hardwareplugin_manager_setup.go
+++ b/internal/controllers/hardwareplugin_manager_setup.go
@@ -197,6 +197,15 @@ func (t *reconcilerTask) createHardwarePluginManagerClusterRole(ctx context.Cont
 					"update",
 				},
 			},
+			// HardwarePlugin registration verification
+			{
+				NonResourceURLs: []string{
+					"/hardware-manager/provisioning/*",
+				},
+				Verbs: []string{
+					"get",
+				},
+			},
 		},
 	}
 

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -83,6 +83,7 @@ import (
 //+kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=allocatednodes,verbs=get;create;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=allocatednodes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=allocatednodes/finalizers,verbs=update;patch
+//+kubebuilder:rbac:urls="/hardware-manager/provisioning/*",verbs=get
 
 // Reconciler reconciles a Inventory object
 type Reconciler struct {

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -338,3 +338,13 @@ const (
 	OAuthClientIDEnvName     = "SMO_OAUTH_CLIENT_ID"
 	OAuthClientSecretEnvName = "SMO_OAUTH_CLIENT_SECRET" // nolint: gosec
 )
+
+// OAuth Secret fields
+const (
+	OAuthClientIDField     = "client-id"
+	OAuthClientSecretField = "client-secret"
+)
+
+// HardwarePluginValidationEndpoint is the endpoint that the HardwarePlugin manager will try to reach for the plugin being
+// registered.
+const HardwarePluginValidationEndpoint = "/hardware-manager/provisioning/api_versions"


### PR DESCRIPTION
# Summary

This PR introduces the registration validation process for onboarding new `HardwarePlugins`. It includes logic to verify that the `apiRoot` of the HardwarePlugin server is accessible.

/cc @browsell @alegacy