### PR TITLE
OCPBUGS-60633: Improve handling for multiple node matches

### DIFF
--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -1173,6 +1173,7 @@ func (t *provisioningRequestReconcilerTask) isHardwareProvisionSkipped() bool {
 // resources in the status.
 func (t *provisioningRequestReconcilerTask) finalizeProvisioningIfComplete(ctx context.Context) error {
 	if ctlrutils.IsClusterProvisionCompleted(t.object) && ctlrutils.IsClusterConfigCompleted(t.object) &&
+		(t.isHardwareProvisionSkipped() || ctlrutils.IsHardwareConfigCompleted(t.object)) &&
 		(!ctlrutils.IsClusterUpgradeInitiated(t.object) || ctlrutils.IsClusterUpgradeCompleted(t.object)) {
 
 		ctlrutils.SetProvisioningStateFulfilled(t.object)

--- a/internal/controllers/utils/conditions.go
+++ b/internal/controllers/utils/conditions.go
@@ -143,6 +143,20 @@ func IsClusterConfigCompleted(cr *provisioningv1alpha1.ProvisioningRequest) bool
 	return condition != nil && condition.Status == metav1.ConditionTrue
 }
 
+// IsHardwareConfigCompleted checks if the hardware config condition status is completed
+// For initial provisioning, this condition may not exist, which is considered completed.
+// For Day2 updates, the condition must be present and True.
+func IsHardwareConfigCompleted(cr *provisioningv1alpha1.ProvisioningRequest) bool {
+	condition := meta.FindStatusCondition(cr.Status.Conditions,
+		string(provisioningv1alpha1.PRconditionTypes.HardwareConfigured))
+	if condition == nil {
+		// No HardwareConfigured condition means no Day2 hardware config was needed
+		return true
+	}
+	// If condition exists, it must be True to be considered completed
+	return condition.Status == metav1.ConditionTrue
+}
+
 // IsSmoRegistrationCompleted checks if registration with SMO has been completed
 func IsSmoRegistrationCompleted(cr *inventoryv1alpha1.Inventory) bool {
 	condition := meta.FindStatusCondition(cr.Status.Conditions,


### PR DESCRIPTION
This update improves the handling when there are multiple nodes with the same resource selector labels matching a NodeAllocationRequest. It also ensures the networkData is cleared properly in the case where there are day0 updates during provisioning.

In addition, Cursor was used to update test code, including adding some coverage for recent updates.

Assisted-by: Cursor/claude-4-sonnet