### PR TITLE
OCPBUGS-61727: Improve ClusterInstance handling with server-side apply

### DIFF
--- a/internal/controllers/provisioningrequest_setup.go
+++ b/internal/controllers/provisioningrequest_setup.go
@@ -111,16 +111,12 @@ func (r *ProvisioningRequestReconciler) SetupWithManager(mgr ctrl.Manager) error
 			&siteconfig.ClusterInstance{},
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					// Watch on ClusterInstance status conditions changes only
+					// Watch on ClusterInstance status conditions changes
 					ciOld := e.ObjectOld.(*siteconfig.ClusterInstance)
 					ciNew := e.ObjectNew.(*siteconfig.ClusterInstance)
 
-					if ciOld.GetGeneration() == ciNew.GetGeneration() {
-						if !equality.Semantic.DeepEqual(ciOld.Status.Conditions, ciNew.Status.Conditions) {
-							return true
-						}
-					}
-					return false
+					// Trigger reconciliation if status conditions have changed
+					return !equality.Semantic.DeepEqual(ciOld.Status.Conditions, ciNew.Status.Conditions)
 				},
 				CreateFunc:  func(ce event.CreateEvent) bool { return false },
 				GenericFunc: func(ge event.GenericEvent) bool { return false },

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -67,6 +67,14 @@ const (
 	PATCH  = "Patch"
 )
 
+// Field Manager Names for Server-Side Apply
+const (
+	// ProvisioningRequestFieldManager is the unique identifier for the ProvisioningRequest controller
+	// when performing Server-Side Apply operations. This name is used by the Kubernetes API server
+	// to track field ownership for SSA.
+	ProvisioningRequestFieldManager = "provisioning-request-reconciler"
+)
+
 // Container arguments
 var (
 	AlarmServerArgs = []string{

--- a/internal/controllers/utils/provision.go
+++ b/internal/controllers/utils/provision.go
@@ -184,9 +184,9 @@ func ValidateDefaultInterfaces[T any](data T) error {
 	return nil
 }
 
-// removeLabelFromInterfaces removed the label property for each interface as the label
+// RemoveLabelFromInterfaces removes the label property for each interface as the label
 // property is not part of the ClusterInstance schema.
-func removeLabelFromInterfaces[T any](data T) error {
+func RemoveLabelFromInterfaces[T any](data T) error {
 	dataMap, _ := any(data).(map[string]any)
 	nodes, ok := dataMap["nodes"].([]any)
 	if ok {
@@ -289,7 +289,7 @@ func ValidateConfigmapSchemaAgainstClusterInstanceCRD[T any](ctx context.Context
 	provisioningv1alpha1.DisallowUnknownFieldsInSchema(openAPIV3SchemaSpec)
 	// Remove the interface label properties as it's not part of the ClusterInstance CRD schema.
 	dataMap, _ := any(data).(map[string]any)
-	if err := removeLabelFromInterfaces(dataMap); err != nil {
+	if err := RemoveLabelFromInterfaces(dataMap); err != nil {
 		return fmt.Errorf("error removing label from interfaces")
 	}
 

--- a/internal/controllers/utils/provision_test.go
+++ b/internal/controllers/utils/provision_test.go
@@ -406,7 +406,7 @@ var _ = Describe("ClusterIsReadyForPolicyConfig", func() {
 	})
 })
 
-var _ = Describe("removeLabelFromInterfaces", func() {
+var _ = Describe("RemoveLabelFromInterfaces", func() {
 
 	It("returns error for invalid node structure", func() {
 		data := map[string]interface{}{
@@ -415,7 +415,7 @@ var _ = Describe("removeLabelFromInterfaces", func() {
 				42, // should be a map
 			},
 		}
-		err := removeLabelFromInterfaces(data)
+		err := RemoveLabelFromInterfaces(data)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("unexpected: invalid node data structure"))
 	})
@@ -429,7 +429,7 @@ var _ = Describe("removeLabelFromInterfaces", func() {
 				},
 			},
 		}
-		err := removeLabelFromInterfaces(data)
+		err := RemoveLabelFromInterfaces(data)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("failed to extract the interfaces from the node map"))
 	})
@@ -451,7 +451,7 @@ var _ = Describe("removeLabelFromInterfaces", func() {
 				},
 			},
 		}
-		err := removeLabelFromInterfaces(data)
+		err := RemoveLabelFromInterfaces(data)
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(
 			data["nodes"].([]interface{})[0].(map[string]interface{})["nodeNetwork"].(map[string]interface{})["interfaces"].([]interface{})[0].(map[string]interface{})).


### PR DESCRIPTION
# Summary

This PR improves ClusterInstance handling by implementing server-side apply:
- Replace manual Client-Side create/update logic with Kubernetes Server-Side Apply (SSA) pattern to resolve ClusterInstance update conflicts and provide idempotent resource management.
- Add interface label removal before ClusterInstance creation since these labels are needed for hardware provisioning MAC address assignment but are not part of the ClusterInstance CRD schema
- Simplify ClusterInstance watch predicate logic to only trigger reconciliation on status condition changes, removing unnecessary generation checks
- Create SSACompatibleClient wrapper for test infrastructure to support Server-Side Apply operations with fake clients

ℹ️ Assisted-by: Cursor and claude-4-sonnet

Resolves: [OCPBUGS-61727](https://issues.redhat.com/browse/OCPBUGS-61727)

/cc @browsell @donpenney 