### PR TITLE
Wait for BMH to become Available before powering off the host

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -2019,6 +2019,7 @@ spec:
       operations:
       - CREATE
       - UPDATE
+      - DELETE
       resources:
       - provisioningrequests
     sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -21,6 +21,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - provisioningrequests
   sideEffects: None

--- a/hwmgr-plugins/metal3/controller/helpers.go
+++ b/hwmgr-plugins/metal3/controller/helpers.go
@@ -798,3 +798,10 @@ func getNodeAllocationRequestBMHNamespace(ctx context.Context,
 
 	return "", nil // No allocated BMH found, return empty namespace
 }
+
+func isNodeProvisioningInProgress(allocatednode *pluginsv1alpha1.AllocatedNode) bool {
+	condition := meta.FindStatusCondition(allocatednode.Status.Conditions, string(hwmgmtv1alpha1.Provisioned))
+	return condition != nil &&
+		condition.Status == metav1.ConditionFalse &&
+		condition.Reason == string(hwmgmtv1alpha1.InProgress)
+}


### PR DESCRIPTION
When a node is deleted, the deallocation hook powers off the host as part
of the deprovisioning process. However, if a BIOS firmware update job
is still in progress at the time of deletion, the job may get stuck,
preventing the BMH from transitioning to the Available state.

This update ensures the host is powered off only after deprovisioning is
complete and the BMH has reached the Available state, allowing any pending
jobs to finish successfully. This behavior applies only if the BMH has not
been provisioned.

To protect provisioned hosts, deletion of a ProvisionRequest in the
Configuration In Progress state (i.e., after the host has been provisioned)
will now be blocked by a validating webhook.