### PR TITLE
CNF-18183:: Added BMH deprovisioning on AllocatedNode deletion

### DIFF
--- a/hwmgr-plugins/api/server/provisioning/server.go
+++ b/hwmgr-plugins/api/server/provisioning/server.go
@@ -247,9 +247,11 @@ func (h *HardwarePluginServer) DeleteNodeAllocationRequest(
 				Status: http.StatusNotFound,
 			}), nil
 	}
+	deletePolicy := metav1.DeletePropagationForeground
+	deleteOptions := &client.DeleteOptions{PropagationPolicy: &deletePolicy}
 
 	// Delete the NodeAllocationRequest resource
-	if err := h.HubClient.Delete(ctx, existingNodeAllocationRequest); err != nil {
+	if err := h.HubClient.Delete(ctx, existingNodeAllocationRequest, deleteOptions); err != nil {
 		return nil, fmt.Errorf("failed to delete NodeAllocationRequest '%s', err: %w", request.NodeAllocationRequestId, err)
 	}
 

--- a/hwmgr-plugins/metal3/cmd/start_metal3plugin_server.go
+++ b/hwmgr-plugins/metal3/cmd/start_metal3plugin_server.go
@@ -33,7 +33,6 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal"
 	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/exit"
-	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 )
 
@@ -186,18 +185,8 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		return exit.Error(1)
 	}
 
-	metal3HWPluginReconciler := &metal3ctrl.Metal3PluginReconciler{
-		Manager:         mgr,
-		Client:          mgr.GetClient(),
-		NoncachedClient: mgr.GetAPIReader(),
-		Scheme:          mgr.GetScheme(),
-		Logger:          slog.New(logging.NewLoggingContextHandler(slog.LevelInfo)).With(slog.String("controller", "Metal3HWPlugin")),
-		PluginNamespace: hwpluginserver.GetMetal3HWPluginNamespace(),
-	}
-
-	// Start the Metal3 HardwarePlugin controller
-	if err := metal3HWPluginReconciler.SetupWithManager(mgr); err != nil {
-		logger.ErrorContext(ctx, "Unable to create controller",
+	if err := metal3ctrl.SetupMetal3Controllers(mgr, hwpluginserver.GetMetal3HWPluginNamespace()); err != nil {
+		logger.ErrorContext(ctx, "Unable to create metal3 plugin controller",
 			slog.String("controller", "Metal3HWPlugin"), slog.String("error", err.Error()))
 		return exit.Error(1)
 	}

--- a/hwmgr-plugins/metal3/controller/inventory.go
+++ b/hwmgr-plugins/metal3/controller/inventory.go
@@ -228,7 +228,8 @@ func includeInInventory(bmh *metal3v1alpha1.BareMetalHost) bool {
 	case metal3v1alpha1.StateAvailable,
 		metal3v1alpha1.StateProvisioning,
 		metal3v1alpha1.StateProvisioned,
-		metal3v1alpha1.StatePreparing:
+		metal3v1alpha1.StatePreparing,
+		metal3v1alpha1.StateDeprovisioning:
 		return true
 	}
 	return false

--- a/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller.go
+++ b/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller.go
@@ -1,0 +1,139 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	hwpluginutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
+)
+
+// AllocatedNodeReconciler reconciles NodeAllocationRequest objects associated with the Metal3 H/W plugin
+type AllocatedNodeReconciler struct {
+	ctrl.Manager
+	client.Client
+	NoncachedClient client.Reader
+	Scheme          *runtime.Scheme
+	Logger          *slog.Logger
+	PluginNamespace string
+}
+
+// +kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=allocatednodes,verbs=get;create;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=allocatednodes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=o2ims-hardwaremanagement.oran.openshift.io,resources=allocatednodes/finalizers,verbs=update
+func (r *AllocatedNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+	_ = log.FromContext(ctx)
+
+	// Add logging context with the resource name
+	ctx = logging.AppendCtx(ctx, slog.String("ReconcileRequest", req.Name))
+
+	allocatedNode, err := hwpluginutils.GetNode(ctx, r.Logger, r.NoncachedClient, req.Namespace, req.Name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// The AllocatedNode object has likely been deleted
+			r.Logger.InfoContext(ctx, "Node no longer exists.")
+			return hwpluginutils.DoNotRequeue(), nil
+		}
+		r.Logger.InfoContext(ctx, "Unable to fetch AllocatedNode. Requeuing", slog.String("error", err.Error()))
+		return hwpluginutils.RequeueWithShortInterval(), nil
+	}
+
+	// Add logging context with data from the CR
+	ctx = logging.AppendCtx(ctx, slog.String("startingResourceVersion", allocatedNode.ResourceVersion))
+
+	r.Logger.InfoContext(ctx, "Reconciling AllocatedNode")
+
+	if allocatedNode.GetDeletionTimestamp() != nil {
+		// Handle deletion
+		r.Logger.InfoContext(ctx, "AllocatedNode is being deleted")
+		if controllerutil.ContainsFinalizer(allocatedNode, hwpluginutils.AllocatedNodeFinalizer) {
+			completed, deleteErr := r.handleAllocatedNodeDeletion(ctx, allocatedNode)
+			if deleteErr != nil {
+				return hwpluginutils.RequeueWithShortInterval(), fmt.Errorf("failed CleanupForDeletedNode: %w", deleteErr)
+			}
+
+			if !completed {
+				r.Logger.InfoContext(ctx, "Node deletion handling in progress, requeueing")
+				return hwpluginutils.RequeueWithShortInterval(), nil
+			}
+
+			if finalizerErr := hwpluginutils.AllocatedNodeRemoveFinalizer(ctx, r.NoncachedClient, r.Client, allocatedNode); finalizerErr != nil {
+				r.Logger.InfoContext(ctx, "Failed to remove finalizer, requeueing", slog.String("error", finalizerErr.Error()))
+				return hwpluginutils.RequeueWithShortInterval(), nil
+			}
+
+			r.Logger.InfoContext(ctx, "Deletion handling complete, finalizer removed")
+			return hwpluginutils.DoNotRequeue(), nil
+		}
+
+		r.Logger.InfoContext(ctx, "No finalizer, deletion handling complete")
+		return hwpluginutils.DoNotRequeue(), nil
+	}
+
+	if !controllerutil.ContainsFinalizer(allocatedNode, hwpluginutils.AllocatedNodeFinalizer) {
+		if finalizerErr := hwpluginutils.AllocatedNodeAddFinalizer(ctx, r.NoncachedClient, r.Client, allocatedNode); finalizerErr != nil {
+			r.Logger.InfoContext(ctx, "Failed to add node finalizer, requeueing", slog.String("error", finalizerErr.Error()))
+			return hwpluginutils.RequeueWithShortInterval(), nil
+		}
+	}
+
+	return hwpluginutils.DoNotRequeue(), nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *AllocatedNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	// Create a label selector for filtering AllocatedNode pertaining to the Metal3 HardwarePlugin
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			hwpluginutils.HardwarePluginLabel: hwpluginutils.Metal3HardwarePluginID,
+		},
+	}
+
+	// Create a predicate to filter AllocatedNode with the specified metal3 H/W plugin label
+	pred, err := predicate.LabelSelectorPredicate(labelSelector)
+	if err != nil {
+		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&hwmgmtv1alpha1.AllocatedNode{}).
+		WithEventFilter(pred).
+		Complete(r); err != nil {
+		return fmt.Errorf("failed to create allocated node controller: %w", err)
+	}
+
+	return nil
+}
+
+// CleanupForDeletedNode
+func (r *AllocatedNodeReconciler) handleAllocatedNodeDeletion(ctx context.Context, allocatednode *hwmgmtv1alpha1.AllocatedNode) (bool, error) {
+
+	r.Logger.InfoContext(ctx, "handleAllocatedNodeDeletion")
+	bmh, err := getBMHForNode(ctx, r.Client, allocatednode)
+	if err != nil {
+		return true, fmt.Errorf("failed to get BMH for node %s: %w", allocatednode.Name, err)
+	}
+
+	if err = deallocateBMH(ctx, r.Client, r.Logger, bmh); err != nil {
+		return false, fmt.Errorf("failed to deallocate BMH: %w", err)
+	}
+	return true, nil
+}

