### PR TITLE
CNF-18815: metal3: Add hardwaredata resource selector support

### DIFF
--- a/hwmgr-plugins/metal3/controller/helpers.go
+++ b/hwmgr-plugins/metal3/controller/helpers.go
@@ -338,7 +338,7 @@ func processNewNodeAllocationRequest(ctx context.Context,
 		}
 
 		// Fetch unallocated BMHs for the specific site and NodeGroupData
-		bmhListForGroup, err := fetchBMHList(ctx, c, logger, nodeAllocationRequest.Spec.Site, nodeGroup.NodeGroupData, UnallocatedBMHs)
+		bmhListForGroup, err := fetchBMHList(ctx, c, logger, nodeAllocationRequest.Spec.Site, nodeGroup.NodeGroupData)
 		if err != nil {
 			return fmt.Errorf("unable to fetch BMHs for nodegroup=%s: %w", nodeGroup.NodeGroupData.Name, err)
 		}
@@ -768,7 +768,7 @@ func processNodeAllocationRequestAllocation(ctx context.Context,
 
 		// Only fetch unallocated BMHs if we actually need new nodes
 		unallocatedBMHs, err := fetchBMHList(ctx, c, logger, nodeAllocationRequest.Spec.Site,
-			nodeGroup.NodeGroupData, UnallocatedBMHs)
+			nodeGroup.NodeGroupData)
 		if err != nil {
 			return RequeueAfterShortInterval, fmt.Errorf("unable to fetch unallocated BMHs for site=%s, nodegroup=%s: %w",
 				nodeAllocationRequest.Spec.Site, nodeGroup.NodeGroupData.Name, err)

--- a/hwmgr-plugins/metal3/controller/resource_selection.go
+++ b/hwmgr-plugins/metal3/controller/resource_selection.go
@@ -1,0 +1,710 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// This file provides resource selection functionality for filtering BareMetalHosts
+// based on hardware characteristics and resource criteria. The resource selection system
+// uses a two-stage filtering approach:
+//
+//  1. Primary Filter: Uses Kubernetes label selectors for efficient server-side filtering
+//     of allocation status, site ID, resource pool ID, and custom resource selector labels.
+//
+//  2. Secondary Filter: Evaluates hardware data criteria by fetching HardwareData CRs
+//     and applying complex matching logic for CPU, memory, network, and storage requirements.
+//
+// This approach optimizes performance by reducing the number of BMHs that need detailed
+// hardware evaluation while supporting sophisticated hardware-based selection criteria.
+package controller
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+)
+
+// ============================================================================
+// Hardware Data Field Constants
+// ============================================================================
+
+const (
+	// HardwareDataPrefix is the prefix used to identify hardware data criteria
+	// in resource selector keys. Only keys starting with this prefix are processed
+	// by the secondary filter.
+	HardwareDataPrefix = "hardwaredata/"
+
+	// Hardware data field names - these correspond to fields in the HardwareDetails struct
+	FieldCPUArch      = "cpu_arch"     // CPU architecture (e.g., "x86_64", "arm64")
+	FieldCPUModel     = "cpu_model"    // CPU model string
+	FieldNumThreads   = "num_threads"  // Number of CPU threads
+	FieldRAM          = "ramMebibytes" // RAM size in mebibytes
+	FieldNIC          = "nics"         // Network interface criteria
+	FieldStorage      = "storage"      // Storage device criteria
+	FieldManufacturer = "manufacturer" // System manufacturer
+	FieldProductName  = "productname"  // System product name
+)
+
+// ============================================================================
+// String Qualifier Constants
+// ============================================================================
+
+const (
+	// String qualifier names - used for string field matching behavior
+	QualifierSubstring = "substring" // Match substring within field value
+	QualifierICase     = "icase"     // Case-insensitive matching
+)
+
+// ============================================================================
+// Integer Comparison Constants
+// ============================================================================
+
+const (
+	// Integer comparison qualifier names - used for numeric field comparisons
+	QualifierGT  = "gt"  // Greater than
+	QualifierGTE = "gte" // Greater than or equal
+	QualifierLT  = "lt"  // Less than
+	QualifierLTE = "lte" // Less than or equal
+	QualifierEQ  = "eq"  // Equal
+	QualifierNEQ = "neq" // Not equal
+)
+
+// ============================================================================
+// Operator Symbol Constants
+// ============================================================================
+
+const (
+	// Operator symbols for comparisons - alternative syntax for qualifiers
+	OpEqual              = "="  // Equal
+	OpEqualStrict        = "==" // Strict equal
+	OpNotEqual           = "!=" // Not equal
+	OpGreaterThan        = ">"  // Greater than
+	OpGreaterThanOrEqual = ">=" // Greater than or equal
+	OpLessThan           = "<"  // Less than
+	OpLessThanOrEqual    = "<=" // Less than or equal
+	OpContains           = "~"  // Contains substring
+	OpNotContains        = "!~" // Does not contain substring
+)
+
+// ============================================================================
+// Types and Variables
+// ============================================================================
+
+// OpQualifier represents a parsed qualifier with operator and value
+type OpQualifier struct {
+	Op    string
+	Value string
+}
+
+// OpQualifierSet is a map of qualifier keys to their parsed OpQualifier objects
+type OpQualifierSet map[string]OpQualifier
+
+// REPatternHardwareData matches hardware data criteria keys and extracts the field and qualifiers.
+// It captures everything after the "hardwaredata/" prefix as group 1, which contains
+// the field name and optional qualifiers separated by semicolons.
+// Example: "hardwaredata/cpu_arch;icase" -> captures "cpu_arch;icase"
+var REPatternHardwareData = regexp.MustCompile(`^` + HardwareDataPrefix + `(.*)`)
+
+// REPatternQualifierOp parses qualifier strings in "key<operator>value" format.
+// Captures: group 1 = key, group 2 = operator, group 3 = value
+// Example: "speedGbps>=10" -> captures ["speedGbps", ">=", "10"]
+var REPatternQualifierOp = regexp.MustCompile(`^([^!<>=~]+)([!<>=~]+)(.*)$`)
+
+// ============================================================================
+// Primary Filter Functions (Label-based filtering)
+// ============================================================================
+
+// ResourceSelectionPrimaryFilter creates Kubernetes client list options for the primary filtering stage.
+// This function builds label selectors to filter BareMetalHosts by allocation status, site ID,
+// resource pool ID, and other label-based criteria. Hardware data criteria are excluded from
+// this stage and handled by ResourceSelectionSecondaryFilter.
+//
+// The primary filter includes:
+// - Allocation status: excludes BMHs with allocated=true label
+// - Site ID: matches the specified site if provided
+// - Resource pool ID: matches the pool ID from nodeGroupData if provided
+// - Resource selector labels: applies non-hardware data labels from nodeGroupData.ResourceSelector
+//
+// Example usage:
+//
+//	nodeGroupData := hwmgmtv1alpha1.NodeGroupData{
+//	  ResourcePoolId: "pool1",
+//	  ResourceSelector: map[string]string{
+//	    "zone": "east",
+//	    "hardwaredata/cpu_arch": "x86_64", // This will be skipped in primary filter
+//	  },
+//	}
+//	opts, err := ResourceSelectionPrimaryFilter(ctx, client, logger, "site1", nodeGroupData)
+//	if err != nil {
+//	  return err
+//	}
+//	// Use opts with client.List() to fetch filtered BMHs
+//
+// Returns a slice of client.ListOption that can be used with client.List() to fetch BMHs.
+func ResourceSelectionPrimaryFilter(ctx context.Context,
+	c client.Client,
+	logger *slog.Logger,
+	site string,
+	nodeGroupData hwmgmtv1alpha1.NodeGroupData) ([]client.ListOption, error) {
+
+	opts := []client.ListOption{}
+
+	// Fetch only unallocated BMHs
+	selector := metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      BmhAllocatedLabel,
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{ValueTrue}, // Exclude allocated=true
+			},
+		},
+	}
+	labelSelector, err := metav1.LabelSelectorAsSelector(&selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create label selector: %w", err)
+	}
+	opts = append(opts, client.MatchingLabelsSelector{Selector: labelSelector})
+
+	matchingLabels := make(client.MatchingLabels)
+
+	// Add site ID filter if provided
+	if site != "" {
+		matchingLabels[LabelSiteID] = site
+	}
+
+	// Add pool ID filter if provided
+	if nodeGroupData.ResourcePoolId != "" {
+		matchingLabels[LabelResourcePoolID] = nodeGroupData.ResourcePoolId
+	}
+
+	for key, value := range nodeGroupData.ResourceSelector {
+		fullLabelName := key
+
+		// HardwareData criteria is processed by the secondary filter, so we skip it here
+		if REPatternHardwareData.MatchString(fullLabelName) {
+			continue
+		}
+
+		if !REPatternResourceSelectorLabel.MatchString(fullLabelName) {
+			fullLabelName = LabelPrefixResourceSelector + key
+		}
+
+		matchingLabels[fullLabelName] = value
+	}
+
+	opts = append(opts, matchingLabels)
+
+	return opts, nil
+}
+
+// ============================================================================
+// Secondary Filter Functions (Hardware data filtering)
+// ============================================================================
+
+// ResourceSelectionSecondaryFilter applies hardware data criteria to filter BareMetalHosts.
+// This function processes BMHs that passed the primary filter and evaluates them against
+// hardware data criteria specified in nodeGroupData.ResourceSelector. Only criteria with
+// the "hardwaredata/" prefix are processed in this stage.
+//
+// Supported hardware data fields:
+// - cpu_arch: CPU architecture (e.g., "x86_64", "arm64")
+// - cpu_model: CPU model string
+// - num_threads: Number of CPU threads (supports comparison operators)
+// - ramMebibytes: RAM size in mebibytes (supports comparison operators)
+// - nic: Network interface presence (value must be "present")
+// - storage: Storage device presence (value must be "present")
+// - manufacturer: System manufacturer string
+// - productname: System product name string
+//
+// String qualifiers:
+// - substring: Match substring within the field value
+// - icase: Case-insensitive matching
+//
+// Integer qualifiers and operators:
+// - gt, >: Greater than
+// - gte, >=: Greater than or equal
+// - lt, <: Less than
+// - lte, <=: Less than or equal
+// - eq, ==: Equal
+// - neq, !=: Not equal
+//
+// NIC and storage qualifiers use key=value format:
+// - model=<value>: Match device model
+// - speedGbps=<value>: Match NIC speed (integer operators supported)
+// - count=<value>: Match device count (integer operators supported)
+// - type=<value>: Match storage type (HDD, SSD, etc.)
+// - sizeBytes=<value>: Match storage size (integer operators supported)
+// - vendor=<value>: Match storage vendor
+// - name=<value>: Match storage name
+//
+// Example usage:
+//
+//	nodeGroupData := hwmgmtv1alpha1.NodeGroupData{
+//	  ResourceSelector: map[string]string{
+//	    "hardwaredata/cpu_arch": "x86_64",
+//	    "hardwaredata/num_threads;gte": "8",
+//	    "hardwaredata/ramMebibytes;gt": "16384",
+//	    "hardwaredata/nic;model=Intel": "present",
+//	    "hardwaredata/storage;type=SSD;count>=2": "present",
+//	  },
+//	}
+//	filtered, err := ResourceSelectionSecondaryFilter(ctx, client, logger, nodeGroupData, bmhList)
+//
+// Returns a filtered BareMetalHostList containing only BMHs that match all hardware criteria.
+// BMHs without corresponding HardwareData CRs are excluded but logged as errors.
+// BMHs that are not in "Available" state are excluded.
+func ResourceSelectionSecondaryFilter(ctx context.Context,
+	c client.Client,
+	logger *slog.Logger,
+	nodeGroupData hwmgmtv1alpha1.NodeGroupData,
+	bmhList metal3v1alpha1.BareMetalHostList) (metal3v1alpha1.BareMetalHostList, error) {
+	var filteredBMHs metal3v1alpha1.BareMetalHostList
+	for _, bmh := range bmhList.Items {
+		if bmh.Status.Provisioning.State != metal3v1alpha1.StateAvailable {
+			continue
+		}
+
+		// Get the corresponding HardwareData CR and check it against the resource selector criteria
+		hwdata := &metal3v1alpha1.HardwareData{}
+		if err := c.Get(ctx, types.NamespacedName{Namespace: bmh.Namespace, Name: bmh.Name}, hwdata); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				logger.ErrorContext(ctx, "Failed to get HardwareData for BMH, skipping", "bmh", bmh.Name, "error", err)
+			} else {
+				logger.ErrorContext(ctx, "HardwareData not found for BMH, skipping hardware criteria evaluation", "bmh", bmh.Name)
+			}
+			continue
+		}
+
+		if hwdata.Spec.HardwareDetails == nil {
+			continue
+		}
+
+		include := true
+		for key, value := range nodeGroupData.ResourceSelector {
+			rc, err := ResourceSelectionSecondaryFilterHardwareData(ctx, c, logger, key, value, hwdata)
+			if err != nil {
+				return filteredBMHs, fmt.Errorf("failed to evaluate criteria: criteria=%s, %w", key, err)
+			}
+			if !rc {
+				include = false
+				break
+			}
+		}
+		if !include {
+			continue
+		}
+
+		filteredBMHs.Items = append(filteredBMHs.Items, bmh)
+	}
+	return filteredBMHs, nil
+}
+
+// ResourceSelectionSecondaryFilterHardwareData evaluates a single hardware data criterion.
+// This function checks if the given HardwareData matches the specified key-value criterion.
+// Only keys with the "hardwaredata/" prefix are processed; other keys return true (pass).
+//
+// The key format is: "hardwaredata/<field>[;<qualifier1>[;<qualifier2>...]]"
+// Examples:
+//   - "hardwaredata/cpu_arch" - exact CPU architecture match
+//   - "hardwaredata/cpu_model;substring;icase" - case-insensitive substring match in CPU model
+//   - "hardwaredata/num_threads;gte" - CPU thread count greater than or equal to value
+//   - "hardwaredata/nic;model=Intel;speedGbps>=10" - Intel NICs with speed >= 10 Gbps
+//
+// Returns true if the hardware data matches the criterion, false otherwise.
+func ResourceSelectionSecondaryFilterHardwareData(ctx context.Context,
+	c client.Client,
+	logger *slog.Logger,
+	key, value string,
+	hwdata *metal3v1alpha1.HardwareData) (bool, error) {
+	match := REPatternHardwareData.FindStringSubmatch(key)
+	if len(match) != 2 {
+		// Skip non-HardwareData criteria
+		return true, nil
+	}
+
+	// The hardwaredata criteria key is composed of a field with a series of optional qualifiers, delimited by a semicolon.
+	// We need to split the key, minus the HardwareDataPrefix, and process each qualifier accordingly.
+	parts := strings.Split(match[1], ";")
+	qualifiers := parts[1:]
+
+	caseSensitive := true
+	if slices.Contains(qualifiers, QualifierICase) {
+		caseSensitive = false
+		// Delete icase from the list of qualifiers, since we have the caseSensitive bool
+		qualifiers = slices.DeleteFunc(qualifiers, func(s string) bool {
+			return s == QualifierICase
+		})
+	}
+
+	switch parts[0] {
+	case FieldCPUArch:
+		return checkStringWithQualifiers(qualifiers, value, hwdata.Spec.HardwareDetails.CPU.Arch, caseSensitive), nil
+	case FieldCPUModel:
+		return checkStringWithQualifiers(qualifiers, value, hwdata.Spec.HardwareDetails.CPU.Model, caseSensitive), nil
+	case FieldNumThreads:
+		rc, err := checkIntWithQualifiers(qualifiers, value, hwdata.Spec.HardwareDetails.CPU.Count)
+		if err != nil {
+			return false, fmt.Errorf("checkIntWithQualifiers failed: %w", err)
+		}
+		return rc, nil
+	case FieldRAM:
+		rc, err := checkIntWithQualifiers(qualifiers, value, hwdata.Spec.HardwareDetails.RAMMebibytes)
+		if err != nil {
+			return false, fmt.Errorf("checkIntWithQualifiers failed: %w", err)
+		}
+		return rc, nil
+	case FieldNIC:
+		rc, err := checkNicsWithQualifiers(qualifiers, value, hwdata.Spec.HardwareDetails.NIC, caseSensitive)
+		if err != nil {
+			return false, fmt.Errorf("checkNicsWithQualifiers failed: %w", err)
+		}
+		return rc, nil
+	case FieldStorage:
+		rc, err := checkStorageWithQualifiers(qualifiers, value, hwdata.Spec.HardwareDetails.Storage, caseSensitive)
+		if err != nil {
+			return false, fmt.Errorf("checkStorageWithQualifiers failed: %w", err)
+		}
+		return rc, nil
+	case FieldManufacturer:
+		return checkStringWithQualifiers(qualifiers, value, hwdata.Spec.HardwareDetails.SystemVendor.Manufacturer, caseSensitive), nil
+	case FieldProductName:
+		return checkStringWithQualifiers(qualifiers, value, hwdata.Spec.HardwareDetails.SystemVendor.ProductName, caseSensitive), nil
+	}
+	return true, nil
+}
+
+// ============================================================================
+// Basic Field Matching Functions
+// ============================================================================
+
+// checkStringWithQualifiers performs string matching with optional qualifiers.
+// Supports case-insensitive matching and substring matching.
+//
+// Qualifiers:
+// - "substring": Match if value is a substring of fieldValue
+// - "icase": Perform case-insensitive matching
+// - Both qualifiers can be combined for case-insensitive substring matching
+//
+// Examples:
+//
+//	checkStringWithQualifiers([]string{}, "x86_64", "x86_64") // true (exact match)
+//	checkStringWithQualifiers([]string{"icase"}, "X86_64", "x86_64") // true
+//	checkStringWithQualifiers([]string{"substring"}, "Intel", "Intel Xeon") // true
+//	checkStringWithQualifiers([]string{"substring", "icase"}, "INTEL", "Intel Xeon") // true
+func checkStringWithQualifiers(qualifiers []string, value, fieldValue string, caseSensitive bool) bool {
+	if !caseSensitive {
+		fieldValue = strings.ToLower(fieldValue)
+		value = strings.ToLower(value)
+	}
+
+	substringMatch := slices.Contains(qualifiers, QualifierSubstring)
+	if substringMatch {
+		return strings.Contains(fieldValue, value)
+	}
+
+	return fieldValue == value
+}
+
+// checkIntWithQualifiers performs integer comparison with optional qualifiers.
+// Supports various comparison operators for numeric hardware data fields.
+//
+// Supported qualifiers and operators:
+// - "gt", ">": Greater than
+// - "gte", ">=": Greater than or equal
+// - "lt", "<": Less than
+// - "lte", "<=": Less than or equal
+// - "eq", "==", "=": Equal
+// - "neq", "!=": Not equal
+//
+// Examples:
+//
+//	checkIntWithQualifiers([]string{}, "8", 8) // true (exact match when no qualifier)
+//	checkIntWithQualifiers([]string{"gt"}, "4", 8) // true (8 > 4)
+//	checkIntWithQualifiers([]string{">="}, "8", 8) // true (8 >= 8)
+//	checkIntWithQualifiers([]string{"lt"}, "16", 8) // true (8 < 16)
+func checkIntWithQualifiers(qualifiers []string, value string, fieldValue int) (bool, error) {
+	valueInt, err := strconv.Atoi(value)
+	if err != nil {
+		return false, fmt.Errorf("invalid value: %s", value)
+	}
+
+	if len(qualifiers) == 0 {
+		return fieldValue == valueInt, nil
+	}
+
+	if len(qualifiers) != 1 {
+		return false, fmt.Errorf("supports at most one qualifier")
+	}
+
+	switch qualifiers[0] {
+	case QualifierGT, OpGreaterThan:
+		return fieldValue > valueInt, nil
+	case QualifierGTE, OpGreaterThanOrEqual:
+		return fieldValue >= valueInt, nil
+	case QualifierLT, OpLessThan:
+		return fieldValue < valueInt, nil
+	case QualifierLTE, OpLessThanOrEqual:
+		return fieldValue <= valueInt, nil
+	case QualifierEQ, OpEqual, OpEqualStrict:
+		return fieldValue == valueInt, nil
+	case QualifierNEQ, OpNotEqual:
+		return fieldValue != valueInt, nil
+	default:
+		return false, fmt.Errorf("invalid qualifier: %s", qualifiers[0])
+	}
+}
+
+// checkStringWithOpQualifier performs string comparison using operator qualifiers.
+// This function handles string operations with explicit operators.
+func checkStringWithOpQualifier(op, value, fieldValue string, caseSensitive bool) (bool, error) {
+	if !caseSensitive {
+		fieldValue = strings.ToLower(fieldValue)
+		value = strings.ToLower(value)
+	}
+
+	switch op {
+	case OpNotEqual:
+		return fieldValue != value, nil
+	case OpEqual, OpEqualStrict:
+		return fieldValue == value, nil
+	case OpContains:
+		return strings.Contains(fieldValue, value), nil
+	case OpNotContains:
+		return !strings.Contains(fieldValue, value), nil
+	}
+
+	return false, fmt.Errorf("invalid operator: %s", op)
+}
+
+// checkIntWithOpQualifier performs integer comparison using operator qualifiers.
+// This function handles numeric operations with explicit operators.
+func checkIntWithOpQualifier(op, value string, fieldValue int) (bool, error) {
+	valueInt, err := strconv.Atoi(value)
+	if err != nil {
+		return false, fmt.Errorf("invalid value: %s", value)
+	}
+
+	switch op {
+	case OpEqual, OpEqualStrict:
+		return fieldValue == valueInt, nil
+	case OpNotEqual:
+		return fieldValue != valueInt, nil
+	case OpGreaterThan:
+		return fieldValue > valueInt, nil
+	case OpGreaterThanOrEqual:
+		return fieldValue >= valueInt, nil
+	case OpLessThan:
+		return fieldValue < valueInt, nil
+	case OpLessThanOrEqual:
+		return fieldValue <= valueInt, nil
+	default:
+		return false, fmt.Errorf("invalid operator: %s", op)
+	}
+}
+
+// ============================================================================
+// Complex Device Matching Functions
+// ============================================================================
+
+// qualifierSetFromQualifiers parses qualifier strings into structured OpQualifier objects.
+// Each qualifier string should be in the format "key<operator>value" where operator
+// can be =, !=, ~, !~, >, >=, <, <=, ==.
+//
+// Examples:
+//
+//	qualifierSetFromQualifiers([]string{"model=Intel", "speedGbps>=10"})
+//	// Returns: map["model"]{Op: "=", Value: "Intel"}, map["speedGbps"]{Op: ">=", Value: "10"}
+func qualifierSetFromQualifiers(qualifiers []string) (OpQualifierSet, error) {
+	qualifierSet := make(OpQualifierSet)
+	for _, qualifier := range qualifiers {
+		match := REPatternQualifierOp.FindStringSubmatch(qualifier)
+		if len(match) != 4 {
+			return nil, fmt.Errorf("invalid qualifier: %s", qualifier)
+		}
+		qualifierSet[match[1]] = OpQualifier{Op: match[2], Value: match[3]}
+	}
+	return qualifierSet, nil
+}
+
+// checkNicsWithQualifiers evaluates NIC presence and characteristics against criteria.
+// The value parameter must be "present". Qualifiers specify matching criteria for NICs.
+//
+// Supported qualifiers (key=value format):
+// - model=<value>: Match NIC model (supports string operators =, !=, ~, !~)
+// - speedGbps=<value>: Match NIC speed (supports integer operators ==, !=, >, >=, <, <=)
+// - count=<value>: Match total count of NICs that meet other criteria (supports integer operators)
+//
+// Examples:
+//
+//	// Check for presence of any NIC
+//	checkNicsWithQualifiers([]string{}, "present", nics)
+//
+//	// Check for Intel NICs
+//	checkNicsWithQualifiers([]string{"model=Intel"}, "present", nics)
+//
+//	// Check for NICs with speed >= 10 Gbps
+//	checkNicsWithQualifiers([]string{"speedGbps>=10"}, "present", nics)
+//
+//	// Check for at least 2 Intel NICs with speed >= 10 Gbps
+//	checkNicsWithQualifiers([]string{"model~Intel", "speedGbps>=10", "count>=2"}, "present", nics)
+//
+// Returns true if the NIC criteria are satisfied, false otherwise.
+func checkNicsWithQualifiers(qualifiers []string, value string, nics []metal3v1alpha1.NIC, caseSensitive bool) (bool, error) {
+	qualifierSet, err := qualifierSetFromQualifiers(qualifiers)
+	if err != nil {
+		return false, fmt.Errorf("qualifierSetFromQualifiers failed: %w", err)
+	}
+
+	if value != "present" {
+		return false, fmt.Errorf("expected value to be 'present', actual value: %s", value)
+	}
+
+	matchingCount := 0
+	for _, nic := range nics {
+		if model, ok := qualifierSet["model"]; ok {
+			rc, err := checkStringWithOpQualifier(model.Op, model.Value, nic.Model, caseSensitive)
+			if err != nil {
+				return false, fmt.Errorf("checkStringWithOpQualifier failed: %w", err)
+			}
+			if !rc {
+				continue
+			}
+		}
+		if speedGbps, ok := qualifierSet["speedGbps"]; ok {
+			rc, err := checkIntWithOpQualifier(speedGbps.Op, speedGbps.Value, nic.SpeedGbps)
+			if err != nil {
+				return false, fmt.Errorf("checkIntWithOpQualifier failed: %w", err)
+			}
+			if !rc {
+				continue
+			}
+		}
+		matchingCount++
+	}
+
+	if count, ok := qualifierSet["count"]; ok {
+		rc, err := checkIntWithOpQualifier(count.Op, count.Value, matchingCount)
+		if err != nil {
+			return false, fmt.Errorf("checkIntWithOpQualifier failed: %w", err)
+		}
+		return rc, nil
+	}
+
+	return matchingCount > 0, nil
+}
+
+// checkStorageWithQualifiers evaluates storage device presence and characteristics against criteria.
+// The value parameter must be "present". Qualifiers specify matching criteria for storage devices.
+//
+// Supported qualifiers (key=value format):
+// - type=<value>: Match storage type (HDD, SSD, etc.) (supports string operators =, !=, ~, !~)
+// - sizeBytes=<value>: Match storage size in bytes (supports integer operators ==, !=, >, >=, <, <=)
+// - vendor=<value>: Match storage vendor (supports string operators =, !=, ~, !~)
+// - model=<value>: Match storage model (supports string operators =, !=, ~, !~)
+// - name=<value>: Match storage name or any alternate name (supports string operators =, !=, ~, !~)
+// - count=<value>: Match total count of storage devices that meet other criteria (supports integer operators)
+//
+// Examples:
+//
+//	// Check for presence of any storage device
+//	checkStorageWithQualifiers([]string{}, "present", storage)
+//
+//	// Check for SSD storage
+//	checkStorageWithQualifiers([]string{"type=SSD"}, "present", storage)
+//
+//	// Check for storage devices larger than 1TB
+//	checkStorageWithQualifiers([]string{"sizeBytes>1000000000000"}, "present", storage)
+//
+//	// Check for at least 2 Samsung SSDs larger than 500GB
+//	checkStorageWithQualifiers([]string{"type=SSD", "vendor~Samsung", "sizeBytes>500000000000", "count>=2"}, "present", storage)
+//
+// Returns true if the storage criteria are satisfied, false otherwise.
+func checkStorageWithQualifiers(qualifiers []string, value string, storage []metal3v1alpha1.Storage, caseSensitive bool) (bool, error) {
+	qualifierSet, err := qualifierSetFromQualifiers(qualifiers)
+	if err != nil {
+		return false, fmt.Errorf("qualifierSetFromQualifiers failed: %w", err)
+	}
+
+	if value != "present" {
+		return false, fmt.Errorf("expected value to be 'present', actual value: %s", value)
+	}
+
+	matchingCount := 0
+	for _, storage := range storage {
+		if diskType, ok := qualifierSet["type"]; ok {
+			rc, err := checkStringWithOpQualifier(diskType.Op, diskType.Value, string(storage.Type), caseSensitive)
+			if err != nil {
+				return false, fmt.Errorf("checkStringWithOpQualifier failed: %w", err)
+			}
+			if !rc {
+				continue
+			}
+		}
+		if sizeBytes, ok := qualifierSet["sizeBytes"]; ok {
+			rc, err := checkIntWithOpQualifier(sizeBytes.Op, sizeBytes.Value, int(storage.SizeBytes))
+			if err != nil {
+				return false, fmt.Errorf("checkIntWithOpQualifier failed: %w", err)
+			}
+			if !rc {
+				continue
+			}
+		}
+		if name, ok := qualifierSet["name"]; ok {
+			names := storage.AlternateNames
+			names = append(names, storage.Name)
+			matchFound := false
+			for _, itername := range names {
+				rc, err := checkStringWithOpQualifier(name.Op, name.Value, itername, caseSensitive)
+				if err != nil {
+					return false, fmt.Errorf("checkStringWithOpQualifier failed: %w", err)
+				}
+				if rc {
+					matchFound = true
+					break
+				}
+			}
+			if !matchFound {
+				continue
+			}
+		}
+		if vendor, ok := qualifierSet["vendor"]; ok {
+			rc, err := checkStringWithOpQualifier(vendor.Op, vendor.Value, storage.Vendor, caseSensitive)
+			if err != nil {
+				return false, fmt.Errorf("checkStringWithOpQualifier failed: %w", err)
+			}
+			if !rc {
+				continue
+			}
+		}
+		if model, ok := qualifierSet["model"]; ok {
+			rc, err := checkStringWithOpQualifier(model.Op, model.Value, storage.Model, caseSensitive)
+			if err != nil {
+				return false, fmt.Errorf("checkStringWithOpQualifier failed: %w", err)
+			}
+			if !rc {
+				continue
+			}
+		}
+		matchingCount++
+	}
+
+	if count, ok := qualifierSet["count"]; ok {
+		rc, err := checkIntWithOpQualifier(count.Op, count.Value, matchingCount)
+		if err != nil {
+			return false, fmt.Errorf("checkIntWithOpQualifier failed: %w", err)
+		}
+		return rc, nil
+	}
+	return matchingCount > 0, nil
+}

