### PR TITLE
metal3: Drop temporary node-name annotation

### DIFF
--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
@@ -44,7 +44,6 @@ const (
 	BiosUpdateNeededAnnotation     = "clcm.openshift.io/bios-update-needed"
 	FirmwareUpdateNeededAnnotation = "clcm.openshift.io/firmware-update-needed"
 	BmhAllocatedLabel              = "clcm.openshift.io/allocated"
-	NodeNameAnnotation             = "clcm.openshift.io/node-name"
 	BmhDeallocationDoneAnnotation  = "clcm.openshift.io/deallocation-complete"
 	BmhErrorTimestampAnnotation    = "clcm.openshift.io/bmh-error-timestamp"
 	SkipCleanupAnnotation          = "clcm.openshift.io/skip-cleanup"

--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager_test.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager_test.go
@@ -927,7 +927,6 @@ var _ = Describe("BareMetalHost Manager", func() {
 			Expect(BiosUpdateNeededAnnotation).To(Equal("clcm.openshift.io/bios-update-needed"))
 			Expect(FirmwareUpdateNeededAnnotation).To(Equal("clcm.openshift.io/firmware-update-needed"))
 			Expect(BmhAllocatedLabel).To(Equal("clcm.openshift.io/allocated"))
-			Expect(NodeNameAnnotation).To(Equal("clcm.openshift.io/node-name"))
 			Expect(BmhHostMgmtAnnotation).To(Equal("bmac.agent-install.openshift.io/allow-provisioned-host-management"))
 			Expect(BmhInfraEnvLabel).To(Equal("infraenvs.agent-install.openshift.io"))
 			Expect(SiteConfigOwnedByLabel).To(Equal("siteconfig.open-cluster-management.io/owned-by"))

--- a/hwmgr-plugins/metal3/controller/helpers.go
+++ b/hwmgr-plugins/metal3/controller/helpers.go
@@ -621,14 +621,8 @@ func allocateBMHToNodeAllocationRequest(ctx context.Context,
 ) (int, error) {
 
 	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
-	nodeName := bmh.Annotations[NodeNameAnnotation]
-	if nodeName == "" {
-		nodeName = hwmgrutils.GenerateNodeName(hwmgrutils.Metal3HardwarePluginID, nodeAllocationRequest.Spec.ClusterId, bmh.Namespace, bmh.Name)
-		if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation, NodeNameAnnotation,
-			nodeName, OpAdd); err != nil {
-			return DoNotRequeue, fmt.Errorf("failed to save AllocatedNode name annotation to BMH (%s): %w", bmh.Name, err)
-		}
-	}
+
+	nodeName := hwmgrutils.GenerateNodeName(hwmgrutils.Metal3HardwarePluginID, nodeAllocationRequest.Spec.ClusterId, bmh.Namespace, bmh.Name)
 
 	// Set AllocatedNode label
 	allocatedNodeLbl := bmh.Labels[ctlrutils.AllocatedNodeLabel]
@@ -705,11 +699,6 @@ func allocateBMHToNodeAllocationRequest(ctx context.Context,
 		} else if requeue > DoNotRequeue {
 			return requeue, nil
 		}
-	}
-
-	// Clean up annotation
-	if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, "annotation", NodeNameAnnotation, "", OpRemove); err != nil {
-		logger.ErrorContext(ctx, "failed to clear node name annotation from BMH", slog.Any("bmh", bmhName), slog.String("error", err.Error()))
 	}
 
 	return DoNotRequeue, nil


### PR DESCRIPTION
The temporary node-name BMH annotation used by the metal3 plugin can result in reuse of a stale name, so is being removed.