### PR TITLE
OCPBUGS-60657: Handle optional fields in API filtering gracefully

### DIFF
--- a/internal/search/path_evaluator_test.go
+++ b/internal/search/path_evaluator_test.go
@@ -172,4 +172,41 @@ var _ = Describe("Path evaluator", func() {
 			"failed to evaluate 'mykey': map doesn't have a 'mykey' key",
 		),
 	)
+
+	Describe("With missing fields allowed", func() {
+		DescribeTable(
+			"Returns nil for missing fields",
+			func(path []string, producer func() any) {
+				evaluator, err := NewPathEvaluator().
+					SetLogger(logger).
+					SetAllowMissingFields(true).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				result, err := evaluator.Evaluate(context.Background(), path, producer())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeNil())
+			},
+			Entry(
+				"Struct field that doesn't exist",
+				[]string{"MissingField"},
+				func() any {
+					type MyObject struct {
+						ExistingField string
+					}
+					return MyObject{
+						ExistingField: "value",
+					}
+				},
+			),
+			Entry(
+				"Map key that doesn't exist",
+				[]string{"missingkey"},
+				func() any {
+					return map[string]any{
+						"existingkey": "value",
+					}
+				},
+			),
+		)
+	})
 })

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -193,7 +193,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 		AddSource: true,
 		Level:     slog.LevelDebug,
 	}))
-	filterAdapter, err := middleware.NewFilterAdapter(logger)
+	filterAdapter, err := middleware.NewFilterAdapterFromSwagger(logger, swagger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -96,7 +96,7 @@ func Serve(config *api.ArtifactsServerConfig) error {
 	}))
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters.
-	filterAdapter, err := middleware.NewFilterAdapter(logger)
+	filterAdapter, err := middleware.NewFilterAdapterFromSwagger(logger, swagger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -154,7 +154,7 @@ func Serve(config *api.ClusterServerConfig) error {
 	}))
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters
-	filterAdapter, err := middleware.NewFilterAdapter(logger)
+	filterAdapter, err := middleware.NewFilterAdapterFromSwagger(logger, swagger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}