--- a/hwmgr-plugins/metal3/controller/resource_selection_test.go
+++ b/hwmgr-plugins/metal3/controller/resource_selection_test.go
@@ -1,0 +1,800 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+/*
+Generated-By: Claude Code/claude-sonnet-4
+*/
+
+package controller
+
+import (
+	"context"
+	"log/slog"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+)
+
+var _ = Describe("Resource Selection", func() {
+	var (
+		ctx    context.Context
+		logger *slog.Logger
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		logger = slog.Default()
+		scheme = runtime.NewScheme()
+		Expect(metal3v1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(hwmgmtv1alpha1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	createBMHForResourceSelection := func(name, namespace string, labels map[string]string, state metal3v1alpha1.ProvisioningState) *metal3v1alpha1.BareMetalHost {
+		bmh := &metal3v1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			Status: metal3v1alpha1.BareMetalHostStatus{
+				Provisioning: metal3v1alpha1.ProvisionStatus{
+					State: state,
+				},
+			},
+		}
+		return bmh
+	}
+
+	createHardwareData := func(name, namespace string, details *metal3v1alpha1.HardwareDetails) *metal3v1alpha1.HardwareData {
+		return &metal3v1alpha1.HardwareData{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: metal3v1alpha1.HardwareDataSpec{
+				HardwareDetails: details,
+			},
+		}
+	}
+
+	Describe("ResourceSelectionPrimaryFilter", func() {
+		It("should create filters for site ID", func() {
+			nodeGroupData := hwmgmtv1alpha1.NodeGroupData{
+				ResourceSelector: map[string]string{},
+			}
+
+			opts, err := ResourceSelectionPrimaryFilter(ctx, nil, logger, "test-site", nodeGroupData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(opts)).To(Equal(2)) // MatchingLabelsSelector + MatchingLabels
+
+			// Check that the site ID filter is present
+			matchingLabels, ok := opts[1].(client.MatchingLabels)
+			Expect(ok).To(BeTrue())
+			Expect(matchingLabels[LabelSiteID]).To(Equal("test-site"))
+		})
+
+		It("should create filters for resource pool ID", func() {
+			nodeGroupData := hwmgmtv1alpha1.NodeGroupData{
+				ResourcePoolId:   "test-pool",
+				ResourceSelector: map[string]string{},
+			}
+
+			opts, err := ResourceSelectionPrimaryFilter(ctx, nil, logger, "", nodeGroupData)
+			Expect(err).NotTo(HaveOccurred())
+
+			matchingLabels, ok := opts[1].(client.MatchingLabels)
+			Expect(ok).To(BeTrue())
+			Expect(matchingLabels[LabelResourcePoolID]).To(Equal("test-pool"))
+		})
+
+		It("should create filters for resource selector labels", func() {
+			nodeGroupData := hwmgmtv1alpha1.NodeGroupData{
+				ResourceSelector: map[string]string{
+					"zone":                              "east",
+					LabelPrefixResourceSelector + "env": "prod",   // Use correct prefix
+					HardwareDataPrefix + FieldCPUArch:   "x86_64", // Should be skipped
+				},
+			}
+
+			opts, err := ResourceSelectionPrimaryFilter(ctx, nil, logger, "", nodeGroupData)
+			Expect(err).NotTo(HaveOccurred())
+
+			matchingLabels, ok := opts[1].(client.MatchingLabels)
+			Expect(ok).To(BeTrue())
+			Expect(matchingLabels[LabelPrefixResourceSelector+"zone"]).To(Equal("east"))
+			Expect(matchingLabels[LabelPrefixResourceSelector+"env"]).To(Equal("prod"))
+			_, hasHardwareData := matchingLabels[HardwareDataPrefix+FieldCPUArch]
+			Expect(hasHardwareData).To(BeFalse()) // Should be excluded from primary filter
+		})
+
+		It("should exclude allocated BMHs", func() {
+			nodeGroupData := hwmgmtv1alpha1.NodeGroupData{
+				ResourceSelector: map[string]string{},
+			}
+
+			opts, err := ResourceSelectionPrimaryFilter(ctx, nil, logger, "", nodeGroupData)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Check that the label selector excludes allocated BMHs
+			labelSelector, ok := opts[0].(client.MatchingLabelsSelector)
+			Expect(ok).To(BeTrue())
+
+			requirements, _ := labelSelector.Selector.Requirements()
+			found := false
+			for _, req := range requirements {
+				if req.Key() == BmhAllocatedLabel {
+					Expect(string(req.Operator())).To(Equal("notin"))
+					Expect(req.Values().List()).To(ContainElement(ValueTrue))
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue())
+		})
+	})
+
+	Describe("ResourceSelectionSecondaryFilter", func() {
+		var (
+			fakeClient client.Client
+		)
+
+		BeforeEach(func() {
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+		})
+
+		It("should filter BMHs by availability state", func() {
+			bmhList := metal3v1alpha1.BareMetalHostList{
+				Items: []metal3v1alpha1.BareMetalHost{
+					*createBMHForResourceSelection("bmh1", "test-ns", nil, metal3v1alpha1.StateAvailable),
+					*createBMHForResourceSelection("bmh2", "test-ns", nil, metal3v1alpha1.StateProvisioning),
+				},
+			}
+
+			nodeGroupData := hwmgmtv1alpha1.NodeGroupData{
+				ResourceSelector: map[string]string{},
+			}
+
+			result, err := ResourceSelectionSecondaryFilter(ctx, fakeClient, logger, nodeGroupData, bmhList)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(result.Items)).To(Equal(0)) // No hardware data available, so no BMHs pass
+		})
+
+		It("should filter BMHs with hardware data criteria", func() {
+			// Create BMH and corresponding HardwareData
+			bmh1 := createBMHForResourceSelection("bmh1", "test-ns", nil, metal3v1alpha1.StateAvailable)
+			hwData1 := createHardwareData("bmh1", "test-ns", &metal3v1alpha1.HardwareDetails{
+				CPU: metal3v1alpha1.CPU{
+					Arch:  "x86_64",
+					Model: "Intel Xeon",
+					Count: 8,
+				},
+				RAMMebibytes: 16384,
+			})
+
+			bmh2 := createBMHForResourceSelection("bmh2", "test-ns", nil, metal3v1alpha1.StateAvailable)
+			hwData2 := createHardwareData("bmh2", "test-ns", &metal3v1alpha1.HardwareDetails{
+				CPU: metal3v1alpha1.CPU{
+					Arch:  "arm64",
+					Model: "ARM Cortex",
+					Count: 4,
+				},
+				RAMMebibytes: 8192,
+			})
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh1, bmh2, hwData1, hwData2).Build()
+
+			bmhList := metal3v1alpha1.BareMetalHostList{
+				Items: []metal3v1alpha1.BareMetalHost{*bmh1, *bmh2},
+			}
+
+			nodeGroupData := hwmgmtv1alpha1.NodeGroupData{
+				ResourceSelector: map[string]string{
+					HardwareDataPrefix + FieldCPUArch: "x86_64",
+				},
+			}
+
+			result, err := ResourceSelectionSecondaryFilter(ctx, fakeClient, logger, nodeGroupData, bmhList)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(result.Items)).To(Equal(1))
+			Expect(result.Items[0].Name).To(Equal("bmh1"))
+		})
+
+		It("should handle BMHs without hardware data", func() {
+			bmh1 := createBMHForResourceSelection("bmh1", "test-ns", nil, metal3v1alpha1.StateAvailable)
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh1).Build()
+
+			bmhList := metal3v1alpha1.BareMetalHostList{
+				Items: []metal3v1alpha1.BareMetalHost{*bmh1},
+			}
+
+			nodeGroupData := hwmgmtv1alpha1.NodeGroupData{
+				ResourceSelector: map[string]string{
+					HardwareDataPrefix + FieldCPUArch: "x86_64",
+				},
+			}
+
+			result, err := ResourceSelectionSecondaryFilter(ctx, fakeClient, logger, nodeGroupData, bmhList)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(result.Items)).To(Equal(0))
+		})
+	})
+
+	Describe("ResourceSelectionSecondaryFilterHardwareData", func() {
+		It("should return true for non-hardwaredata criteria", func() {
+			hwData := createHardwareData("test", "test-ns", &metal3v1alpha1.HardwareDetails{})
+
+			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, "zone", "east", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
+		It("should filter by CPU architecture", func() {
+			hwData := createHardwareData("test", "test-ns", &metal3v1alpha1.HardwareDetails{
+				CPU: metal3v1alpha1.CPU{Arch: "x86_64"},
+			})
+
+			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldCPUArch, "x86_64", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+
+			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldCPUArch, "arm64", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should filter by CPU model", func() {
+			hwData := createHardwareData("test", "test-ns", &metal3v1alpha1.HardwareDetails{
+				CPU: metal3v1alpha1.CPU{Model: "Intel Xeon"},
+			})
+
+			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldCPUModel, "Intel Xeon", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+
+			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldCPUModel, "AMD EPYC", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should filter by number of threads", func() {
+			hwData := createHardwareData("test", "test-ns", &metal3v1alpha1.HardwareDetails{
+				CPU: metal3v1alpha1.CPU{Count: 8},
+			})
+
+			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldNumThreads, "8", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+
+			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldNumThreads+";gt", "4", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+
+			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldNumThreads+";lt", "4", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should filter by RAM", func() {
+			hwData := createHardwareData("test", "test-ns", &metal3v1alpha1.HardwareDetails{
+				RAMMebibytes: 16384,
+			})
+
+			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldRAM, "16384", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+
+			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldRAM+";gte", "8192", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
+		It("should filter by manufacturer", func() {
+			hwData := createHardwareData("test", "test-ns", &metal3v1alpha1.HardwareDetails{
+				SystemVendor: metal3v1alpha1.HardwareSystemVendor{
+					Manufacturer: "Dell Inc.",
+				},
+			})
+
+			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldManufacturer, "Dell Inc.", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+
+			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldManufacturer, "HP", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should filter by product name", func() {
+			hwData := createHardwareData("test", "test-ns", &metal3v1alpha1.HardwareDetails{
+				SystemVendor: metal3v1alpha1.HardwareSystemVendor{
+					ProductName: "PowerEdge R640",
+				},
+			})
+
+			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldProductName, "PowerEdge R640", hwData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	Describe("String matching with qualifiers", func() {
+		Describe("checkStringWithQualifiers", func() {
+			It("should match exact strings by default", func() {
+				result := checkStringWithQualifiers([]string{}, "test", "test", true)
+				Expect(result).To(BeTrue())
+
+				result = checkStringWithQualifiers([]string{}, "test", "Test", true)
+				Expect(result).To(BeFalse())
+			})
+
+			It("should match case insensitive with icase qualifier", func() {
+				result := checkStringWithQualifiers([]string{"icase"}, "test", "Test", false)
+				Expect(result).To(BeTrue())
+
+				result = checkStringWithQualifiers([]string{"icase"}, "test", "TEST", false)
+				Expect(result).To(BeTrue())
+			})
+
+			It("should match substrings with substring qualifier", func() {
+				result := checkStringWithQualifiers([]string{"substring"}, "Dell", "Dell Inc.", true)
+				Expect(result).To(BeTrue())
+
+				result = checkStringWithQualifiers([]string{"substring"}, "HP", "Dell Inc.", true)
+				Expect(result).To(BeFalse())
+			})
+
+			It("should combine qualifiers", func() {
+				result := checkStringWithQualifiers([]string{"substring", "icase"}, "DELL", "Dell Inc.", false)
+				Expect(result).To(BeTrue())
+
+				result = checkStringWithQualifiers([]string{"icase", "substring"}, "inc", "Dell Inc.", false)
+				Expect(result).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Integer matching with qualifiers", func() {
+		Describe("checkIntWithQualifiers", func() {
+			It("should match exact values by default", func() {
+				result, err := checkIntWithQualifiers([]string{}, "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{}, "8", 4)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should handle greater than comparisons", func() {
+				result, err := checkIntWithQualifiers([]string{"gt"}, "4", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{">"}, "4", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{"gt"}, "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should handle greater than or equal comparisons", func() {
+				result, err := checkIntWithQualifiers([]string{"gte"}, "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{">="}, "8", 16)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{"gte"}, "16", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should handle less than comparisons", func() {
+				result, err := checkIntWithQualifiers([]string{"lt"}, "16", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{"<"}, "16", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{"lt"}, "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should handle less than or equal comparisons", func() {
+				result, err := checkIntWithQualifiers([]string{"lte"}, "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{"<="}, "16", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{"lte"}, "4", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should handle equality and inequality", func() {
+				result, err := checkIntWithQualifiers([]string{"eq"}, "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{"=="}, "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{"neq"}, "8", 4)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{"!="}, "8", 4)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithQualifiers([]string{"neq"}, "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return error for invalid qualifiers", func() {
+				_, err := checkIntWithQualifiers([]string{"invalid"}, "8", 8)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid qualifier"))
+			})
+
+			It("should return error for invalid values", func() {
+				_, err := checkIntWithQualifiers([]string{}, "invalid", 8)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid value"))
+			})
+
+			It("should return error for multiple qualifiers", func() {
+				_, err := checkIntWithQualifiers([]string{"gt", "lt"}, "8", 8)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("supports at most one qualifier"))
+			})
+		})
+	})
+
+	Describe("NIC filtering", func() {
+		Describe("checkNicsWithQualifiers", func() {
+			var nics []metal3v1alpha1.NIC
+
+			BeforeEach(func() {
+				nics = []metal3v1alpha1.NIC{
+					{Model: "Intel E1000", SpeedGbps: 1},
+					{Model: "Broadcom BCM", SpeedGbps: 10},
+					{Model: "Intel X710", SpeedGbps: 10},
+				}
+			})
+
+			It("should filter by model", func() {
+				result, err := checkNicsWithQualifiers([]string{"model=Intel E1000"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkNicsWithQualifiers([]string{"model!=Intel E1000"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue()) // Should match other NICs
+
+				result, err = checkNicsWithQualifiers([]string{"model=NonExistent"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should filter by speed", func() {
+				result, err := checkNicsWithQualifiers([]string{"speedGbps==10"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkNicsWithQualifiers([]string{"speedGbps>5"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkNicsWithQualifiers([]string{"speedGbps>20"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should filter by count", func() {
+				result, err := checkNicsWithQualifiers([]string{"count==3"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkNicsWithQualifiers([]string{"count>=2"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkNicsWithQualifiers([]string{"count>5"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should combine multiple criteria", func() {
+				// Should match Intel NICs with speed >= 10
+				result, err := checkNicsWithQualifiers([]string{"model~Intel", "speedGbps>=10"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				// Should count NICs with speed >= 10 and check if count >= 2
+				result, err = checkNicsWithQualifiers([]string{"speedGbps>=10", "count>=2"}, "present", nics, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Storage filtering", func() {
+		Describe("checkStorageWithQualifiers", func() {
+			var storage []metal3v1alpha1.Storage
+
+			BeforeEach(func() {
+				storage = []metal3v1alpha1.Storage{
+					{
+						Name:      "sda",
+						Type:      metal3v1alpha1.HDD,
+						SizeBytes: 1000000000000, // 1TB
+						Vendor:    "Seagate",
+						Model:     "ST1000",
+					},
+					{
+						Name:      "sdb",
+						Type:      metal3v1alpha1.SSD,
+						SizeBytes: 500000000000, // 500GB
+						Vendor:    "Samsung",
+						Model:     "860 EVO",
+					},
+				}
+			})
+
+			It("should filter by storage type", func() {
+				result, err := checkStorageWithQualifiers([]string{"type=HDD"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStorageWithQualifiers([]string{"type=SSD"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStorageWithQualifiers([]string{"type=NVME"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should filter by size", func() {
+				result, err := checkStorageWithQualifiers([]string{"sizeBytes>600000000000"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStorageWithQualifiers([]string{"sizeBytes<400000000000"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should filter by vendor", func() {
+				result, err := checkStorageWithQualifiers([]string{"vendor=Seagate"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStorageWithQualifiers([]string{"vendor~Sam"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStorageWithQualifiers([]string{"vendor=Intel"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should filter by model", func() {
+				result, err := checkStorageWithQualifiers([]string{"model=ST1000"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStorageWithQualifiers([]string{"model~EVO"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+
+			It("should filter by name including alternate names", func() {
+				storage[0].AlternateNames = []string{"disk1", "primary-disk"}
+
+				result, err := checkStorageWithQualifiers([]string{"name=sda"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStorageWithQualifiers([]string{"name=disk1"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStorageWithQualifiers([]string{"name=nonexistent"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should filter by count", func() {
+				result, err := checkStorageWithQualifiers([]string{"count==2"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStorageWithQualifiers([]string{"count>=1"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStorageWithQualifiers([]string{"count>5"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should combine multiple criteria", func() {
+				// Should count SSD devices and verify count >= 1
+				result, err := checkStorageWithQualifiers([]string{"type=SSD", "count>=1"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				// Should match devices with size > 600GB and vendor Seagate
+				result, err = checkStorageWithQualifiers([]string{"sizeBytes>600000000000", "vendor=Seagate"}, "present", storage, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Operator qualifier parsing", func() {
+		Describe("qualifierSetFromQualifiers", func() {
+			It("should parse simple qualifiers", func() {
+				qualifiers := []string{"model=Intel", "speedGbps>10"}
+
+				result, err := qualifierSetFromQualifiers(qualifiers)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(result)).To(Equal(2))
+				Expect(result["model"].Op).To(Equal("="))
+				Expect(result["model"].Value).To(Equal("Intel"))
+				Expect(result["speedGbps"].Op).To(Equal(">"))
+				Expect(result["speedGbps"].Value).To(Equal("10"))
+			})
+
+			It("should handle complex operators", func() {
+				qualifiers := []string{"size>=1000", "name!=sda", "vendor~Samsung"}
+
+				result, err := qualifierSetFromQualifiers(qualifiers)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result["size"].Op).To(Equal(">="))
+				Expect(result["size"].Value).To(Equal("1000"))
+				Expect(result["name"].Op).To(Equal("!="))
+				Expect(result["name"].Value).To(Equal("sda"))
+				Expect(result["vendor"].Op).To(Equal("~"))
+				Expect(result["vendor"].Value).To(Equal("Samsung"))
+			})
+
+			It("should return error for invalid qualifier format", func() {
+				qualifiers := []string{"invalidqualifier"}
+
+				_, err := qualifierSetFromQualifiers(qualifiers)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid qualifier"))
+			})
+		})
+	})
+
+	Describe("String operator qualifiers", func() {
+		Describe("checkStringWithOpQualifier", func() {
+			It("should handle equality operators", func() {
+				result, err := checkStringWithOpQualifier("=", "test", "test", true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStringWithOpQualifier("!=", "test", "other", true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStringWithOpQualifier("!=", "test", "test", true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should handle substring operators", func() {
+				result, err := checkStringWithOpQualifier("~", "tel", "Intel", true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStringWithOpQualifier("!~", "AMD", "Intel", true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkStringWithOpQualifier("!~", "tel", "Intel", true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return error for invalid operators", func() {
+				_, err := checkStringWithOpQualifier("invalid", "test", "test", true)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid operator"))
+			})
+		})
+	})
+
+	Describe("Integer operator qualifiers", func() {
+		Describe("checkIntWithOpQualifier", func() {
+			It("should handle all comparison operators", func() {
+				result, err := checkIntWithOpQualifier("==", "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithOpQualifier("!=", "8", 4)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithOpQualifier(">", "4", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithOpQualifier(">=", "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithOpQualifier("<", "16", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+
+				result, err = checkIntWithOpQualifier("<=", "8", 8)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return error for invalid values", func() {
+				_, err := checkIntWithOpQualifier("==", "invalid", 8)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid value"))
+			})
+
+			It("should return error for invalid operators", func() {
+				_, err := checkIntWithOpQualifier("invalid", "8", 8)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid operator"))
+			})
+		})
+	})
+
+	Describe("Constants and patterns", func() {
+		It("should have correct hardwaredata prefix", func() {
+			Expect(HardwareDataPrefix).To(Equal("hardwaredata/"))
+		})
+
+		It("should have correct regex patterns", func() {
+			// Test hardwaredata pattern
+			matches := REPatternHardwareData.FindStringSubmatch(HardwareDataPrefix + FieldCPUArch)
+			Expect(matches).To(HaveLen(2))
+			Expect(matches[1]).To(Equal(FieldCPUArch))
+
+			matches = REPatternHardwareData.FindStringSubmatch("other/" + FieldCPUArch)
+			Expect(matches).To(BeNil())
+
+			// Test qualifier operation pattern
+			matches = REPatternQualifierOp.FindStringSubmatch("model=Intel")
+			Expect(matches).To(HaveLen(4)) // Full match + 3 groups (but 0-indexed: [0] is full match, [1], [2], [3] are groups)
+			Expect(matches[1]).To(Equal("model"))
+			Expect(matches[2]).To(Equal("="))
+			Expect(matches[3]).To(Equal("Intel"))
+		})
+	})
+})


### PR DESCRIPTION
This update moves resource selection logic into its own resource_selection.go module, with primary and secondary filtering.

The primary filtering parses the resource selection criteria to get any specified label references, which are then used to generate a List filter for the initial BMH query when fetching the list of available nodes. The resulting BMH list is then passed through the new secondary filter, which checks applicable criteria against the corresponding HardwareData CR.

Key features:
- Two-stage filtering architecture (primary/secondary filters)
- Hardware data criteria matching with configurable case sensitivity
- Support for string/integer operators (==, !=, >, <, >=, <=, ~, !~)
- Advanced device filtering for NICs and storage with complex qualifiers

Assisted-by: Claude Code/claude-sonnet-4