### PR TITLE
Remove slot from nic f/w schema

### DIFF
--- a/api/hardwaremanagement/v1alpha1/hardwareprofile_types.go
+++ b/api/hardwaremanagement/v1alpha1/hardwareprofile_types.go
@@ -26,8 +26,6 @@ type Firmware struct {
 }
 
 type Nic struct {
-	// Slot is the NIC slot identifier
-	Slot string `json:"slot,omitempty"`
 	// Version is the NIC firmware version
 	Version string `json:"version,omitempty"`
 	// URL points to the NIC firmware file
@@ -50,9 +48,9 @@ type HardwareProfileSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="BMC Firmware",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	BmcFirmware Firmware `json:"bmcFirmware,omitempty"`
 
-	// NIC firmware information mapped by NIC identifier
+	// NIC firmware information list
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="NIC Firmware",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
-	NicFirmware map[string]Nic `json:"nicFirmware,omitempty"`
+	NicFirmware []Nic `json:"nicFirmware,omitempty"`
 }
 
 // HardwareProfileStatus defines the observed state of HardwareProfile

--- a/api/hardwaremanagement/v1alpha1/zz_generated.deepcopy.go
+++ b/api/hardwaremanagement/v1alpha1/zz_generated.deepcopy.go
@@ -227,10 +227,8 @@ func (in *HardwareProfileSpec) DeepCopyInto(out *HardwareProfileSpec) {
 	out.BmcFirmware = in.BmcFirmware
 	if in.NicFirmware != nil {
 		in, out := &in.NicFirmware, &out.NicFirmware
-		*out = make(map[string]Nic, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
+		*out = make([]Nic, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/bundle/manifests/clcm.openshift.io_hardwareprofiles.yaml
+++ b/bundle/manifests/clcm.openshift.io_hardwareprofiles.yaml
@@ -88,11 +88,9 @@ spec:
                     type: string
                 type: object
               nicFirmware:
-                additionalProperties:
+                description: NIC firmware information list
+                items:
                   properties:
-                    slot:
-                      description: Slot is the NIC slot identifier
-                      type: string
                     url:
                       description: URL points to the NIC firmware file
                       type: string
@@ -100,8 +98,7 @@ spec:
                       description: Version is the NIC firmware version
                       type: string
                   type: object
-                description: NIC firmware information mapped by NIC identifier
-                type: object
+                type: array
             required:
             - bios
             type: object

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -904,7 +904,7 @@ spec:
         path: bmcFirmware
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: NIC firmware information mapped by NIC identifier
+      - description: NIC firmware information list
         displayName: NIC Firmware
         path: nicFirmware
         x-descriptors:

--- a/config/crd/bases/clcm.openshift.io_hardwareprofiles.yaml
+++ b/config/crd/bases/clcm.openshift.io_hardwareprofiles.yaml
@@ -88,11 +88,9 @@ spec:
                     type: string
                 type: object
               nicFirmware:
-                additionalProperties:
+                description: NIC firmware information list
+                items:
                   properties:
-                    slot:
-                      description: Slot is the NIC slot identifier
-                      type: string
                     url:
                       description: URL points to the NIC firmware file
                       type: string
@@ -100,8 +98,7 @@ spec:
                       description: Version is the NIC firmware version
                       type: string
                   type: object
-                description: NIC firmware information mapped by NIC identifier
-                type: object
+                type: array
             required:
             - bios
             type: object

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -238,7 +238,7 @@ spec:
         path: bmcFirmware
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: NIC firmware information mapped by NIC identifier
+      - description: NIC firmware information list
         displayName: NIC Firmware
         path: nicFirmware
         x-descriptors:

--- a/hwmgr-plugins/metal3/controller/helpers_test.go
+++ b/hwmgr-plugins/metal3/controller/helpers_test.go
@@ -844,14 +844,12 @@ var _ = Describe("Helpers", func() {
 						Version: "4.5.6",
 						URL:     "http://example.com/bmc.bin",
 					},
-					NicFirmware: map[string]hwmgmtv1alpha1.Nic{
-						"nic1": {
-							Slot:    "pci-0000:01:00.0",
+					NicFirmware: []hwmgmtv1alpha1.Nic{
+						{
 							Version: "7.8.9",
 							URL:     "http://example.com/nic1.bin",
 						},
-						"nic2": {
-							Slot:    "pci-0000:02:00.0",
+						{
 							Version: "10.11.12",
 							URL:     "http://example.com/nic2.bin",
 						},
@@ -1018,7 +1016,7 @@ var _ = Describe("Helpers", func() {
 
 			It("should return true when no NIC firmware is specified", func() {
 				// Update profile to have no NIC firmware
-				testHwProfile.Spec.NicFirmware = map[string]hwmgmtv1alpha1.Nic{}
+				testHwProfile.Spec.NicFirmware = []hwmgmtv1alpha1.Nic{}
 				Expect(testClient.Update(ctx, testHwProfile)).To(Succeed())
 
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, pluginNamespace, "test-profile")
@@ -1057,10 +1055,11 @@ var _ = Describe("Helpers", func() {
 
 			It("should skip NIC validation when NIC version is empty", func() {
 				// Update profile to have empty NIC version
-				testHwProfile.Spec.NicFirmware["nic1"] = hwmgmtv1alpha1.Nic{
-					Slot:    "pci-0000:01:00.0",
-					Version: "", // Empty version should be skipped
-					URL:     "http://example.com/nic1.bin",
+				testHwProfile.Spec.NicFirmware = []hwmgmtv1alpha1.Nic{
+					{
+						Version: "", // Empty version should be skipped
+						URL:     "http://example.com/nic1.bin",
+					},
 				}
 				Expect(testClient.Update(ctx, testHwProfile)).To(Succeed())
 


### PR DESCRIPTION
The SimpleUpdate API does not take a device id as a parameter. It is passed a URL to an image, the BMC will consume that image and apply it to all applicable devices. 

This PR removed the slot/location identifier associated with each image, now the hardware profile will just specify a list of image versions and URLs.

 nicFirmware:
  - url:  <>
    version: 0.0.0.0
  - url: <>
    version: 1.1.1.1


Generated-By: Cursor/claude-4-sonnet