### PR TITLE
refactor: centralize string literals into constants for improved main…

### DIFF
--- a/dev-tools/crd-watcher/inventory.go
+++ b/dev-tools/crd-watcher/inventory.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
+
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 )
 
 // debugTransport logs HTTP requests for debugging OAuth issues
@@ -215,7 +217,7 @@ func NewInventoryClient(config *InventoryConfig) (*InventoryClient, error) {
 	return &InventoryClient{
 		httpClient: httpClient,
 		config:     config,
-		baseURL:    config.ServerURL + "/o2ims-infrastructureInventory/v1",
+		baseURL:    config.ServerURL + constants.O2IMSInventoryBaseURL,
 		maxRetries: maxRetries,
 		retryDelay: time.Duration(retryDelayMs) * time.Millisecond,
 	}, nil
@@ -359,7 +361,7 @@ func (c *InventoryClient) GetNodeClusters(ctx context.Context) ([]NodeCluster, e
 	klog.V(2).Info("Fetching node clusters from inventory API")
 
 	// Node clusters use a different API path: /o2ims-infrastructureCluster/v1 instead of /o2ims-infrastructureInventory/v1
-	clusterBaseURL := strings.Replace(c.baseURL, "/o2ims-infrastructureInventory/v1", "/o2ims-infrastructureCluster/v1", 1)
+	clusterBaseURL := strings.Replace(c.baseURL, constants.O2IMSInventoryBaseURL, constants.O2IMSClusterBaseURL, 1)
 	url := clusterBaseURL + "/nodeClusters"
 
 	resp, err := c.retryHTTPRequest(ctx, func() (*http.Response, error) {

--- a/hwmgr-plugins/api/client/inventory/client.go
+++ b/hwmgr-plugins/api/client/inventory/client.go
@@ -14,7 +14,7 @@ import (
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	clientutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/utils"
-	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 )
 
@@ -37,7 +37,7 @@ func NewInventoryClient(
 	}
 
 	// Build OAuth client information if type is not ServiceAccount
-	cf := notifier.NewClientFactory(config, sharedutils.DefaultBackendTokenFile)
+	cf := notifier.NewClientFactory(config, constants.DefaultBackendTokenFile)
 	httpClient, err := cf.NewClient(ctx, hwPlugin.Spec.AuthClientConfig.Type)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build HTTP client: %w", err)

--- a/hwmgr-plugins/api/client/provisioning/client.go
+++ b/hwmgr-plugins/api/client/provisioning/client.go
@@ -16,7 +16,7 @@ import (
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	clientutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/utils"
-	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 )
 
@@ -50,7 +50,7 @@ func NewHardwarePluginClient(
 	}
 
 	// Build OAuth client information if type is not ServiceAccount
-	cf := notifier.NewClientFactory(config, sharedutils.DefaultBackendTokenFile)
+	cf := notifier.NewClientFactory(config, constants.DefaultBackendTokenFile)
 	httpClient, err := cf.NewClient(ctx, hwPlugin.Spec.AuthClientConfig.Type)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build HTTP client: %w", err)

--- a/hwmgr-plugins/api/client/utils/auth.go
+++ b/hwmgr-plugins/api/client/utils/auth.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
@@ -54,7 +55,7 @@ func setupCABundle(ctx context.Context, c client.Client, hwPlugin *hwmgmtv1alpha
 		return fmt.Errorf("failed to get CA bundle configmap: %w", err)
 	}
 
-	caBundle, err := sharedutils.GetConfigMapField(cm, sharedutils.CABundleFilename)
+	caBundle, err := sharedutils.GetConfigMapField(cm, constants.CABundleFilename)
 	if err != nil {
 		return fmt.Errorf("failed to get certificate bundle from configmap: %w", err)
 	}

--- a/hwmgr-plugins/api/server/inventory/server.go
+++ b/hwmgr-plugins/api/server/inventory/server.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -22,7 +23,7 @@ type InventoryServer struct {
 var _ StrictServerInterface = (*InventoryServer)(nil)
 
 // baseURL is the prefix for all of our supported API endpoints
-var baseURL = "/hardware-manager/inventory/v1"
+var baseURL = constants.HardwareManagerInventoryBaseURL
 var currentVersion = "1.0.0"
 
 // GetAllVersions handles an API request to fetch all versions

--- a/hwmgr-plugins/api/server/provisioning/server.go
+++ b/hwmgr-plugins/api/server/provisioning/server.go
@@ -20,6 +20,7 @@ import (
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	hwpluginutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 )
@@ -37,7 +38,7 @@ type HardwarePluginServer struct {
 	ResourcePrefix   string
 }
 
-var baseURL = "/hardware-manager/provisioning/v1"
+var baseURL = constants.HardwareManagerProvisioningBaseURL
 var currentVerion = "1.0.0"
 
 // GetAllVersions handles an API request to fetch all versions

--- a/hwmgr-plugins/cmd/start_hardwareplugin_manager.go
+++ b/hwmgr-plugins/cmd/start_hardwareplugin_manager.go
@@ -26,6 +26,7 @@ import (
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	hwmgrcontroller "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller"
 	"github.com/openshift-kni/oran-o2ims/internal"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/exit"
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
 )
@@ -43,7 +44,7 @@ func init() {
 // Create creates and returns the `start` command.
 func Start() *cobra.Command {
 	result := &cobra.Command{
-		Use:   "hardwareplugin-manager",
+		Use:   constants.HardwarePluginManagerCmd,
 		Short: "HardwarePlugin Manager",
 		Args:  cobra.NoArgs,
 	}
@@ -80,7 +81,7 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.metricsAddr,
 		"metrics-bind-address",
-		":8080",
+		constants.MetricsPort,
 		"The address the metric endpoint binds to.",
 	)
 	flags.StringVar(
@@ -92,7 +93,7 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.probeAddr,
 		"health-probe-bind-address",
-		":8081",
+		constants.HealthProbePort,
 		"The address the probe endpoint binds to.",
 	)
 	flags.BoolVar(

--- a/hwmgr-plugins/loopback/cmd/start_loopbackplugin_server.go
+++ b/hwmgr-plugins/loopback/cmd/start_loopbackplugin_server.go
@@ -30,7 +30,7 @@ import (
 	loopbackctrl "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/loopback/controller"
 	loopbackserver "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/loopback/server"
 	"github.com/openshift-kni/oran-o2ims/internal"
-	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/exit"
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
@@ -49,7 +49,7 @@ func init() {
 // Create creates and returns the `start` command.
 func Start() *cobra.Command {
 	result := &cobra.Command{
-		Use:   "loopback-hardwareplugin-manager",
+		Use:   constants.LoopbackHardwarePluginManagerCmd,
 		Short: "Loopback HardwarePlugin Manager",
 		Args:  cobra.NoArgs,
 	}
@@ -87,7 +87,7 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.metricsAddr,
 		"metrics-bind-address",
-		":8080",
+		constants.MetricsPort,
 		"The address the metric endpoint binds to.",
 	)
 	flags.StringVar(
@@ -99,7 +99,7 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.probeAddr,
 		"health-probe-bind-address",
-		":8081",
+		constants.HealthProbePort,
 		"The address the probe endpoint binds to.",
 	)
 	flags.BoolVar(
@@ -118,19 +118,19 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.Listener.Address,
 		svcutils.ListenerFlagName,
-		fmt.Sprintf("127.0.0.1:%d", sharedutils.DefaultContainerPort),
+		fmt.Sprintf("127.0.0.1:%d", constants.DefaultContainerPort),
 		"API listener address",
 	)
 	flags.StringVar(
 		&c.TLS.CertFile,
 		svcutils.ServerCertFileFlagName,
-		fmt.Sprintf("%s/tls.crt", sharedutils.TLSServerMountPath),
+		fmt.Sprintf("%s/tls.crt", constants.TLSServerMountPath),
 		"Server certificate file",
 	)
 	flags.StringVar(
 		&c.TLS.KeyFile,
 		svcutils.ServerKeyFileFlagName,
-		fmt.Sprintf("%s/tls.key", sharedutils.TLSServerMountPath),
+		fmt.Sprintf("%s/tls.key", constants.TLSServerMountPath),
 		"Server private key file",
 	)
 	return result

--- a/hwmgr-plugins/loopback/server/serve.go
+++ b/hwmgr-plugins/loopback/server/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api"
 	"github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/server/inventory"
 	"github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/server/provisioning"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
@@ -144,8 +145,8 @@ func Serve(ctx context.Context, config svcutils.CommonServerConfig, hubClient cl
 	})
 
 	// Mount subrouters to base router with path prefixes
-	baseRouter.Handle("/hardware-manager/provisioning/", provisioningRouter)
-	baseRouter.Handle("/hardware-manager/inventory/", inventoryRouter)
+	baseRouter.Handle(constants.HardwareManagerProvisioningAPIPath+"/", provisioningRouter)
+	baseRouter.Handle(constants.HardwareManagerInventoryAPIPath+"/", inventoryRouter)
 
 	// Apply global middleware chain
 	handler := middleware.ChainHandlers(

--- a/hwmgr-plugins/metal3/cmd/start_metal3plugin_server.go
+++ b/hwmgr-plugins/metal3/cmd/start_metal3plugin_server.go
@@ -32,7 +32,7 @@ import (
 	metal3ctrl "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/metal3/controller"
 	metal3server "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/metal3/server"
 	"github.com/openshift-kni/oran-o2ims/internal"
-	sharedutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/exit"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 )
@@ -51,7 +51,7 @@ func init() {
 // Create creates and returns the `start` command.
 func Start() *cobra.Command {
 	result := &cobra.Command{
-		Use:   "metal3-hardwareplugin-manager",
+		Use:   constants.Metal3HardwarePluginManagerCmd,
 		Short: "Metal3 HardwarePlugin Manager",
 		Args:  cobra.NoArgs,
 	}
@@ -89,7 +89,7 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.metricsAddr,
 		"metrics-bind-address",
-		":8080",
+		constants.MetricsPort,
 		"The address the metric endpoint binds to.",
 	)
 	flags.StringVar(
@@ -101,7 +101,7 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.probeAddr,
 		"health-probe-bind-address",
-		":8081",
+		constants.HealthProbePort,
 		"The address the probe endpoint binds to.",
 	)
 	flags.BoolVar(
@@ -120,19 +120,19 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.Listener.Address,
 		svcutils.ListenerFlagName,
-		fmt.Sprintf("127.0.0.1:%d", sharedutils.DefaultContainerPort),
+		fmt.Sprintf("127.0.0.1:%d", constants.DefaultContainerPort),
 		"API listener address",
 	)
 	flags.StringVar(
 		&c.TLS.CertFile,
 		svcutils.ServerCertFileFlagName,
-		fmt.Sprintf("%s/tls.crt", sharedutils.TLSServerMountPath),
+		fmt.Sprintf("%s/tls.crt", constants.TLSServerMountPath),
 		"Server certificate file",
 	)
 	flags.StringVar(
 		&c.TLS.KeyFile,
 		svcutils.ServerKeyFileFlagName,
-		fmt.Sprintf("%s/tls.key", sharedutils.TLSServerMountPath),
+		fmt.Sprintf("%s/tls.key", constants.TLSServerMountPath),
 		"Server private key file",
 	)
 	return result

--- a/hwmgr-plugins/metal3/server/serve.go
+++ b/hwmgr-plugins/metal3/server/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api"
 	"github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/server/inventory"
 	"github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/server/provisioning"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
@@ -147,8 +148,8 @@ func Serve(ctx context.Context, config svcutils.CommonServerConfig, hubClient cl
 	})
 
 	// Mount subrouters to base router with path prefixes
-	baseRouter.Handle("/hardware-manager/provisioning/", provisioningRouter)
-	baseRouter.Handle("/hardware-manager/inventory/", inventoryRouter)
+	baseRouter.Handle(constants.HardwareManagerProvisioningAPIPath+"/", provisioningRouter)
+	baseRouter.Handle(constants.HardwareManagerInventoryAPIPath+"/", inventoryRouter)
 
 	// Apply global middleware chain
 	handler := middleware.ChainHandlers(

--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -15,6 +15,7 @@ import (
 	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -63,7 +64,7 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.metricsAddr,
 		"metrics-bind-address",
-		":8080",
+		constants.MetricsPort,
 		"The address the metric endpoint binds to.",
 	)
 	flags.StringVar(
@@ -75,7 +76,7 @@ func ControllerManager() *cobra.Command {
 	flags.StringVar(
 		&c.probeAddr,
 		"health-probe-bind-address",
-		":8081",
+		constants.HealthProbePort,
 		"The address the probe endpoint binds to.",
 	)
 	flag.BoolVar(
@@ -99,7 +100,7 @@ func ControllerManager() *cobra.Command {
 		imageFlagName,
 		// Intentionally setting the default value to "" if the environment variable is not set to ensure we never
 		// run an image that we didn't intend on running.
-		utils.GetEnvOrDefault(utils.ServerImageName, ""),
+		utils.GetEnvOrDefault(constants.ServerImageName, ""),
 		"Reference of the container image containing the servers.",
 	)
 	return result

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,143 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package constants
+
+// O2 IMS API path prefixes
+const (
+	O2IMSInventoryAPIPath    = "/o2ims-infrastructureInventory"
+	O2IMSClusterAPIPath      = "/o2ims-infrastructureCluster"
+	O2IMSMonitoringAPIPath   = "/o2ims-infrastructureMonitoring"
+	O2IMSArtifactsAPIPath    = "/o2ims-infrastructureArtifacts"
+	O2IMSProvisioningAPIPath = "/o2ims-infrastructureProvisioning"
+)
+
+// Hardware Manager API path prefixes
+const (
+	HardwareManagerProvisioningAPIPath = "/hardware-manager/provisioning"
+	HardwareManagerInventoryAPIPath    = "/hardware-manager/inventory"
+)
+
+// API version suffix
+const APIVersionV1 = "/v1"
+
+// Full API base URLs (computed constants)
+var (
+	O2IMSInventoryBaseURL              = O2IMSInventoryAPIPath + APIVersionV1
+	O2IMSClusterBaseURL                = O2IMSClusterAPIPath + APIVersionV1
+	O2IMSMonitoringBaseURL             = O2IMSMonitoringAPIPath + APIVersionV1
+	O2IMSArtifactsBaseURL              = O2IMSArtifactsAPIPath + APIVersionV1
+	O2IMSProvisioningBaseURL           = O2IMSProvisioningAPIPath + APIVersionV1
+	HardwareManagerProvisioningBaseURL = HardwareManagerProvisioningAPIPath + APIVersionV1
+	HardwareManagerInventoryBaseURL    = HardwareManagerInventoryAPIPath + APIVersionV1
+)
+
+// Command line argument constants
+const (
+	HealthProbeFlag = "--health-probe-bind-address"
+	MetricsFlag     = "--metrics-bind-address"
+	LeaderElectFlag = "--leader-elect"
+)
+
+// Port constants
+const (
+	MetricsPort     = ":8080"
+	HealthProbePort = ":8081"
+)
+
+// Server command names
+const (
+	AlarmsServerCmd       = "alarms-server"
+	ArtifactsServerCmd    = "artifacts-server"
+	ClusterServerCmd      = "cluster-server"
+	ProvisioningServerCmd = "provisioning-server"
+	ResourceServerCmd     = "resource-server"
+)
+
+// Hardware plugin command names
+const (
+	HardwarePluginManagerCmd         = "hardwareplugin-manager"
+	LoopbackHardwarePluginManagerCmd = "loopback-hardwareplugin-manager"
+	Metal3HardwarePluginManagerCmd   = "metal3-hardwareplugin-manager"
+)
+
+// TLS/Certificate field names
+const (
+	TLSCertField  = "tls.crt"
+	TLSKeyField   = "tls.key"
+	CABundleField = "ca-bundle"
+)
+
+// Kubernetes service domains
+const (
+	ClusterLocalDomain   = "svc.cluster.local"
+	KubernetesAPIService = "kubernetes.default.svc"
+)
+
+// Network addresses
+const (
+	Localhost = "127.0.0.1"
+)
+
+// Common server arguments
+const (
+	ServeSubcommand = "serve"
+	StartSubcommand = "start"
+)
+
+// Executable paths
+const (
+	ManagerExec = "/usr/bin/oran-o2ims"
+	PsqlExec    = "psql"
+)
+
+// Default namespace and environment variables
+const (
+	DefaultNamespace        = "oran-o2ims"
+	DefaultNamespaceEnvName = "OCLOUD_MANAGER_NAMESPACE"
+	ImagePullPolicyEnvName  = "IMAGE_PULL_POLICY"
+)
+
+// Application and resource names
+const (
+	DefaultAppName     = "o2ims"
+	DefaultInventoryCR = "default"
+	DefaultOCloudID    = "undefined"
+)
+
+// Port constants
+const (
+	DefaultServicePort   = 8443
+	DefaultContainerPort = 8443
+	DatabaseServicePort  = 5432
+)
+
+// Container names
+const (
+	MigrationContainerName = "migration"
+	ServerContainerName    = "server"
+)
+
+// TLS mount paths
+const (
+	TLSServerMountPath = "/secrets/tls"
+	TLSClientMountPath = "/secrets/smo/tls"
+	CABundleMountPath  = "/secrets/smo/certs"
+	CABundleFilename   = "ca-bundle.crt"
+)
+
+// Standard Kubernetes service account paths
+const (
+	DefaultBackendTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token" // nolint: gosec // hardcoded path only
+	DefaultServiceCAFile    = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+)
+
+// Environment variable names
+const (
+	ServerImageName         = "IMAGE"
+	PostgresImageName       = "POSTGRES_IMAGE"
+	InternalServicePortName = "INTERNAL_SERVICE_PORT"
+)

--- a/internal/controllers/hardwareplugin_manager_setup.go
+++ b/internal/controllers/hardwareplugin_manager_setup.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +47,7 @@ func (t *reconcilerTask) setupHardwarePluginManager(ctx context.Context, default
 		return
 	}
 
-	if err = t.createService(ctx, utils.HardwarePluginManagerServerName, utils.DefaultServicePort, utils.DefaultServiceTargetPort); err != nil {
+	if err = t.createService(ctx, utils.HardwarePluginManagerServerName, constants.DefaultServicePort, utils.DefaultServiceTargetPort); err != nil {
 		t.logger.ErrorContext(ctx, "Failed to deploy Service for the HardwarePlugin manager.",
 			slog.String("error", err.Error()))
 		return
@@ -200,7 +201,7 @@ func (t *reconcilerTask) createHardwarePluginManagerClusterRole(ctx context.Cont
 			// HardwarePlugin registration verification
 			{
 				NonResourceURLs: []string{
-					"/hardware-manager/provisioning/*",
+					constants.HardwareManagerProvisioningAPIPath + "/*",
 				},
 				Verbs: []string{
 					"get",

--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sptr "k8s.io/utils/ptr"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/postgres"
 )
@@ -77,9 +78,9 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 		},
 	}
 
-	postgresImage := os.Getenv(utils.PostgresImageName)
+	postgresImage := os.Getenv(constants.PostgresImageName)
 	if postgresImage == "" {
-		return fmt.Errorf("missing %s environment variable value", utils.PostgresImageName)
+		return fmt.Errorf("missing %s environment variable value", constants.PostgresImageName)
 	}
 
 	// Disable privilege escalation
@@ -96,7 +97,7 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					"kubectl.kubernetes.io/default-container": utils.ServerContainerName,
+					"kubectl.kubernetes.io/default-container": constants.ServerContainerName,
 				},
 				Labels: map[string]string{
 					"app": serverName,
@@ -107,7 +108,7 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 				Volumes:            deploymentVolumes,
 				Containers: []corev1.Container{
 					{
-						Name: utils.ServerContainerName,
+						Name: constants.ServerContainerName,
 						EnvFrom: []corev1.EnvFromSource{
 							{
 								SecretRef: &corev1.SecretEnvSource{
@@ -129,7 +130,7 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 							{
 								Name:          utils.DatabaseTargetPort,
 								Protocol:      corev1.ProtocolTCP,
-								ContainerPort: utils.DatabaseServicePort,
+								ContainerPort: constants.DatabaseServicePort,
 							},
 						},
 						VolumeMounts: deploymentVolumeMounts,
@@ -224,7 +225,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 		return
 	}
 
-	err = t.createService(ctx, utils.InventoryDatabaseServerName, utils.DatabaseServicePort, utils.DatabaseTargetPort)
+	err = t.createService(ctx, utils.InventoryDatabaseServerName, constants.DatabaseServicePort, utils.DatabaseTargetPort)
 	if err != nil {
 		t.logger.ErrorContext(
 			ctx,

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -49,7 +49,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
-
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	//+kubebuilder:scaffold:imports
 )
@@ -86,7 +86,7 @@ var _ = Describe("Inventory Controller", func() {
 			// Declare the Namespace for the O-Cloud Manager resource.
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "oran-o2ims",
+					Name: constants.DefaultNamespace,
 				},
 			}
 
@@ -130,7 +130,7 @@ var _ = Describe("Inventory Controller", func() {
 			}
 
 			// Set up necessary env variables
-			err := os.Setenv(utils.PostgresImageName, "postgres:test")
+			err := os.Setenv(constants.PostgresImageName, "postgres:test")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Update the testcase objects to include the Namespace.
@@ -221,7 +221,7 @@ var _ = Describe("Inventory Controller", func() {
 				&inventoryv1alpha1.Inventory{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "oran-o2ims-sample-1",
-						Namespace:         "oran-o2ims",
+						Namespace:         constants.DefaultNamespace,
 						CreationTimestamp: metav1.Now(),
 					},
 					Spec: inventoryv1alpha1.InventorySpec{

--- a/internal/controllers/loopbackplugin_server_setup.go
+++ b/internal/controllers/loopbackplugin_server_setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/api/common"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	hwpluginutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
@@ -51,7 +52,7 @@ func (t *reconcilerTask) setupLoopbackPluginServer(ctx context.Context, defaultR
 		return
 	}
 
-	if err = t.createService(ctx, utils.LoopbackPluginServerName, utils.DefaultServicePort, utils.DefaultServiceTargetPort); err != nil {
+	if err = t.createService(ctx, utils.LoopbackPluginServerName, constants.DefaultServicePort, utils.DefaultServiceTargetPort); err != nil {
 		t.logger.ErrorContext(ctx, "Failed to deploy Service for the Loopback hardware plugin server.",
 			slog.String("error", err.Error()))
 		return

--- a/internal/controllers/metal3plugin_server_setup.go
+++ b/internal/controllers/metal3plugin_server_setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/api/common"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	hwpluginutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
@@ -51,7 +52,7 @@ func (t *reconcilerTask) setupMetal3PluginServer(ctx context.Context, defaultRes
 		return
 	}
 
-	if err = t.createService(ctx, utils.Metal3PluginServerName, utils.DefaultServicePort, utils.DefaultServiceTargetPort); err != nil {
+	if err = t.createService(ctx, utils.Metal3PluginServerName, constants.DefaultServicePort, utils.DefaultServiceTargetPort); err != nil {
 		t.logger.ErrorContext(ctx, "Failed to deploy Service for the Metal3 hardware plugin server.",
 			slog.String("error", err.Error()))
 		return

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -9,11 +9,13 @@ package utils
 import (
 	"fmt"
 	"time"
+
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 )
 
 // Default namespace
 const (
-	InventoryNamespace = "oran-o2ims"
+	InventoryNamespace = constants.DefaultNamespace
 )
 
 // Base resource names
@@ -70,92 +72,81 @@ const (
 // Container arguments
 var (
 	AlarmServerArgs = []string{
-		"alarms-server",
-		"serve",
-		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", DefaultContainerPort),
-		fmt.Sprintf("--tls-server-cert=%s/tls.crt", TLSServerMountPath),
-		fmt.Sprintf("--tls-server-key=%s/tls.key", TLSServerMountPath),
+		constants.AlarmsServerCmd,
+		constants.ServeSubcommand,
+		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", constants.DefaultContainerPort),
+		fmt.Sprintf("--tls-server-cert=%s/%s", constants.TLSServerMountPath, constants.TLSCertField),
+		fmt.Sprintf("--tls-server-key=%s/%s", constants.TLSServerMountPath, constants.TLSKeyField),
 	}
 
 	ArtifactsServerArgs = []string{
-		"artifacts-server",
-		"serve",
-		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", DefaultContainerPort),
-		fmt.Sprintf("--tls-server-cert=%s/tls.crt", TLSServerMountPath),
-		fmt.Sprintf("--tls-server-key=%s/tls.key", TLSServerMountPath),
+		constants.ArtifactsServerCmd,
+		constants.ServeSubcommand,
+		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", constants.DefaultContainerPort),
+		fmt.Sprintf("--tls-server-cert=%s/%s", constants.TLSServerMountPath, constants.TLSCertField),
+		fmt.Sprintf("--tls-server-key=%s/%s", constants.TLSServerMountPath, constants.TLSKeyField),
 	}
 
 	ResourceServerArgs = []string{
-		"resource-server",
-		"serve",
-		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", DefaultContainerPort),
-		fmt.Sprintf("--tls-server-cert=%s/tls.crt", TLSServerMountPath),
-		fmt.Sprintf("--tls-server-key=%s/tls.key", TLSServerMountPath),
+		constants.ResourceServerCmd,
+		constants.ServeSubcommand,
+		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", constants.DefaultContainerPort),
+		fmt.Sprintf("--tls-server-cert=%s/%s", constants.TLSServerMountPath, constants.TLSCertField),
+		fmt.Sprintf("--tls-server-key=%s/%s", constants.TLSServerMountPath, constants.TLSKeyField),
 	}
 
 	ClusterServerArgs = []string{
-		"cluster-server",
-		"serve",
-		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", DefaultContainerPort),
-		fmt.Sprintf("--tls-server-cert=%s/tls.crt", TLSServerMountPath),
-		fmt.Sprintf("--tls-server-key=%s/tls.key", TLSServerMountPath),
+		constants.ClusterServerCmd,
+		constants.ServeSubcommand,
+		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", constants.DefaultContainerPort),
+		fmt.Sprintf("--tls-server-cert=%s/%s", constants.TLSServerMountPath, constants.TLSCertField),
+		fmt.Sprintf("--tls-server-key=%s/%s", constants.TLSServerMountPath, constants.TLSKeyField),
 	}
 
 	ProvisioningServerArgs = []string{
-		"provisioning-server",
-		"serve",
-		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", DefaultContainerPort),
-		fmt.Sprintf("--tls-server-cert=%s/tls.crt", TLSServerMountPath),
-		fmt.Sprintf("--tls-server-key=%s/tls.key", TLSServerMountPath),
+		constants.ProvisioningServerCmd,
+		constants.ServeSubcommand,
+		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", constants.DefaultContainerPort),
+		fmt.Sprintf("--tls-server-cert=%s/%s", constants.TLSServerMountPath, constants.TLSCertField),
+		fmt.Sprintf("--tls-server-key=%s/%s", constants.TLSServerMountPath, constants.TLSKeyField),
 	}
 
 	HardwarePluginManagerArgs = []string{
-		"hardwareplugin-manager",
-		"start",
-		"--health-probe-bind-address=:8081",
-		"--metrics-bind-address=:8080",
-		fmt.Sprintf("--metrics-tls-cert-dir=%s", TLSServerMountPath),
-		"--leader-elect",
+		constants.HardwarePluginManagerCmd,
+		constants.StartSubcommand,
+		constants.HealthProbeFlag + "=" + constants.HealthProbePort,
+		constants.MetricsFlag + "=" + constants.MetricsPort,
+		fmt.Sprintf("--metrics-tls-cert-dir=%s", constants.TLSServerMountPath),
+		constants.LeaderElectFlag,
 	}
 
 	LoopbackPluginServerArgs = []string{
-		"loopback-hardwareplugin-manager",
-		"start",
-		"--health-probe-bind-address=:8081",
-		"--metrics-bind-address=:8080",
-		fmt.Sprintf("--metrics-tls-cert-dir=%s", TLSServerMountPath),
-		"--leader-elect",
-		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", DefaultContainerPort),
-		fmt.Sprintf("--tls-server-cert=%s/tls.crt", TLSServerMountPath),
-		fmt.Sprintf("--tls-server-key=%s/tls.key", TLSServerMountPath),
+		constants.LoopbackHardwarePluginManagerCmd,
+		constants.StartSubcommand,
+		constants.HealthProbeFlag + "=" + constants.HealthProbePort,
+		constants.MetricsFlag + "=" + constants.MetricsPort,
+		fmt.Sprintf("--metrics-tls-cert-dir=%s", constants.TLSServerMountPath),
+		constants.LeaderElectFlag,
+		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", constants.DefaultContainerPort),
+		fmt.Sprintf("--tls-server-cert=%s/%s", constants.TLSServerMountPath, constants.TLSCertField),
+		fmt.Sprintf("--tls-server-key=%s/%s", constants.TLSServerMountPath, constants.TLSKeyField),
 	}
 
 	Metal3PluginServerArgs = []string{
-		"metal3-hardwareplugin-manager",
-		"start",
-		"--health-probe-bind-address=:8081",
-		"--metrics-bind-address=:8080",
-		fmt.Sprintf("--metrics-tls-cert-dir=%s", TLSServerMountPath),
-		"--leader-elect",
-		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", DefaultContainerPort),
-		fmt.Sprintf("--tls-server-cert=%s/tls.crt", TLSServerMountPath),
-		fmt.Sprintf("--tls-server-key=%s/tls.key", TLSServerMountPath),
+		constants.Metal3HardwarePluginManagerCmd,
+		constants.StartSubcommand,
+		constants.HealthProbeFlag + "=" + constants.HealthProbePort,
+		constants.MetricsFlag + "=" + constants.MetricsPort,
+		fmt.Sprintf("--metrics-tls-cert-dir=%s", constants.TLSServerMountPath),
+		constants.LeaderElectFlag,
+		fmt.Sprintf("--api-listener-address=0.0.0.0:%d", constants.DefaultContainerPort),
+		fmt.Sprintf("--tls-server-cert=%s/%s", constants.TLSServerMountPath, constants.TLSCertField),
+		fmt.Sprintf("--tls-server-key=%s/%s", constants.TLSServerMountPath, constants.TLSKeyField),
 	}
 )
 
-// DefaultOCloudID defines the default Global O-Cloud ID to be used until the end user configures this value.
-const DefaultOCloudID = "undefined"
-
-// DefaultAppName defines the name prepended to the ingress host to form our FQDN hostname.
-const DefaultAppName = "o2ims"
-
-// Defines information related to the operator instance in a namespace
-const (
-	DefaultInventoryCR      = "default"
-	DefaultNamespace        = "oran-o2ims"
-	DefaultNamespaceEnvName = "OCLOUD_MANAGER_NAMESPACE"
-	ImagePullPolicyEnvName  = "IMAGE_PULL_POLICY"
-)
+// NOTE: DefaultOCloudID, DefaultAppName, DefaultInventoryCR, DefaultNamespace,
+// DefaultNamespaceEnvName, and ImagePullPolicyEnvName have been moved to internal/constants
 
 // Search API attributes
 const (
@@ -165,10 +156,9 @@ const (
 
 // Default values for backend URL and token:
 const (
-	defaultApiServerURL     = "https://kubernetes.default.svc"
-	DefaultBackendTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"          // nolint: gosec // hardcoded path only
-	defaultBackendCABundle  = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"         // nolint: gosec // hardcoded path only
-	DefaultServiceCAFile    = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" // nolint: gosec // hardcoded path only
+	defaultApiServerURL    = "https://" + constants.KubernetesAPIService
+	defaultBackendCABundle = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" // nolint: gosec // hardcoded path only
+	// NOTE: DefaultBackendTokenFile and DefaultServiceCAFile moved to internal/constants
 )
 
 // Default timeout values
@@ -273,32 +263,24 @@ const (
 const (
 	UnitTestHwPluginRef    = "hwmgr"
 	UnitTestHwmgrNamespace = "hwmgr"
-	DefaultPluginNamespace = "oran-o2ims"
-)
-
-// POD Container Names
-const (
-	MigrationContainerName = "migration"
-	ServerContainerName    = "server"
+	DefaultPluginNamespace = constants.DefaultNamespace
 )
 
 // POD Port Values
 const (
-	DefaultServicePort       = 8443
 	DefaultServiceTargetPort = "https"
-	DefaultContainerPort     = 8443
-
-	DatabaseServicePort = 5432
-	DatabaseTargetPort  = "database"
+	DatabaseTargetPort       = "database"
 )
+
+// NOTE: DefaultServicePort, DefaultContainerPort, DatabaseServicePort moved to internal/constants
+// NOTE: MigrationContainerName, ServerContainerName moved to internal/constants
 
 // Environment values
 const (
-	ServerImageName         = "IMAGE"
-	PostgresImageName       = "POSTGRES_IMAGE"
-	HwMgrPluginNameSpace    = "HWMGR_PLUGIN_NAMESPACE"
-	InternalServicePortName = "INTERNAL_SERVICE_PORT"
+	HwMgrPluginNameSpace = "HWMGR_PLUGIN_NAMESPACE"
 )
+
+// NOTE: ServerImageName, PostgresImageName, InternalServicePortName moved to internal/constants
 
 // Deploy Loopback HardwarePlugin constants
 const (
@@ -361,13 +343,7 @@ const (
 	AlertmanagerSA                              = "alertmanager"
 )
 
-// TLS Mount Paths
-const (
-	TLSServerMountPath = "/secrets/tls"
-	TLSClientMountPath = "/secrets/smo/tls"
-	CABundleMountPath  = "/secrets/smo/certs"
-	CABundleFilename   = "ca-bundle.crt"
-)
+// NOTE: TLS Mount Paths (TLSServerMountPath, TLSClientMountPath, CABundleMountPath, CABundleFilename) moved to internal/constants
 
 // SMO OAuth specific environment variables.  These values are stored in environment variables to
 // avoid them being visible in the command line arguments.

--- a/internal/controllers/utils/secret.go
+++ b/internal/controllers/utils/secret.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -99,12 +100,12 @@ func GetKeyPairFromSecret(ctx context.Context, c client.Client, name, namespace 
 		return nil, nil, fmt.Errorf("failed to retrieve secret '%s': %w", name, err)
 	}
 
-	certBytes, ok := secret.Data["tls.crt"]
+	certBytes, ok := secret.Data[constants.TLSCertField]
 	if !ok {
 		return nil, nil, NewInputError("secret '%s' does not contain key 'tls.crt'", name)
 	}
 
-	keyBytes, ok := secret.Data["tls.key"]
+	keyBytes, ok := secret.Data[constants.TLSKeyField]
 	if !ok {
 		return nil, nil, NewInputError("secret '%s' does not contain key 'tls.key'", name)
 	}

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	openshiftv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -102,13 +103,13 @@ var _ = Describe("DoesK8SResourceExist", func() {
 	objs := []client.Object{
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "oran-o2ims",
+				Name: constants.DefaultNamespace,
 			},
 		},
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "metadata-server",
-				Namespace: "oran-o2ims",
+				Namespace: constants.DefaultNamespace,
 			},
 		},
 	}
@@ -128,7 +129,7 @@ var _ = Describe("DoesK8SResourceExist", func() {
 		deployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "deployment-server",
-				Namespace: "oran-o2ims",
+				Namespace: constants.DefaultNamespace,
 			},
 		}
 		// Check that the deployment does not exist.
@@ -161,7 +162,7 @@ var _ = Describe("DoesK8SResourceExist", func() {
 		deployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "deployment-server-2",
-				Namespace: "oran-o2ims",
+				Namespace: constants.DefaultNamespace,
 			},
 			Spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
@@ -220,10 +221,10 @@ var _ = Describe("DoesK8SResourceExist", func() {
 		obj := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "metadata-server",
-				Namespace: "oran-o2ims",
+				Namespace: constants.DefaultNamespace,
 			},
 		}
-		k8sResourceExists, err := DoesK8SResourceExist(context.TODO(), fakeClient, "metadata-server", "oran-o2ims", obj)
+		k8sResourceExists, err := DoesK8SResourceExist(context.TODO(), fakeClient, "metadata-server", constants.DefaultNamespace, obj)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(k8sResourceExists).To(Equal(true))
 	})

--- a/internal/service/alarms/api/server.go
+++ b/internal/service/alarms/api/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	api "github.com/openshift-kni/oran-o2ims/internal/service/alarms/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/alertmanager"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/db/models"
@@ -62,7 +63,7 @@ type AlarmsServer struct {
 var _ api.StrictServerInterface = (*AlarmsServer)(nil)
 
 // baseURL is the prefix for all of our supported API endpoints
-var baseURL = "/o2ims-infrastructureMonitoring/v1"
+var baseURL = constants.O2IMSMonitoringBaseURL
 var currentVersion = "1.0.0"
 
 // GetAllVersions receives the API request to this endpoint, executes the request, and responds appropriately

--- a/internal/service/alarms/cmd/root.go
+++ b/internal/service/alarms/cmd/root.go
@@ -11,12 +11,13 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/spf13/cobra"
 )
 
 // AlarmRootCmd represents the root command for working alarms server
 var AlarmRootCmd = &cobra.Command{
-	Use:   "alarms-server",
+	Use:   constants.AlarmsServerCmd,
 	Short: "All things needed for alarms server",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		configureAlarmLogger()

--- a/internal/service/alarms/cmd/serve.go
+++ b/internal/service/alarms/cmd/serve.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-kni/oran-o2ims/internal/cmd/server"
-	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms"
 	utils2 "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 )
@@ -52,7 +52,7 @@ func setServerFlags(cmd *cobra.Command) error {
 	flags.StringVar(
 		&config.GlobalCloudID,
 		server.GlobalCloudIDFlagName,
-		utils.DefaultOCloudID,
+		constants.DefaultOCloudID,
 		"The global O-Cloud identifier.",
 	)
 	return nil

--- a/internal/service/alarms/internal/alertmanager/api_test.go
+++ b/internal/service/alarms/internal/alertmanager/api_test.go
@@ -17,6 +17,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/alertmanager"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/db/repo/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/infrastructure"
@@ -211,7 +212,7 @@ var _ = Describe("Alertmanager API Client", func() {
 			// Assert
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).NotTo(BeEmpty())
-			Expect(host).To(ContainSubstring("127.0.0.1"))
+			Expect(host).To(ContainSubstring(constants.Localhost))
 		})
 
 		It("should return error when route not found", func() {

--- a/internal/service/alarms/internal/alertmanager/config.go
+++ b/internal/service/alarms/internal/alertmanager/config.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
 )
@@ -108,10 +109,10 @@ func updateReceivers(config map[string]interface{}) {
 				"http_config": map[string]interface{}{ // Auth config.
 					"authorization": map[string]interface{}{
 						"type":             "Bearer",
-						"credentials_file": utils.DefaultBackendTokenFile,
+						"credentials_file": constants.DefaultBackendTokenFile,
 					},
 					"tls_config": map[string]interface{}{
-						"ca_file": utils.DefaultServiceCAFile,
+						"ca_file": constants.DefaultServiceCAFile,
 					},
 				},
 			},

--- a/internal/service/alarms/internal/db/models/converters.go
+++ b/internal/service/alarms/internal/db/models/converters.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db/models"
-
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 
 	api "github.com/openshift-kni/oran-o2ims/internal/service/alarms/api/generated"
@@ -50,7 +50,7 @@ func ConvertAlarmEventRecordModelToApi(aerModel AlarmEventRecord) api.AlarmEvent
 
 // ConvertAlarmEventRecordModelToAlarmEventNotification converts an AlarmEventRecord to api AlarmEventNotification
 func ConvertAlarmEventRecordModelToAlarmEventNotification(aerModel AlarmEventRecord, globalCloudID uuid.UUID) api.AlarmEventNotification {
-	or := fmt.Sprintf("%s/alarms/%v", "/o2ims-infrastructureMonitoring/v1", aerModel.AlarmEventRecordID.String())
+	or := fmt.Sprintf("%s/alarms/%v", constants.O2IMSMonitoringBaseURL, aerModel.AlarmEventRecordID.String())
 	notification := api.AlarmEventNotification{
 		AlarmAcknowledgeTime:  aerModel.AlarmAcknowledgedTime,
 		AlarmAcknowledged:     aerModel.AlarmAcknowledged,

--- a/internal/service/alarms/internal/infrastructure/clusterserver.go
+++ b/internal/service/alarms/internal/infrastructure/clusterserver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	"k8s.io/client-go/transport"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/infrastructure/clusterserver/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients"
@@ -67,7 +68,7 @@ func (r *ClusterServer) Setup() error {
 
 	hc := http.Client{Transport: tr}
 
-	tokenPath := utils.DefaultBackendTokenFile
+	tokenPath := constants.DefaultBackendTokenFile
 
 	// Use for local development
 	path := os.Getenv(tokenPathEnvName)

--- a/internal/service/alarms/internal/serviceconfig/serviceconfig.go
+++ b/internal/service/alarms/internal/serviceconfig/serviceconfig.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"strconv"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -208,7 +209,7 @@ func (c *Config) generateCronJob(configMap corev1.ConfigMap) batchv1.CronJob {
 								{
 									Name:    cleanupCronJobName,
 									Image:   c.PostgresImage,
-									Command: []string{"psql"},
+									Command: []string{constants.PsqlExec},
 									Args:    []string{"-f", fmt.Sprintf("%s/%s", cleanScriptDir, cleanScriptName)},
 									Env:     pgEnv,
 									Resources: corev1.ResourceRequirements{

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -21,6 +21,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/uuid"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/api/generated"
@@ -127,7 +128,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 
 	// Parse global cloud id
 	var globalCloudID uuid.UUID
-	if config.GlobalCloudID != utils.DefaultOCloudID {
+	if config.GlobalCloudID != constants.DefaultOCloudID {
 		globalCloudID, err = uuid.Parse(config.GlobalCloudID)
 		if err != nil {
 			return fmt.Errorf("failed to parse global cloud id: %w", err)
@@ -151,7 +152,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 	newNotifier := notifier.NewNotifier(
 		notifier_provider.NewSubscriptionStorageProvider(alarmRepository),
 		notifier_provider.NewNotificationStorageProvider(alarmRepository, globalCloudID),
-		notifier.NewClientFactory(oauthConfig, utils.DefaultBackendTokenFile),
+		notifier.NewClientFactory(oauthConfig, constants.DefaultBackendTokenFile),
 	)
 
 	// Attribute needed when subscription event happens

--- a/internal/service/artifacts/api/server.go
+++ b/internal/service/artifacts/api/server.go
@@ -14,18 +14,19 @@ import (
 
 	"github.com/google/uuid"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
-	orano2imsutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/openshift-kni/oran-o2ims/internal/service/artifacts/api/generated"
 	commonapi "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api/generated"
-	"github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
+	commonutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 )
 
 type ArtifactsServerConfig struct {
-	utils.CommonServerConfig
+	commonutils.CommonServerConfig
 }
 type ArtifactsServer struct {
 	HubClient client.Client
@@ -35,7 +36,7 @@ type ArtifactsServer struct {
 var _ api.StrictServerInterface = (*ArtifactsServer)(nil)
 
 // baseURL is the prefix for all of our supported API endpoints
-var baseURL = "/o2ims-infrastructureArtifacts/v1"
+var baseURL = constants.O2IMSArtifactsBaseURL
 var currentVersion = "1.0.0"
 
 // GetAllVersions receives the API request to this endpoint, executes the request, and responds appropriately.
@@ -156,11 +157,11 @@ func (r *ArtifactsServer) GetManagedInfrastructureTemplateDefaults(
 	oranct := clusterTemplatesItems[0]
 
 	// Get the response for the ClusterInstance default values.
-	clusterInstanceResults, err := orano2imsutils.GetDefaultsFromConfigMap(
+	clusterInstanceResults, err := utils.GetDefaultsFromConfigMap(
 		ctx, r.HubClient,
 		oranct.Spec.Templates.ClusterInstanceDefaults,
 		oranct.Namespace,
-		orano2imsutils.ClusterInstanceTemplateDefaultsConfigmapKey,
+		utils.ClusterInstanceTemplateDefaultsConfigmapKey,
 		oranct.Spec.TemplateParameterSchema.Raw,
 		provisioningv1alpha1.TemplateParamClusterInstance,
 	)
@@ -169,11 +170,11 @@ func (r *ArtifactsServer) GetManagedInfrastructureTemplateDefaults(
 	}
 
 	// Get the response for the Policy default values.
-	policyTemplateResults, err := orano2imsutils.GetDefaultsFromConfigMap(
+	policyTemplateResults, err := utils.GetDefaultsFromConfigMap(
 		ctx, r.HubClient,
 		oranct.Spec.Templates.PolicyTemplateDefaults,
 		oranct.Namespace,
-		orano2imsutils.PolicyTemplateDefaultsConfigmapKey,
+		utils.PolicyTemplateDefaultsConfigmapKey,
 		oranct.Spec.TemplateParameterSchema.Raw,
 		provisioningv1alpha1.TemplateParamPolicyConfig,
 	)

--- a/internal/service/artifacts/cmd/root.go
+++ b/internal/service/artifacts/cmd/root.go
@@ -11,12 +11,13 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/spf13/cobra"
 )
 
 // artifactsRootCmd represents the root command for working artifacts server
 var artifactsRootCmd = &cobra.Command{
-	Use:   "artifacts-server",
+	Use:   constants.ArtifactsServerCmd,
 	Short: "All things needed for the artifacts server",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		configureArtifactsLogger()

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
@@ -31,7 +32,7 @@ import (
 
 // Resource server config values
 const (
-	host         = "127.0.0.1"
+	host         = constants.Localhost
 	port         = "8000"
 	readTimeout  = 5 * time.Second
 	writeTimeout = 10 * time.Second

--- a/internal/service/cluster/api/server.go
+++ b/internal/service/cluster/api/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	api "github.com/openshift-kni/oran-o2ims/internal/service/cluster/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/repo"
@@ -315,7 +316,7 @@ func (r *ClusterServer) GetNodeCluster(ctx context.Context, request api.GetNodeC
 func (r *ClusterServer) GetAllVersions(ctx context.Context, request api.GetAllVersionsRequestObject) (api.GetAllVersionsResponseObject, error) {
 	// We currently only support a single version
 	version := utils2.CurrentVersion
-	baseURL := utils2.BaseURL
+	baseURL := constants.O2IMSClusterBaseURL
 	versions := []generated.APIVersion{
 		{
 			Version: &version,
@@ -332,7 +333,7 @@ func (r *ClusterServer) GetAllVersions(ctx context.Context, request api.GetAllVe
 func (r *ClusterServer) GetMinorVersions(ctx context.Context, request api.GetMinorVersionsRequestObject) (api.GetMinorVersionsResponseObject, error) {
 	// We currently only support a single version
 	version := utils2.CurrentVersion
-	baseURL := utils2.BaseURL
+	baseURL := constants.O2IMSClusterBaseURL
 	versions := []generated.APIVersion{
 		{
 			Version: &version,

--- a/internal/service/cluster/cmd/root.go
+++ b/internal/service/cluster/cmd/root.go
@@ -11,12 +11,13 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/spf13/cobra"
 )
 
 // clusterRootCmd represents the root command for working resource server
 var clusterRootCmd = &cobra.Command{
-	Use:   "cluster-server",
+	Use:   constants.ClusterServerCmd,
 	Short: "All things needed for the cluster server",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		configureDefaultLogger()

--- a/internal/service/cluster/db/models/converters.go
+++ b/internal/service/cluster/db/models/converters.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/api/generated"
-	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/utils"
 	commonapi "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db/models"
@@ -177,13 +177,13 @@ func getObjectReference(objectType string, objectID uuid.UUID) *string {
 	var value string
 	switch objectType {
 	case ClusterResourceType{}.TableName():
-		value = fmt.Sprintf("%s/clusterResourceTypes/%s", utils.BaseURL, objectID.String())
+		value = fmt.Sprintf("%s/clusterResourceTypes/%s", constants.O2IMSClusterBaseURL, objectID.String())
 	case ClusterResource{}.TableName():
-		value = fmt.Sprintf("%s/clusterResource/%s", utils.BaseURL, objectID.String())
+		value = fmt.Sprintf("%s/clusterResource/%s", constants.O2IMSClusterBaseURL, objectID.String())
 	case NodeClusterType{}.TableName():
-		value = fmt.Sprintf("%s/nodeClusterTypes/%s", utils.BaseURL, objectID.String())
+		value = fmt.Sprintf("%s/nodeClusterTypes/%s", constants.O2IMSClusterBaseURL, objectID.String())
 	case NodeCluster{}.TableName():
-		value = fmt.Sprintf("%s/nodeClusters/%s", utils.BaseURL, objectID.String())
+		value = fmt.Sprintf("%s/nodeClusters/%s", constants.O2IMSClusterBaseURL, objectID.String())
 	default:
 		return nil
 	}

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/api/generated"
@@ -125,7 +126,7 @@ func Serve(config *api.ClusterServerConfig) error {
 	// Create the notifier with our resource-specific subscription and notification providers.
 	notificationsProvider := repo2.NewNotificationStorageProvider(commonRepository)
 	subscriptionsProvider := repo2.NewSubscriptionStorageProvider(commonRepository, collector.NewNotificationTransformer())
-	clientFactory := notifier.NewClientFactory(oauthConfig, utils.DefaultBackendTokenFile)
+	clientFactory := notifier.NewClientFactory(oauthConfig, constants.DefaultBackendTokenFile)
 	clusterNotifier := notifier.NewNotifier(subscriptionsProvider, notificationsProvider, clientFactory)
 
 	// Create the collector

--- a/internal/service/cluster/utils/constants.go
+++ b/internal/service/cluster/utils/constants.go
@@ -6,5 +6,4 @@ SPDX-License-Identifier: Apache-2.0
 
 package utils
 
-var BaseURL = "/o2ims-infrastructureCluster/v1"
 var CurrentVersion = "1.0.0"

--- a/internal/service/common/auth/auth_test.go
+++ b/internal/service/common/auth/auth_test.go
@@ -15,6 +15,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -93,7 +94,7 @@ var _ = Describe("Authenticator", func() {
 	})
 
 	It("Authorizes the request using OAuth behind proxy", func() {
-		req.Header.Set("x-forwarded-for", "127.0.0.1")
+		req.Header.Set("x-forwarded-for", constants.Localhost)
 		handler.ServeHTTP(recorder, &req)
 		Expect(oauthAuthenticator.called).To(BeTrue())
 		Expect(k8sAuthenticator.called).To(BeFalse())
@@ -105,7 +106,7 @@ var _ = Describe("Authenticator", func() {
 	})
 
 	It("Authorizes the request using Kubernetes behind proxy when no OAuth handler provided", func() {
-		req.Header.Set("x-forwarded-for", "127.0.0.1")
+		req.Header.Set("x-forwarded-for", constants.Localhost)
 		handler = Authenticator(nil, &k8sAuthenticator)(next)
 		handler.ServeHTTP(recorder, &req)
 		Expect(oauthAuthenticator.called).To(BeFalse())

--- a/internal/service/common/db/migration.go
+++ b/internal/service/common/db/migration.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/pgx/v5"
 	"github.com/golang-migrate/migrate/v4/source"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
@@ -102,8 +103,8 @@ func NewHandler(cfg MigrationConfig) (*MigrationHandler, error) {
 		connStr += fmt.Sprintf("&x-migrations-table=%s", cfg.MigrationsTable)
 	}
 
-	if _, err := os.Stat(utils.DefaultServiceCAFile); err == nil {
-		connStr += fmt.Sprintf("&sslrootcert=%s", utils.DefaultServiceCAFile)
+	if _, err := os.Stat(constants.DefaultServiceCAFile); err == nil {
+		connStr += fmt.Sprintf("&sslrootcert=%s", constants.DefaultServiceCAFile)
 	} else {
 		slog.Warn("No service CA file found")
 	}

--- a/internal/service/common/db/postgres.go
+++ b/internal/service/common/db/postgres.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/tracelog"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
@@ -67,7 +68,7 @@ func NewPgxPool(ctx context.Context, cfg PgConfig) (*pgxpool.Pool, error) {
 // GetPgConfig common postgres config for alarms server
 func GetPgConfig(username, password, database string) PgConfig {
 	hostname := utils.GetDatabaseHostname()
-	port := fmt.Sprintf("%d", utils.DatabaseServicePort)
+	port := fmt.Sprintf("%d", constants.DatabaseServicePort)
 
 	return PgConfig{
 		Host:     hostname,

--- a/internal/service/common/utils/config.go
+++ b/internal/service/common/utils/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
@@ -75,7 +76,7 @@ func SetCommonServerFlags(cmd *cobra.Command, config *CommonServerConfig) error 
 	flags.StringVar(
 		&config.Listener.Address,
 		ListenerFlagName,
-		fmt.Sprintf("127.0.0.1:%d", utils.DefaultContainerPort),
+		fmt.Sprintf("127.0.0.1:%d", constants.DefaultContainerPort),
 		"API listener address",
 	)
 	flags.StringVar(
@@ -117,13 +118,13 @@ func SetCommonServerFlags(cmd *cobra.Command, config *CommonServerConfig) error 
 	flags.StringVar(
 		&config.TLS.CertFile,
 		ServerCertFileFlagName,
-		fmt.Sprintf("%s/tls.crt", utils.TLSServerMountPath),
+		fmt.Sprintf("%s/tls.crt", constants.TLSServerMountPath),
 		"Server certificate file",
 	)
 	flags.StringVar(
 		&config.TLS.KeyFile,
 		ServerKeyFileFlagName,
-		fmt.Sprintf("%s/tls.key", utils.TLSServerMountPath),
+		fmt.Sprintf("%s/tls.key", constants.TLSServerMountPath),
 		"Server private key file",
 	)
 	flags.StringVar(

--- a/internal/service/constants.go
+++ b/internal/service/constants.go
@@ -6,14 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 package service
 
-import "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+import "github.com/openshift-kni/oran-o2ims/internal/constants"
 
 const (
-	// default namespace should be changed to official namespace when it is available
-	DefaultNamespace                   = utils.DefaultNamespace // TODO: consolidate
-	DefaultAlarmConfigmapName          = "oran-o2ims-alarm-subscriptions"
-	DefaultInfraInventoryConfigmapName = "oran-o2ims-inventory-subscriptions"
-	FieldOwner                         = "oran-o2ims"
+	DefaultAlarmConfigmapName          = constants.DefaultNamespace + "-alarm-subscriptions"
+	DefaultInfraInventoryConfigmapName = constants.DefaultNamespace + "-inventory-subscriptions"
+	FieldOwner                         = constants.DefaultNamespace
 )
 
 const (

--- a/internal/service/provisioning/api/server.go
+++ b/internal/service/provisioning/api/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,7 +41,7 @@ type ProvisioningServerConfig struct {
 var _ api.StrictServerInterface = (*ProvisioningServer)(nil)
 
 // baseURL is the prefix for all of our supported API endpoints
-var baseURL = "/o2ims-infrastructureProvisioning/v1"
+var baseURL = constants.O2IMSProvisioningBaseURL
 var currentVersion = "1.0.0"
 
 // GetAllVersions handles an API request to fetch all versions

--- a/internal/service/provisioning/cmd/root.go
+++ b/internal/service/provisioning/cmd/root.go
@@ -11,12 +11,13 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/spf13/cobra"
 )
 
 // provisioningRootCmd represents the root command for working provisioning server
 var provisioningRootCmd = &cobra.Command{
-	Use:   "provisioning-server",
+	Use:   constants.ProvisioningServerCmd,
 	Short: "All things needed for the provisioning server",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		configureProvisioningLogger()

--- a/internal/service/resources/api/server.go
+++ b/internal/service/resources/api/server.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	commonapi "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/generated"
 	models2 "github.com/openshift-kni/oran-o2ims/internal/service/common/db/models"
@@ -49,7 +50,7 @@ type ResourceServer struct {
 func (r *ResourceServer) GetAllVersions(ctx context.Context, request api.GetAllVersionsRequestObject) (api.GetAllVersionsResponseObject, error) {
 	// We currently only support a single version
 	version := utils2.CurrentInventoryVersion
-	baseURL := utils2.BaseInventoryURL
+	baseURL := constants.O2IMSInventoryBaseURL
 	versions := []generated.APIVersion{
 		{
 			Version: &version,
@@ -83,7 +84,7 @@ func (r *ResourceServer) GetCloudInfo(ctx context.Context, request api.GetCloudI
 func (r *ResourceServer) GetMinorVersions(ctx context.Context, request api.GetMinorVersionsRequestObject) (api.GetMinorVersionsResponseObject, error) {
 	// We currently only support a single version
 	version := utils2.CurrentInventoryVersion
-	baseURL := utils2.BaseInventoryURL
+	baseURL := constants.O2IMSInventoryBaseURL
 	versions := []generated.APIVersion{
 		{
 			Version: &version,

--- a/internal/service/resources/cmd/root.go
+++ b/internal/service/resources/cmd/root.go
@@ -11,12 +11,13 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/spf13/cobra"
 )
 
 // resourcesRootCmd represents the root command for working resource server
 var resourcesRootCmd = &cobra.Command{
-	Use:   "resource-server",
+	Use:   constants.ResourceServerCmd,
 	Short: "All things needed for the resource server",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		configureResourcesLogger()

--- a/internal/service/resources/cmd/serve.go
+++ b/internal/service/resources/cmd/serve.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-kni/oran-o2ims/internal/cmd/server"
-	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	utils2 "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/api"
@@ -70,7 +70,7 @@ func setServerFlags(cmd *cobra.Command) error {
 	flags.StringVar(
 		&config.GlobalCloudID,
 		server.GlobalCloudIDFlagName,
-		utils.DefaultOCloudID,
+		constants.DefaultOCloudID,
 		"The global O-Cloud identifier.",
 	)
 

--- a/internal/service/resources/db/models/converters.go
+++ b/internal/service/resources/db/models/converters.go
@@ -12,12 +12,12 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	commonapi "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api/generated"
 	models2 "github.com/openshift-kni/oran-o2ims/internal/service/common/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/api/generated"
-	"github.com/openshift-kni/oran-o2ims/internal/service/resources/utils"
 )
 
 // managementInterfaceID defines the unique identifier for the IMS O2 interface
@@ -213,13 +213,13 @@ func getObjectReference(objectType string, objectID uuid.UUID, parentID *uuid.UU
 	var value string
 	switch objectType {
 	case ResourceType{}.TableName():
-		value = fmt.Sprintf("%s/resourceTypes/%s", utils.BaseInventoryURL, objectID.String())
+		value = fmt.Sprintf("%s/resourceTypes/%s", constants.O2IMSInventoryBaseURL, objectID.String())
 	case Resource{}.TableName():
-		value = fmt.Sprintf("%s/resourcePools/%s/resources/%s", utils.BaseInventoryURL, parentID.String(), objectID.String())
+		value = fmt.Sprintf("%s/resourcePools/%s/resources/%s", constants.O2IMSInventoryBaseURL, parentID.String(), objectID.String())
 	case ResourcePool{}.TableName():
-		value = fmt.Sprintf("%s/resourcePools/%s", utils.BaseInventoryURL, objectID.String())
+		value = fmt.Sprintf("%s/resourcePools/%s", constants.O2IMSInventoryBaseURL, objectID.String())
 	case DeploymentManager{}.TableName():
-		value = fmt.Sprintf("%s/deploymentManagers/%s", utils.BaseInventoryURL, objectID.String())
+		value = fmt.Sprintf("%s/deploymentManagers/%s", constants.O2IMSInventoryBaseURL, objectID.String())
 	default:
 		return nil
 	}

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/uuid"
 
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
@@ -101,7 +102,7 @@ func Serve(config *api.ResourceServerConfig) error {
 
 	// Convert arguments
 	var globalCloudID uuid.UUID
-	if config.GlobalCloudID != utils.DefaultOCloudID {
+	if config.GlobalCloudID != constants.DefaultOCloudID {
 		value, err := uuid.Parse(config.GlobalCloudID)
 		if err != nil {
 			return fmt.Errorf("failed to parse global cloud NotificationID '%s': %w", config.GlobalCloudID, err)
@@ -129,7 +130,7 @@ func Serve(config *api.ResourceServerConfig) error {
 	// Create the notifier with our resource-specific subscription and notification providers.
 	notificationsProvider := repo2.NewNotificationStorageProvider(commonRepository)
 	subscriptionsProvider := repo2.NewSubscriptionStorageProvider(commonRepository, collector.NewNotificationTransformer())
-	clientFactory := notifier.NewClientFactory(oauthConfig, utils.DefaultBackendTokenFile)
+	clientFactory := notifier.NewClientFactory(oauthConfig, constants.DefaultBackendTokenFile)
 	resourceNotifier := notifier.NewNotifier(subscriptionsProvider, notificationsProvider, clientFactory)
 
 	hwMgrDataSourceLoader, err := collector.NewHwPluginDataSourceLoader(cloudID, globalCloudID)

--- a/internal/service/resources/utils/constants.go
+++ b/internal/service/resources/utils/constants.go
@@ -6,5 +6,4 @@ SPDX-License-Identifier: Apache-2.0
 
 package utils
 
-var BaseInventoryURL = "/o2ims-infrastructureInventory/v1"
 var CurrentInventoryVersion = "1.0.0"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -37,6 +37,7 @@ import (
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	provisioningcontrollers "github.com/openshift-kni/oran-o2ims/internal/controllers"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
@@ -168,7 +169,7 @@ var _ = BeforeSuite(func() {
 		// oran-o2ims
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "oran-o2ims",
+				Name: constants.DefaultNamespace,
 			},
 		},
 		// HardwarePlugin CRs


### PR DESCRIPTION
…tainability

- Add network address constants (Localhost = "127.0.0.1")
- Add executable path constants (ManagerExec, PsqlExec)
- Replace hardcoded strings with centralized constants throughout codebase
- Fix go vet issues by updating missing constant references
- Remove unused wrapper constants and clean up imports
- Update controller deployments, service configs, and test files
- Consolidate API base URL references to use central constants

This change eliminates hardcoded string literals across 15+ files, centralizes configuration in internal/constants/constants.go, and improves code maintainability by providing single sources of truth for commonly used values like namespaces, ports, file paths, and executables.

Files affected:
- internal/constants/constants.go (new constants added)
- internal/controllers/* (deployment specs updated)
- internal/service/* (API paths and configs centralized)
- hwmgr-plugins/* (authentication tokens centralized)
- test/* (namespace references standardized)

Generated-By: Cursor/claude-4-sonnet