### PR TITLE
Clear callback annotations after hardware provisioning status is processed

### DIFF
--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
@@ -577,6 +577,14 @@ func processBMHUpdateCase(ctx context.Context,
 			return ctrl.Result{}, fmt.Errorf("failed to set node failed status for %s: %w", node.Name, err)
 		}
 
+		// Clear config-in-progress annotation when node fails
+		if err := clearConfigAnnotationWithPatch(ctx, c, node); err != nil {
+			logger.ErrorContext(ctx, "Failed to clear config annotation",
+				slog.String("node", node.Name),
+				slog.String("error", err.Error()))
+			return ctrl.Result{}, err
+		}
+
 		// Clear BMH error annotation to allow future retry attempts
 		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "failed to clear BMH error annotation for future retries",


### PR DESCRIPTION
- Clear PR callback annotations after hardware provisioning status is processed
- Clear config-in-progress annotation when node fails in processBMHUpdateCase()
- Prevent stale callback annotations from causing false callback detection in future reconciliations

Assisted-by: Cursor/claude-4-sonnet