--- a/internal/service/common/api/middleware/filtering_test.go
+++ b/internal/service/common/api/middleware/filtering_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -29,8 +30,9 @@ var _ = Describe("ResponseFilter", func() {
 	)
 
 	type object struct {
-		Name  string `json:"name"`
-		Value int    `json:"value"`
+		Name          string  `json:"name"`
+		Value         int     `json:"value"`
+		OptionalField *string `json:"optionalField,omitempty"`
 	}
 
 	BeforeEach(func() {
@@ -139,11 +141,17 @@ var _ = Describe("ResponseFilter", func() {
 		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
 	})
 
-	It("should return bad request on unknown field name", func() {
+	It("should handle unknown field name gracefully when no schema validation", func() {
 		req.URL.RawQuery = "filter=(eq,unknown,foo)"
 		handler.ServeHTTP(recorder, req)
 
-		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+		// Without schema validation, unknown fields should be handled gracefully
+		// and return an empty result since no objects have that field
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		var result []object
+		err := json.Unmarshal(recorder.Body.Bytes(), &result)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(HaveLen(0))
 	})
 
 	It("should return bad request on type mismatch", func() {
@@ -164,5 +172,165 @@ var _ = Describe("ResponseFilter", func() {
 		handler.ServeHTTP(recorder, req)
 
 		Expect(recorder.Code).To(Equal(http.StatusInternalServerError))
+	})
+
+	It("should handle filtering on optional fields gracefully", func() {
+		// Create a list with objects where some have the optional field and some don't
+		valueWithOptional := "optional_value"
+		list := []object{
+			{Name: "hello", Value: 1, OptionalField: &valueWithOptional},
+			{Name: "world", Value: 10, OptionalField: nil},
+		}
+		body, err := json.Marshal(list)
+		Expect(err).NotTo(HaveOccurred())
+
+		next = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}
+		handler = ResponseFilter(adapter)(next)
+
+		// Filter by an optional field that only exists in some objects
+		req.URL.RawQuery = "filter=(eq,optionalField,optional_value)"
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		var result []object
+		err = json.Unmarshal(recorder.Body.Bytes(), &result)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(HaveLen(1))
+		Expect(result[0].Name).To(Equal("hello"))
+		Expect(result[0].OptionalField).NotTo(BeNil())
+		Expect(*result[0].OptionalField).To(Equal("optional_value"))
+	})
+
+	It("should handle filtering on missing optional fields without errors", func() {
+		// Create a list where none of the objects have the optional field populated
+		list := []object{
+			{Name: "hello", Value: 1, OptionalField: nil},
+			{Name: "world", Value: 10, OptionalField: nil},
+		}
+		body, err := json.Marshal(list)
+		Expect(err).NotTo(HaveOccurred())
+
+		next = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}
+		handler = ResponseFilter(adapter)(next)
+
+		// Filter by an optional field that doesn't exist in any object
+		req.URL.RawQuery = "filter=(eq,optionalField,some_value)"
+		handler.ServeHTTP(recorder, req)
+
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		var result []object
+		err = json.Unmarshal(recorder.Body.Bytes(), &result)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(HaveLen(0)) // No objects should match since the field is nil
+	})
+
+	Context("with schema validation", func() {
+		var schemaAdapter *FilterAdapter
+
+		BeforeEach(func() {
+			// Create test schemas that match our object structure
+			schemas := map[string]*openapi3.Schema{
+				"TestObject": {
+					Type: &openapi3.Types{"object"},
+					Properties: map[string]*openapi3.SchemaRef{
+						"name": {
+							Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+						},
+						"value": {
+							Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}},
+						},
+						"optionalField": {
+							Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+						},
+					},
+				},
+			}
+
+			logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+			var err error
+			schemaAdapter, err = NewFilterAdapterWithSchemas(logger, schemas)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return bad request for truly invalid field names with schema validation", func() {
+			list := []object{{Name: "hello", Value: 1}, {Name: "world", Value: 10}}
+			body, err := json.Marshal(list)
+			Expect(err).NotTo(HaveOccurred())
+
+			next := func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(body)
+			}
+			handler := ResponseFilter(schemaAdapter)(http.HandlerFunc(next))
+
+			req.URL.RawQuery = "filter=(eq,invalidField,foo)"
+			handler.ServeHTTP(recorder, req)
+
+			Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+
+			// Verify the error message is user-friendly
+			var errorResponse map[string]interface{}
+			err = json.Unmarshal(recorder.Body.Bytes(), &errorResponse)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(errorResponse["detail"]).To(ContainSubstring("invalid field name 'invalidField'"))
+			Expect(errorResponse["detail"]).To(ContainSubstring("does not exist in the API schema"))
+		})
+
+		It("should return descriptive error for typos in field names", func() {
+			list := []object{{Name: "hello", Value: 1}, {Name: "world", Value: 10}}
+			body, err := json.Marshal(list)
+			Expect(err).NotTo(HaveOccurred())
+
+			next := func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(body)
+			}
+			handler := ResponseFilter(schemaAdapter)(http.HandlerFunc(next))
+
+			// Test with a typo in field name (filte2r instead of filter)
+			req.URL.RawQuery = "filter=(eq,filte2r,ACK)"
+			handler.ServeHTTP(recorder, req)
+
+			Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+
+			// Verify the error message specifically mentions the typo
+			var errorResponse map[string]interface{}
+			err = json.Unmarshal(recorder.Body.Bytes(), &errorResponse)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(errorResponse["detail"]).To(ContainSubstring("invalid field name 'filte2r'"))
+			Expect(errorResponse["detail"]).To(ContainSubstring("does not exist in the API schema"))
+		})
+
+		It("should allow valid optional fields with schema validation", func() {
+			valueWithOptional := "optional_value"
+			list := []object{
+				{Name: "hello", Value: 1, OptionalField: &valueWithOptional},
+				{Name: "world", Value: 10, OptionalField: nil},
+			}
+			body, err := json.Marshal(list)
+			Expect(err).NotTo(HaveOccurred())
+
+			next := func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(body)
+			}
+			handler := ResponseFilter(schemaAdapter)(http.HandlerFunc(next))
+
+			req.URL.RawQuery = "filter=(eq,optionalField,optional_value)"
+			handler.ServeHTTP(recorder, req)
+
+			Expect(recorder.Code).To(Equal(http.StatusOK))
+			var result []object
+			err = json.Unmarshal(recorder.Body.Bytes(), &result)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Name).To(Equal("hello"))
+		})
 	})
 })

