### PR TITLE
Update PR reconciler to requeue when ClusterProvision condition is not yet present

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1825,6 +1825,7 @@ spec:
         serviceAccountName: oran-o2ims-controller-manager
       deployments:
       - label:
+          app: o-cloud-manager
           app.kubernetes.io/component: manager
           app.kubernetes.io/created-by: oran-o2ims
           app.kubernetes.io/instance: controller-manager
@@ -1844,6 +1845,7 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
+                app: o-cloud-manager
                 control-plane: controller-manager
             spec:
               containers:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,7 @@ metadata:
     app.kubernetes.io/created-by: oran-o2ims
     app.kubernetes.io/part-of: oran-o2ims
     app.kubernetes.io/managed-by: kustomize
+    app: o-cloud-manager
 spec:
   selector:
     matchLabels:
@@ -35,6 +36,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app: o-cloud-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -693,7 +693,7 @@ func (t *reconcilerTask) setupSmo(ctx context.Context) (err error) {
 
 		registerOnRestart = false // this is a one-time registration on restarts for development/debug
 	} else {
-		t.logger.InfoContext(
+		t.logger.DebugContext(
 			ctx, fmt.Sprintf("already registered with the SMO at: %s", t.object.Spec.SmoConfig.URL),
 		)
 	}
@@ -1453,7 +1453,7 @@ func (t *reconcilerTask) createServerClusterRoleBinding(ctx context.Context, ser
 }
 
 func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (utils.InventoryConditionReason, error) {
-	t.logger.InfoContext(ctx, "[deploy server]", "Name", serverName)
+	t.logger.DebugContext(ctx, "[deploy server]", "Name", serverName)
 
 	// Server variables.
 	deploymentVolumes := utils.GetDeploymentVolumes(serverName, t.object)
@@ -1648,7 +1648,7 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (u
 		Spec:       deploymentSpec,
 	}
 
-	t.logger.InfoContext(ctx, "[deployManagerServer] Create/Update/Patch Server", "Name", serverName)
+	t.logger.DebugContext(ctx, "[deployManagerServer] Create/Update/Patch Server", "Name", serverName)
 	if err := utils.CreateK8sCR(ctx, t.client, newDeployment, t.object, utils.UPDATE); err != nil {
 		return "", fmt.Errorf("failed to deploy ManagerServer: %w", err)
 	}
@@ -1657,7 +1657,7 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (u
 }
 
 func (t *reconcilerTask) createServiceAccount(ctx context.Context, resourceName string) error {
-	t.logger.InfoContext(ctx, "[createServiceAccount]")
+	t.logger.DebugContext(ctx, "[createServiceAccount]")
 	// Build the ServiceAccount object.
 	serviceAccountMeta := metav1.ObjectMeta{
 		Name:      resourceName,
@@ -1670,7 +1670,7 @@ func (t *reconcilerTask) createServiceAccount(ctx context.Context, resourceName 
 		ObjectMeta: serviceAccountMeta,
 	}
 
-	t.logger.InfoContext(ctx, "[createServiceAccount] Create/Update/Patch ServiceAccount: ", "name", resourceName)
+	t.logger.DebugContext(ctx, "[createServiceAccount] Create/Update/Patch ServiceAccount: ", "name", resourceName)
 	if err := utils.CreateK8sCR(ctx, t.client, newServiceAccount, t.object, utils.UPDATE); err != nil {
 		return fmt.Errorf("failed to create ServiceAccount for deployment: %w", err)
 	}
@@ -1679,7 +1679,7 @@ func (t *reconcilerTask) createServiceAccount(ctx context.Context, resourceName 
 }
 
 func (t *reconcilerTask) createService(ctx context.Context, resourceName string, port int32, targetPort string) error {
-	t.logger.InfoContext(ctx, "[createService]")
+	t.logger.DebugContext(ctx, "[createService]")
 	// Build the Service object.
 	serviceMeta := metav1.ObjectMeta{
 		Name:      resourceName,
@@ -1710,7 +1710,7 @@ func (t *reconcilerTask) createService(ctx context.Context, resourceName string,
 		Spec:       serviceSpec,
 	}
 
-	t.logger.InfoContext(ctx, "[createService] Create/Update/Patch Service: ", "name", resourceName)
+	t.logger.DebugContext(ctx, "[createService] Create/Update/Patch Service: ", "name", resourceName)
 	if err := utils.CreateK8sCR(ctx, t.client, newService, t.object, utils.UPDATE); err != nil {
 		return fmt.Errorf("failed to create Service for deployment: %w", err)
 	}
@@ -1719,7 +1719,7 @@ func (t *reconcilerTask) createService(ctx context.Context, resourceName string,
 }
 
 func (t *reconcilerTask) createIngress(ctx context.Context) error {
-	t.logger.InfoContext(ctx, "[createIngress]")
+	t.logger.DebugContext(ctx, "[createIngress]")
 	// Build the Ingress object.
 	className := utils.IngressClassName
 	ingressMeta := metav1.ObjectMeta{
@@ -1834,7 +1834,7 @@ func (t *reconcilerTask) createIngress(ctx context.Context) error {
 		Spec:       ingressSpec,
 	}
 
-	t.logger.InfoContext(ctx, "[createIngress] Create/Update/Patch Ingress: ", "name", utils.IngressPortName)
+	t.logger.DebugContext(ctx, "[createIngress] Create/Update/Patch Ingress: ", "name", utils.IngressPortName)
 	if err := utils.CreateK8sCR(ctx, t.client, newIngress, t.object, utils.UPDATE); err != nil {
 		return fmt.Errorf("failed to create Ingress for deployment: %w", err)
 	}
@@ -1897,7 +1897,7 @@ func (t *reconcilerTask) updateInventoryStatusConditions(ctx context.Context, de
 func (t *reconcilerTask) updateInventoryUsedConfigStatus(
 	ctx context.Context, serverName string, deploymentArgs []string,
 	errorReason utils.InventoryConditionReason, err error) error {
-	t.logger.InfoContext(ctx, "[updateInventoryUsedConfigStatus]")
+	t.logger.DebugContext(ctx, "[updateInventoryUsedConfigStatus]")
 
 	if serverName == utils.InventoryResourceServerName {
 		t.object.Status.UsedServerConfig.ResourceServerUsedConfig = deploymentArgs
@@ -1949,7 +1949,7 @@ func (t *reconcilerTask) updateInventoryUsedConfigStatus(
 
 func (t *reconcilerTask) updateInventoryDeploymentStatus(ctx context.Context) error {
 
-	t.logger.InfoContext(ctx, "[updateInventoryDeploymentStatus]")
+	t.logger.DebugContext(ctx, "[updateInventoryDeploymentStatus]")
 	t.updateInventoryStatusConditions(ctx, utils.InventoryAlarmServerName)
 	t.updateInventoryStatusConditions(ctx, utils.InventoryResourceServerName)
 	t.updateInventoryStatusConditions(ctx, utils.InventoryClusterServerName)

--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -27,7 +27,7 @@ import (
 // deployPostgresServer deploys the actual Postgres database server instance.  Prior to invoking this method the other
 // required resources must have already been created (i.e., configmaps, secrets, service accounts, etc...).
 func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName string) error {
-	t.logger.InfoContext(ctx, "[deploy postgres server]", "Name", serverName)
+	t.logger.DebugContext(ctx, "[deploy postgres server]", "Name", serverName)
 
 	// Default server volumes.
 	deploymentVolumes := utils.GetDeploymentVolumes(serverName, t.object)
@@ -151,7 +151,7 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 		Spec:       deploymentSpec,
 	}
 
-	t.logger.InfoContext(ctx, "[deployDatabase] Create/Update/Patch Server", "Name", serverName)
+	t.logger.DebugContext(ctx, "[deployDatabase] Create/Update/Patch Server", "Name", serverName)
 	if err := utils.CreateK8sCR(ctx, t.client, newDeployment, t.object, utils.UPDATE); err != nil {
 		return fmt.Errorf("failed to deploy database: %w", err)
 	}
@@ -161,7 +161,7 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 
 // createPasswords sets up the admin and service passwords for the Postgres database.
 func (t *reconcilerTask) createPasswords(ctx context.Context, serverName string) error {
-	t.logger.InfoContext(ctx, "[createPasswords]")
+	t.logger.DebugContext(ctx, "[createPasswords]")
 
 	// Create the passwords secret
 	passwordSecretName := fmt.Sprintf("%s-passwords", serverName)
@@ -212,7 +212,7 @@ func (t *reconcilerTask) createPasswords(ctx context.Context, serverName string)
 
 // createDatabase sets up all necessary resources to instantiate a Postgres database server.
 func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
-	t.logger.InfoContext(ctx, "[createDatabase]")
+	t.logger.DebugContext(ctx, "[createDatabase]")
 
 	err = t.createServiceAccount(ctx, utils.InventoryDatabaseServerName)
 	if err != nil {
@@ -235,7 +235,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 	}
 
 	// Create the config volume
-	t.logger.InfoContext(ctx, "[createDatabase] creating database config volume")
+	t.logger.DebugContext(ctx, "[createDatabase] creating database config volume")
 	configVolumeName := fmt.Sprintf("%s-config", utils.InventoryDatabaseServerName)
 	err = utils.CreateConfigMapFromEmbeddedFile(ctx, t.client, t.object,
 		postgres.Artifacts, postgres.ConfigFilePath, t.object.Namespace, configVolumeName, postgres.ConfigFileName)
@@ -249,7 +249,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 	}
 
 	// Create the startup volume
-	t.logger.InfoContext(ctx, "[createDatabase] creating database startup volume")
+	t.logger.DebugContext(ctx, "[createDatabase] creating database startup volume")
 	startupVolumeName := fmt.Sprintf("%s-startup", utils.InventoryDatabaseServerName)
 	err = utils.CreateConfigMapFromEmbeddedFile(ctx, t.client, t.object,
 		postgres.Artifacts, postgres.StartupFilePath, t.object.Namespace, startupVolumeName, postgres.StartupFileName)
@@ -263,7 +263,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 	}
 
 	// Create the service passwords
-	t.logger.InfoContext(ctx, "[createDatabase] creating database service passwords")
+	t.logger.DebugContext(ctx, "[createDatabase] creating database service passwords")
 	err = t.createPasswords(ctx, utils.InventoryDatabaseServerName)
 	if err != nil {
 		t.logger.ErrorContext(

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -193,10 +193,13 @@ func (t *provisioningRequestReconcilerTask) run(ctx context.Context) (ctrl.Resul
 	if err != nil {
 		return requeueWithError(err)
 	}
-	if !utils.IsClusterProvisionPresent(t.object) ||
-		utils.IsClusterProvisionTimedOutOrFailed(t.object) {
+	if !utils.IsClusterProvisionPresent(t.object) {
+		t.logger.InfoContext(ctx, "ClusterProvision not present, requeueing", slog.String("name", t.object.Name))
+		return requeueWithShortInterval(), nil
+	} else if utils.IsClusterProvisionTimedOutOrFailed(t.object) {
 		// If the cluster installation has not started due to
 		// processing issue, failed or timed out, do not requeue.
+		t.logger.InfoContext(ctx, "ClusterProvision timed out or failed, do not requeue", slog.String("name", t.object.Name))
 		return doNotRequeue(), nil
 	}
 

--- a/internal/controllers/provisioningrequest_upgrade.go
+++ b/internal/controllers/provisioningrequest_upgrade.go
@@ -51,13 +51,15 @@ func (t *provisioningRequestReconcilerTask) IsUpgradeRequested(
 		return false, fmt.Errorf("failed to parse ManagedCluster version: %w", err)
 	}
 	cmp := templateReleaseVersion.Compare(*managedClusterVersion)
-	if cmp == 1 {
+	switch cmp {
+	case 1:
 		return true, nil
-	} else if cmp == -1 {
+	case -1:
 		return false, fmt.Errorf("template version (%v) is lower then ManagedCluster version (%v), no upgrade requested",
 			templateReleaseVersion, managedClusterVersion)
+	default:
+		return false, nil
 	}
-	return false, nil
 }
 
 // handleUpgrade handles the upgrade of the cluster through IBGU. It returns a ctrl.Result to indicate

--- a/internal/service/alarms/internal/serviceconfig/serviceconfig.go
+++ b/internal/service/alarms/internal/serviceconfig/serviceconfig.go
@@ -197,6 +197,11 @@ func (c *Config) generateCronJob(configMap corev1.ConfigMap) batchv1.CronJob {
 				Spec: batchv1.JobSpec{
 					BackoffLimit: ptr.To(jobBackoffLimit),
 					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": cleanupCronJobName,
+							},
+						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: corev1.RestartPolicyOnFailure,
 							Containers: []corev1.Container{


### PR DESCRIPTION
- Update PR reconciler to requeue when ClusterProvision condition is not yet present
- Change recurrent inventory reconciler logs to Debug to eliminate flood of logs every 5 minutes
- Add app label to controller-manager and alarms-server-events-cleanup pods to get rid of warning in controller-manager logs