### PR TITLE
Add transient error retry handling for BMH errors

### DIFF
--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,8 @@ import (
 // BMHAllocationStatus defines filtering options for FetchBMHList
 type BMHAllocationStatus string
 
+const ErrorRetryWindow = 3 * time.Minute
+
 const (
 	AllBMHs         BMHAllocationStatus = "all"
 	UnallocatedBMHs BMHAllocationStatus = "unallocated"
@@ -42,6 +45,7 @@ const (
 	FirmwareUpdateNeededAnnotation = "clcm.openshift.io/firmware-update-needed"
 	BmhAllocatedLabel              = "clcm.openshift.io/allocated"
 	NodeNameAnnotation             = "clcm.openshift.io/node-name"
+	BmhErrorTimestampAnnotation    = "clcm.openshift.io/bmh-error-timestamp"
 	BmhHostMgmtAnnotation          = "bmac.agent-install.openshift.io/allow-provisioned-host-management"
 	BmhInfraEnvLabel               = "infraenvs.agent-install.openshift.io"
 	SiteConfigOwnedByLabel         = "siteconfig.open-cluster-management.io/owned-by"
@@ -239,7 +243,9 @@ func filterAvailableBMHs(bmhList metal3v1alpha1.BareMetalHostList) metal3v1alpha
 }
 
 // GroupBMHsByResourcePool groups unallocated BMHs by resource pool ID.
-func GroupBMHsByResourcePool(unallocatedBMHs metal3v1alpha1.BareMetalHostList) map[string][]metal3v1alpha1.BareMetalHost {
+func GroupBMHsByResourcePool(
+	unallocatedBMHs metal3v1alpha1.BareMetalHostList,
+) map[string][]metal3v1alpha1.BareMetalHost {
 	grouped := make(map[string][]metal3v1alpha1.BareMetalHost)
 	for _, bmh := range unallocatedBMHs.Items {
 		if resourcePoolID, exists := bmh.Labels[LabelResourcePoolID]; exists {
@@ -249,7 +255,9 @@ func GroupBMHsByResourcePool(unallocatedBMHs metal3v1alpha1.BareMetalHostList) m
 	return grouped
 }
 
-func buildInterfacesFromBMH(nodeAllocationRequest *pluginsv1alpha1.NodeAllocationRequest, bmh *metal3v1alpha1.BareMetalHost) ([]*pluginsv1alpha1.Interface, error) {
+func buildInterfacesFromBMH(
+	nodeAllocationRequest *pluginsv1alpha1.NodeAllocationRequest,
+	bmh *metal3v1alpha1.BareMetalHost) ([]*pluginsv1alpha1.Interface, error) {
 	var interfaces []*pluginsv1alpha1.Interface
 
 	if bmh.Status.HardwareDetails == nil {
@@ -500,11 +508,8 @@ func handleTransitionNodes(ctx context.Context,
 			if _, exists := bmh.Annotations[uc.AnnotationKey]; !exists {
 				continue
 			}
-
-			if err := processBMHUpdateCase(ctx, c, logger, pluginNamespace, &node, bmh, uc, postInstall); err != nil {
-				return true, err
-			}
-			return true, nil
+			// Only handle one update case per reconciliation cycle
+			return true, processBMHUpdateCase(ctx, c, logger, pluginNamespace, &node, bmh, uc, postInstall)
 		}
 	}
 
@@ -582,8 +587,13 @@ func processBMHUpdateCase(ctx context.Context,
 		LogLabel      string
 	}, postInstall bool) error {
 
-	if bmh.Status.OperationalStatus == metal3v1alpha1.OperationalStatusError && bmh.Status.ErrorType != metal3v1alpha1.PowerManagementError {
-		message := "BMH in error state"
+	if bmh.Status.OperationalStatus == metal3v1alpha1.OperationalStatusError {
+		tolerate, err := tolerateAndAnnotateTransientBMHError(ctx, c, logger, bmh)
+		if err != nil || tolerate {
+			return nil
+		}
+
+		message := fmt.Sprintf("BMH in error state: %s", bmh.Status.ErrorType)
 		logger.WarnContext(ctx, message, slog.String("BMH", bmh.Name))
 		condType := hwmgmtv1alpha1.Provisioned
 		if postInstall {
@@ -593,6 +603,12 @@ func processBMHUpdateCase(ctx context.Context,
 			logger.ErrorContext(ctx, "failed to set node failed status", slog.String("node", node.Name), slog.String("error", err.Error()))
 		}
 		return fmt.Errorf("unable to initiate update for BMH %s/%s", bmh.Namespace, bmh.Name)
+	}
+
+	// clear transient error annotation if BMH recovered
+	if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
+		logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+		return nil
 	}
 
 	// Check whether the current state of the BMH meets the transition condition.
@@ -667,12 +683,14 @@ func handleBMHCompletion(ctx context.Context,
 	}
 
 	// Check if BMH has transitioned to "Available"
-	bmhAvailable := checkBMHStatus(ctx, logger, bmh, metal3v1alpha1.StateAvailable)
-
 	// If BMH is not available yet, update is still ongoing
-	if !bmhAvailable {
+	if !checkBMHStatus(ctx, logger, bmh, metal3v1alpha1.StateAvailable) {
 		// BMH entered an error state
 		if bmh.Status.OperationalStatus == metal3v1alpha1.OperationalStatusError {
+			tolerate, err := tolerateAndAnnotateTransientBMHError(ctx, c, logger, bmh)
+			if err != nil || tolerate {
+				return true, err
+			}
 			errMessage := fmt.Errorf("bmh %s/%s in an error state %s", bmh.Namespace, bmh.Name, bmh.Status.Provisioning.State)
 			if err := hwpluginutils.SetNodeConditionStatus(ctx, c, noncachedClient, node.Name, node.Namespace,
 				string(hwmgmtv1alpha1.Provisioned), metav1.ConditionFalse,
@@ -682,7 +700,11 @@ func handleBMHCompletion(ctx context.Context,
 			}
 			return false, errMessage
 		}
-		return true, nil
+		// if BMH is not in error state, clean up transient annotation if it exists
+		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
+			logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+		}
+		return true, nil // still waiting for available
 	}
 
 	// Apply post-config updates and finalize the process
@@ -765,7 +787,6 @@ func removeInfraEnvLabelFromPreprovisioningImage(ctx context.Context, c client.C
 			slog.String("bmh", name.String()))
 		return nil
 	})
-
 }
 
 // removeInfraEnvLabel removes InfraEnvLabel from BMH and the corresponding PreprovisioningImage resource.
@@ -876,4 +897,71 @@ func allowHostManagement(ctx context.Context, c client.Client, logger *slog.Logg
 	}
 	name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 	return updateBMHMetaWithRetry(ctx, c, logger, name, MetaTypeAnnotation, BmhHostMgmtAnnotation, "", OpAdd)
+}
+
+func markBMHTransitenError(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
+	if bmh.Annotations == nil {
+		bmh.Annotations = make(map[string]string)
+	}
+	if _, exists := bmh.Annotations[BmhErrorTimestampAnnotation]; exists {
+		return nil // Already marked
+	}
+	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
+	return updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation,
+		BmhErrorTimestampAnnotation,
+		time.Now().Format(time.RFC3339), OpAdd)
+}
+
+func clearTransientBMHErrorAnnotation(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
+	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
+	return updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation,
+		BmhErrorTimestampAnnotation,
+		"", OpRemove)
+}
+
+func isTransientBMHError(bmh *metal3v1alpha1.BareMetalHost) (bool, error) {
+	if bmh.Status.OperationalStatus != metal3v1alpha1.OperationalStatusError {
+		return false, nil
+	}
+
+	tsStr, ok := bmh.Annotations[BmhErrorTimestampAnnotation]
+	if !ok {
+		// First time seeing the error, should be treated as transient error
+		return true, nil
+	}
+
+	ts, err := time.Parse(time.RFC3339, tsStr)
+	if err != nil {
+		return false, fmt.Errorf("invalid BMH error timestamp format: %w", err)
+	}
+
+	// Return true if still within retry window
+	return time.Since(ts) < ErrorRetryWindow, nil
+}
+
+func tolerateAndAnnotateTransientBMHError(
+	ctx context.Context,
+	c client.Client,
+	logger *slog.Logger,
+	bmh *metal3v1alpha1.BareMetalHost,
+) (bool, error) {
+	tolerate, err := isTransientBMHError(bmh)
+	if err != nil {
+		message := "error checking transient BMH error"
+		logger.WarnContext(ctx, message, slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+		return false, fmt.Errorf("%s: %w", message, err)
+	}
+
+	if tolerate {
+		if err := markBMHTransitenError(ctx, c, logger, bmh); err != nil {
+			message := "failed to annotate transient BMH error"
+			logger.WarnContext(ctx, message, slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+			return false, fmt.Errorf("%s: %w", message, err)
+		}
+		logger.InfoContext(ctx, "BMH in transient error — tolerating and skipping failure",
+			slog.String("BMH", bmh.Name))
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/hwmgr-plugins/metal3/controller/helpers.go
+++ b/hwmgr-plugins/metal3/controller/helpers.go
@@ -380,6 +380,11 @@ func handleInProgressUpdate(ctx context.Context,
 	if bmh.Status.OperationalStatus == metal3v1alpha1.OperationalStatusOK {
 		logger.InfoContext(ctx, "BMH update complete", slog.String("BMH", bmh.Name))
 
+		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
+			logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+			return hwpluginutils.RequeueImmediately(), true, err
+		}
+
 		// Update the node's status to reflect the new hardware profile.
 		node.Status.HwProfile = node.Spec.HwProfile
 		hwpluginutils.SetStatusCondition(&node.Status.Conditions,
@@ -399,6 +404,10 @@ func handleInProgressUpdate(ctx context.Context,
 	}
 
 	if bmh.Status.OperationalStatus == metal3v1alpha1.OperationalStatusError {
+		tolerate, err := tolerateAndAnnotateTransientBMHError(ctx, c, logger, bmh)
+		if err != nil || tolerate {
+			return hwpluginutils.RequeueWithMediumInterval(), true, err
+		}
 		logger.InfoContext(ctx, "BMH update failed", slog.String("BMH", bmh.Name))
 		if err := hwpluginutils.SetNodeConditionStatus(ctx, c, noncachedClient,
 			node.Name, node.Namespace,


### PR DESCRIPTION
This update introduces logic to detect and tolerate transient BareMetalHost errors. When a BMH enters an error state, the controller now records the first occurrence timestamp and allows retries within the 3-minute window.

During this window, the error is treated as transient and will not cause the AllocatedNode to be marked as failed. If the error persists beyond the window, the node status is updated to reflect the failure.

The retry timestamp is stored in a BMH annotation, and is cleared once recovery is detected.