### PR TITLE
replace 'alertManager' with 'alertmanager' for consistent naming

### DIFF
--- a/docs/dev/env_acm.md
+++ b/docs/dev/env_acm.md
@@ -235,7 +235,7 @@ spec:
 export TOKEN=$(oc create token oauth-apiserver-sa -n openshift-oauth-apiserver --duration=8760h)
 ```
 
-### Access AlertManager API
+### Access Alertmanager API
 
 <https://alertmanager-open-cluster-management-observability.apps.ostest.test.metalkube.org/api/v2/alerts>
 

--- a/internal/service/alarms/api/server.go
+++ b/internal/service/alarms/api/server.go
@@ -488,7 +488,7 @@ func (a *AlarmsServer) UpdateAlarmServiceConfiguration(ctx context.Context, requ
 
 }
 
-// AmNotification handles an API request coming from AlertManager with CaaS alerts. This api is used internally.
+// AmNotification handles an API request coming from Alertmanager with CaaS alerts. This api is used internally.
 // Note: the errors returned can also be view under alertmanager pod logs but also logging here for convenience
 func (a *AlarmsServer) AmNotification(ctx context.Context, request api.AmNotificationRequestObject) (api.AmNotificationResponseObject, error) {
 	// TODO: AM auto retries if it receives 5xx error code. That means any error, even if permanent (e.g postgres syntax), will be processed the same way. Once we have a better retry mechanism for pg, update all 5xx to 4xx as needed.

--- a/internal/service/alarms/internal/alertmanager/api.go
+++ b/internal/service/alarms/internal/alertmanager/api.go
@@ -48,15 +48,15 @@ type Status struct {
 	InhibitedBy []string `json:"inhibitedBy"`
 }
 
-// AMClient provides methods to interact with AlertManager
+// AMClient provides methods to interact with Alertmanager
 type AMClient struct {
 	k8sClient        client.Client
 	alarmsRepository repo.AlarmRepositoryInterface
 	infrastructure   *infrastructure.Infrastructure
 }
 
-// NewAlertManagerClient creates a new AMClient
-func NewAlertManagerClient(k8sClient client.Client, amrepo repo.AlarmRepositoryInterface, infra *infrastructure.Infrastructure) *AMClient {
+// NewAlertmanagerClient creates a new AMClient
+func NewAlertmanagerClient(k8sClient client.Client, amrepo repo.AlarmRepositoryInterface, infra *infrastructure.Infrastructure) *AMClient {
 	return &AMClient{
 		k8sClient:        k8sClient,
 		alarmsRepository: amrepo,
@@ -108,10 +108,10 @@ func (c *AMClient) SyncAlerts(ctx context.Context) error {
 	return nil
 }
 
-// getAlerts retrieves all alerts from AlertManager API
+// getAlerts retrieves all alerts from Alertmanager API
 func (c *AMClient) getAlerts(ctx context.Context) ([]APIAlert, error) {
 	// Get the alertmanager route
-	alertManagerHost, err := c.GetAlertmanagerRoute(ctx)
+	alertmanagerHost, err := c.GetAlertmanagerRoute(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get alertmanager route: %w", err)
 	}
@@ -125,7 +125,7 @@ func (c *AMClient) getAlerts(ctx context.Context) ([]APIAlert, error) {
 	// Create request
 	u := url.URL{
 		Scheme: "https",
-		Host:   alertManagerHost,
+		Host:   alertmanagerHost,
 		Path:   "/api/v2/alerts",
 	}
 

--- a/internal/service/alarms/internal/alertmanager/api_test.go
+++ b/internal/service/alarms/internal/alertmanager/api_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Alertmanager API Client", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockRepo = generated.NewMockAlarmRepositoryInterface(ctrl)
 
-		// Create mock AlertManager server
+		// Create mock Alertmanager server
 		mockAMServer = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Verify request has correct path
 			Expect(r.URL.Path).To(Equal("/api/v2/alerts"))
@@ -118,7 +118,7 @@ var _ = Describe("Alertmanager API Client", func() {
 			},
 		}
 
-		amClient = alertmanager.NewAlertManagerClient(fakeClient, mockRepo, infra)
+		amClient = alertmanager.NewAlertmanagerClient(fakeClient, mockRepo, infra)
 
 		// Set up test alerts
 		testAPIAlerts = []alertmanager.APIAlert{
@@ -149,7 +149,7 @@ var _ = Describe("Alertmanager API Client", func() {
 	})
 
 	Describe("SyncAlerts", func() {
-		It("should successfully sync alerts from AlertManager", func() {
+		It("should successfully sync alerts from Alertmanager", func() {
 			mockRepo.EXPECT().
 				WithTransaction(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(ctx context.Context, fn func(tx pgx.Tx) error) error {
@@ -221,7 +221,7 @@ var _ = Describe("Alertmanager API Client", func() {
 				WithScheme(runtime.NewScheme()).
 				Build()
 
-			clientWithoutRoute := alertmanager.NewAlertManagerClient(emptyClient, mockRepo, infra)
+			clientWithoutRoute := alertmanager.NewAlertmanagerClient(emptyClient, mockRepo, infra)
 
 			_, err := clientWithoutRoute.GetAlertmanagerRoute(ctx)
 

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -342,7 +342,7 @@ func startAlertmanager(ctx context.Context, alarmServer *api.AlarmsServer) error
 	}
 
 	// Run the first sync - running it outside also makes sure connectivity is good before server starts listening
-	c := alertmanager.NewAlertManagerClient(hubclient, alarmServer.AlarmsRepository, alarmServer.Infrastructure)
+	c := alertmanager.NewAlertmanagerClient(hubclient, alarmServer.AlarmsRepository, alarmServer.Infrastructure)
 	slog.Info("Running initial alert sync")
 	if err := c.SyncAlerts(ctx); err != nil {
 		return fmt.Errorf("failed to run initial alert sync: %w", err)


### PR DESCRIPTION
address [this](https://github.com/openshift-kni/oran-o2ims/pull/820#discussion_r2260552105). Follows the official way https://github.com/prometheus/alertmanager 

/cc @donpenney 