### PR TITLE
Fix timeout logic and NAR reconciler race condition

### DIFF
--- a/hwmgr-plugins/metal3/controller/helpers.go
+++ b/hwmgr-plugins/metal3/controller/helpers.go
@@ -320,9 +320,9 @@ func checkNodeAllocationRequestProgress(
 
 	// check if there are any pending work such as bios configuring
 	if updating, err := checkForPendingUpdate(ctx, c, noncachedClient, logger, pluginNamespace, nodeAllocationRequest); err != nil {
-		return false, DoNotRequeue, err
+		return false, RequeueAfterShortInterval, err
 	} else if updating {
-		return false, DoNotRequeue, nil
+		return false, RequeueAfterShortInterval, nil
 	}
 	return true, DoNotRequeue, nil
 }


### PR DESCRIPTION
This commit addresses two critical issues in the provisioning system:

1. **Fix NAR reconciler race condition**: Modified checkNodeAllocationRequestProgress in helpers.go to return RequeueAfterShortInterval instead of DoNotRequeue when updates are in progress or errors occur. This prevents the NAR from getting stuck in InProgress state while individual AllocatedNodes complete successfully.

2. **Improve timeout condition validation**: Enhanced checkOverallProvisioningTimeout to only trigger timeouts when their respective conditions are False with non-Failed reasons. This prevents inappropriate timeout triggers on already completed or failed operations.

Changes include:
- Fix DoNotRequeue issue in metal3 hwmgr-plugin NAR reconciler
- Add condition state checks before hardware provisioning timeout (HardwareProvisioned)
- Add condition state checks before cluster installation timeout (ClusterProvisioned)
- Add condition state checks before cluster configuration timeout (ConfigurationApplied)
- Comprehensive unit test updates covering all new timeout logic
- Added negative test cases for already-failed and completed conditions
- Updated multiple-timeout test scenarios to include all condition types

The timeout improvements ensure proper lifecycle management by respecting condition states, while the NAR fix resolves a race condition that could leave hardware provisioning requests permanently stuck.

Assisted-by: Claude Code/claude-sonnet-4