### PR TITLE
OCPBUGS-61947: Handle upgrade case when template version < ManagedCluster version

### DIFF
--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -344,11 +344,10 @@ plan:
 				Expect(c.Update(ctx, managedCluster)).To(Succeed())
 			})
 
-			It("should return error", func() {
-				_, err := task.IsUpgradeRequested(ctx, clusterName)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("template version"))
-				Expect(err.Error()).To(ContainSubstring("is lower then ManagedCluster version"))
+			It("should return false with no error", func() {
+				upgradeRequested, err := task.IsUpgradeRequested(ctx, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(upgradeRequested).To(BeFalse())
 			})
 		})
 

--- a/internal/controllers/provisioningrequest_upgrade.go
+++ b/internal/controllers/provisioningrequest_upgrade.go
@@ -55,11 +55,10 @@ func (t *provisioningRequestReconcilerTask) IsUpgradeRequested(
 	case 1:
 		return true, nil
 	case -1:
-		return false, fmt.Errorf("template version (%v) is lower then ManagedCluster version (%v), no upgrade requested",
-			templateReleaseVersion, managedClusterVersion)
-	default:
-		return false, nil
+		t.logger.InfoContext(ctx, "Template version is lower than ManagedCluster version, no upgrade requested",
+			"templateVersion", templateReleaseVersion, "managedClusterVersion", managedClusterVersion)
 	}
+	return false, nil
 }
 
 // handleUpgrade handles the upgrade of the cluster through IBGU. It returns a ctrl.Result to indicate


### PR DESCRIPTION
# Summary

Update `IsUpgradeRequested` function to log info and return nil when template version is lower than ManagedCluster version, rather than returning an error.

Resolves: [OCPBUGS-61947](https://issues.redhat.com/browse/OCPBUGS-61947)

/cc @browsell @donpenney @irinamihai 