### PR TITLE
Improve how the host node ID label is applied to an agent post provisioning

### DIFF
--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -246,6 +246,12 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		return exit.Error(1)
 	}
 
+	// Register the field index for BareMetalHost
+	if err := controllers.SetupBareMetalHostIndexer(ctx, mgr); err != nil {
+		logger.ErrorContext(ctx, "Unable to set up BareMetalHost indexer", slog.Any("error", err))
+		return exit.Error(1)
+	}
+
 	// Start the Cluster Template controller.
 	if err = (&controllers.ClusterTemplateReconciler{
 		Client: mgr.GetClient(),

--- a/internal/controllers/provisioningrequest_clusterconfig.go
+++ b/internal/controllers/provisioningrequest_clusterconfig.go
@@ -329,7 +329,10 @@ func (t *provisioningRequestReconcilerTask) addPostProvisioningLabels(ctx contex
 				continue
 			}
 
-			bmh := utils.GetBareMetalHostForAllocatedNode(ctx, t.client, node.Id)
+			bmh, err := utils.GetBareMetalHostFromHostname(ctx, t.client, hostName)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve BareMetalHost corresponding with hostname '%s': %w", hostName, err)
+			}
 			if bmh == nil {
 				continue
 			}


### PR DESCRIPTION
# Summary

This PR enhances the post-provisioning process by refining the application of the host node ID label to the `Agent` object. It ensures accurate matching of the `BareMetalHost` resource with the specified `hostname`, while also improving support for non-Metal3 hardware plugins, thereby increasing reliability and flexibility in node identification.

/cc @browsell @donpenney @alegacy @tliu2021 