### PR TITLE
Update oran to use input/output Konflux catalog templates

### DIFF
--- a/.konflux/catalog/.gitignore
+++ b/.konflux/catalog/.gitignore
@@ -1,1 +1,2 @@
 o-cloud-manager/catalog.yaml
+catalog-template.out.yaml

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -6,19 +6,22 @@ entries:
       mediatype: image/svg+xml
     name: o-cloud-manager
     schema: olm.package
-  # Add 'replaces' after we ship 4.20.0
+    # Channel entries for 'stable' channel
   - entries:
       - name: o-cloud-manager.v4.20.0
         skipRange: '>=4.9.0 <4.20.0'
     name: stable
     package: o-cloud-manager
     schema: olm.channel
+    # Channel entries for '4.20' channel
   - entries:
       - name: o-cloud-manager.v4.20.0
         skipRange: '>=4.9.0 <4.20.0'
     name: "4.20"
     package: o-cloud-manager
     schema: olm.channel
-  - image: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-4-20@sha256:5049523399de0d53eb8cbf9a845d87732275dfc03624371545f78e549df854c8
+  # v4.20.0 bundle
+  # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
+  - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle
 schema: olm.template.basic

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ OPM_VERSION ?= v1.52.0
 GOLANGCI_LINT_VERSION ?= v2.3.0
 
 PACKAGE_NAME_KONFLUX = o-cloud-manager
-CATALOG_TEMPLATE_KONFLUX = .konflux/catalog/catalog-template.in.yaml
+CATALOG_TEMPLATE_KONFLUX_INPUT = .konflux/catalog/catalog-template.in.yaml
+CATALOG_TEMPLATE_KONFLUX_OUTPUT = .konflux/catalog/catalog-template.out.yaml
 CATALOG_KONFLUX = .konflux/catalog/$(PACKAGE_NAME_KONFLUX)/catalog.yaml
 
 # Konflux bundle image configuration
@@ -620,7 +621,8 @@ ENGINE ?= docker
 .PHONY: konflux-validate-catalog-template-bundle ## validate the last bundle entry on the catalog template file
 konflux-validate-catalog-template-bundle: yq operator-sdk
 	$(MAKE) -C $(PROJECT_DIR)/telco5g-konflux/scripts/catalog konflux-validate-catalog-template-bundle \
-		CATALOG_TEMPLATE_KONFLUX=$(PROJECT_DIR)/$(CATALOG_TEMPLATE_KONFLUX) \
+		CATALOG_TEMPLATE_KONFLUX_INPUT=$(PROJECT_DIR)/$(CATALOG_TEMPLATE_KONFLUX_INPUT) \
+		CATALOG_TEMPLATE_KONFLUX_OUTPUT=$(PROJECT_DIR)/$(CATALOG_TEMPLATE_KONFLUX_OUTPUT) \
 		YQ=$(YQ) \
 		OPERATOR_SDK=$(OPERATOR_SDK) \
 		ENGINE=$(ENGINE)
@@ -634,7 +636,8 @@ konflux-validate-catalog: opm ## validate the current catalog file
 .PHONY: konflux-generate-catalog ## generate a quay.io catalog
 konflux-generate-catalog: yq opm
 	$(MAKE) -C $(PROJECT_DIR)/telco5g-konflux/scripts/catalog konflux-generate-catalog \
-		CATALOG_TEMPLATE_KONFLUX=$(PROJECT_DIR)/$(CATALOG_TEMPLATE_KONFLUX) \
+		CATALOG_TEMPLATE_KONFLUX_INPUT=$(PROJECT_DIR)/$(CATALOG_TEMPLATE_KONFLUX_INPUT) \
+		CATALOG_TEMPLATE_KONFLUX_OUTPUT=$(PROJECT_DIR)/$(CATALOG_TEMPLATE_KONFLUX_OUTPUT) \
 		CATALOG_KONFLUX=$(PROJECT_DIR)/$(CATALOG_KONFLUX) \
 		PACKAGE_NAME_KONFLUX=$(PACKAGE_NAME_KONFLUX) \
 		BUNDLE_BUILDS_FILE=$(PROJECT_DIR)/.konflux/catalog/bundle.builds.in.yaml \
@@ -645,7 +648,8 @@ konflux-generate-catalog: yq opm
 .PHONY: konflux-generate-catalog-production ## generate a registry.redhat.io catalog
 konflux-generate-catalog-production: yq opm
 	$(MAKE) -C $(PROJECT_DIR)/telco5g-konflux/scripts/catalog konflux-generate-catalog-production \
-		CATALOG_TEMPLATE_KONFLUX=$(PROJECT_DIR)/$(CATALOG_TEMPLATE_KONFLUX) \
+		CATALOG_TEMPLATE_KONFLUX_INPUT=$(PROJECT_DIR)/$(CATALOG_TEMPLATE_KONFLUX_INPUT) \
+		CATALOG_TEMPLATE_KONFLUX_OUTPUT=$(PROJECT_DIR)/$(CATALOG_TEMPLATE_KONFLUX_OUTPUT) \
 		CATALOG_KONFLUX=$(PROJECT_DIR)/$(CATALOG_KONFLUX) \
 		PACKAGE_NAME_KONFLUX=$(PACKAGE_NAME_KONFLUX) \
 		BUNDLE_NAME_SUFFIX=$(BUNDLE_NAME_SUFFIX) \


### PR DESCRIPTION
- Update telco5g-konflux submodule to latest commit
- Update Makefile to use the input/output variables
- Update gitignore to ignore the generated file