### PR TITLE
Add Loopback HardwarePlugin server infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,9 @@ OCLOUD_MANAGER_NAMESPACE ?= oran-o2ims
 # HWMGR_PLUGIN_NAMESPACE refers to the namespace of the hardware manager plugin.
 HWMGR_PLUGIN_NAMESPACE ?= oran-hwmgr-plugin
 
+# DEPLOY_LOOPBACK_HW_PLUGIN is a flag to indicate whether the loopback HardwarePlugin should be deployed
+DEPLOY_LOOPBACK_HW_PLUGIN ?= false
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -211,6 +214,7 @@ deploy: install manifests kustomize kubectl ## Deploy controller to the K8s clus
 	@$(KUBECTL) create configmap env-config \
 		--from-literal=HWMGR_PLUGIN_NAMESPACE=$(HWMGR_PLUGIN_NAMESPACE) \
 		--from-literal=imagePullPolicy=$(IMAGE_PULL_POLICY) \
+		--from-literal=DEPLOY_LOOPBACK_HW_PLUGIN=$(DEPLOY_LOOPBACK_HW_PLUGIN) \
 		--dry-run=client -o yaml > config/manager/env-config.yaml
 	cd config/manager \
 		&& $(KUSTOMIZE) edit set image controller=${IMG}
@@ -298,6 +302,7 @@ bundle: operator-sdk manifests kustomize kubectl ## Generate bundle manifests an
 	@$(KUBECTL) create configmap env-config \
 		--from-literal=HWMGR_PLUGIN_NAMESPACE=$(HWMGR_PLUGIN_NAMESPACE) \
 		--from-literal=imagePullPolicy=$(IMAGE_PULL_POLICY) \
