### PR TITLE
metal3: Update inventory reporting

### DIFF
--- a/hwmgr-plugins/metal3/server/inventory_server.go
+++ b/hwmgr-plugins/metal3/server/inventory_server.go
@@ -44,5 +44,5 @@ func (m *Metal3PluginInventoryServer) GetResourcePools(ctx context.Context, requ
 
 func (m *Metal3PluginInventoryServer) GetResources(ctx context.Context, request inventory.GetResourcesRequestObject) (inventory.GetResourcesResponseObject, error) {
 	// nolint: wrapcheck
-	return metal3ctrl.GetResources(ctx, m.HubClient)
+	return metal3ctrl.GetResources(ctx, m.Logger, m.HubClient)
 }

--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -27,7 +27,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 )
 
-const pollingDelay = 10 * time.Minute
+const pollingDelay = 1 * time.Minute
 
 // asyncEventBufferSize defines the number of buffered entries in the async handleWatchEvent channel
 const asyncEventBufferSize = 10

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -25,7 +25,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/repo"
 )
 
-const pollingDelay = 10 * time.Minute
+const pollingDelay = 1 * time.Minute
 
 // asyncEventBufferSize defines the number of buffered entries in the async event channel
 const asyncEventBufferSize = 10


### PR DESCRIPTION
This update includes the following:
- Fix metal3 resource pool reporting so all pools are returned
- Add additional info to metal3 resource query, with annotations to support adding details to the BMH
- Reduce inventory polling interval to 1 minute from 10