### PR TITLE
CNF-18384: Prevent ProvisioningRequest stuck states

### DIFF
--- a/hwmgr-plugins/api/server/provisioning/helpers.go
+++ b/hwmgr-plugins/api/server/provisioning/helpers.go
@@ -106,7 +106,7 @@ func NodeAllocationRequestCRToResponseObject(nodeAllocationRequest *pluginsv1alp
 }
 
 func GetNodeAllocationRequest(ctx context.Context,
-	c client.Client,
+	c client.Reader,
 	namespace, nodeAllocationRequestId string,
 ) (*pluginsv1alpha1.NodeAllocationRequest, error) {
 

--- a/hwmgr-plugins/metal3/cmd/start_metal3plugin_server.go
+++ b/hwmgr-plugins/metal3/cmd/start_metal3plugin_server.go
@@ -218,7 +218,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	defer cancel()
 	go func() {
 		logger.Info("Starting Metal3 HardwarePlugin API server")
-		err = metal3server.Serve(ctx, logger, c.CommonServerConfig, mgr.GetClient())
+		err = metal3server.Serve(ctx, logger, c.CommonServerConfig, mgr.GetClient(), mgr.GetAPIReader())
 	}()
 
 	go func() {

--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager_test.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager_test.go
@@ -417,9 +417,9 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 		It("should clear network data successfully", func() {
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
-			requeue, err := clearBMHNetworkData(ctx, fakeClient, logger, name)
+			result, err := clearBMHNetworkData(ctx, fakeClient, logger, name)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(requeue).To(Equal(DoNotRequeue))
+			Expect(RequeueCodeFromResult(result)).To(Equal(DoNotRequeue))
 
 			// Verify network data was cleared
 			var updatedBMH metal3v1alpha1.BareMetalHost
@@ -433,9 +433,9 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
-			requeue, err := clearBMHNetworkData(ctx, fakeClient, logger, name)
+			result, err := clearBMHNetworkData(ctx, fakeClient, logger, name)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(requeue).To(Equal(DoNotRequeue))
+			Expect(RequeueCodeFromResult(result)).To(Equal(DoNotRequeue))
 		})
 	})
 

--- a/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller.go
+++ b/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller.go
@@ -12,18 +12,20 @@ import (
 	"log/slog"
 	"time"
 
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
 )
