### PR TITLE
CNF-19058: Skip teardown when seed image generation is requested

### DIFF
--- a/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller.go
+++ b/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller.go
@@ -149,8 +149,11 @@ func (r *AllocatedNodeReconciler) handleAllocatedNodeDeletion(ctx context.Contex
 	}
 
 	if bmh.Spec.Online {
-		if err := patchOnlineFalse(ctx, r.Client, bmh); err != nil {
-			return false, fmt.Errorf("failed to patchOnlineFalse for BMH %s: %w", bmh.Name, err)
+		// Skip power-off if skip-cleanup is requested
+		if _, present := bmh.Annotations[SkipCleanupAnnotation]; !present {
+			if err := patchOnlineFalse(ctx, r.Client, bmh); err != nil {
+				return false, fmt.Errorf("failed to patchOnlineFalse for BMH %s: %w", bmh.Name, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Add support for a `skin-clean` annotation on BMH to control deallocation behavior. When this annotation is present, the deallocation process will skip teardown, leaving the BMH online and provisioned when the allocated node is deleted.

Assisted-By: Claude/Cursor AI Assistant