### PR TITLE
feat(crd-watcher): Enhance inventory refresh, deletion handling, and …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /oran-o2ims
 /bin/*
 /catalog/*
+/dev-tools/crd-watcher/bin
 
 # Folders
 .idea/

--- a/dev-tools/crd-watcher/formatter.go
+++ b/dev-tools/crd-watcher/formatter.go
@@ -51,6 +51,9 @@ const (
 	StringFalse          = "false"
 	StringValid          = "Valid"
 	StringChangeDetected = "ChangeDetected"
+	StringLocalCluster   = "local-cluster"
+	StringAvailable      = "available"
+	StringFulfilled      = "fulfilled"
 )
 
 type OutputFormatter interface {
@@ -197,10 +200,10 @@ func (f *TableFormatter) compareEvents(crdType string, a, b WatchEvent) bool {
 		clusterIdB := f.getNodeAllocationRequestClusterId(b.Object)
 		return clusterIdA < clusterIdB
 	case CRDTypeAllocatedNodes:
-		// Sort by HWMGR-NODE-ID
-		hwMgrIdA := f.getAllocatedNodeHwMgrId(a.Object)
-		hwMgrIdB := f.getAllocatedNodeHwMgrId(b.Object)
-		return hwMgrIdA < hwMgrIdB
+		// Sort by name
+		accessor1, _ := meta.Accessor(a.Object)
+		accessor2, _ := meta.Accessor(b.Object)
+		return accessor1.GetName() < accessor2.GetName()
 	case CRDTypeBareMetalHosts, CRDTypeHostFirmwareComponents, CRDTypeHostFirmwareSettings:
 		// Sort by name
 		accessor1, _ := meta.Accessor(a.Object)
@@ -250,15 +253,6 @@ func (f *TableFormatter) getNodeAllocationRequestClusterId(obj runtime.Object) s
 	if nar, ok := obj.(*pluginsv1alpha1.NodeAllocationRequest); ok {
 		if nar.Spec.ClusterId != "" {
 			return nar.Spec.ClusterId
-		}
-	}
-	return StringNone
-}
-
-func (f *TableFormatter) getAllocatedNodeHwMgrId(obj runtime.Object) string {
-	if an, ok := obj.(*pluginsv1alpha1.AllocatedNode); ok {
-		if an.Spec.HwMgrNodeId != "" {
-			return an.Spec.HwMgrNodeId
 		}
 	}
 	return StringNone


### PR DESCRIPTION
…display consistency

This commit implements several critical improvements to the crd-watcher tool to ensure accurate real-time monitoring of infrastructure resources and inventory data.

- Add state-specific logic for ProvisioningRequest events
- Trigger inventory refresh only when provisioningPhase changes to "fulfilled" or on deletion
- Apply 1-second delay for both deletion and fulfilled state events
- Reduce noise from intermediate provisioning status updates
- Add StringFulfilled constant and helper functions for state detection

- Bypass 250ms debouncing for deletion events in TUI formatter
- Implement immediateUpdate() function for instant deletion reflection
- Maintain debouncing for add/modify events to prevent flickering
- Ensure all CR deletions appear immediately in watch output

- Fix filtering logic that prevented HostFirmwareComponent/Settings deletions from displaying
- Always process firmware CR deletion events regardless of BareMetalHost existence
- Resolve race conditions when BMH is deleted before associated firmware CRs
- Maintain normal filtering for non-deletion firmware CR events

- Implement immediate cleanup of stale inventory objects before each refresh
- Add cleanupStaleInventoryObjects() method for targeted inventory verification
- Verify all inventory objects during refresh to remove stale cached data
- Trigger immediate screen updates when stale objects are removed
- Prevent duplicate/ghost entries in inventory display

- Change AllocatedNode sorting from HWMGR-NODE-ID to resource name
- Provide consistent alphabetical ordering with other resource types
- Maintain all original display fields (HWMGR-NODE-ID still shown)
- Remove unused getAllocatedNodeHwMgrId helper functions

- Update triggerEventBasedInventoryRefresh to accept runtime.Object parameter
- Add shouldTriggerRefreshForPREvent and isPRPhaseFulfilled helper functions
- Improve logging with specific trigger reasons (pr-state-triggered, bmh-state-triggered)
- Consolidate 1-second delay timing for all priority events

- Pre-refresh cleanup ensures fresh inventory data accuracy
- Two-tier cleanup strategy: immediate (inventory refresh) + periodic (background)
- Resource-specific verification prevents unnecessary API calls
- Immediate visual feedback for cache cleanup operations

- Immediate deletion reflection across all CR types
- Consistent sorting patterns for better user experience
- Enhanced documentation reflecting all new behaviors
- Preserved backward compatibility for non-TUI output modes

- dev-tools/crd-watcher/watcher.go: Core refresh and filtering logic
- dev-tools/crd-watcher/tui.go: Display updates and cache cleanup
- dev-tools/crd-watcher/formatter.go: Sorting and constants
- dev-tools/crd-watcher/README.md: Updated documentation

- Eliminates stale cached objects in inventory display
- Provides immediate visual feedback for all deletion events
- Reduces unnecessary inventory refreshes through smart state filtering
- Ensures consistent, accurate real-time infrastructure monitoring
- Improves user experience with predictable resource ordering

Generated-By: Cursor/claude-4-sonnet