@@ -147,7 +149,7 @@ func (r *AllocatedNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *AllocatedNodeReconciler) handleAllocatedNodeDeletion(ctx context.Context, allocatednode *pluginsv1alpha1.AllocatedNode) (bool, error) {
 
 	r.Logger.InfoContext(ctx, "handleAllocatedNodeDeletion", slog.String("node", allocatednode.Name))
-	bmh, err := getBMHForNode(ctx, r.Client, allocatednode)
+	bmh, err := getBMHForNode(ctx, r.NoncachedClient, allocatednode)
 	if err != nil {
 		return true, fmt.Errorf("failed to get BMH for node %s: %w", allocatednode.Name, err)
 	}

--- a/hwmgr-plugins/metal3/controller/resource_selection.go
+++ b/hwmgr-plugins/metal3/controller/resource_selection.go
@@ -153,7 +153,7 @@ var REPatternQualifierOp = regexp.MustCompile(`^([^!<>=~]+)([!<>=~]+)(.*)$`)
 //
 // Returns a slice of client.ListOption that can be used with client.List() to fetch BMHs.
 func ResourceSelectionPrimaryFilter(ctx context.Context,
-	c client.Client,
+	c client.Reader,
 	logger *slog.Logger,
 	site string,
 	nodeGroupData hwmgmtv1alpha1.NodeGroupData) ([]client.ListOption, error) {
@@ -265,7 +265,7 @@ func ResourceSelectionPrimaryFilter(ctx context.Context,
 // BMHs without corresponding HardwareData CRs are excluded but logged as errors.
 // BMHs that are not in "Available" state are excluded.
 func ResourceSelectionSecondaryFilter(ctx context.Context,
-	c client.Client,
+	c client.Reader,
 	logger *slog.Logger,
 	nodeGroupData hwmgmtv1alpha1.NodeGroupData,
 	bmhList metal3v1alpha1.BareMetalHostList) (metal3v1alpha1.BareMetalHostList, error) {
@@ -323,7 +323,7 @@ func ResourceSelectionSecondaryFilter(ctx context.Context,
 //
 // Returns true if the hardware data matches the criterion, false otherwise.
 func ResourceSelectionSecondaryFilterHardwareData(ctx context.Context,
-	c client.Client,
+	c client.Reader,
 	logger *slog.Logger,
 	key, value string,
 	hwdata *metal3v1alpha1.HardwareData) (bool, error) {

--- a/hwmgr-plugins/metal3/server/provisioning_server.go
+++ b/hwmgr-plugins/metal3/server/provisioning_server.go
@@ -30,12 +30,14 @@ type Metal3PluginServer struct {
 func NewMetal3PluginServer(
 	config svcutils.CommonServerConfig,
 	hubClient client.Client,
+	noncachedClient client.Reader,
 	logger *slog.Logger,
 ) (*Metal3PluginServer, error) {
 	return &Metal3PluginServer{
 		HardwarePluginServer: provisioning.HardwarePluginServer{
 			CommonServerConfig: config,
 			HubClient:          hubClient,
+			NoncachedClient:    noncachedClient,
 			Logger:             logger,
 			Namespace:          provisioning.GetMetal3HWPluginNamespace(),
 			HardwarePluginID:   hwmgrutils.Metal3HardwarePluginID,

--- a/hwmgr-plugins/metal3/server/provisioning_server_test.go
+++ b/hwmgr-plugins/metal3/server/provisioning_server_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Metal3PluginServer", func() {
 	Describe("NewMetal3PluginServer", func() {
 		Context("when creating a new Metal3 plugin server", func() {
 			It("should create a server successfully with valid parameters", func() {
-				server, err := NewMetal3PluginServer(config, mockClient, logger)
+				server, err := NewMetal3PluginServer(config, mockClient, mockClient, logger)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(server).ToNot(BeNil())
@@ -66,7 +66,7 @@ var _ = Describe("Metal3PluginServer", func() {
 			})
 
 			It("should implement the StrictServerInterface", func() {
-				server, err := NewMetal3PluginServer(config, mockClient, logger)
+				server, err := NewMetal3PluginServer(config, mockClient, mockClient, logger)
 
 				Expect(err).ToNot(HaveOccurred())
 				// Verify that the server can be used as a StrictServerInterface
@@ -75,7 +75,7 @@ var _ = Describe("Metal3PluginServer", func() {
 			})
 
 			It("should properly initialize all embedded struct fields", func() {
-				server, err := NewMetal3PluginServer(config, mockClient, logger)
+				server, err := NewMetal3PluginServer(config, mockClient, mockClient, logger)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(server.HardwarePluginServer.CommonServerConfig).To(Equal(config))
@@ -84,7 +84,7 @@ var _ = Describe("Metal3PluginServer", func() {
 			})
 
 			It("should set the correct Metal3-specific configuration", func() {
-				server, err := NewMetal3PluginServer(config, mockClient, logger)
+				server, err := NewMetal3PluginServer(config, mockClient, mockClient, logger)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(server.HardwarePluginServer.Namespace).To(Equal(provisioning.GetMetal3HWPluginNamespace()))
@@ -93,14 +93,14 @@ var _ = Describe("Metal3PluginServer", func() {
 			})
 
 			It("should set the Metal3ResourcePrefix constant correctly", func() {
-				server, err := NewMetal3PluginServer(config, mockClient, logger)
+				server, err := NewMetal3PluginServer(config, mockClient, mockClient, logger)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(server.HardwarePluginServer.ResourcePrefix).To(Equal("metal3"))
 			})
 
 			It("should set the correct Hardware Plugin ID", func() {
-				server, err := NewMetal3PluginServer(config, mockClient, logger)
+				server, err := NewMetal3PluginServer(config, mockClient, mockClient, logger)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(server.HardwarePluginServer.HardwarePluginID).To(Equal("metal3-hwplugin"))
@@ -109,7 +109,7 @@ var _ = Describe("Metal3PluginServer", func() {
 
 		Context("when handling different parameter combinations", func() {
 			It("should work with a nil logger", func() {
-				server, err := NewMetal3PluginServer(config, mockClient, nil)
+				server, err := NewMetal3PluginServer(config, mockClient, mockClient, nil)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(server).ToNot(BeNil())
@@ -118,7 +118,7 @@ var _ = Describe("Metal3PluginServer", func() {
 
 			It("should work with empty config", func() {
 				emptyConfig := svcutils.CommonServerConfig{}
-				server, err := NewMetal3PluginServer(emptyConfig, mockClient, logger)
+				server, err := NewMetal3PluginServer(emptyConfig, mockClient, mockClient, logger)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(server).ToNot(BeNil())
@@ -126,7 +126,7 @@ var _ = Describe("Metal3PluginServer", func() {
 			})
 
 			It("should work with nil client", func() {
-				server, err := NewMetal3PluginServer(config, nil, logger)
+				server, err := NewMetal3PluginServer(config, nil, nil, logger)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(server).ToNot(BeNil())
@@ -146,7 +146,7 @@ var _ = Describe("Metal3PluginServer", func() {
 
 		Context("when verifying field initialization order", func() {
 			It("should initialize all fields in the correct order", func() {
-				server, err := NewMetal3PluginServer(config, mockClient, logger)
+				server, err := NewMetal3PluginServer(config, mockClient, mockClient, logger)
 
 				Expect(err).ToNot(HaveOccurred())
 

--- a/hwmgr-plugins/metal3/server/serve.go
+++ b/hwmgr-plugins/metal3/server/serve.go
@@ -38,7 +38,7 @@ const (
 )
 
 // Serve starts the Metal3 HardwarePlugin API server and blocks until it terminates or context is canceled.
-func Serve(ctx context.Context, logger *slog.Logger, config svcutils.CommonServerConfig, hubClient client.Client) error {
+func Serve(ctx context.Context, logger *slog.Logger, config svcutils.CommonServerConfig, hubClient client.Client, noncachedClient client.Reader) error {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -72,6 +72,7 @@ func Serve(ctx context.Context, logger *slog.Logger, config svcutils.CommonServe
 	metal3ProvisioningServer, err := NewMetal3PluginServer(
 		config,
 		hubClient,
+		noncachedClient,
 		slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			AddSource: true,
 			Level:     slog.LevelDebug,

--- a/hwmgr-plugins/metal3/server/serve_test.go
+++ b/hwmgr-plugins/metal3/server/serve_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Serve", func() {
 			// Since we're not in a Kubernetes environment, the function should fail
 			// when trying to set up authentication middleware
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
-			err := Serve(timeoutCtx, logger, config, mockClient)
+			err := Serve(timeoutCtx, logger, config, mockClient, mockClient)
 
 			// In local env: should fail on authenticator setup (err != nil)
 			// In CI env: may succeed past auth and return nil on context timeout (graceful shutdown)
@@ -132,7 +132,7 @@ var _ = Describe("Serve", func() {
 			// Test that the function attempts to get swagger specs
 			// This tests the early validation logic
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
-			err := Serve(timeoutCtx, logger, config, mockClient)
+			err := Serve(timeoutCtx, logger, config, mockClient, mockClient)
 
 			// In local env: should fail on auth setup, not on swagger retrieval
 			// In CI env: may succeed past auth and return nil on context timeout (graceful shutdown)
@@ -174,7 +174,7 @@ var _ = Describe("Serve", func() {
 
 			config.Listener.Address = "invalid-address"
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
-			err := Serve(timeoutCtx, logger, config, mockClient)
+			err := Serve(timeoutCtx, logger, config, mockClient, mockClient)
 
 			// In local env: will fail on auth setup first, not address validation
 			// In CI env: may succeed past auth and return nil on context timeout (graceful shutdown)
@@ -208,7 +208,7 @@ var _ = Describe("Serve", func() {
 
 			// This should fail at auth setup stage, not get to server startup
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
-			err := Serve(cancelledCtx, logger, config, mockClient)
+			err := Serve(cancelledCtx, logger, config, mockClient, mockClient)
 
 			// In local env: should fail on authenticator setup (err != nil)
 			// In CI env: may succeed past auth and return nil on context cancellation (graceful shutdown)

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -332,6 +332,9 @@ const HardwarePluginValidationEndpoint = "/hardware-manager/provisioning/api_ver
 
 const AllocatedNodeLabel = "clcm.openshift.io/allocated-node"
 
+// Status message constants
+const ValidationMessage = "Validating and preparing resources"
+
 // Callback annotation keys used by both the NAR callback server and provisioning request controller
 const (
 	CallbackReceivedAnnotation                = "callback.received"


### PR DESCRIPTION
Callback-Only Status Updates: Hardware status is now updated only during plugin-triggered callbacks, avoiding race conditions from reconcile cycles. This approach is consistent with the metal3 plugin behavior, which sends callbacks for every NodeAllocationRequest status change.

Hybrid Client Architecture: NodeAllocationRequest fetches now use a non-cached client during callbacks for up-to-date data, while cached client is retained for other operations.

Reset NAR provisioning/configuring timers on failure or completion to avoid stale timeouts.

Refactored logic with new checkHardwareProvisioningTimeout() helper for clarity.