--- a/hwmgr-plugins/metal3/controller/metal3_hardwareplugin_setup.go
+++ b/hwmgr-plugins/metal3/controller/metal3_hardwareplugin_setup.go
@@ -1,0 +1,47 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupMetal3Controllers(mgr ctrl.Manager, namespace string) error {
+	baseLogger := slog.New(logging.NewLoggingContextHandler(slog.LevelInfo))
+
+	nodeAllocationReconciler := &NodeAllocationRequestReconciler{
+		Client:          mgr.GetClient(),
+		NoncachedClient: mgr.GetAPIReader(),
+		Scheme:          mgr.GetScheme(),
+		Logger:          baseLogger.With(slog.String("controller", "metal3_nodeallocationrequest_controller")),
+		PluginNamespace: namespace,
+		Manager:         mgr,
+	}
+
+	if err := nodeAllocationReconciler.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("failed to setup NodeAllocationRequest controller: %w", err)
+	}
+
+	allocatedReconciler := &AllocatedNodeReconciler{
+		Client:          mgr.GetClient(),
+		NoncachedClient: mgr.GetAPIReader(),
+		Scheme:          mgr.GetScheme(),
+		Logger:          baseLogger.With(slog.String("controller", "metal3_allocatednode_controller")),
+		PluginNamespace: namespace,
+		Manager:         mgr,
+	}
+
+	if err := allocatedReconciler.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("failed to setup AllocatedNode controller: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This update introduces a reconcile hook on AllocatedNode deletion that initiates deprovisioning of the associated BMH.

Additionally, it ensures that the corresponding NodeAllocationRequest is deleted once all its child AllocatedNode resources are removed.

The deletion uses the DeletePropagationForeground policy to guarantee that all dependent resources are fully cleaned up before the NodeAllocationRequest itself is deleted.