### PR TITLE
fix dependabot Prow error...

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,6 @@ updates:
     golang:
      patterns: ["golang.org/*"]
      update-types: ["major", "minor", "patch"]
-   ignore:
    #ignore:
    #  - dependency-name: "*"
    #    update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
"The property '#/updates/0/ignore' of type null did not match the following type: array"

This stops our automatic konflux merges.