### PR TITLE
feat(crd-watcher): unify output formatting between watch and non-watc…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /bin/*
 /catalog/*
 /dev-tools/crd-watcher/bin
+/dev-tools/crd-watcher/crd-watcher
 
 # Folders
 .idea/

--- a/dev-tools/crd-watcher/formatter.go
+++ b/dev-tools/crd-watcher/formatter.go
@@ -51,6 +51,8 @@ const (
 	StringFalse          = "false"
 	StringValid          = "Valid"
 	StringChangeDetected = "ChangeDetected"
+	SidebarCharUnicode   = "│"
+	SidebarCharASCII     = "|"
 	StringLocalCluster   = "local-cluster"
 	StringAvailable      = "available"
 	StringFulfilled      = "fulfilled"
@@ -64,13 +66,15 @@ type TableFormatter struct {
 	headersPrinted map[string]bool         // Track headers printed per CRD type
 	events         map[string][]WatchEvent // Collect events for sorting
 	eventMutex     sync.Mutex
+	crdTypes       []string // List of CRD types being watched
+	useUnicode     bool     // Whether to use Unicode characters (default true)
 }
 
 type JSONFormatter struct{}
 
 type YAMLFormatter struct{}
 
-func NewOutputFormatter(format string, watchMode bool, refreshInterval int, crdTypes []string, verifyFunc func(WatchEvent) bool) OutputFormatter {
+func NewOutputFormatter(format string, watchMode bool, refreshInterval int, crdTypes []string, verifyFunc func(WatchEvent) bool, useASCII bool) OutputFormatter {
 	switch format {
 	case "json":
 		return &JSONFormatter{}
@@ -78,16 +82,20 @@ func NewOutputFormatter(format string, watchMode bool, refreshInterval int, crdT
 		return &YAMLFormatter{}
 	default:
 		if watchMode {
-			return NewTUIFormatter(refreshInterval, crdTypes, verifyFunc)
+			return NewTUIFormatter(refreshInterval, crdTypes, verifyFunc, !useASCII)
 		}
-		return NewTableFormatter()
+		tableFormatter := NewTableFormatter(crdTypes)
+		tableFormatter.useUnicode = !useASCII
+		return tableFormatter
 	}
 }
 
-func NewTableFormatter() *TableFormatter {
+func NewTableFormatter(crdTypes []string) *TableFormatter {
 	return &TableFormatter{
 		headersPrinted: make(map[string]bool),
 		events:         make(map[string][]WatchEvent),
+		crdTypes:       crdTypes,
+		useUnicode:     true, // Default to Unicode characters
 	}
 }
 
@@ -105,64 +113,83 @@ func (f *TableFormatter) FlushEvents() error {
 	f.eventMutex.Lock()
 	defer f.eventMutex.Unlock()
 
-	// Display events sorted by CRD type
-	for crdType, events := range f.events {
+	// Print main header like TUIFormatter
+	f.printMainHeader()
+
+	// Get ordered CRD types based on preferred order
+	orderedTypes := f.getOrderedCRDTypes()
+
+	// Process each CRD type in order
+	for i, crdType := range orderedTypes {
+		events := f.events[crdType]
+
+		// Print section header for this CRD type
+		f.printSectionHeader(crdType)
+
+		// Calculate dynamic field widths for this CRD type
+		widths := f.calculateFieldWidths(crdType, events)
+
+		// Print table header for this CRD type
+		f.printTableHeader(crdType, widths)
+
 		if len(events) == 0 {
-			continue
-		}
+			// Show empty message when no resources exist
+			sidebarChar := SidebarCharUnicode
+			if !f.useUnicode {
+				sidebarChar = "|"
+			}
+			fmt.Printf("%s No resources found\n", sidebarChar)
+		} else {
+			// Sort and display events for this CRD type
+			sortedEvents := f.sortEventsByCRDType(crdType, events)
 
-		// Print header if not already printed
-		if !f.headersPrinted[crdType] {
-			f.printTableHeader(crdType)
-			f.headersPrinted[crdType] = true
-		}
+			for _, event := range sortedEvents {
+				age := getAge(getTimestamp(event.Object))
 
-		// Sort events for this CRD type
-		sortedEvents := f.sortEventsByCRDType(crdType, events)
-
-		// Display sorted events
-		for _, event := range sortedEvents {
-			timestamp := event.Timestamp.Format("15:04:05")
-			age := getAge(getTimestamp(event.Object))
-
-			switch event.CRDType {
-			case CRDTypeProvisioningRequests:
-				if err := f.formatProvisioningRequest(timestamp, string(event.Type), age, event.Object); err != nil {
-					return err
-				}
-			case CRDTypeNodeAllocationRequests:
-				if err := f.formatNodeAllocationRequest(timestamp, string(event.Type), age, event.Object); err != nil {
-					return err
-				}
-			case CRDTypeAllocatedNodes:
-				if err := f.formatAllocatedNode(timestamp, string(event.Type), age, event.Object); err != nil {
-					return err
-				}
-			case CRDTypeBareMetalHosts:
-				if err := f.formatBareMetalHost(timestamp, string(event.Type), age, event.Object); err != nil {
-					return err
-				}
-			case CRDTypeHostFirmwareComponents:
-				if err := f.formatHostFirmwareComponents(timestamp, string(event.Type), age, event.Object); err != nil {
-					return err
-				}
-			case CRDTypeHostFirmwareSettings:
-				if err := f.formatHostFirmwareSettings(timestamp, string(event.Type), age, event.Object); err != nil {
-					return err
-				}
-			case CRDTypeInventoryResources:
-				if err := f.formatInventoryResource(timestamp, string(event.Type), age, event.Object); err != nil {
-					return err
-				}
-			case CRDTypeInventoryResourcePools:
-				if err := f.formatInventoryResourcePool(timestamp, string(event.Type), age, event.Object); err != nil {
-					return err
-				}
-			case CRDTypeInventoryNodeClusters:
-				if err := f.formatInventoryNodeCluster(timestamp, string(event.Type), age, event.Object); err != nil {
-					return err
+				switch event.CRDType {
+				case CRDTypeProvisioningRequests:
+					if err := f.formatProvisioningRequest(age, event.Object, widths); err != nil {
+						return err
+					}
+				case CRDTypeNodeAllocationRequests:
+					if err := f.formatNodeAllocationRequest(age, event.Object, widths); err != nil {
+						return err
+					}
+				case CRDTypeAllocatedNodes:
+					if err := f.formatAllocatedNode(age, event.Object, widths); err != nil {
+						return err
+					}
+				case CRDTypeBareMetalHosts:
+					if err := f.formatBareMetalHost(age, event.Object, widths); err != nil {
+						return err
+					}
+				case CRDTypeHostFirmwareComponents:
+					if err := f.formatHostFirmwareComponents(age, event.Object, widths); err != nil {
+						return err
+					}
+				case CRDTypeHostFirmwareSettings:
+					if err := f.formatHostFirmwareSettings(age, event.Object, widths); err != nil {
+						return err
+					}
+				case CRDTypeInventoryResources:
+					if err := f.formatInventoryResource(age, event.Object, widths); err != nil {
+						return err
+					}
+				case CRDTypeInventoryResourcePools:
+					if err := f.formatInventoryResourcePool(age, event.Object, widths); err != nil {
+						return err
+					}
+				case CRDTypeInventoryNodeClusters:
+					if err := f.formatInventoryNodeCluster(age, event.Object, widths); err != nil {
+						return err
+					}
 				}
 			}
+		}
+
+		// Add spacing between sections (except for last section)
+		if i < len(orderedTypes)-1 {
+			fmt.Println()
 		}
 	}
 
@@ -313,178 +340,234 @@ func (f *TableFormatter) getInventoryNodeClusterName(obj runtime.Object) string 
 	return StringNone
 }
 
-func (f *TableFormatter) printTableHeader(crdType string) {
+func (f *TableFormatter) printTableHeader(crdType string, widths FieldWidths) {
+	sidebarChar := SidebarCharUnicode
+	if !f.useUnicode {
+		sidebarChar = SidebarCharASCII
+	}
+
 	switch crdType {
 	case CRDTypeProvisioningRequests:
-		fmt.Printf("%-40s %-20s %-10s %-15s %-20s %-15s %-30s\n",
-			"NAME", "DISPLAYNAME", "AGE", "TIME", "EVENT", "PHASE", "DETAILS")
+		fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Name, "NAME", widths.Field1, "DISPLAYNAME", widths.Age, "AGE",
+			widths.Field2, "PHASE", widths.Field3, "DETAILS")
 	case CRDTypeNodeAllocationRequests:
-		fmt.Printf("%-40s %-20s %-10s %-15s %-20s %-20s %-20s\n",
-			"NAME", "CLUSTER-ID", "AGE", "TIME", "EVENT", "PROVISIONING", "DAY2-UPDATE")
+		fmt.Printf("%s %-*s   %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Name, "NAME", widths.Field1, "CLUSTER-ID",
+			widths.Field2, "PROVISIONING", widths.Field3, "DAY2-UPDATE")
 	case CRDTypeAllocatedNodes:
-		fmt.Printf("%-40s %-30s %-30s %-10s %-15s %-20s %-20s %-20s\n",
-			"NAME", "NODE-ALLOC-REQUEST", "HWMGR-NODE-ID", "AGE", "TIME", "EVENT", "PROVISIONING", "DAY2-UPDATE")
+		fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Name, "NAME", widths.Field1, "NODE-ALLOC-REQUEST",
+			widths.Field2, "HWMGR-NODE-ID", widths.Field3, "PROVISIONING", widths.Field4, "DAY2-UPDATE")
 	case CRDTypeBareMetalHosts:
-		fmt.Printf("%-15s %-40s %-12s %-15s %-10s %-12s %-30s %-20s\n",
-			"NS", "BMH", "STATUS", "STATE", "ONLINE", "POWEREDON", "NETDATA", "ERROR")
+		fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s   %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Namespace, "NS", widths.Name, "BMH", widths.Field1, "STATUS", widths.Field2, "STATE",
+			widths.Field3, "ONLINE", widths.Field4, "POWEREDON", widths.Field5, "NETDATA", widths.Field6, "ERROR")
 	case CRDTypeHostFirmwareComponents:
-		fmt.Printf("%-40s %-10s %-15s %-10s %-10s\n",
-			"HOSTFIRMWARECOMPONENTS", "GEN", "OBSERVED", "VALID", "CHANGE")
+		fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Name, "HOSTFIRMWARECOMPONENTS", widths.Field1, "GEN", widths.Field2, "OBSERVED",
+			widths.Field3, "VALID", widths.Field4, "CHANGE")
 	case CRDTypeHostFirmwareSettings:
-		fmt.Printf("%-10s %-8s %-15s %-20s %-12s %-12s %-8s %-15s\n",
-			"TIME", "EVENT", "AGE", "NAME", "GENERATION", "OBSERVED", "VALID", "CHANGE-DETECTED")
-		fmt.Printf("%s\n", strings.Repeat("-", 120))
+		fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Name, "HOSTFIRMWARESETTINGS", widths.Field1, "GEN", widths.Field2, "OBSERVED",
+			widths.Field3, "VALID", widths.Field4, "CHANGE")
 	case CRDTypeInventoryResources:
-		fmt.Printf("%-30s %-20s %-36s %-25s %-15s %-15s %-8s %-10s\n",
-			"NAME", "POOL", "RESOURCE-ID", "MODEL", "ADMIN", "OPER", "POWER", "USAGE")
-		fmt.Printf("%s\n", strings.Repeat("-", 165))
+		fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s   %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Field1, "NAME", widths.Field2, "POOL", widths.Field3, "RESOURCE-ID",
+			widths.Field4, "MODEL", widths.Field5, "ADMIN", widths.Field6, "OPER",
+			widths.Field7, "POWER", widths.Field8, "USAGE")
 	case CRDTypeInventoryResourcePools:
-		fmt.Printf("%-20s %-30s %-36s\n",
-			"SITE", "POOL", "RESOURCE-POOL-ID")
-		fmt.Printf("%s\n", strings.Repeat("-", 88))
+		fmt.Printf("%s %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Field1, "SITE", widths.Field2, "POOL", widths.Field3, "RESOURCE-POOL-ID")
 	case CRDTypeInventoryNodeClusters:
-		fmt.Printf("%-20s %-30s %-36s\n",
-			"NODE-NAME", "NODE-CLUSTER-ID", "NODE-CLUSTER-TYPE-ID")
-		fmt.Printf("%s\n", strings.Repeat("-", 88))
+		fmt.Printf("%s %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Field1, "NODE-NAME", widths.Field2, "NODE-CLUSTER-ID", widths.Field3, "NODE-CLUSTER-TYPE-ID")
 	default:
-		fmt.Printf("%-10s %-8s %-15s %-30s %-20s %-15s\n",
-			"TIME", "EVENT", "AGE", "NAME", "NAMESPACE", "KIND")
-		fmt.Printf("%s\n", strings.Repeat("-", 100))
+		fmt.Printf("%s %-*s   %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Age, "AGE", widths.Name, "NAME", widths.Namespace, "NAMESPACE", 15, "KIND")
 	}
 }
 
-func (f *TableFormatter) formatProvisioningRequest(timestamp, eventType, age string, obj runtime.Object) error {
+func (f *TableFormatter) formatProvisioningRequest(age string, obj runtime.Object, widths FieldWidths) error {
 	pr, ok := obj.(*provisioningv1alpha1.ProvisioningRequest)
 	if !ok {
 		return fmt.Errorf("expected ProvisioningRequest, got %T", obj)
 	}
 
-	name := pr.ObjectMeta.Name
+	sidebarChar := SidebarCharUnicode
+	if !f.useUnicode {
+		sidebarChar = SidebarCharASCII
+	}
+
+	name := truncateToWidth(pr.ObjectMeta.Name, widths.Name)
 	displayName := pr.Spec.Name
 	if displayName == "" {
 		displayName = StringNone
 	}
+	displayName = truncateToWidth(displayName, widths.Field1)
 
 	phase := string(pr.Status.ProvisioningStatus.ProvisioningPhase)
 	if phase == "" {
 		phase = StringNone
 	}
+	phase = truncateToWidth(phase, widths.Field2)
 
 	details := pr.Status.ProvisioningStatus.ProvisioningDetails
 	if details == "" {
 		details = StringNone
 	}
+	details = truncateToWidth(details, widths.Field3)
 
-	fmt.Printf("%-8s %-8s %-25s %-25s %-8s %-15s %-30s\n",
-		timestamp, eventType, truncate(name, 25), truncate(displayName, 25),
-		age, truncate(phase, 15), truncate(details, 30))
+	fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s\n",
+		sidebarChar, widths.Name, name, widths.Field1, displayName, widths.Age, age,
+		widths.Field2, phase, widths.Field3, details)
 
 	return nil
 }
 
-func (f *TableFormatter) formatNodeAllocationRequest(timestamp, eventType, age string, obj runtime.Object) error {
+//nolint:unparam // age parameter required for interface consistency
+func (f *TableFormatter) formatNodeAllocationRequest(age string, obj runtime.Object, widths FieldWidths) error {
 	nar, ok := obj.(*pluginsv1alpha1.NodeAllocationRequest)
 	if !ok {
 		return fmt.Errorf("expected NodeAllocationRequest, got %T", obj)
 	}
 
-	name := nar.ObjectMeta.Name
+	sidebarChar := SidebarCharUnicode
+	if !f.useUnicode {
+		sidebarChar = SidebarCharASCII
+	}
+
+	name := truncateToWidth(nar.ObjectMeta.Name, widths.Name)
 	clusterId := nar.Spec.ClusterId
 	if clusterId == "" {
 		clusterId = StringNone
 	}
+	clusterId = truncateToWidth(clusterId, widths.Field1)
 
 	provisioning := getConditionReason(nar.Status.Conditions, "Provisioned")
+	provisioning = truncateToWidth(provisioning, widths.Field2)
 	day2Update := getConditionReason(nar.Status.Conditions, "Configured")
+	day2Update = truncateToWidth(day2Update, widths.Field3)
 
-	fmt.Printf("%-8s %-8s %-25s %-25s %-8s %-15s %-15s\n",
-		timestamp, eventType, truncate(name, 25), truncate(clusterId, 25),
-		age, truncate(provisioning, 15), truncate(day2Update, 15))
+	fmt.Printf("%s %-*s   %-*s   %-*s   %-*s\n",
+		sidebarChar, widths.Name, name, widths.Field1, clusterId,
+		widths.Field2, provisioning, widths.Field3, day2Update)
 
 	return nil
 }
 
-func (f *TableFormatter) formatAllocatedNode(timestamp, eventType, age string, obj runtime.Object) error {
+//nolint:unparam // age parameter required for interface consistency
+func (f *TableFormatter) formatAllocatedNode(age string, obj runtime.Object, widths FieldWidths) error {
 	an, ok := obj.(*pluginsv1alpha1.AllocatedNode)
 	if !ok {
 		return fmt.Errorf("expected AllocatedNode, got %T", obj)
 	}
 
-	name := an.ObjectMeta.Name
+	sidebarChar := SidebarCharUnicode
+	if !f.useUnicode {
+		sidebarChar = SidebarCharASCII
+	}
+
+	name := truncateToWidth(an.ObjectMeta.Name, widths.Name)
 	nodeAllocRequest := an.Spec.NodeAllocationRequest
 	if nodeAllocRequest == "" {
 		nodeAllocRequest = StringNone
 	}
+	nodeAllocRequest = truncateToWidth(nodeAllocRequest, widths.Field1)
 
 	hwMgrNodeId := an.Spec.HwMgrNodeId
 	if hwMgrNodeId == "" {
 		hwMgrNodeId = StringNone
 	}
+	hwMgrNodeId = truncateToWidth(hwMgrNodeId, widths.Field2)
 
 	provisioning := getConditionReason(an.Status.Conditions, "Provisioned")
+	provisioning = truncateToWidth(provisioning, widths.Field3)
 	day2Update := getConditionReason(an.Status.Conditions, "Configured")
+	day2Update = truncateToWidth(day2Update, widths.Field4)
 
-	fmt.Printf("%-8s %-8s %-25s %-25s %-15s %-8s %-15s %-15s\n",
-		timestamp, eventType, truncate(name, 25), truncate(nodeAllocRequest, 25),
-		truncate(hwMgrNodeId, 15), age, truncate(provisioning, 15), truncate(day2Update, 15))
+	fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s\n",
+		sidebarChar, widths.Name, name,
+		widths.Field1, nodeAllocRequest,
+		widths.Field2, hwMgrNodeId,
+		widths.Field3, provisioning, widths.Field4, day2Update)
 
 	return nil
 }
 
-//nolint:unparam // timestamp parameter required for interface consistency
-func (f *TableFormatter) formatBareMetalHost(timestamp, eventType, age string, obj runtime.Object) error {
+//nolint:unparam // age parameter required for interface consistency
+func (f *TableFormatter) formatBareMetalHost(age string, obj runtime.Object, widths FieldWidths) error {
 	bmh, ok := obj.(*metal3v1alpha1.BareMetalHost)
 	if !ok {
 		return fmt.Errorf("expected BareMetalHost, got %T", obj)
 	}
 
-	namespace := bmh.ObjectMeta.Namespace
-	name := bmh.ObjectMeta.Name
+	sidebarChar := SidebarCharUnicode
+	if !f.useUnicode {
+		sidebarChar = SidebarCharASCII
+	}
+
+	namespace := truncateToWidth(bmh.ObjectMeta.Namespace, widths.Namespace)
+	name := truncateToWidth(bmh.ObjectMeta.Name, widths.Name)
+
 	status := string(bmh.Status.OperationalStatus)
 	if status == "" {
 		status = StringNone
 	}
+	status = truncateToWidth(status, widths.Field1)
 
 	state := string(bmh.Status.Provisioning.State)
 	if state == "" {
 		state = StringNone
 	}
+	state = truncateToWidth(state, widths.Field2)
 
 	online := StringFalse
 	if bmh.Spec.Online {
 		online = StringTrue
 	}
+	online = truncateToWidth(online, widths.Field3)
 
 	poweredOn := StringFalse
 	if bmh.Status.PoweredOn {
 		poweredOn = StringTrue
 	}
+	poweredOn = truncateToWidth(poweredOn, widths.Field4)
 
 	netData := bmh.Spec.PreprovisioningNetworkDataName
 	if netData == "" {
 		netData = StringNone
 	}
+	netData = truncateToWidth(netData, widths.Field5)
 
 	errorType := string(bmh.Status.ErrorType)
 	if errorType == "" {
 		errorType = StringNone
 	}
+	errorType = truncateToWidth(errorType, widths.Field6)
 
-	fmt.Printf("%-15s %-40s %-12s %-15s %-10s %-12s %-30s %-20s\n",
-		namespace, name, status, state, online, poweredOn, netData, errorType)
+	fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s   %-*s   %-*s   %-*s\n",
+		sidebarChar, widths.Namespace, namespace, widths.Name, name, widths.Field1, status, widths.Field2, state,
+		widths.Field3, online, widths.Field4, poweredOn, widths.Field5, netData, widths.Field6, errorType)
 
 	return nil
 }
 
-//nolint:unparam // timestamp parameter required for interface consistency
-func (f *TableFormatter) formatHostFirmwareComponents(timestamp, eventType, age string, obj runtime.Object) error {
+//nolint:unparam // age parameter required for interface consistency
+func (f *TableFormatter) formatHostFirmwareComponents(age string, obj runtime.Object, widths FieldWidths) error {
 	hfc, ok := obj.(*metal3v1alpha1.HostFirmwareComponents)
 	if !ok {
 		return fmt.Errorf("expected HostFirmwareComponents, got %T", obj)
 	}
 
-	name := hfc.ObjectMeta.Name
+	sidebarChar := SidebarCharUnicode
+	if !f.useUnicode {
+		sidebarChar = SidebarCharASCII
+	}
+
+	name := truncateToWidth(hfc.ObjectMeta.Name, widths.Name)
 	generation := fmt.Sprintf("%d", hfc.ObjectMeta.Generation)
+	generation = truncateToWidth(generation, widths.Field1)
 
 	// Get all observedGeneration values from all conditions
 	var observedGens []string
@@ -495,6 +578,7 @@ func (f *TableFormatter) formatHostFirmwareComponents(timestamp, eventType, age 
 	if len(observedGens) > 0 {
 		observedGeneration = strings.Join(observedGens, ",")
 	}
+	observedGeneration = truncateToWidth(observedGeneration, widths.Field2)
 
 	// Get Valid condition status
 	validStatus := StringNone
@@ -504,6 +588,7 @@ func (f *TableFormatter) formatHostFirmwareComponents(timestamp, eventType, age 
 			break
 		}
 	}
+	validStatus = truncateToWidth(validStatus, widths.Field3)
 
 	// Get ChangeDetected condition status
 	changeStatus := StringNone
@@ -513,22 +598,30 @@ func (f *TableFormatter) formatHostFirmwareComponents(timestamp, eventType, age 
 			break
 		}
 	}
+	changeStatus = truncateToWidth(changeStatus, widths.Field4)
 
-	fmt.Printf("%-40s %-10s %-15s %-10s %-10s\n",
-		name, generation, observedGeneration, validStatus, changeStatus)
+	fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s\n",
+		sidebarChar, widths.Name, name, widths.Field1, generation, widths.Field2, observedGeneration,
+		widths.Field3, validStatus, widths.Field4, changeStatus)
 
 	return nil
 }
 
-//nolint:unparam // timestamp parameter required for interface consistency
-func (f *TableFormatter) formatHostFirmwareSettings(timestamp, eventType, age string, obj runtime.Object) error {
+//nolint:unparam // age parameter required for interface consistency
+func (f *TableFormatter) formatHostFirmwareSettings(age string, obj runtime.Object, widths FieldWidths) error {
 	hfs, ok := obj.(*metal3v1alpha1.HostFirmwareSettings)
 	if !ok {
 		return fmt.Errorf("expected HostFirmwareSettings, got %T", obj)
 	}
 
-	name := hfs.ObjectMeta.Name
+	sidebarChar := SidebarCharUnicode
+	if !f.useUnicode {
+		sidebarChar = SidebarCharASCII
+	}
+
+	name := truncateToWidth(hfs.ObjectMeta.Name, widths.Name)
 	generation := fmt.Sprintf("%d", hfs.ObjectMeta.Generation)
+	generation = truncateToWidth(generation, widths.Field1)
 
 	// Get all observedGeneration values from all conditions
 	var observedGens []string
@@ -539,6 +632,7 @@ func (f *TableFormatter) formatHostFirmwareSettings(timestamp, eventType, age st
 	if len(observedGens) > 0 {
 		observedGeneration = strings.Join(observedGens, ",")
 	}
+	observedGeneration = truncateToWidth(observedGeneration, widths.Field2)
 
 	// Get Valid condition status
 	validStatus := StringNone
@@ -548,6 +642,7 @@ func (f *TableFormatter) formatHostFirmwareSettings(timestamp, eventType, age st
 			break
 		}
 	}
+	validStatus = truncateToWidth(validStatus, widths.Field3)
 
 	// Get ChangeDetected condition status
 	changeStatus := StringNone
@@ -557,15 +652,17 @@ func (f *TableFormatter) formatHostFirmwareSettings(timestamp, eventType, age st
 			break
 		}
 	}
+	changeStatus = truncateToWidth(changeStatus, widths.Field4)
 
-	fmt.Printf("%-40s %-10s %-15s %-10s %-10s\n",
-		name, generation, observedGeneration, validStatus, changeStatus)
+	fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s\n",
+		sidebarChar, widths.Name, name, widths.Field1, generation, widths.Field2, observedGeneration,
+		widths.Field3, validStatus, widths.Field4, changeStatus)
 
 	return nil
 }
 
-//nolint:unparam,gocyclo // timestamp parameter required for interface consistency; complex state field extraction logic is required for inventory resource formatting
-func (f *TableFormatter) formatInventoryResource(timestamp, eventType, age string, obj runtime.Object) error {
+//nolint:gocyclo,unparam // Complex state field extraction logic is required for inventory resources, age parameter required for interface consistency
+func (f *TableFormatter) formatInventoryResource(age string, obj runtime.Object, widths FieldWidths) error {
 	if iro, ok := obj.(*InventoryResourceObject); ok {
 		resource := iro.Resource
 
@@ -647,21 +744,30 @@ func (f *TableFormatter) formatInventoryResource(timestamp, eventType, age strin
 			}
 		}
 
-		fmt.Printf("%-30s %-20s %-36s %-25s %-15s %-15s %-8s %-10s\n",
-			truncate(name, 30),
-			truncate(pool, 20),
-			truncate(resource.ResourceID, 36),
-			truncate(model, 25),
-			truncate(adminState, 15),
-			truncate(operationalState, 15),
-			truncate(powerState, 8),
-			truncate(usageState, 10))
+		sidebarChar := SidebarCharUnicode
+		if !f.useUnicode {
+			sidebarChar = "|"
+		}
+
+		name = truncateToWidth(name, widths.Field1)
+		pool = truncateToWidth(pool, widths.Field2)
+		resourceID := truncateToWidth(resource.ResourceID, widths.Field3)
+		model = truncateToWidth(model, widths.Field4)
+		adminState = truncateToWidth(adminState, widths.Field5)
+		operationalState = truncateToWidth(operationalState, widths.Field6)
+		powerState = truncateToWidth(powerState, widths.Field7)
+		usageState = truncateToWidth(usageState, widths.Field8)
+
+		fmt.Printf("%s %-*s   %-*s   %-*s   %-*s   %-*s   %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Field1, name, widths.Field2, pool, widths.Field3, resourceID,
+			widths.Field4, model, widths.Field5, adminState, widths.Field6, operationalState,
+			widths.Field7, powerState, widths.Field8, usageState)
 	}
 	return nil
 }
 
-//nolint:unparam // timestamp parameter required for interface consistency
-func (f *TableFormatter) formatInventoryResourcePool(timestamp, eventType, age string, obj runtime.Object) error {
+//nolint:unparam // age parameter required for interface consistency
+func (f *TableFormatter) formatInventoryResourcePool(age string, obj runtime.Object, widths FieldWidths) error {
 	if rpo, ok := obj.(*ResourcePoolObject); ok && rpo != nil {
 		// Add comprehensive safety checks before accessing fields
 		site := StringUnknown
@@ -695,16 +801,23 @@ func (f *TableFormatter) formatInventoryResourcePool(timestamp, eventType, age s
 			}
 		}
 
-		fmt.Printf("%-20s %-30s %-36s\n",
-			truncate(site, 20),
-			truncate(poolName, 30),
-			truncate(resourcePoolID, 36))
+		sidebarChar := SidebarCharUnicode
+		if !f.useUnicode {
+			sidebarChar = "|"
+		}
+
+		site = truncateToWidth(site, widths.Field1)
+		poolName = truncateToWidth(poolName, widths.Field2)
+		resourcePoolID = truncateToWidth(resourcePoolID, widths.Field3)
+
+		fmt.Printf("%s %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Field1, site, widths.Field2, poolName, widths.Field3, resourcePoolID)
 	}
 	return nil
 }
 
-//nolint:unparam // timestamp parameter required for interface consistency
-func (f *TableFormatter) formatInventoryNodeCluster(timestamp, eventType, age string, obj runtime.Object) error {
+//nolint:unparam // age parameter required for interface consistency
+func (f *TableFormatter) formatInventoryNodeCluster(age string, obj runtime.Object, widths FieldWidths) error {
 	if nco, ok := obj.(*NodeClusterObject); ok && nco != nil {
 		// Add comprehensive safety checks before accessing fields
 		nodeName := StringUnknown
@@ -722,10 +835,17 @@ func (f *TableFormatter) formatInventoryNodeCluster(timestamp, eventType, age st
 			nodeClusterTypeID = nco.NodeCluster.NodeClusterTypeID
 		}
 
-		fmt.Printf("%-20s %-30s %-36s\n",
-			truncate(nodeName, 20),
-			truncate(nodeClusterID, 30),
-			truncate(nodeClusterTypeID, 36))
+		sidebarChar := SidebarCharUnicode
+		if !f.useUnicode {
+			sidebarChar = "|"
+		}
+
+		nodeName = truncateToWidth(nodeName, widths.Field1)
+		nodeClusterID = truncateToWidth(nodeClusterID, widths.Field2)
+		nodeClusterTypeID = truncateToWidth(nodeClusterTypeID, widths.Field3)
+
+		fmt.Printf("%s %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Field1, nodeName, widths.Field2, nodeClusterID, widths.Field3, nodeClusterTypeID)
 	}
 	return nil
 }
@@ -811,4 +931,623 @@ func truncate(s string, maxLen int) string {
 		return s[:maxLen]
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// New helper functions for sectioned output formatting
+
+func (f *TableFormatter) printMainHeader() {
+	currentTime := time.Now().UTC().Format("2006-01-02 15:04:05 UTC")
+
+	if f.useUnicode {
+		// Unicode version like TUIFormatter
+		headerContent := fmt.Sprintf("╔═══ O-Cloud Manager Provisioning Watcher ═══ %s", currentTime)
+		contentLength := len(fmt.Sprintf("═══ O-Cloud Manager Provisioning Watcher ═══ %s", currentTime))
+		bottomLine := "╚" + strings.Repeat("═", contentLength)
+
+		fmt.Println(headerContent)
+		fmt.Println(bottomLine)
+	} else {
+		// ASCII version
+		headerContent := fmt.Sprintf("+--- O-Cloud Manager Provisioning Watcher --- %s", currentTime)
+		contentLength := len(fmt.Sprintf("--- O-Cloud Manager Provisioning Watcher --- %s", currentTime))
+		bottomLine := "+" + strings.Repeat("-", contentLength)
+
+		fmt.Println(headerContent)
+		fmt.Println(bottomLine)
+	}
+}
+
+func (f *TableFormatter) printSectionHeader(crdType string) {
+	// Map CRD types to readable headers (same as TUIFormatter)
+	headerMap := map[string]string{
+		CRDTypeProvisioningRequests:   "Provisioning Requests",
+		CRDTypeNodeAllocationRequests: "Node Allocation Requests",
+		CRDTypeAllocatedNodes:         "Allocated Nodes",
+		CRDTypeBareMetalHosts:         "Bare Metal Hosts",
+		CRDTypeHostFirmwareComponents: "Host Firmware Component CRs",
+		CRDTypeHostFirmwareSettings:   "Firmware Settings CRs",
+		CRDTypeInventoryResourcePools: "O-RAN Resource Pools",
+		CRDTypeInventoryResources:     "O-RAN Resources",
+		CRDTypeInventoryNodeClusters:  "O-RAN Nodes",
+	}
+
+	// Use the mapped header or fall back to the original crdType
+	displayName := headerMap[crdType]
+	if displayName == "" {
+		displayName = crdType
+	}
+
+	if f.useUnicode {
+		fmt.Printf("┌─ %s ─\n", displayName)
+	} else {
+		fmt.Printf("+- %s -\n", displayName)
+	}
+}
+
+func (f *TableFormatter) getOrderedCRDTypes() []string {
+	// Define preferred order for all possible CRD types (same as TUIFormatter)
+	preferredOrder := []string{
+		CRDTypeProvisioningRequests,
+		CRDTypeNodeAllocationRequests,
+		CRDTypeAllocatedNodes,
+		CRDTypeBareMetalHosts,
+		CRDTypeHostFirmwareComponents,
+		CRDTypeHostFirmwareSettings,
+		CRDTypeInventoryResourcePools,
+		CRDTypeInventoryResources,
+		CRDTypeInventoryNodeClusters,
+	}
+
+	var result []string
+
+	// Add watched CRD types in preferred order (show all watched types, even if empty)
+	for _, crdType := range preferredOrder {
+		// Check if this CRD type is being watched
+		for _, watchedType := range f.crdTypes {
+			if crdType == watchedType {
+				result = append(result, crdType)
+				break
+			}
+		}
+		// Also include inventory types that have events (even if not explicitly in watched types)
+		if strings.HasPrefix(crdType, "inventory-") {
+			if _, exists := f.events[crdType]; exists {
+				// Check if we already added it
+				found := false
+				for _, addedType := range result {
+					if addedType == crdType {
+						found = true
+						break
+					}
+				}
+				if !found {
+					result = append(result, crdType)
+				}
+			}
+		}
+	}
+
+	// Add any other CRD types that might exist but aren't in our predefined order
+	for crdType := range f.events {
+		found := false
+		for _, addedType := range result {
+			if crdType == addedType {
+				found = true
+				break
+			}
+		}
+		if !found {
+			result = append(result, crdType)
+		}
+	}
+
+	return result
+}
+
+// calculateFieldWidths calculates dynamic field widths based on actual data
+// This mirrors the logic from tui.go exactly
+func (f *TableFormatter) calculateFieldWidths(crdType string, events []WatchEvent) FieldWidths {
+	// Initialize minimum widths for headers
+	widths := f.initializeHeaderWidths(crdType)
+
+	// Calculate NAME field width based on actual data (like TUIFormatter)
+	for _, event := range events {
+		if event.Object == nil {
+			continue
+		}
+
+		accessor, _ := meta.Accessor(event.Object)
+		nameLen := 0
+		if accessor != nil {
+			nameLen = len(accessor.GetName())
+		} else {
+			// For objects that don't implement metav1.Object (like ResourcePoolObject),
+			// use a fallback approach to get a meaningful name
+			switch obj := event.Object.(type) {
+			case *ResourcePoolObject:
+				if obj == nil {
+					nameLen = len("UNKNOWN")
+				} else {
+					nameLen = len(obj.ResourcePool.ResourcePoolID)
+				}
+			case *InventoryResourceObject:
+				if obj == nil {
+					nameLen = len("UNKNOWN")
+				} else {
+					nameLen = len(obj.Resource.ResourceID)
+				}
+			default:
+				nameLen = len("UNKNOWN")
+			}
+		}
+		widths.Name = safeMax(widths.Name, nameLen)
+	}
+
+	// Calculate field widths based on CRD type
+	switch crdType {
+	case CRDTypeProvisioningRequests:
+		widths = f.calculateProvisioningRequestWidths(events, widths)
+	case CRDTypeNodeAllocationRequests:
+		widths = f.calculateNodeAllocationRequestWidths(events, widths)
+	case CRDTypeAllocatedNodes:
+		widths = f.calculateAllocatedNodeWidths(events, widths)
+	case CRDTypeBareMetalHosts:
+		widths = f.calculateBareMetalHostWidths(events, widths)
+	case CRDTypeHostFirmwareComponents:
+		widths = f.calculateHostFirmwareComponentsWidths(events, widths)
+	case CRDTypeHostFirmwareSettings:
+		widths = f.calculateHostFirmwareSettingsWidths(events, widths)
+	case CRDTypeInventoryResources:
+		widths = f.calculateInventoryResourceWidths(events, widths)
+	case CRDTypeInventoryResourcePools:
+		widths = f.calculateInventoryResourcePoolWidths(events, widths)
+	case CRDTypeInventoryNodeClusters:
+		widths = f.calculateInventoryNodeClusterWidths(events, widths)
+	}
+
+	// Apply maximum width limits
+	return f.applyMaxWidthLimits(widths)
+}
+
+// initializeHeaderWidths sets minimum widths based on headers
+func (f *TableFormatter) initializeHeaderWidths(crdType string) FieldWidths {
+	widths := FieldWidths{
+		Name:      8,  // "NAME"
+		Field1:    8,  // varies by CRD
+		Field2:    8,  // varies by CRD
+		Field3:    8,  // varies by CRD
+		Field4:    12, // varies by CRD
+		Field5:    8,  // BareMetalHost only
+		Field6:    8,  // BareMetalHost only
+		Field7:    8,  // future use
+		Field8:    8,  // future use
+		Age:       3,  // "AGE"
+		Namespace: 10, // "NAMESPACE"
+	}
+
+	switch crdType {
+	case CRDTypeProvisioningRequests:
+		widths.Field1 = safeMax(widths.Field1, len("DISPLAYNAME"))
+		widths.Field2 = safeMax(widths.Field2, len("PHASE"))
+		widths.Field3 = safeMax(widths.Field3, len("DETAILS"))
+	case CRDTypeNodeAllocationRequests:
+		widths.Field1 = safeMax(widths.Field1, len("CLUSTER-ID"))
+		widths.Field2 = safeMax(widths.Field2, len("PROVISIONING"))
+		widths.Field3 = safeMax(widths.Field3, len("DAY2-UPDATE"))
+	case CRDTypeAllocatedNodes:
+		widths.Field1 = safeMax(widths.Field1, len("NODE-ALLOC-REQUEST"))
+		widths.Field2 = safeMax(widths.Field2, len("HWMGR-NODE-ID"))
+		widths.Field3 = safeMax(widths.Field3, len("PROVISIONING"))
+		widths.Field4 = safeMax(widths.Field4, len("DAY2-UPDATE"))
+	case CRDTypeBareMetalHosts:
+		widths.Namespace = safeMax(widths.Namespace, len("NS"))
+		widths.Name = safeMax(widths.Name, len("BMH"))
+		widths.Field1 = safeMax(widths.Field1, len("STATUS"))
+		widths.Field2 = safeMax(widths.Field2, len("STATE"))
+		widths.Field3 = safeMax(widths.Field3, len("ONLINE"))
+		widths.Field4 = safeMax(widths.Field4, len("POWEREDON"))
+		widths.Field5 = safeMax(widths.Field5, len("NETDATA"))
+		widths.Field6 = safeMax(widths.Field6, len("ERROR"))
+	case CRDTypeHostFirmwareComponents:
+		widths.Name = safeMax(widths.Name, len("HOSTFIRMWARECOMPONENTS"))
+		widths.Field1 = safeMax(widths.Field1, len("GEN"))
+		widths.Field2 = safeMax(widths.Field2, len("OBSERVED"))
+		widths.Field3 = safeMax(widths.Field3, len("VALID"))
+		widths.Field4 = safeMax(widths.Field4, len("CHANGE"))
+	case CRDTypeHostFirmwareSettings:
+		widths.Name = safeMax(widths.Name, len("HOSTFIRMWARESETTINGS"))
+		widths.Field1 = safeMax(widths.Field1, len("GEN"))
+		widths.Field2 = safeMax(widths.Field2, len("OBSERVED"))
+		widths.Field3 = safeMax(widths.Field3, len("VALID"))
+		widths.Field4 = safeMax(widths.Field4, len("CHANGE"))
+	case CRDTypeInventoryResources:
+		widths.Field1 = safeMax(widths.Field1, len("NAME"))
+		widths.Field2 = safeMax(widths.Field2, len("POOL"))
+		widths.Field3 = safeMax(widths.Field3, len("RESOURCE-ID"))
+		widths.Field4 = safeMax(widths.Field4, len("MODEL"))
+		widths.Field5 = safeMax(widths.Field5, len("ADMIN"))
+		widths.Field6 = safeMax(widths.Field6, len("OPER"))
+		widths.Field7 = safeMax(widths.Field7, len("POWER"))
+		widths.Field8 = safeMax(widths.Field8, len("USAGE"))
+	case CRDTypeInventoryResourcePools:
+		widths.Field1 = safeMax(widths.Field1, len("SITE"))
+		widths.Field2 = safeMax(widths.Field2, len("POOL"))
+		widths.Field3 = safeMax(widths.Field3, len("RESOURCE-POOL-ID"))
+	case CRDTypeInventoryNodeClusters:
+		widths.Field1 = safeMax(widths.Field1, len("NODE-NAME"))
+		widths.Field2 = safeMax(widths.Field2, len("NODE-CLUSTER-ID"))
+		widths.Field3 = safeMax(widths.Field3, len("NODE-CLUSTER-TYPE-ID"))
+	}
+
+	return widths
+}
+
+// Real width calculation functions - exactly like TUIFormatter
+
+func (f *TableFormatter) calculateProvisioningRequestWidths(events []WatchEvent, widths FieldWidths) FieldWidths {
+	for _, event := range events {
+		pr, ok := event.Object.(*provisioningv1alpha1.ProvisioningRequest)
+		if !ok {
+			continue
+		}
+		displayName := pr.Spec.Name
+		if displayName == "" {
+			displayName = StringNone
+		}
+		widths.Field1 = safeMax(widths.Field1, len(displayName))
+
+		phase := string(pr.Status.ProvisioningStatus.ProvisioningPhase)
+		if phase == "" {
+			phase = StringNone
+		}
+		widths.Field2 = safeMax(widths.Field2, len(phase))
+
+		details := pr.Status.ProvisioningStatus.ProvisioningDetails
+		if details == "" {
+			details = StringNone
+		}
+		widths.Field3 = safeMax(widths.Field3, len(details))
+	}
+	return widths
+}
+
+func (f *TableFormatter) calculateNodeAllocationRequestWidths(events []WatchEvent, widths FieldWidths) FieldWidths {
+	for _, event := range events {
+		nar, ok := event.Object.(*pluginsv1alpha1.NodeAllocationRequest)
+		if !ok {
+			continue
+		}
+		clusterId := nar.Spec.ClusterId
+		if clusterId == "" {
+			clusterId = StringNone
+		}
+		widths.Field1 = safeMax(widths.Field1, len(clusterId))
+
+		provisioning := getConditionReason(nar.Status.Conditions, "Provisioned")
+		widths.Field2 = safeMax(widths.Field2, len(provisioning))
+
+		day2Update := getConditionReason(nar.Status.Conditions, "Configured")
+		widths.Field3 = safeMax(widths.Field3, len(day2Update))
+	}
+	return widths
+}
+
+func (f *TableFormatter) calculateAllocatedNodeWidths(events []WatchEvent, widths FieldWidths) FieldWidths {
+	for _, event := range events {
+		an, ok := event.Object.(*pluginsv1alpha1.AllocatedNode)
+		if !ok {
+			continue
+		}
+		nodeAllocRequest := an.Spec.NodeAllocationRequest
+		if nodeAllocRequest == "" {
+			nodeAllocRequest = StringNone
+		}
+		widths.Field1 = safeMax(widths.Field1, len(nodeAllocRequest))
+
+		hwMgrNodeId := an.Spec.HwMgrNodeId
+		if hwMgrNodeId == "" {
+			hwMgrNodeId = StringNone
+		}
+		widths.Field2 = safeMax(widths.Field2, len(hwMgrNodeId))
+
+		provisioning := getConditionReason(an.Status.Conditions, "Provisioned")
+		widths.Field3 = safeMax(widths.Field3, len(provisioning))
+
+		day2Update := getConditionReason(an.Status.Conditions, "Configured")
+		widths.Field4 = safeMax(widths.Field4, len(day2Update))
+	}
+	return widths
+}
+
+func (f *TableFormatter) calculateBareMetalHostWidths(events []WatchEvent, widths FieldWidths) FieldWidths {
+	for _, event := range events {
+		bmh, ok := event.Object.(*metal3v1alpha1.BareMetalHost)
+		if !ok {
+			continue
+		}
+		widths.Namespace = safeMax(widths.Namespace, len(bmh.ObjectMeta.Namespace))
+
+		status := string(bmh.Status.OperationalStatus)
+		if status == "" {
+			status = StringNone
+		}
+		widths.Field1 = safeMax(widths.Field1, len(status))
+
+		state := string(bmh.Status.Provisioning.State)
+		if state == "" {
+			state = StringNone
+		}
+		widths.Field2 = safeMax(widths.Field2, len(state))
+
+		online := StringFalse
+		if bmh.Spec.Online {
+			online = StringTrue
+		}
+		widths.Field3 = safeMax(widths.Field3, len(online))
+
+		poweredOn := StringFalse
+		if bmh.Status.PoweredOn {
+			poweredOn = StringTrue
+		}
+		widths.Field4 = safeMax(widths.Field4, len(poweredOn))
+
+		netData := bmh.Spec.PreprovisioningNetworkDataName
+		if netData == "" {
+			netData = StringNone
+		}
+		widths.Field5 = safeMax(widths.Field5, len(netData))
+
+		errorType := string(bmh.Status.ErrorType)
+		if errorType == "" {
+			errorType = StringNone
+		}
+		widths.Field6 = safeMax(widths.Field6, len(errorType))
+	}
+	return widths
+}
+
+func (f *TableFormatter) calculateHostFirmwareComponentsWidths(events []WatchEvent, widths FieldWidths) FieldWidths {
+	for _, event := range events {
+		hfc, ok := event.Object.(*metal3v1alpha1.HostFirmwareComponents)
+		if !ok {
+			continue
+		}
+		widths.Name = safeMax(widths.Name, len(hfc.ObjectMeta.Name))
+
+		generation := fmt.Sprintf("%d", hfc.ObjectMeta.Generation)
+		widths.Field1 = safeMax(widths.Field1, len(generation))
+
+		// Get all observedGeneration values from all conditions
+		var observedGens []string
+		for _, condition := range hfc.Status.Conditions {
+			observedGens = append(observedGens, fmt.Sprintf("%d", condition.ObservedGeneration))
+		}
+		observedGeneration := StringNone
+		if len(observedGens) > 0 {
+			observedGeneration = strings.Join(observedGens, ",")
+		}
+		widths.Field2 = safeMax(widths.Field2, len(observedGeneration))
+
+		// Get Valid condition status
+		validStatus := StringNone
+		for _, condition := range hfc.Status.Conditions {
+			if condition.Type == StringValid {
+				validStatus = string(condition.Status)
+				break
+			}
+		}
+		widths.Field3 = safeMax(widths.Field3, len(validStatus))
+
+		// Get ChangeDetected condition status
+		changeStatus := StringNone
+		for _, condition := range hfc.Status.Conditions {
+			if condition.Type == StringChangeDetected {
+				changeStatus = string(condition.Status)
+				break
+			}
+		}
+		widths.Field4 = safeMax(widths.Field4, len(changeStatus))
+	}
+	return widths
+}
+
+func (f *TableFormatter) calculateHostFirmwareSettingsWidths(events []WatchEvent, widths FieldWidths) FieldWidths {
+	for _, event := range events {
+		hfs, ok := event.Object.(*metal3v1alpha1.HostFirmwareSettings)
+		if !ok {
+			continue
+		}
+		widths.Name = safeMax(widths.Name, len(hfs.ObjectMeta.Name))
+
+		generation := fmt.Sprintf("%d", hfs.ObjectMeta.Generation)
+		widths.Field1 = safeMax(widths.Field1, len(generation))
+
+		// Get all observedGeneration values from all conditions
+		var observedGens []string
+		for _, condition := range hfs.Status.Conditions {
+			observedGens = append(observedGens, fmt.Sprintf("%d", condition.ObservedGeneration))
+		}
+		observedGeneration := StringNone
+		if len(observedGens) > 0 {
+			observedGeneration = strings.Join(observedGens, ",")
+		}
+		widths.Field2 = safeMax(widths.Field2, len(observedGeneration))
+
+		// Get Valid condition status
+		validStatus := StringNone
+		for _, condition := range hfs.Status.Conditions {
+			if condition.Type == StringValid {
+				validStatus = string(condition.Status)
+				break
+			}
+		}
+		widths.Field3 = safeMax(widths.Field3, len(validStatus))
+
+		// Get ChangeDetected condition status
+		changeStatus := StringNone
+		for _, condition := range hfs.Status.Conditions {
+			if condition.Type == StringChangeDetected {
+				changeStatus = string(condition.Status)
+				break
+			}
+		}
+		widths.Field4 = safeMax(widths.Field4, len(changeStatus))
+	}
+	return widths
+}
+
+//nolint:gocyclo // Complex state field extraction logic is required for width calculations
+func (f *TableFormatter) calculateInventoryResourceWidths(events []WatchEvent, widths FieldWidths) FieldWidths {
+	for _, event := range events {
+		iro, ok := event.Object.(*InventoryResourceObject)
+		if !ok {
+			continue
+		}
+		resource := iro.Resource
+
+		// Extract Name from extensions.labels."resourceselector.clcm.openshift.io/server-id"
+		name := StringUnknown
+		if resource.Extensions != nil {
+			if labelsVal, exists := resource.Extensions["labels"]; exists {
+				if labelsMap, ok := labelsVal.(map[string]interface{}); ok {
+					if nameVal, exists := labelsMap["resourceselector.clcm.openshift.io/server-id"]; exists {
+						if nameStr, ok := nameVal.(string); ok && nameStr != "" {
+							name = nameStr
+						}
+					}
+				}
+			}
+		}
+		if name == StringUnknown && resource.Description != "" {
+			name = resource.Description
+		}
+
+		// Extract Pool from extensions.labels."resources.clcm.openshift.io/resourcePoolId"
+		pool := StringUnknown
+		if resource.Extensions != nil {
+			if labelsVal, exists := resource.Extensions["labels"]; exists {
+				if labelsMap, ok := labelsVal.(map[string]interface{}); ok {
+					if poolVal, exists := labelsMap["resources.clcm.openshift.io/resourcePoolId"]; exists {
+						if poolStr, ok := poolVal.(string); ok && poolStr != "" {
+							pool = poolStr
+						}
+					}
+				}
+			}
+		}
+
+		// Extract Model from extensions
+		model := StringUnknown
+		if resource.Extensions != nil {
+			if modelVal, exists := resource.Extensions["model"]; exists {
+				if modelStr, ok := modelVal.(string); ok && modelStr != "" {
+					model = modelStr
+				}
+			}
+		}
+
+		// Extract state fields from extensions
+		adminState := StringUnknown
+		if resource.Extensions != nil {
+			if adminVal, exists := resource.Extensions["adminState"]; exists {
+				if adminStr, ok := adminVal.(string); ok && adminStr != "" {
+					adminState = adminStr
+				}
+			}
+		}
+
+		operationalState := StringUnknown
+		if resource.Extensions != nil {
+			if operVal, exists := resource.Extensions["operationalState"]; exists {
+				if operStr, ok := operVal.(string); ok && operStr != "" {
+					operationalState = operStr
+				}
+			}
+		}
+
+		powerState := StringUnknown
+		if resource.Extensions != nil {
+			if powerVal, exists := resource.Extensions["powerState"]; exists {
+				if powerStr, ok := powerVal.(string); ok && powerStr != "" {
+					powerState = powerStr
+				}
+			}
+		}
+
+		usageState := StringUnknown
+		if resource.Extensions != nil {
+			if usageVal, exists := resource.Extensions["usageState"]; exists {
+				if usageStr, ok := usageVal.(string); ok && usageStr != "" {
+					usageState = usageStr
+				}
+			}
+		}
+
+		widths.Field1 = safeMax(widths.Field1, len(name))
+		widths.Field2 = safeMax(widths.Field2, len(pool))
+		widths.Field3 = safeMax(widths.Field3, len(resource.ResourceID))
+		widths.Field4 = safeMax(widths.Field4, len(model))
+		widths.Field5 = safeMax(widths.Field5, len(adminState))
+		widths.Field6 = safeMax(widths.Field6, len(operationalState))
+		widths.Field7 = safeMax(widths.Field7, len(powerState))
+		widths.Field8 = safeMax(widths.Field8, len(usageState))
+	}
+	return widths
+}
+
+func (f *TableFormatter) calculateInventoryResourcePoolWidths(events []WatchEvent, widths FieldWidths) FieldWidths {
+	for _, event := range events {
+		rpo, ok := event.Object.(*ResourcePoolObject)
+		if !ok || rpo == nil {
+			continue
+		}
+
+		// Calculate field widths based on actual content
+		if rpo.ResourcePool.Name != "" {
+			widths.Field2 = safeMax(widths.Field2, len(rpo.ResourcePool.Name))
+		}
+		if rpo.ResourcePool.ResourcePoolID != "" {
+			widths.Field3 = safeMax(widths.Field3, len(rpo.ResourcePool.ResourcePoolID))
+		}
+	}
+	return widths
+}
+
+func (f *TableFormatter) calculateInventoryNodeClusterWidths(events []WatchEvent, widths FieldWidths) FieldWidths {
+	for _, event := range events {
+		nco, ok := event.Object.(*NodeClusterObject)
+		if !ok || nco == nil {
+			continue
+		}
+
+		// Calculate field widths based on actual content
+		if nco.NodeCluster.Name != "" {
+			widths.Field1 = safeMax(widths.Field1, len(nco.NodeCluster.Name))
+		}
+		if nco.NodeCluster.NodeClusterID != "" {
+			widths.Field2 = safeMax(widths.Field2, len(nco.NodeCluster.NodeClusterID))
+		}
+		if nco.NodeCluster.NodeClusterTypeID != "" {
+			widths.Field3 = safeMax(widths.Field3, len(nco.NodeCluster.NodeClusterTypeID))
+		}
+	}
+	return widths
+}
+
+// applyMaxWidthLimits applies reasonable maximum widths to prevent excessive column widths
+func (f *TableFormatter) applyMaxWidthLimits(widths FieldWidths) FieldWidths {
+	// Apply reasonable maximum widths to prevent overly wide columns
+	const maxWidth = 50
+	widths.Name = safeMin(widths.Name, maxWidth)
+	widths.Field1 = safeMin(widths.Field1, maxWidth)
+	widths.Field2 = safeMin(widths.Field2, maxWidth)
+	widths.Field3 = safeMin(widths.Field3, maxWidth)
+	widths.Field4 = safeMin(widths.Field4, 25) // Limit MODEL field to 25 characters
+	widths.Field5 = safeMin(widths.Field5, maxWidth)
+	widths.Field6 = safeMin(widths.Field6, maxWidth)
+	widths.Field7 = safeMin(widths.Field7, maxWidth)
+	widths.Field8 = safeMin(widths.Field8, maxWidth)
+	widths.Namespace = safeMin(widths.Namespace, 20)
+
+	return widths
 }

--- a/dev-tools/crd-watcher/formatter_test.go
+++ b/dev-tools/crd-watcher/formatter_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -30,7 +29,7 @@ var _ = Describe("TableFormatter", func() {
 	)
 
 	BeforeEach(func() {
-		formatter = NewTableFormatter()
+		formatter = NewTableFormatter([]string{CRDTypeInventoryResources})
 
 		// Create a sample inventory resource with all state fields
 		resource = &InventoryResourceObject{
@@ -76,7 +75,7 @@ var _ = Describe("TableFormatter", func() {
 		})
 
 		It("should format inventory resource with all state fields", func() {
-			err := formatter.formatInventoryResource("2024-01-01T10:00:00Z", "ADDED", "1m", resource)
+			err := formatter.formatInventoryResource("1m", resource, FieldWidths{Field1: 25, Field2: 20, Field3: 35, Field4: 25, Field5: 15, Field6: 15, Field7: 10, Field8: 12})
 			Expect(err).ToNot(HaveOccurred())
 
 			// Wait a bit for output to be captured
@@ -97,7 +96,7 @@ var _ = Describe("TableFormatter", func() {
 		})
 
 		It("should truncate MODEL field to 25 characters", func() {
-			err := formatter.formatInventoryResource("2024-01-01T10:00:00Z", "ADDED", "1m", resource)
+			err := formatter.formatInventoryResource("1m", resource, FieldWidths{Field1: 25, Field2: 20, Field3: 35, Field4: 25, Field5: 15, Field6: 15, Field7: 10, Field8: 12})
 			Expect(err).ToNot(HaveOccurred())
 
 			time.Sleep(100 * time.Millisecond)
@@ -128,7 +127,8 @@ var _ = Describe("TableFormatter", func() {
 				},
 			}
 
-			err := formatter.formatInventoryResource("2024-01-01T10:00:00Z", "ADDED", "1m", resourceWithoutStates)
+			widths := FieldWidths{Field1: 25, Field2: 20, Field3: 35, Field4: 25, Field5: 15, Field6: 15, Field7: 10, Field8: 12}
+			err := formatter.formatInventoryResource("1m", resourceWithoutStates, widths)
 			Expect(err).ToNot(HaveOccurred())
 
 			time.Sleep(100 * time.Millisecond)
@@ -158,7 +158,8 @@ var _ = Describe("TableFormatter", func() {
 				},
 			}
 
-			err := formatter.formatInventoryResource("2024-01-01T10:00:00Z", "ADDED", "1m", resourceWithoutLabels)
+			widths := FieldWidths{Field1: 25, Field2: 20, Field3: 35, Field4: 25, Field5: 15, Field6: 15, Field7: 10, Field8: 12}
+			err := formatter.formatInventoryResource("1m", resourceWithoutLabels, widths)
 			Expect(err).ToNot(HaveOccurred())
 
 			time.Sleep(100 * time.Millisecond)
@@ -193,7 +194,8 @@ var _ = Describe("TableFormatter", func() {
 		})
 
 		It("should print correct header for inventory resources", func() {
-			formatter.printTableHeader(CRDTypeInventoryResources)
+			widths := FieldWidths{Field1: 25, Field2: 20, Field3: 35, Field4: 25, Field5: 15, Field6: 15, Field7: 10, Field8: 12}
+			formatter.printTableHeader(CRDTypeInventoryResources, widths)
 
 			time.Sleep(100 * time.Millisecond)
 			os.Stdout.Close()
@@ -210,8 +212,8 @@ var _ = Describe("TableFormatter", func() {
 			Expect(output).To(ContainSubstring("POWER"))
 			Expect(output).To(ContainSubstring("USAGE"))
 
-			// Verify separator line is present
-			Expect(output).To(ContainSubstring(strings.Repeat("-", 165)))
+			// Verify Unicode sidebar character is present
+			Expect(output).To(ContainSubstring("│"))
 		})
 	})
 
@@ -277,7 +279,7 @@ var _ = Describe("TableFormatter Events", func() {
 	)
 
 	BeforeEach(func() {
-		formatter = NewTableFormatter()
+		formatter = NewTableFormatter([]string{CRDTypeInventoryResources})
 
 		// Create sample events with inventory resources
 		events = []WatchEvent{

--- a/dev-tools/crd-watcher/main.go
+++ b/dev-tools/crd-watcher/main.go
@@ -65,6 +65,8 @@ type Config struct {
 	InventoryRetryDelayMs int
 	// Refresh configuration
 	InventoryRefreshInterval int // Interval in seconds for refreshing inventory data from O2IMS API
+	// Output formatting configuration
+	UseASCII bool // Use ASCII characters instead of Unicode for table formatting
 }
 
 var (
@@ -137,6 +139,7 @@ func addFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&config.Watch, "watch", "w", false, "Enable real-time screen updates (live dashboard mode)")
 	flags.IntVar(&config.RefreshInterval, "refresh-interval", 2, "Screen refresh interval in seconds during inactivity (watch mode only)")
 	flags.IntVar(&config.InventoryRefreshInterval, "inventory-refresh-interval", 120, "Inventory data refresh interval in seconds (0 to disable periodic refresh)")
+	flags.BoolVar(&config.UseASCII, "ascii", false, "Use ASCII characters instead of Unicode for table formatting")
 
 	// Inventory module flags
 	flags.BoolVar(&config.EnableInventory, "enable-inventory", false, "Enable inventory module to fetch resources from O2IMS API")

--- a/dev-tools/crd-watcher/tui_test.go
+++ b/dev-tools/crd-watcher/tui_test.go
@@ -35,6 +35,7 @@ var _ = Describe("TUIFormatter", func() {
 			verifyFunc:      func(event WatchEvent) bool { return true },
 			maxEvents:       100,
 			isTerminal:      false,
+			useUnicode:      true, // Use Unicode characters for tests
 		}
 
 		// Create sample inventory resource with all state fields

--- a/dev-tools/crd-watcher/watcher.go
+++ b/dev-tools/crd-watcher/watcher.go
@@ -86,7 +86,7 @@ func NewCRDWatcher(clientset kubernetes.Interface, restConfig *rest.Config, sche
 		return true // Default to keeping resources if verification isn't available yet
 	}
 
-	formatter := NewOutputFormatter(config.OutputFormat, config.Watch, config.RefreshInterval, crdTypes, verifyFunc)
+	formatter := NewOutputFormatter(config.OutputFormat, config.Watch, config.RefreshInterval, crdTypes, verifyFunc, config.UseASCII)
 
 	watcher := &CRDWatcher{
 		clientset:        clientset,


### PR DESCRIPTION
…h modes

- Make TableFormatter output identical to TUIFormatter display format
- Add dynamic field width calculation based on actual data content
- Add --ascii flag support for both watch and non-watch modes
- Fix NAME field width limits to match between modes (50 chars)
- Implement complete O-RAN Resources field width calculations
- Add sectioned output with headers for each CRD type in non-watch mode
- Use consistent sidebar characters and spacing across all modes

Key changes:
* TableFormatter now uses same width calculation logic as TUIFormatter
* Both modes examine actual data to determine optimal column widths
* Non-watch mode shows sectioned output with proper headers
* ASCII/Unicode character selection works in both watch and non-watch
* Field truncation behavior is now identical between modes
* All CRD types (Provisioning Requests, Allocated Nodes, etc.) display consistently

Fixes truncation issues where non-watch mode showed abbreviated data while watch mode displayed full content. Both modes now provide the same rich, properly-formatted output with user-selectable ASCII/Unicode characters for maximum terminal compatibility.

Assisted-by: Cursor/claude-4-sonnet