### PR TITLE
Add missing RBAC permissions for hardware plugin API access

### DIFF
--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -92,6 +92,7 @@ func GetClusterTemplateRefName(name, version string) string {
 //+kubebuilder:rbac:groups=lcm.openshift.io,resources=imagebasedgroupupgrades/status,verbs=get
 //+kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;patch;update;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;patch;update;watch
+//+kubebuilder:rbac:urls="/hardware-manager/provisioning/*",verbs=get;list;create;post;put;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
# Summary

This PR adds non-resource URL permissions for `/hardware-manager/provisioning/*` to the `ProvisioningRequestReconciler` to resolve authorization failures when updating `NodeAllocationRequest` resources via the hardware manager plugin client.

/cc @browsell @donpenney @alegacy 