### PR TITLE
Add ClusterImageSet release version validation to ClusterTemplates

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1522,6 +1522,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - hive.openshift.io
+          resources:
+          - clusterimagesets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - lcm.openshift.io
           resources:
           - imagebasedgroupupgrades

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -204,6 +204,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterimagesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - lcm.openshift.io
   resources:
   - imagebasedgroupupgrades

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/openshift/api v0.0.0-20250725072657-92b1455121e1
 	github.com/openshift/assisted-service/api v0.0.0
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
+	github.com/openshift/hive/apis v0.0.0-20250725035156-a29a23859060
 	github.com/pashagolub/pgxmock/v4 v4.6.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.85.0
 	github.com/r3labs/diff/v3 v3.0.2
@@ -118,7 +119,6 @@ require (
 	github.com/openshift-kni/lifecycle-agent v0.0.0-20250227204303-42df68297836 // indirect
 	github.com/openshift/assisted-service v1.0.10-0.20230830164851-6573b5d7021d // indirect
 	github.com/openshift/assisted-service/models v0.0.0 // indirect
-	github.com/openshift/hive/apis v0.0.0-20250725035156-a29a23859060 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -42,6 +42,7 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/spf13/cobra"
 	observabilityv1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
@@ -156,6 +157,7 @@ func init() {
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(metal3v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(observabilityv1beta1.AddToScheme(scheme))
+	utilruntime.Must(hivev1.AddToScheme(scheme))
 }
 
 // run executes the `start controller-manager` command.

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -80,6 +80,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -124,6 +125,7 @@ var _ = Describe("policyManagement", func() {
 					Name:       tName,
 					Version:    tVersion,
 					TemplateID: "57b39bda-ac56-4143-9b10-d1a71517d04f",
+					Release:    "4.15.0",
 					Templates: provisioningv1alpha1.Templates{
 						ClusterInstanceDefaults: ciDefaultsCm,
 						PolicyTemplateDefaults:  ptDefaultsCm,
@@ -149,7 +151,7 @@ var _ = Describe("policyManagement", func() {
 				},
 				Data: map[string]string{
 					utils.ClusterInstanceTemplateDefaultsConfigmapKey: `
-clusterImageSetNameRef: "4.15"
+clusterImageSetNameRef: "4.15.0"
 pullSecretRef:
   name: "pull-secret"
 templateRefs:
@@ -264,6 +266,15 @@ defaultHugepagesSize: "1G"`,
 				},
 				Spec: clusterv1.ManagedClusterSpec{
 					HubAcceptsClient: true,
+				},
+			},
+			// ClusterImageSet for the test
+			&hivev1.ClusterImageSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "4.15.0",
+				},
+				Spec: hivev1.ClusterImageSetSpec{
+					ReleaseImage: "quay.io/openshift-release-dev/ocp-release:4.15.0-x86_64",
 				},
 			},
 		}
@@ -2199,6 +2210,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 					Name:       tName,
 					Version:    tVersion,
 					TemplateID: "57b39bda-ac56-4143-9b10-d1a71517d04f",
+					Release:    "4.15.0",
 					Templates: provisioningv1alpha1.Templates{
 						ClusterInstanceDefaults: ciDefaultsCm,
 						PolicyTemplateDefaults:  ptDefaultsCm,
@@ -2219,6 +2231,15 @@ var _ = Describe("addPostProvisioningLabels", func() {
 			provisioningRequest,
 			// Managed clusters
 			managedCluster,
+			// ClusterImageSet for the test
+			&hivev1.ClusterImageSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "4.15.0",
+				},
+				Spec: hivev1.ClusterImageSetSpec{
+					ReleaseImage: "quay.io/openshift-release-dev/ocp-release:4.15.0-x86_64",
+				},
+			},
 		}
 
 		c = getFakeClientFromObjects(crs...)

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -128,6 +128,7 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
@@ -342,4 +343,5 @@ var _ = BeforeSuite(func() {
 	scheme.AddKnownTypes(assistedservicev1beta1.GroupVersion, &assistedservicev1beta1.AgentList{})
 	scheme.AddKnownTypes(apiextensionsv1.SchemeGroupVersion, &apiextensionsv1.CustomResourceDefinition{})
 	utilruntime.Must(bmhv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(hivev1.AddToScheme(scheme))
 })

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -349,3 +349,13 @@ const (
 	CallbackStatusAnnotation                  = "callback.status"
 	CallbackNodeAllocationRequestIdAnnotation = "callback.nodeAllocationRequestId"
 )
+
+// ClusterTemplate annotation keys
+const (
+	// SkipClusterImageSetValidationAnnotation when set to "true" (case-insensitive),
+	// skips the validation that ensures the ClusterImageSet referenced in the
+	// ClusterInstanceDefaults matches the release version specified in the ClusterTemplate.
+	// This is useful in scenarios where the ClusterImageSet validation needs to be bypassed,
+	// such as during testing or when using custom image sets that don't follow standard naming.
+	SkipClusterImageSetValidationAnnotation = "clcm.openshift.io/skip-clusterimageset-validation"
+)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -44,6 +44,7 @@ import (
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
 const testHwMgrPluginNameSpace = "hwmgr"
@@ -114,6 +115,8 @@ var _ = BeforeSuite(func() {
 	err = clusterv1.AddToScheme(testScheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = pluginsv1alpha1.AddToScheme(testScheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = hivev1.AddToScheme(testScheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Get the needed external CRDs. Their details are under test/utils/vars.go - ExternalCrdsData.
@@ -289,7 +292,7 @@ var _ = Describe("Dry-run-ProvisioningRequestReconcile", func() {
 			Data: map[string]string{
 				ctlrutils.ClusterInstallationTimeoutConfigKey: "60s",
 				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
-clusterImageSetNameRef: "4.15"
+clusterImageSetNameRef: "4.15.0"
 holdInstallation: false
 cpuPartitioningMode: AllNodes
 networkType: OVNKubernetes
@@ -323,7 +326,7 @@ nodes:
 			Data: map[string]string{
 				ctlrutils.ClusterInstallationTimeoutConfigKey: "60s",
 				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
-clusterImageSetNameRef: "4.15"
+clusterImageSetNameRef: "4.15.0"
 holdInstallation: false
 cpuPartitioningMode: AllNodes
 networkType: OVNKubernetes
@@ -403,6 +406,15 @@ defaultHugepagesSize: "1G"`,
 			},
 			Type: corev1.SecretTypeDockerConfigJson,
 		},
+		// ClusterImageSet for e2e tests
+		&hivev1.ClusterImageSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "4.15.0",
+			},
+			Spec: hivev1.ClusterImageSetSpec{
+				ReleaseImage: "quay.io/openshift-release-dev/ocp-release:4.15.0-x86_64",
+			},
+		},
 	}
 	// Define the cluster templates.
 	ctIncomplete = &provisioningv1alpha1.ClusterTemplate{
@@ -413,6 +425,7 @@ defaultHugepagesSize: "1G"`,
 		Spec: provisioningv1alpha1.ClusterTemplateSpec{
 			Name:       tName,
 			Version:    tVersion1,
+			Release:    "4.15.0",
 			TemplateID: "aab39bda-ac56-4143-9b10-d1a71517d04f",
 			Templates: provisioningv1alpha1.Templates{
 				ClusterInstanceDefaults: ciDefaultsCmIncomplete,
@@ -430,6 +443,7 @@ defaultHugepagesSize: "1G"`,
 		Spec: provisioningv1alpha1.ClusterTemplateSpec{
 			Name:       tName,
 			Version:    tVersion2,
+			Release:    "4.15.0",
 			TemplateID: "bbb39bda-ac56-4143-9b10-d1a71517d04f",
 			Templates: provisioningv1alpha1.Templates{
 				ClusterInstanceDefaults: ciDefaultsCmComplete,
@@ -481,7 +495,9 @@ defaultHugepagesSize: "1G"`,
 		for _, cr := range ctCRs {
 			crCopy := cr.DeepCopyObject().(client.Object)
 			err := K8SClient.Create(testCtx, crCopy)
-			Expect(err).ToNot(HaveOccurred())
+			if err != nil && !errors.IsAlreadyExists(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
 		}
 
 		Eventually(func() bool {

--- a/test/utils/functions.go
+++ b/test/utils/functions.go
@@ -98,7 +98,13 @@ func VerifyProvisioningStatus(provStatus provisioningv1alpha1.ProvisioningStatus
 func GetExternalCrdFiles(destDir string) error {
 	for _, externalCrd := range ExternalCrdData {
 		// Get the commit sha from the go.mod of the IMS repo.
-		policyMod := externalCrd["modName"] + "/" + externalCrd["repoName"]
+		// Use modulePath if provided, otherwise construct from modName/repoName
+		var policyMod string
+		if modulePath, exists := externalCrd["modulePath"]; exists && modulePath != "" {
+			policyMod = modulePath
+		} else {
+			policyMod = externalCrd["modName"] + "/" + externalCrd["repoName"]
+		}
 		_, policyModPseudoVersionNew, err := GetModuleFromGoMod(policyMod)
 		if err != nil {
 			return fmt.Errorf("error getting module from go.mod: %w", err)

--- a/test/utils/vars.go
+++ b/test/utils/vars.go
@@ -375,5 +375,12 @@ var (
 			"owner":       "openshift-kni",
 			"crdFileName": "lcm.openshift.io_imagebasedgroupupgrades.yaml",
 		},
+		{
+			"repoName":    "hive",
+			"modulePath":  "github.com/openshift/hive/apis",
+			"crdPath":     "config/crds",
+			"owner":       "openshift",
+			"crdFileName": "hive.openshift.io_clusterimagesets.yaml",
+		},
 	}
 )


### PR DESCRIPTION
# Summary

This PR introduces validation to ensure that `ClusterImageSet` versions match `ClusterTemplate` release version during template validation.
- The validation runs during `ClusterTemplate` validation ensuring cluster consistency from the template level.
- It works by:
  - Extracting the `ClusterImageSet` reference from the `clusterInstanceDefaults` ConfigMap referenced in the `ClusterTemplate`.
  - Fetching the corresponding `ClusterImageSet` resource.
  - Comparing its `release` image version with the `ClusterTemplate` `release` version using semantic versioning.
- Templates with mismatched versions will fail validation and cannot be used for provisioning until corrected.
- Validation can be bypassed by setting the annotation `clcm.openshift.io/skip-clusterimageset-validation: "true"` on the `ClusterTemplate`.

**Example ClusterTemplate validation failure**

```sh
oc get clustertemplates.clcm.openshift.io -A
NAMESPACE             NAME                                                    AGE   STATE    DETAILS
sno-ran-du-v4-18-15   xr8620t-green-idrac-7.10.70.10-bios-2.3.5.v4-18-15-v1   79s   Failed   ClusterImageSet img4.18.17-x86-64-appsub version (4.18.17) does not match ClusterTemplate release version (4.18.15): versions do not match exactly: ClusterImageSet version 4.18.17 != ClusterTemplate version 4.18.15
```

ℹ️ Assisted-by: Cursor and claude-4-sonnet

/cc @browsell @donpenney @irinamihai 