### PR TITLE
OCPBUGS-61950 / OCPBUGS-62072: Resolve hardware provisioning callback and timeout detection issues

### DIFF
--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -374,8 +374,8 @@ func (t *provisioningRequestReconcilerTask) updateClusterInstanceProcessedStatus
 		message := fmt.Sprintf("Waiting for ClusterInstance (%s) to be processed", ci.Name)
 		ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
 			provisioningv1alpha1.PRconditionTypes.ClusterInstanceProcessed,
-			provisioningv1alpha1.CRconditionReasons.Unknown,
-			metav1.ConditionUnknown,
+			provisioningv1alpha1.CRconditionReasons.InProgress,
+			metav1.ConditionFalse,
 			message,
 		)
 		ctlrutils.SetProvisioningStateInProgress(t.object, message)
@@ -422,8 +422,8 @@ func (t *provisioningRequestReconcilerTask) updateClusterProvisionStatus(ci *sit
 			message = "Waiting for cluster installation to start"
 			ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
 				provisioningv1alpha1.PRconditionTypes.ClusterProvisioned,
-				provisioningv1alpha1.CRconditionReasons.Unknown,
-				metav1.ConditionUnknown,
+				provisioningv1alpha1.CRconditionReasons.InProgress,
+				metav1.ConditionFalse,
 				message,
 			)
 			ctlrutils.SetProvisioningStateInProgress(t.object, message)

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -525,8 +525,10 @@ func (t *provisioningRequestReconcilerTask) checkHardwareProvisioningTimeout(ctx
 	}
 
 	hwProvisionedCond := meta.FindStatusCondition(t.object.Status.Conditions, string(provisioningv1alpha1.PRconditionTypes.HardwareProvisioned))
-	if hwProvisionedCond == nil || hwProvisionedCond.Status != metav1.ConditionFalse ||
-		hwProvisionedCond.Reason == string(provisioningv1alpha1.CRconditionReasons.Failed) {
+	// Skip only on outcomes: succeeded, failed or timed-out
+	if hwProvisionedCond != nil && (hwProvisionedCond.Status == metav1.ConditionTrue ||
+		hwProvisionedCond.Reason == string(provisioningv1alpha1.CRconditionReasons.Failed) ||
+		hwProvisionedCond.Reason == string(provisioningv1alpha1.CRconditionReasons.TimedOut)) {
 		return ctrl.Result{}
 	}
 

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -1166,24 +1166,22 @@ func IsValidURL(u string) bool {
 	return err == nil && parsed.Scheme != "" && parsed.Host != ""
 }
 
-// ClearPRCallbackAnnotations removes all PR callback annotations from a client.Object
-func ClearPRCallbackAnnotations(object client.Object) {
+// ClearPRCallbackReceivedAnnotation removes CallbackReceivedAnnotation from a client.Object
+func ClearPRCallbackReceivedAnnotation(object client.Object) {
 	annotations := object.GetAnnotations()
 	if annotations == nil {
 		return
 	}
 
-	// Remove all callback-related annotations
+	// Only clears CallbackReceivedAnnotation
 	delete(annotations, CallbackReceivedAnnotation)
-	delete(annotations, CallbackStatusAnnotation)
-	delete(annotations, CallbackNodeAllocationRequestIdAnnotation)
 
 	object.SetAnnotations(annotations)
 }
 
-// ClearPRCallbackAnnotationsWithPatch removes all PR callback annotations from a client.Object and patches it
+// ClearPRCallbackAnnotationsWithPatch removes CallbackReceivedAnnotation from a client.Object and patches it
 func ClearPRCallbackAnnotationsWithPatch(ctx context.Context, c client.Client, object client.Object) error {
-	ClearPRCallbackAnnotations(object)
+	ClearPRCallbackReceivedAnnotation(object)
 	if err := CreateK8sCR(ctx, c, object, nil, PATCH); err != nil {
 		return fmt.Errorf("failed to clear PR callback annotations from %T %s: %w", object, object.GetName(), err)
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -572,10 +572,10 @@ defaultHugepagesSize: "1G"`,
 				if len(reconciledPR.Status.Conditions) < 4 {
 					return false
 				}
-				// Look for HardwareProvisioned condition with status Unknown (in progress)
+				// Look for HardwareProvisioned condition with status False (in progress)
 				for _, cond := range reconciledPR.Status.Conditions {
 					if cond.Type == string(provisioningv1alpha1.PRconditionTypes.HardwareProvisioned) &&
-						cond.Status == metav1.ConditionUnknown {
+						cond.Status == metav1.ConditionFalse {
 						return true
 					}
 				}
@@ -605,8 +605,8 @@ defaultHugepagesSize: "1G"`,
 			Expect(hwProvCondition).ToNot(BeNil())
 			testutils.VerifyStatusCondition(*hwProvCondition, metav1.Condition{
 				Type:    string(provisioningv1alpha1.PRconditionTypes.HardwareProvisioned),
-				Status:  metav1.ConditionUnknown,
-				Reason:  string(metav1.ConditionUnknown),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(provisioningv1alpha1.CRconditionReasons.InProgress),
 				Message: "Hardware provisioning is in progress",
 			})
 			// Verify the provisioningState moves to progressing.


### PR DESCRIPTION
This commit fixes several issues in the hardware provisioning workflow to improve reliability.

1. Improves callback deduplication: Prevents the server from incorrectly filtering out necessary "InProgress" callbacks, ensuring timely status updates are processed correctly.

2. Corrects timeout detection: The timeout check is now only skipped for final states (Succeeded, Failed, TimedOut), ensuring that provisioning timeouts are properly detected.

3. Fixes callback annotation persistence: Ensures that when callback annotations are cleared, the change is saved correctly. This prevents false callback detections in subsequent reconciliations.

4. Initialize the ClusterInstanceProcessed, ClusterProvisioned, and HardwareProvisioned conditions with a status of False and a reason of InProgress

Assisted-by: Cursor/claude-4-sonnet