--- a/internal/service/common/api/middleware/schema_utils.go
+++ b/internal/service/common/api/middleware/schema_utils.go
@@ -1,0 +1,37 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package middleware
+
+import (
+	"log/slog"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// NewFilterAdapterFromSwagger creates a FilterAdapter with schemas extracted from an OpenAPI specification.
+// This is a convenience function that extracts all component schemas from the swagger spec and passes
+// them to NewFilterAdapterWithSchemas for field validation.
+func NewFilterAdapterFromSwagger(logger *slog.Logger, swagger *openapi3.T) (*FilterAdapter, error) {
+	schemas := extractSchemasFromSwagger(swagger)
+	return NewFilterAdapterWithSchemas(logger, schemas)
+}
+
+// extractSchemasFromSwagger extracts all component schemas from an OpenAPI specification.
+// Returns a map of schema names to schema objects that can be used for field validation.
+func extractSchemasFromSwagger(swagger *openapi3.T) map[string]*openapi3.Schema {
+	schemas := make(map[string]*openapi3.Schema)
+
+	if swagger != nil && swagger.Components != nil && swagger.Components.Schemas != nil {
+		for name, schemaRef := range swagger.Components.Schemas {
+			if schemaRef != nil && schemaRef.Value != nil {
+				schemas[name] = schemaRef.Value
+			}
+		}
+	}
+
+	return schemas
+}

--- a/internal/service/common/api/middleware/schema_utils_test.go
+++ b/internal/service/common/api/middleware/schema_utils_test.go
@@ -1,0 +1,138 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package middleware
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SchemaUtils", func() {
+	var logger *slog.Logger
+
+	BeforeEach(func() {
+		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	})
+
+	Describe("extractSchemasFromSwagger", func() {
+		It("should extract schemas from a valid swagger spec", func() {
+			swagger := &openapi3.T{
+				Components: &openapi3.Components{
+					Schemas: map[string]*openapi3.SchemaRef{
+						"User": {
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"object"},
+								Properties: map[string]*openapi3.SchemaRef{
+									"id": {
+										Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+									},
+									"name": {
+										Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+									},
+								},
+							},
+						},
+						"Product": {
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"object"},
+								Properties: map[string]*openapi3.SchemaRef{
+									"id": {
+										Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}},
+									},
+									"title": {
+										Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			schemas := extractSchemasFromSwagger(swagger)
+
+			Expect(schemas).To(HaveLen(2))
+			Expect(schemas).To(HaveKey("User"))
+			Expect(schemas).To(HaveKey("Product"))
+			Expect(schemas["User"].Type.Is("object")).To(BeTrue())
+			Expect(schemas["Product"].Type.Is("object")).To(BeTrue())
+		})
+
+		It("should return empty map for nil swagger", func() {
+			schemas := extractSchemasFromSwagger(nil)
+			Expect(schemas).To(BeEmpty())
+		})
+
+		It("should return empty map for swagger without components", func() {
+			swagger := &openapi3.T{}
+			schemas := extractSchemasFromSwagger(swagger)
+			Expect(schemas).To(BeEmpty())
+		})
+
+		It("should handle nil schema refs gracefully", func() {
+			swagger := &openapi3.T{
+				Components: &openapi3.Components{
+					Schemas: map[string]*openapi3.SchemaRef{
+						"ValidSchema": {
+							Value: &openapi3.Schema{Type: &openapi3.Types{"object"}},
+						},
+						"NilRef": nil,
+						"EmptyRef": {
+							Value: nil,
+						},
+					},
+				},
+			}
+
+			schemas := extractSchemasFromSwagger(swagger)
+
+			Expect(schemas).To(HaveLen(1))
+			Expect(schemas).To(HaveKey("ValidSchema"))
+			Expect(schemas).NotTo(HaveKey("NilRef"))
+			Expect(schemas).NotTo(HaveKey("EmptyRef"))
+		})
+	})
+
+	Describe("NewFilterAdapterFromSwagger", func() {
+		It("should create a filter adapter with schema validation", func() {
+			swagger := &openapi3.T{
+				Components: &openapi3.Components{
+					Schemas: map[string]*openapi3.SchemaRef{
+						"TestSchema": {
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"object"},
+								Properties: map[string]*openapi3.SchemaRef{
+									"validField": {
+										Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			adapter, err := NewFilterAdapterFromSwagger(logger, swagger)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter).NotTo(BeNil())
+			Expect(adapter.schemaValidator).NotTo(BeNil())
+		})
+
+		It("should work with nil swagger (no schema validation)", func() {
+			adapter, err := NewFilterAdapterFromSwagger(logger, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter).NotTo(BeNil())
+			Expect(adapter.schemaValidator).To(BeNil())
+		})
+	})
+})

--- a/internal/service/common/api/middleware/schema_validator.go
+++ b/internal/service/common/api/middleware/schema_validator.go
@@ -1,0 +1,95 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package middleware
+
+import (
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// SchemaValidator validates field names against OpenAPI schemas
+type SchemaValidator struct {
+	schemas map[string]*openapi3.Schema
+}
+
+// NewSchemaValidator creates a new schema validator with the provided schemas
+func NewSchemaValidator(schemas map[string]*openapi3.Schema) *SchemaValidator {
+	return &SchemaValidator{
+		schemas: schemas,
+	}
+}
+
+// ValidateFieldPath validates that a field path exists in any of the provided schemas
+// Returns true if the field is valid (exists in at least one schema), false otherwise
+func (v *SchemaValidator) ValidateFieldPath(fieldPath []string) bool {
+	if len(fieldPath) == 0 {
+		return false
+	}
+
+	// Check each schema to see if any contains this field path
+	for _, schema := range v.schemas {
+		if v.validateFieldInSchema(fieldPath, schema) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateFieldInSchema recursively validates a field path against a specific schema
+func (v *SchemaValidator) validateFieldInSchema(fieldPath []string, schema *openapi3.Schema) bool {
+	if len(fieldPath) == 0 {
+		return true
+	}
+
+	if schema == nil {
+		return false
+	}
+
+	// Handle object schemas
+	if (schema.Type != nil && schema.Type.Is("object")) || len(schema.Properties) > 0 {
+		fieldName := fieldPath[0]
+
+		// Check if the field exists in this schema's properties
+		if property, exists := schema.Properties[fieldName]; exists {
+			// If this is the last field in the path, it's valid
+			if len(fieldPath) == 1 {
+				return true
+			}
+			// Continue validation with the remaining path
+			return v.validateFieldInSchema(fieldPath[1:], property.Value)
+		}
+
+		// Check if the schema has additionalProperties that allow any field
+		if schema.AdditionalProperties.Has != nil && *schema.AdditionalProperties.Has {
+			return true
+		}
+
+		// Check allOf, anyOf, oneOf schemas
+		for _, subSchema := range schema.AllOf {
+			if v.validateFieldInSchema(fieldPath, subSchema.Value) {
+				return true
+			}
+		}
+		for _, subSchema := range schema.AnyOf {
+			if v.validateFieldInSchema(fieldPath, subSchema.Value) {
+				return true
+			}
+		}
+		for _, subSchema := range schema.OneOf {
+			if v.validateFieldInSchema(fieldPath, subSchema.Value) {
+				return true
+			}
+		}
+	}
+
+	// Handle array schemas
+	if schema.Type != nil && schema.Type.Is("array") && schema.Items != nil {
+		// For arrays, validate against the item schema
+		return v.validateFieldInSchema(fieldPath, schema.Items.Value)
+	}
+
+	return false
+}

--- a/internal/service/common/api/middleware/schema_validator_test.go
+++ b/internal/service/common/api/middleware/schema_validator_test.go
@@ -1,0 +1,92 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package middleware
+
+import (
+	"github.com/getkin/kin-openapi/openapi3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SchemaValidator", func() {
+	var validator *SchemaValidator
+
+	BeforeEach(func() {
+		// Create test schemas
+		schemas := map[string]*openapi3.Schema{
+			"Resource": {
+				Type: &openapi3.Types{"object"},
+				Properties: map[string]*openapi3.SchemaRef{
+					"id": {
+						Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+					},
+					"name": {
+						Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+					},
+					"metadata": {
+						Value: &openapi3.Schema{
+							Type: &openapi3.Types{"object"},
+							Properties: map[string]*openapi3.SchemaRef{
+								"created": {
+									Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+								},
+								"labels": {
+									Value: &openapi3.Schema{Type: &openapi3.Types{"object"}},
+								},
+							},
+						},
+					},
+					"optionalField": {
+						Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+					},
+				},
+			},
+		}
+		validator = NewSchemaValidator(schemas)
+	})
+
+	It("should validate existing top-level fields", func() {
+		Expect(validator.ValidateFieldPath([]string{"id"})).To(BeTrue())
+		Expect(validator.ValidateFieldPath([]string{"name"})).To(BeTrue())
+		Expect(validator.ValidateFieldPath([]string{"optionalField"})).To(BeTrue())
+	})
+
+	It("should validate nested fields", func() {
+		Expect(validator.ValidateFieldPath([]string{"metadata", "created"})).To(BeTrue())
+		Expect(validator.ValidateFieldPath([]string{"metadata", "labels"})).To(BeTrue())
+	})
+
+	It("should reject invalid field names", func() {
+		Expect(validator.ValidateFieldPath([]string{"nonexistent"})).To(BeFalse())
+		Expect(validator.ValidateFieldPath([]string{"metadata", "nonexistent"})).To(BeFalse())
+	})
+
+	It("should handle empty field paths", func() {
+		Expect(validator.ValidateFieldPath([]string{})).To(BeFalse())
+	})
+
+	It("should handle schemas with additionalProperties", func() {
+		schemas := map[string]*openapi3.Schema{
+			"FlexibleResource": {
+				Type: &openapi3.Types{"object"},
+				Properties: map[string]*openapi3.SchemaRef{
+					"id": {
+						Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+					},
+				},
+				AdditionalProperties: openapi3.AdditionalProperties{
+					Has: func() *bool { b := true; return &b }(),
+				},
+			},
+		}
+		flexValidator := NewSchemaValidator(schemas)
+
+		// Should accept any field name when additionalProperties is true
+		Expect(flexValidator.ValidateFieldPath([]string{"id"})).To(BeTrue())
+		Expect(flexValidator.ValidateFieldPath([]string{"anyField"})).To(BeTrue())
+	})
+})

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -93,7 +93,7 @@ func Serve(config *api.ProvisioningServerConfig) error {
 	}))
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters.
-	filterAdapter, err := middleware.NewFilterAdapter(logger)
+	filterAdapter, err := middleware.NewFilterAdapterFromSwagger(logger, swagger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -170,7 +170,7 @@ func Serve(config *api.ResourceServerConfig) error {
 	}))
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters
-	filterAdapter, err := middleware.NewFilterAdapter(logger)
+	filterAdapter, err := middleware.NewFilterAdapterFromSwagger(logger, swagger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}


### PR DESCRIPTION
The API filtering mechanism was incorrectly returning errors when filtering on valid optional fields that weren't populated in response objects. This was caused by the PathEvaluator treating missing fields as invalid rather than checking against the API schema.

Changes:
- Enhanced PathEvaluator with allowMissingFields option to return nil for missing optional fields instead of errors
- Added SchemaValidator component for validating field names against OpenAPI schemas before evaluation
- Updated FilterAdapter to support schema-based validation and use enhanced PathEvaluator
- Added comprehensive tests for optional field handling in both search and middleware components

The fix implements proper API semantics where optional fields can be filtered without errors, while maintaining validation for truly invalid field names when schema validation is enabled.

🤖 Generated with [Claude Code](https://claude.ai/code)

Assisted-by: Claude Code/claude-sonnet-4