+		--from-literal=DEPLOY_LOOPBACK_HW_PLUGIN=$(DEPLOY_LOOPBACK_HW_PLUGIN) \
 		--dry-run=client -o yaml > config/manager/env-config.yaml
 	cd config/manager \
 		&& $(KUSTOMIZE) edit set image controller=$(IMG)

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1119,7 +1119,12 @@ spec:
         - nonResourceURLs:
           - /hardware-manager/provisioning/*
           verbs:
+          - create
+          - delete
           - get
+          - list
+          - post
+          - put
         - nonResourceURLs:
           - /internal/v1/caas-alerts/alertmanager
           verbs:
@@ -1656,6 +1661,8 @@ spec:
                   value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
                 - name: HWMGR_PLUGIN_NAMESPACE
                   value: oran-hwmgr-plugin
+                - name: DEPLOY_LOOPBACK_HW_PLUGIN
+                  value: "false"
                 - name: OCLOUD_MANAGER_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -40,6 +40,16 @@ replacements:
       kind: Deployment
       name: controller-manager
 - source:
+    fieldPath: data.DEPLOY_LOOPBACK_HW_PLUGIN
+    kind: ConfigMap
+    name: env-config
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=manager].env.[name=DEPLOY_LOOPBACK_HW_PLUGIN].value
+    select:
+      kind: Deployment
+      name: controller-manager
+- source:
     fieldPath: data.imagePullPolicy
     kind: ConfigMap
     name: env-config

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -80,6 +80,9 @@ spec:
         - name: HWMGR_PLUGIN_NAMESPACE
           # A placeholder for the replacement kustomization that will inject the value from the config map
           value: plugin-namespace-placeholder
+        - name: DEPLOY_LOOPBACK_HW_PLUGIN
+          # A placeholder for the replacement kustomization that will inject the value from the config map
+          value: "false"
         - name: OCLOUD_MANAGER_NAMESPACE
           valueFrom:
             fieldRef:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,7 +12,12 @@ rules:
 - nonResourceURLs:
   - /hardware-manager/provisioning/*
   verbs:
+  - create
+  - delete
   - get
+  - list
+  - post
+  - put
 - nonResourceURLs:
   - /internal/v1/caas-alerts/alertmanager
   verbs:

--- a/hwmgr-plugins/controller/utils/allocated_node.utils.go
+++ b/hwmgr-plugins/controller/utils/allocated_node.utils.go
@@ -1,0 +1,82 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	pluginv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+)
+
+const (
+	AllocatedNodeSpecNodeAllocationRequestKey = "spec.nodeAllocationRequest"
+)
+
+// GetNode get a node resource for a provided name
+func GetNode(
+	ctx context.Context,
+	logger *slog.Logger,
+	c client.Client,
+	namespace, nodename string) (*pluginv1alpha1.AllocatedNode, error) {
+
+	logger.InfoContext(ctx, "Getting AllocatedNode", slog.String("nodename", nodename))
+
+	node := &pluginv1alpha1.AllocatedNode{}
+
+	if err := sharedutils.RetryOnConflictOrRetriableOrNotFound(retry.DefaultRetry, func() error {
+		return c.Get(ctx, types.NamespacedName{Name: nodename, Namespace: namespace}, node)
+	}); err != nil {
+		return node, fmt.Errorf("failed to get AllocatedNode for update: %w", err)
+	}
+	return node, nil
+}
+
+// GenerateNodeName
+func GenerateNodeName() string {
+	return uuid.NewString()
+}
+
+func FindNodeInList(nodelist pluginv1alpha1.AllocatedNodeList, hwMgrId, nodeId string) string {
+	for _, node := range nodelist.Items {
+		if node.Spec.HwMgrId == hwMgrId && node.Spec.HwMgrNodeId == nodeId {
+			return node.Name
+		}
+	}
+	return ""
+}
+
+// GetChildNodes gets a list of nodes allocated to a NodeAllocationRequest
+func GetChildNodes(
+	ctx context.Context,
+	logger *slog.Logger,
+	c client.Client,
+	nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest) (*pluginv1alpha1.AllocatedNodeList, error) {
+
+	nodelist := &pluginv1alpha1.AllocatedNodeList{}
+
+	opts := []client.ListOption{
+		client.MatchingFields{"spec.allocatedNodeRequest": nodeAllocationRequest.Name},
+	}
+
+	if err := sharedutils.RetryOnConflictOrRetriableOrNotFound(retry.DefaultRetry, func() error {
+		return c.List(ctx, nodelist, opts...)
+	}); err != nil {
+		logger.InfoContext(ctx, "Unable to query node list", slog.String("error", err.Error()))
+		return nil, fmt.Errorf("failed to query node list: %w", err)
+	}
+
+	return nodelist, nil
+}

--- a/hwmgr-plugins/controller/utils/node_allocation_request.utils.go
+++ b/hwmgr-plugins/controller/utils/node_allocation_request.utils.go
@@ -1,0 +1,216 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	pluginv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+)
+
+const (
+	NodeAllocationRequestFinalizer = "o2ims-hardwaremanagement.oran.openshift.io/nodeallocationrequest-finalizer"
+)
+
+var nodeAllocationRequestGVK schema.GroupVersionKind
+
+func InitNodeAllocationRequestUtils(scheme *runtime.Scheme) error {
+	nodeAllocationRequest := &pluginv1alpha1.NodeAllocationRequest{}
+	gvks, unversioned, err := scheme.ObjectKinds(nodeAllocationRequest)
+	if err != nil {
+		return fmt.Errorf("failed to query scheme to get GVK for NodeAllocationRequest CR: %w", err)
+	}
+	if unversioned || len(gvks) != 1 {
+		return fmt.Errorf("expected a single versioned item in ObjectKinds response, got %d with unversioned=%t", len(gvks), unversioned)
+	}
+
+	nodeAllocationRequestGVK = gvks[0]
+
+	return nil
+}
+
+func GetNodeAllocationRequest(ctx context.Context, client client.Reader, key client.ObjectKey, nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest) error {
+	if err := client.Get(ctx, key, nodeAllocationRequest); err != nil {
+		return fmt.Errorf("failed to get NodeAllocationRequest: %w", err)
+	}
+
+	if nodeAllocationRequest.Kind == "" {
+		// The non-caching query doesn't set the GVK for the CR, so do it now
+		nodeAllocationRequest.SetGroupVersionKind(nodeAllocationRequestGVK)
+	}
+
+	return nil
+}
+
+func GetNodeAllocationRequestProvisionedCondition(nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest) *metav1.Condition {
+	return meta.FindStatusCondition(
+		nodeAllocationRequest.Status.Conditions,
+		string(pluginv1alpha1.Provisioned))
+}
+
+func IsNodeAllocationRequestProvisionedCompleted(nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest) bool {
+	provisionedCondition := GetNodeAllocationRequestProvisionedCondition(nodeAllocationRequest)
+	if provisionedCondition != nil && provisionedCondition.Status == metav1.ConditionTrue {
+		return true
+	}
+
+	return false
+}
+
+func IsNodeAllocationRequestProvisionedFailed(nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest) bool {
+	provisionedCondition := GetNodeAllocationRequestProvisionedCondition(nodeAllocationRequest)
+	if provisionedCondition != nil && provisionedCondition.Reason == string(pluginv1alpha1.Failed) {
+		return true
+	}
+
+	return false
+}
+
+func UpdateNodeAllocationRequestSelectedGroups(
+	ctx context.Context,
+	c client.Client,
+	nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest) error {
+
+	// nolint: wrapcheck
+	err := sharedutils.RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
+		newNodeAllocationRequest := &pluginv1alpha1.NodeAllocationRequest{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(nodeAllocationRequest), newNodeAllocationRequest); err != nil {
+			return err
+		}
+		newNodeAllocationRequest.Status.SelectedGroups = nodeAllocationRequest.Status.SelectedGroups
+		if err := c.Status().Update(ctx, newNodeAllocationRequest); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to update NodeAllocationRequest selectedGroups: %w", err)
+	}
+
+	return nil
+}
+
+func UpdateNodeAllocationRequestPluginStatus(
+	ctx context.Context,
+	c client.Client,
+	nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest) error {
+
+	// nolint: wrapcheck
+	err := sharedutils.RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
+		newNodeAllocationRequest := &pluginv1alpha1.NodeAllocationRequest{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(nodeAllocationRequest), newNodeAllocationRequest); err != nil {
+			return err
+		}
+		newNodeAllocationRequest.Status.HwMgrPlugin.ObservedGeneration = newNodeAllocationRequest.ObjectMeta.Generation
+		if err := c.Status().Update(ctx, newNodeAllocationRequest); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to update NodeAllocationRequest condition: %w", err)
+	}
+
+	return nil
+}
+
+func UpdateNodeAllocationRequestStatusCondition(
+	ctx context.Context,
+	c client.Client,
+	nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest,
+	conditionType pluginv1alpha1.ConditionType,
+	conditionReason pluginv1alpha1.ConditionReason,
+	conditionStatus metav1.ConditionStatus,
+	message string) error {
+
+	SetStatusCondition(&nodeAllocationRequest.Status.Conditions,
+		string(conditionType),
+		string(conditionReason),
+		conditionStatus,
+		message)
+
+	// nolint: wrapcheck
+	err := sharedutils.RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
+		newNodeAllocationRequest := &pluginv1alpha1.NodeAllocationRequest{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(nodeAllocationRequest), newNodeAllocationRequest); err != nil {
+			return err
+		}
+		SetStatusCondition(&newNodeAllocationRequest.Status.Conditions,
+			string(conditionType),
+			string(conditionReason),
+			conditionStatus,
+			message)
+		if err := c.Status().Update(ctx, newNodeAllocationRequest); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to update NodeAllocationRequest condition: %s, %w", nodeAllocationRequest.Name, err)
+	}
+
+	return nil
+}
+
+func NodeAllocationRequestAddFinalizer(
+	ctx context.Context,
+	c client.Client,
+	nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest,
+) error {
+	// nolint: wrapcheck
+	err := sharedutils.RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
+		newNodeAllocationRequest := &pluginv1alpha1.NodeAllocationRequest{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(nodeAllocationRequest), newNodeAllocationRequest); err != nil {
+			return err
+		}
+		controllerutil.AddFinalizer(newNodeAllocationRequest, NodeAllocationRequestFinalizer)
+		if err := c.Update(ctx, newNodeAllocationRequest); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add finalizer to NodeAllocationRequest: %w", err)
+	}
+	return nil
+}
+
+func NodeAllocationRequestRemoveFinalizer(
+	ctx context.Context,
+	c client.Client,
+	nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest,
+) error {
+	// nolint: wrapcheck
+	err := sharedutils.RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
+		newNodeAllocationRequest := &pluginv1alpha1.NodeAllocationRequest{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(nodeAllocationRequest), newNodeAllocationRequest); err != nil {
+			return err
+		}
+		controllerutil.RemoveFinalizer(newNodeAllocationRequest, NodeAllocationRequestFinalizer)
+		if err := c.Update(ctx, newNodeAllocationRequest); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to remove finalizer from NodeAllocationRequest: %w", err)
+	}
+	return nil
+}

--- a/hwmgr-plugins/loopback/cmd/start_loopbackplugin_server.go
+++ b/hwmgr-plugins/loopback/cmd/start_loopbackplugin_server.go
@@ -1,0 +1,239 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	hwpluginutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
+	loopbackctrl "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/loopback/controllers"
+	loopbackserver "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/loopback/server"
+	"github.com/openshift-kni/oran-o2ims/internal"
+	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/exit"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
+	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(hwmgmtv1alpha1.AddToScheme(scheme))
+}
+
+// Create creates and returns the `start` command.
+func Start() *cobra.Command {
+	result := &cobra.Command{
+		Use:   "loopback-hardwareplugin-manager",
+		Short: "Loopback HardwarePlugin Manager",
+		Args:  cobra.NoArgs,
+	}
+	result.AddCommand(ControllerManager())
+	return result
+}
+
+// ControllerManagerCommand contains the data and logic needed to run the `loopback-hardwareplugin-manager start` command.
+type ControllerManagerCommand struct {
+	metricsAddr          string
+	metricsCertDir       string
+	enableHTTP2          bool
+	enableLeaderElection bool
+	probeAddr            string
+	svcutils.CommonServerConfig
+}
+
+// NewControllerManager creates a new runner that knows how to execute the `loopback-hardwareplugin-manager start` command.
+func NewControllerManager() *ControllerManagerCommand {
+	return &ControllerManagerCommand{}
+}
+
+// ControllerManager represents the start command for the Loopback HardwarePlugin Manager
+func ControllerManager() *cobra.Command {
+	c := NewControllerManager()
+	result := &cobra.Command{
+		Use:   "start",
+		Short: "Start the Loopback HardwarePlugin manager",
+		Args:  cobra.NoArgs,
+		RunE:  c.run,
+	}
+
+	flags := result.Flags()
+
+	flags.StringVar(
+		&c.metricsAddr,
+		"metrics-bind-address",
+		":8080",
+		"The address the metric endpoint binds to.",
+	)
+	flags.StringVar(
+		&c.metricsCertDir,
+		"metrics-tls-cert-dir",
+		"",
+		"The directory containing the tls.crt and tls.key.",
+	)
+	flags.StringVar(
+		&c.probeAddr,
+		"health-probe-bind-address",
+		":8081",
+		"The address the probe endpoint binds to.",
+	)
+	flags.BoolVar(
+		&c.enableHTTP2,
+		"enable-http2",
+		false,
+		"If set, HTTP/2 will be enabled for the metrics and webhook servers",
+	)
+	flags.BoolVar(
+		&c.enableLeaderElection,
+		"leader-elect",
+		false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.",
+	)
+	flags.StringVar(
+		&c.Listener.Address,
+		svcutils.ListenerFlagName,
+		fmt.Sprintf("127.0.0.1:%d", sharedutils.DefaultContainerPort),
+		"API listener address",
+	)
+	flags.StringVar(
+		&c.TLS.CertFile,
+		svcutils.ServerCertFileFlagName,
+		fmt.Sprintf("%s/tls.crt", sharedutils.TLSServerMountPath),
+		"Server certificate file",
+	)
+	flags.StringVar(
+		&c.TLS.KeyFile,
+		svcutils.ServerKeyFileFlagName,
+		fmt.Sprintf("%s/tls.key", sharedutils.TLSServerMountPath),
+		"Server private key file",
+	)
+	return result
+}
+
+// run executes the `loopback-hardwareplugin-manager start` command.
+func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error {
+
+	ctx := cmd.Context()
+
+	// Set the logger from context
+	logger := internal.LoggerFromContext(ctx)
+	logAdapter := logr.FromSlogHandler(logger.Handler())
+	ctrl.SetLogger(logAdapter)
+	klog.SetLogger(logAdapter)
+
+	// Set the TLS options
+	// If the enable-http2 flag is false (the default), http/2 will be disabled due to its vulnerabilities.
+	// More specifically, disabling http/2 will prevent from being vulnerable to the HTTP/2 Stream
+	// Cancelation and Rapid Reset CVEs. For more information see:
+	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
+	// - https://github.com/advisories/GHSA-4374-p667-p6c8
+	tlsOpts := []func(*tls.Config){}
+
+	if !c.enableHTTP2 {
+		tlsOpts = append(tlsOpts, func(c *tls.Config) {
+			logger.InfoContext(ctx, "disabling http/2")
+			c.NextProtos = []string{"http/1.1"}
+		})
+	}
+
+	if err := hwpluginutils.InitNodeAllocationRequestUtils(scheme); err != nil {
+		logger.ErrorContext(ctx, "failed InitNodeAllocationRequestUtils", slog.String("error", err.Error()))
+		return exit.Error(1)
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			SecureServing:  c.metricsCertDir != "",
+			CertDir:        c.metricsCertDir,
+			BindAddress:    c.metricsAddr,
+			TLSOpts:        tlsOpts,
+			FilterProvider: filters.WithAuthenticationAndAuthorization,
+		},
+		HealthProbeBindAddress: c.probeAddr,
+		LeaderElection:         c.enableLeaderElection,
+		LeaderElectionID:       "d5b3dd24.openshift.io",
+	})
+	if err != nil {
+		logger.ErrorContext(ctx, "Unable to start manager", slog.String("error", err.Error()))
+		return exit.Error(1)
+	}
+
+	loopbackHWPluginReconciler := &loopbackctrl.LoopbackPluginReconciler{
+		Manager:         mgr,
+		Client:          mgr.GetClient(),
+		NoncachedClient: mgr.GetAPIReader(),
+		Scheme:          mgr.GetScheme(),
+		Logger:          slog.New(logging.NewLoggingContextHandler(slog.LevelInfo)).With(slog.String("controller", "LoopbackHWPlugin")),
+	}
+
+	// Start the Loopback HardwarePlugin controller
+	if err := loopbackHWPluginReconciler.SetupWithManager(mgr); err != nil {
+		logger.ErrorContext(ctx, "Unable to create controller",
+			slog.String("controller", "LoopbackHWPlugin"), slog.String("error", err.Error()))
+		return exit.Error(1)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		logger.ErrorContext(ctx, "Unable to set up health check", slog.String("error", err.Error()))
+		return exit.Error(1)
+	}
+
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		logger.ErrorContext(ctx, "Unable to set up ready check", slog.String("error", err.Error()))
+		return exit.Error(1)
+	}
+
+	serverErrors := make(chan error, 1)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		logger.Info("Starting Loopback HardwarePlugin API server")
+		err = loopbackserver.Serve(ctx, c.CommonServerConfig)
+	}()
+
+	go func() {
+		logger.Info("Starting manager")
+		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+			logger.ErrorContext(ctx, "Problem running manager", slog.String("error", err.Error()))
+			serverErrors <- err
+			return
+		}
+		// The manager has terminated normally. Cancel the context to allow the API server to shutdown
+		cancel()
+	}()
+
+	select {
+	case err = <-serverErrors:
+		// Server failed to start
+		logger.ErrorContext(ctx, "Problem running internal server", slog.String("error", err.Error()))
+		return exit.Error(1)
+	case <-ctx.Done():
+		return exit.Error(0)
+	}
+}

--- a/hwmgr-plugins/loopback/controllers/loopback_hardwareplugin_controller.go
+++ b/hwmgr-plugins/loopback/controllers/loopback_hardwareplugin_controller.go
@@ -1,0 +1,161 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	pluginv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	hwpluginutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
+)
+
+// LoopbackPluginReconciler reconciles NodeAllocationRequest objects associated with the loopback H/W plugin
+type LoopbackPluginReconciler struct {
+	ctrl.Manager
+	client.Client
+	NoncachedClient client.Reader
+	Scheme          *runtime.Scheme
+	Logger          *slog.Logger
+	indexerEnabled  bool
+}
+
+func (r *LoopbackPluginReconciler) SetupIndexer(ctx context.Context) error {
+	// Setup AllocatedNode CRD indexer. This field indexer allows us to query a list of AllocatedNode CRs, filtered by the spec.nodeAllocationRequest field.
+	nodeIndexFunc := func(obj client.Object) []string {
+		return []string{obj.(*pluginv1alpha1.AllocatedNode).Spec.NodeAllocationRequest}
+	}
+
+	if err := r.Manager.GetFieldIndexer().IndexField(ctx, &pluginv1alpha1.AllocatedNode{}, hwpluginutils.AllocatedNodeSpecNodeAllocationRequestKey, nodeIndexFunc); err != nil {
+		return fmt.Errorf("failed to setup node indexer: %w", err)
+	}
+
+	return nil
+}
+
+//+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+//+kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=nodeallocationrequests,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=nodeallocationrequests/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=nodeallocationrequests/finalizers,verbs=update
+//+kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=allocatednodes,verbs=get;create;list;watch;update;patch;delete
+//+kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=allocatednodes/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=allocatednodes/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;create;update;patch;watch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;create;update;patch;watch;delete
+
+func (r *LoopbackPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+	_ = log.FromContext(ctx)
+
+	// Add logging context with the NodeAllocationRequest name
+	ctx = logging.AppendCtx(ctx, slog.String("NodeAllocationRequest", req.Name))
+
+	if !r.indexerEnabled {
+		if err := r.SetupIndexer(ctx); err != nil {
+			return hwpluginutils.DoNotRequeue(), fmt.Errorf("failed to setup indexer: %w", err)
+		}
+		r.Logger.InfoContext(ctx, "NodeAllocationRequest field indexer initialized")
+		r.indexerEnabled = true
+	}
+
+	// Fetch the nodeAllocationRequest, using non-caching client
+	nodeAllocationRequest := &pluginv1alpha1.NodeAllocationRequest{}
+	if err := hwpluginutils.GetNodeAllocationRequest(ctx, r.NoncachedClient, req.NamespacedName, nodeAllocationRequest); err != nil {
+		if errors.IsNotFound(err) {
+			// The NodeAllocationRequest object has likely been deleted
+			return hwpluginutils.DoNotRequeue(), nil
+		}
+		r.Logger.InfoContext(ctx, "Unable to fetch NodeAllocationRequest. Requeuing", slog.String("error", err.Error()))
+		return hwpluginutils.RequeueWithShortInterval(), nil
+	}
+
+	// Add logging context with data from the CR
+	ctx = logging.AppendCtx(ctx, slog.String("CloudID", nodeAllocationRequest.Spec.CloudID))
+	ctx = logging.AppendCtx(ctx, slog.String("startingResourceVersion", nodeAllocationRequest.ResourceVersion))
+
+	r.Logger.InfoContext(ctx, "Reconciling NodeAllocationRequest")
+
+	if nodeAllocationRequest.GetDeletionTimestamp() != nil {
+		// Handle deletion
+		r.Logger.InfoContext(ctx, "NodeAllocationRequest is being deleted")
+		if controllerutil.ContainsFinalizer(nodeAllocationRequest, hwpluginutils.NodeAllocationRequestFinalizer) {
+			completed, deleteErr := r.HandleNodeAllocationRequestDeletion(ctx, nodeAllocationRequest)
+			if deleteErr != nil {
+				return hwpluginutils.RequeueWithShortInterval(), fmt.Errorf("failed HandleNodeAllocationRequestDeletion: %w", deleteErr)
+			}
+
+			if !completed {
+				r.Logger.InfoContext(ctx, "Deletion handling in progress, requeueing")
+				return hwpluginutils.RequeueWithShortInterval(), nil
+			}
+
+			if finalizerErr := hwpluginutils.NodeAllocationRequestRemoveFinalizer(ctx, r.Client, nodeAllocationRequest); finalizerErr != nil {
+				r.Logger.InfoContext(ctx, "Failed to remove finalizer, requeueing", slog.String("error", finalizerErr.Error()))
+				return hwpluginutils.RequeueWithShortInterval(), nil
+			}
+
+			r.Logger.InfoContext(ctx, "Deletion handling complete, finalizer removed")
+			return hwpluginutils.DoNotRequeue(), nil
+		}
+
+		r.Logger.InfoContext(ctx, "No finalizer, deletion handling complete")
+		return hwpluginutils.DoNotRequeue(), nil
+	}
+
+	// Handle NodeAllocationRequest
+	result, err = r.HandleNodeAllocationRequest(ctx, nodeAllocationRequest)
+	if err != nil {
+		return result, fmt.Errorf("failed to handle NodeAllocationRequest: %w", err)
+	}
+
+	return result, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *LoopbackPluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&pluginv1alpha1.NodeAllocationRequest{}).
+		// TODO - add predicate filter to filter for NodeAllocationRequests associated with the Loopback Hw Plugin
+		Complete(r); err != nil {
+		return fmt.Errorf("failed to create controller: %w", err)
+	}
+
+	return nil
+}
+
+// HandleNodeAllocationRequest processes the NodeAllocationRequest CR
+func (r *LoopbackPluginReconciler) HandleNodeAllocationRequest(ctx context.Context, nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest) (ctrl.Result, error) {
+	result := hwpluginutils.DoNotRequeue()
+
+	// TODO
+
+	if !controllerutil.ContainsFinalizer(nodeAllocationRequest, hwpluginutils.NodeAllocationRequestFinalizer) {
+		r.Logger.InfoContext(ctx, "Adding finalizer to NodeAllocationRequest")
+		if err := hwpluginutils.NodeAllocationRequestAddFinalizer(ctx, r.Client, nodeAllocationRequest); err != nil {
+			return hwpluginutils.RequeueImmediately(), fmt.Errorf("failed to add finalizer to NodeAllocationRequest: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// HandleNodeAllocationRequestDeletion processes the NodeAllocationRequest CR deletion
+func (r *LoopbackPluginReconciler) HandleNodeAllocationRequestDeletion(ctx context.Context, nodeAllocationRequest *pluginv1alpha1.NodeAllocationRequest) (bool, error) {
+
+	// TODO
+
+	return true, nil
+}

--- a/hwmgr-plugins/loopback/server/serve.go
+++ b/hwmgr-plugins/loopback/server/serve.go
@@ -1,0 +1,158 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api"
+	hwpluginserver "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/generated/server"
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/auth"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
+	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
+)
+
+// Loopback HardwarePlugin Server config values
+const (
+	readTimeout  = 5 * time.Second
+	writeTimeout = 10 * time.Second
+	idleTimeout  = 120 * time.Second
+)
+
+// Serve starts the Loopback HardwarePlugin API server and blocks until it terminates or context is canceled.
+func Serve(ctx context.Context, config svcutils.CommonServerConfig) error {
+	slog.Info("Initializing the Loopback HardwarePlugin server")
+
+	// Retrieve the OpenAPI spec file
+	swagger, err := hwpluginserver.GetSwagger()
+	if err != nil {
+		return fmt.Errorf("failed to get swagger: %w", err)
+	}
+
+	// Channel for shutdown signals
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		sig := <-shutdown
+		slog.InfoContext(ctx, "Shutdown signal received", slog.String("signal", sig.String()))
+		cancel()
+	}()
+
+	// Get client for hub
+	hubClient, err := k8s.NewClientForHub()
+	if err != nil {
+		return fmt.Errorf("error creating client for hub: %w", err)
+	}
+
+	// Init loopbackServer
+	loopbackServer := LoopbackPluginServer{
+		CommonServerConfig: config,
+		HubClient:          hubClient,
+	}
+
+	serverStrictHandler := hwpluginserver.NewStrictHandlerWithOptions(&loopbackServer, nil,
+		hwpluginserver.StrictHTTPServerOptions{
+			RequestErrorHandlerFunc:  api.GetRequestErrorFunc(),
+			ResponseErrorHandlerFunc: api.GetResponseErrorFunc(),
+		},
+	)
+
+	baseRouter := http.NewServeMux()
+	// Register a default handler that replies with 404 so that we can override the response format
+	baseRouter.HandleFunc("/", api.GetNotFoundFunc())
+
+	// Create authn/authz middleware
+	authn, err := auth.GetAuthenticator(ctx, &config)
+	if err != nil {
+		return fmt.Errorf("error setting up Loopback HardwarePlugin authenticator middleware: %w", err)
+	}
+
+	authz, err := auth.GetAuthorizer()
+	if err != nil {
+		return fmt.Errorf("error setting up Loopback HardwarePlugin authorizer middleware: %w", err)
+	}
+
+	opt := hwpluginserver.StdHTTPServerOptions{
+		BaseRouter: baseRouter,
+		Middlewares: []hwpluginserver.MiddlewareFunc{
+			api.GetOpenAPIValidationFunc(swagger),
+			authz,
+			authn,
+			api.GetLogDurationFunc(),
+		},
+		ErrorHandlerFunc: api.GetRequestErrorFunc(),
+	}
+
+	// Register the handler
+	hwpluginserver.HandlerWithOptions(serverStrictHandler, opt)
+
+	handler := middleware.ChainHandlers(
+		baseRouter,
+		middleware.ErrorJsonifier(),
+		middleware.TrailingSlashStripper(),
+	)
+
+	serverTLSConfig, err := utils.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
+	if err != nil {
+		return fmt.Errorf("failed to get Loopback HardwarePlugin server TLS config: %w", err)
+	}
+
+	srv := &http.Server{
+		Handler:      handler,
+		Addr:         config.Listener.Address,
+		TLSConfig:    serverTLSConfig,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
+		IdleTimeout:  idleTimeout,
+		ErrorLog:     slog.NewLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}), slog.LevelError),
+	}
+
+	// Start server
+	serverErrors := make(chan error, 1)
+	go func() {
+		slog.Info(fmt.Sprintf("Listening on %s", srv.Addr))
+		// Cert/Key files aren't needed here since they've been added to the tls.Config above.
+		if err := srv.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErrors <- err
+		}
+	}()
+
+	defer func() {
+		// Cancel the context in case it wasn't already canceled
+		cancel()
+		// Shutdown the Loopback HardwarePlugin server
+		slog.Info("Shutting down Loopback HardwarePlugin server")
+		if err := common.GracefulShutdown(srv); err != nil {
+			slog.Error("error shutting down Loopback HardwarePlugin server", "error", err)
+		}
+	}()
+
+	// Blocking select
+	select {
+	case err := <-serverErrors:
+		return fmt.Errorf("error starting Loopback HardwarePlugin server: %w", err)
+	case <-ctx.Done():
+		slog.Info("Process shutting down Loopback HardwarePlugin server")
+	}
+
+	return nil
+}

--- a/hwmgr-plugins/loopback/server/server.go
+++ b/hwmgr-plugins/loopback/server/server.go
@@ -1,0 +1,139 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package server
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	generated "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/generated/server"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
+)
+
+// LoopbackPluginServer implements StricerServerInterface.
+// This ensures that we've conformed to the `StrictServerInterface` with a compile-time check.
+var _ generated.StrictServerInterface = (*LoopbackPluginServer)(nil)
+
+type LoopbackPluginServer struct {
+	utils.CommonServerConfig
+	HubClient client.Client
+}
+
+var baseURL = "/hardware-manager/provisioning/v1"
+var currentVerion = "1.0.0"
+
+// GetAllVersions handles an API request to fetch all versions
+func (s *LoopbackPluginServer) GetAllVersions(_ context.Context, _ generated.GetAllVersionsRequestObject,
+) (generated.GetAllVersionsResponseObject, error) {
+	// We currently only support a single version
+	versions := []generated.APIVersion{
+		{
+			Version: &currentVerion,
+		},
+	}
+	return generated.GetAllVersions200JSONResponse(generated.APIVersions{
+		ApiVersions: &versions,
+		UriPrefix:   &baseURL,
+	}), nil
+}
+
+// GetMinorVersions handles an API request to fetch minor versions
+func (s *LoopbackPluginServer) GetMinorVersions(_ context.Context, _ generated.GetMinorVersionsRequestObject,
+) (generated.GetMinorVersionsResponseObject, error) {
+	// We currently support a single version
+	versions := []generated.APIVersion{
+		{
+			Version: &currentVerion,
+		},
+	}
+	return generated.GetMinorVersions200JSONResponse(generated.APIVersions{
+		ApiVersions: &versions,
+		UriPrefix:   &baseURL,
+	}), nil
+}
+
+func (s *LoopbackPluginServer) GetNodeAllocationRequests(
+	ctx context.Context,
+	request generated.GetNodeAllocationRequestsRequestObject,
+) (generated.GetNodeAllocationRequestsResponseObject, error) {
+
+	// TODO
+
+	return generated.GetNodeAllocationRequests200JSONResponse{}, nil
+}
+
+func (s *LoopbackPluginServer) GetNodeAllocationRequest(
+	ctx context.Context,
+	request generated.GetNodeAllocationRequestRequestObject,
+) (generated.GetNodeAllocationRequestResponseObject, error) {
+
+	// TODO
+
+	return generated.GetNodeAllocationRequest200JSONResponse{}, nil
+}
+
+// CreateNodeAllocationRequest creates a NodeAllocationRequest object
+func (s *LoopbackPluginServer) CreateNodeAllocationRequest(
+	ctx context.Context,
+	request generated.CreateNodeAllocationRequestRequestObject,
+) (generated.CreateNodeAllocationRequestResponseObject, error) {
+
+	// TODO
+
+	return generated.CreateNodeAllocationRequest202JSONResponse(""), nil
+}
+
+func (s *LoopbackPluginServer) UpdateNodeAllocationRequest(
+	ctx context.Context,
+	request generated.UpdateNodeAllocationRequestRequestObject,
+) (generated.UpdateNodeAllocationRequestResponseObject, error) {
+
+	// TODO
+
+	return generated.UpdateNodeAllocationRequest202JSONResponse{}, nil
+}
+
+func (s *LoopbackPluginServer) DeleteNodeAllocationRequest(
+	ctx context.Context,
+	request generated.DeleteNodeAllocationRequestRequestObject,
+) (generated.DeleteNodeAllocationRequestResponseObject, error) {
+
+	// TODO
+
+	return generated.DeleteNodeAllocationRequest202JSONResponse{}, nil
+}
+
+func (s *LoopbackPluginServer) GetAllocatedNodes(
+	ctx context.Context,
+	request generated.GetAllocatedNodesRequestObject,
+) (generated.GetAllocatedNodesResponseObject, error) {
+
+	// TODO
+
+	return generated.GetAllocatedNodes200JSONResponse{}, nil
+}
+
+func (s *LoopbackPluginServer) GetAllocatedNode(
+	ctx context.Context,
+	request generated.GetAllocatedNodeRequestObject,
+) (generated.GetAllocatedNodeResponseObject, error) {
+
+	// TODO
+
+	return generated.GetAllocatedNode200JSONResponse{}, nil
+}
+
+func (s *LoopbackPluginServer) GetAllocatedNodesFromNodeAllocationRequest(
+	ctx context.Context,
+	request generated.GetAllocatedNodesFromNodeAllocationRequestRequestObject,
+) (generated.GetAllocatedNodesFromNodeAllocationRequestResponseObject, error) {
+
+	// TODO
+
+	return generated.GetAllocatedNodesFromNodeAllocationRequest200JSONResponse{}, nil
+}

--- a/internal/controllers/loopbackplugin_server_setup.go
+++ b/internal/controllers/loopbackplugin_server_setup.go
@@ -1,0 +1,190 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+)
+
+// setupLoopbackPluginServer creates the Kubernetes resources necessary to start the loopback hardware plugin server.
+func (t *reconcilerTask) setupLoopbackPluginServer(ctx context.Context, defaultResult ctrl.Result) (nextReconcile ctrl.Result, err error) {
+
+	nextReconcile = defaultResult
+
+	if err = t.createServiceAccount(ctx, utils.LoopbackPluginServerName); err != nil {
+		t.logger.ErrorContext(ctx, "Failed to deploy ServiceAccount for the Loopback hardware plugin server.",
+			slog.String("error", err.Error()))
+		return
+	}
+
+	if err = t.createLoopbackPluginServerClusterRole(ctx); err != nil {
+		t.logger.ErrorContext(ctx, "Failed to create ClusterRole for the Loopback hardware plugin server.",
+			slog.String("error", err.Error()))
+		return
+	}
+
+	if err = t.createServerClusterRoleBinding(ctx, utils.LoopbackPluginServerName); err != nil {
+		t.logger.ErrorContext(ctx, "Failed to create server ClusterRoleBinding for the Loopback hardware plugin server.",
+			slog.String("error", err.Error()))
+		return
+	}
+
+	if err = t.createServerRbacClusterRoleBinding(ctx, utils.LoopbackPluginServerName); err != nil {
+		t.logger.ErrorContext(ctx, "Failed to create RBAC ClusterRoleBinding for the Loopback hardware plugin server.",
+			slog.String("error", err.Error()))
+		return
+	}
+
+	if err = t.createService(ctx, utils.LoopbackPluginServerName, utils.DefaultServicePort, utils.DefaultServiceTargetPort); err != nil {
+		t.logger.ErrorContext(ctx, "Failed to deploy Service for the Loopback hardware plugin server.",
+			slog.String("error", err.Error()))
+		return
+	}
+
+	errorReason, err := t.deployServer(ctx, utils.LoopbackPluginServerName)
+	if err != nil {
+		t.logger.ErrorContext(ctx, "Failed to deploy the Loopback plugin hardware server.",
+			slog.String("error", err.Error()))
+		if errorReason == "" {
+			nextReconcile = ctrl.Result{RequeueAfter: 60 * time.Second}
+		}
+	}
+
+	return nextReconcile, err
+}
+
+func (t *reconcilerTask) createLoopbackPluginServerClusterRole(ctx context.Context) error {
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf(
+				"%s-%s", t.object.Namespace, utils.LoopbackPluginServerName,
+			),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"namespaces",
+					"secrets",
+					"configmaps",
+				},
+				Verbs: []string{
+					"create",
+					"get",
+					"list",
+					"patch",
+					"update",
+					"watch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"o2ims-hardwaremanagement.oran.openshift.io",
+				},
+				Resources: []string{
+					"nodeallocationrequests",
+					"allocatednodes",
+				},
+				Verbs: []string{
+					"create",
+					"get",
+					"list",
+					"patch",
+					"update",
+					"watch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"o2ims-hardwaremanagement.oran.openshift.io",
+				},
+				Resources: []string{
+					"nodeallocationrequests/status",
+					"allocatednodes/status",
+				},
+				Verbs: []string{
+					"get",
+					"patch",
+					"update",
+				},
+			},
+			{
+				APIGroups: []string{
+					"o2ims-hardwaremanagement.oran.openshift.io",
+				},
+				Resources: []string{
+					"nodeallocationrequests/finalizers",
+					"allocatednodes/finalizers",
+				},
+				Verbs: []string{
+					"update",
+				},
+			},
+			{
+				APIGroups: []string{
+					"coordination.k8s.io",
+				},
+				Resources: []string{
+					"leases",
+				},
+				Verbs: []string{
+					"create",
+					"get",
+					"list",
+					"patch",
+					"update",
+					"watch",
+					"delete",
+				},
+			},
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"events",
+				},
+				Verbs: []string{
+					"create",
+					"patch",
+					"update",
+				},
+			},
+			// Provisioning URL
+			{
+				NonResourceURLs: []string{
+					"/hardware-manager/provisioning/*",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"create",
+					"post",
+					"put",
+					"delete",
+				},
+			},
+		},
+	}
+
+	if err := utils.CreateK8sCR(ctx, t.client, role, t.object, utils.UPDATE); err != nil {
+		return fmt.Errorf("failed to create Cluster Server cluster role: %w", err)
+	}
+
+	return nil
+}

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -44,6 +44,12 @@ const (
 	HardwarePluginManagerServerName = HardwarePluginManager + serverSuffix
 )
 
+// HardwarePlugins
+const (
+	LoopbackPlugin           = "loopback-hardwareplugin"
+	LoopbackPluginServerName = LoopbackPlugin + serverSuffix
+)
+
 // IngressName defines the name of our ingress controller
 const IngressName = "oran-o2ims-ingress"
 
@@ -110,6 +116,18 @@ var (
 		"--metrics-bind-address=:8080",
 		fmt.Sprintf("--metrics-tls-cert-dir=%s", TLSServerMountPath),
 		"--leader-elect",
+	}
+
+	LoopbackPluginServerArgs = []string{
+		"loopback-hardwareplugin-manager",
+		"start",
+		"--health-probe-bind-address=:8081",
+		"--metrics-bind-address=:8080",
+		fmt.Sprintf("--metrics-tls-cert-dir=%s", TLSServerMountPath),
+		"--leader-elect",
+		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", DefaultContainerPort),
+		fmt.Sprintf("--tls-server-cert=%s/tls.crt", TLSServerMountPath),
+		fmt.Sprintf("--tls-server-key=%s/tls.key", TLSServerMountPath),
 	}
 )
 
@@ -268,6 +286,13 @@ const (
 	PostgresImageName       = "POSTGRES_IMAGE"
 	HwMgrPluginNameSpace    = "HWMGR_PLUGIN_NAMESPACE"
 	InternalServicePortName = "INTERNAL_SERVICE_PORT"
+)
+
+// Deploy Loopback HardwarePlugin constants
+const (
+	DeployLoopbackHWPluginEnvVar  = "DEPLOY_LOOPBACK_HW_PLUGIN"
+	DefaultDeployLoopbackHWPlugin = "false"
+	DeployLoopbackHWPluginOk      = "true"
 )
 
 // ClusterVersionName is the name given to the default ClusterVersion object

--- a/internal/controllers/utils/hardware_utils.go
+++ b/internal/controllers/utils/hardware_utils.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -595,4 +596,14 @@ func GetBMHNamespace(node *hwv1alpha1.AllocatedNode) string {
 		return ns
 	}
 	return node.Spec.HwMgrNodeNs
+}
+
+// GetDeployLoopbackHWPlugin returns the value of environment variable DEPLOY_LOOPBACK_HW_PLUGIN
+func GetDeployLoopbackHWPlugin() string {
+	return GetEnvOrDefault(DeployLoopbackHWPluginEnvVar, DefaultDeployLoopbackHWPlugin)
+}
+
+// ShouldDeployLoopbackHWPlugin returns a boolean value indiciating if the Loopback HardwarePlugin should be installed
+func ShouldDeployLoopbackHWPlugin() bool {
+	return strings.EqualFold(GetDeployLoopbackHWPlugin(), DeployLoopbackHWPluginOk)
 }

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -166,7 +166,8 @@ func HasApiEndpoints(serverName string) bool {
 		serverName == InventoryResourceServerName ||
 		serverName == InventoryArtifactsServerName ||
 		serverName == InventoryProvisioningServerName ||
-		serverName == HardwarePluginManagerServerName
+		serverName == HardwarePluginManagerServerName ||
+		serverName == LoopbackPluginServerName
 }
 
 // HasDatabase determines whether a server owns a logical database instance
@@ -183,7 +184,8 @@ func RequiresInternalListener(serverName string) bool {
 	return serverName == InventoryResourceServerName ||
 		serverName == InventoryClusterServerName ||
 		serverName == InventoryAlarmServerName ||
-		serverName == HardwarePluginManagerServerName
+		serverName == HardwarePluginManagerServerName ||
+		serverName == LoopbackPluginServerName
 }
 
 // IsOAuthEnabled determines if the Inventory CR has OAuth attributes provided.
@@ -200,7 +202,8 @@ func NeedsOAuthAccess(serverName string) bool {
 		serverName == InventoryAlarmServerName ||
 		serverName == InventoryArtifactsServerName ||
 		serverName == InventoryProvisioningServerName ||
-		serverName == HardwarePluginManagerServerName
+		serverName == HardwarePluginManagerServerName ||
+		serverName == LoopbackPluginServerName
 }
 
 // getTLSClientCertificateSecret determines whether there is a TLS secret configured.
@@ -487,6 +490,12 @@ func GetServerArgs(inventory *inventoryv1alpha1.Inventory, serverName string) (r
 	// HwMgr Plugin Controller
 	if serverName == HardwarePluginManagerServerName {
 		result = slices.Clone(HardwarePluginManagerArgs)
+		return
+	}
+
+	// Loopback Plugin Server
+	if serverName == LoopbackPluginServerName {
+		result = slices.Clone(LoopbackPluginServerArgs)
 		return
 	}
 


### PR DESCRIPTION
# Summary

This PR adds the Loopback Hardware Plugin server infrastructure to `hwmgr-plugins`. Subsequent PRs will incorporate the API endpoint logic as well as `NodeAllocationRequest` handling.

/cc @browsell @alegacy @donpenney @tliu2021 