### PR TITLE
OCPBUGS-61948: Propagate failed condition status to provisioning state and detail

### DIFF
--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -55,7 +55,7 @@ Core Reconciliation:
 - IsUpgradeRequested: Version comparison and upgrade decision logic
 - GetIBGUFromUpgradeDefaultsConfigmap: IBGU creation from ConfigMap data
 - Policy Labels and Selectors: Policy filtering and management
-- checkResourcePreparationStatus: Resource readiness validation
+- checkProvisioningConditionsForFailures: Resource readiness validation
 - handleProvisioningRequestDeletion: Cleanup of provisioned resources
 - handlePreProvisioning: Pre-deployment validation and preparation
 - handleNodeAllocationRequestProvisioning: Hardware allocation workflow
@@ -471,7 +471,7 @@ plan:
 		})
 	})
 
-	Describe("checkResourcePreparationStatus", func() {
+	Describe("checkProvisioningConditionsForFailures", func() {
 		var testTask *provisioningRequestReconcilerTask
 
 		BeforeEach(func() {
@@ -525,7 +525,7 @@ plan:
 			})
 
 			It("should not set provisioning state to failed", func() {
-				err := testTask.checkResourcePreparationStatus(ctx)
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify provisioning state is not failed
@@ -554,7 +554,7 @@ plan:
 			})
 
 			It("should not set provisioning state to failed when conditions are missing", func() {
-				err := testTask.checkResourcePreparationStatus(ctx)
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify provisioning state is not failed (missing conditions are not treated as failures)
@@ -583,7 +583,7 @@ plan:
 			})
 
 			It("should set provisioning state to failed with validation error message", func() {
-				err := testTask.checkResourcePreparationStatus(ctx)
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify provisioning state is set to failed
@@ -613,7 +613,7 @@ plan:
 			})
 
 			It("should set provisioning state to failed with rendering error message", func() {
-				err := testTask.checkResourcePreparationStatus(ctx)
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify provisioning state is set to failed
@@ -649,7 +649,7 @@ plan:
 			})
 
 			It("should set provisioning state to failed with resource creation error message", func() {
-				err := testTask.checkResourcePreparationStatus(ctx)
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify provisioning state is set to failed
@@ -691,7 +691,7 @@ plan:
 			})
 
 			It("should set provisioning state to failed with hardware template error message", func() {
-				err := testTask.checkResourcePreparationStatus(ctx)
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify provisioning state is set to failed
@@ -729,7 +729,7 @@ plan:
 			})
 
 			It("should set provisioning state to failed with the first failed condition's message", func() {
-				err := testTask.checkResourcePreparationStatus(ctx)
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify provisioning state is set to failed with the first error message
@@ -770,7 +770,7 @@ plan:
 			})
 
 			It("should set provisioning state to failed based on the first false condition encountered", func() {
-				err := testTask.checkResourcePreparationStatus(ctx)
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Should fail on ClusterResourcesCreated since it's the first false condition in the iteration order
@@ -780,6 +780,110 @@ plan:
 
 				Expect(updatedCR.Status.ProvisioningStatus.ProvisioningPhase).To(Equal(provisioningv1alpha1.StateFailed))
 				Expect(updatedCR.Status.ProvisioningStatus.ProvisioningDetails).To(ContainSubstring("Resource creation failed"))
+			})
+		})
+
+		Context("when HardwareConfigured condition has failed", func() {
+			BeforeEach(func() {
+				// Simulate Day 2 BIOS configuration failure scenario
+				// Set the ProvisioningRequest to a progressing state first
+				testTask.object.Status.ProvisioningStatus = provisioningv1alpha1.ProvisioningStatus{
+					ProvisioningPhase:   provisioningv1alpha1.StateProgressing,
+					ProvisioningDetails: "Hardware configuring is in progress",
+				}
+				testTask.object.Status.ObservedGeneration = 3
+
+				// Set HardwareConfigured condition to False with Failed reason
+				// This simulates the scenario where InvalidUserInput from hardware layer
+				// should be mapped to Failed in provisioning layer
+				utils.SetStatusCondition(&testTask.object.Status.Conditions,
+					provisioningv1alpha1.PRconditionTypes.HardwareConfigured,
+					provisioningv1alpha1.CRconditionReasons.Failed,
+					metav1.ConditionFalse,
+					"Hardware configuring failed due to invalid BIOS configuration parameters")
+
+				// Update the CR in the client
+				Expect(c.Status().Update(ctx, testTask.object)).To(Succeed())
+			})
+
+			It("should propagate hardware configuration failure to provisioning state", func() {
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify the provisioning state is set to failed
+				updatedCR := &provisioningv1alpha1.ProvisioningRequest{}
+				err = c.Get(ctx, types.NamespacedName{Name: testTask.object.Name, Namespace: testTask.object.Namespace}, updatedCR)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(updatedCR.Status.ProvisioningStatus.ProvisioningPhase).To(Equal(provisioningv1alpha1.StateFailed))
+				Expect(updatedCR.Status.ProvisioningStatus.ProvisioningDetails).To(ContainSubstring("Hardware configuring failed due to invalid BIOS configuration parameters"))
+			})
+		})
+
+		Context("when HardwareConfigured condition has timed out", func() {
+			BeforeEach(func() {
+				// Simulate hardware configuration timeout scenario
+				testTask.object.Status.ProvisioningStatus = provisioningv1alpha1.ProvisioningStatus{
+					ProvisioningPhase:   provisioningv1alpha1.StateProgressing,
+					ProvisioningDetails: "Hardware configuring is in progress",
+				}
+
+				// Set HardwareConfigured condition to False with TimedOut reason
+				utils.SetStatusCondition(&testTask.object.Status.Conditions,
+					provisioningv1alpha1.PRconditionTypes.HardwareConfigured,
+					provisioningv1alpha1.CRconditionReasons.TimedOut,
+					metav1.ConditionFalse,
+					"Hardware configuration timed out")
+
+				// Update the CR in the client
+				Expect(c.Status().Update(ctx, testTask.object)).To(Succeed())
+			})
+
+			It("should propagate hardware configuration timeout to provisioning state", func() {
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify the provisioning state is set to failed due to timeout
+				updatedCR := &provisioningv1alpha1.ProvisioningRequest{}
+				err = c.Get(ctx, types.NamespacedName{Name: testTask.object.Name, Namespace: testTask.object.Namespace}, updatedCR)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(updatedCR.Status.ProvisioningStatus.ProvisioningPhase).To(Equal(provisioningv1alpha1.StateFailed))
+				Expect(updatedCR.Status.ProvisioningStatus.ProvisioningDetails).To(ContainSubstring("Hardware configuration timed out"))
+			})
+		})
+
+		Context("when HardwareConfigured condition is False but still in progress", func() {
+			BeforeEach(func() {
+				// Simulate hardware configuration still in progress
+				testTask.object.Status.ProvisioningStatus = provisioningv1alpha1.ProvisioningStatus{
+					ProvisioningPhase:   provisioningv1alpha1.StateProgressing,
+					ProvisioningDetails: "Hardware configuring is in progress",
+				}
+
+				// Set HardwareConfigured condition to False with InProgress reason
+				// This should NOT trigger a failure state
+				utils.SetStatusCondition(&testTask.object.Status.Conditions,
+					provisioningv1alpha1.PRconditionTypes.HardwareConfigured,
+					provisioningv1alpha1.CRconditionReasons.InProgress,
+					metav1.ConditionFalse,
+					"Hardware configuring is in progress")
+
+				// Update the CR in the client
+				Expect(c.Status().Update(ctx, testTask.object)).To(Succeed())
+			})
+
+			It("should not set provisioning state to failed for in-progress hardware configuration", func() {
+				err := testTask.checkProvisioningConditionsForFailures(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify the provisioning state remains progressing (not failed)
+				updatedCR := &provisioningv1alpha1.ProvisioningRequest{}
+				err = c.Get(ctx, types.NamespacedName{Name: testTask.object.Name, Namespace: testTask.object.Namespace}, updatedCR)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Should remain in progressing state since InProgress is not a failure
+				Expect(updatedCR.Status.ProvisioningStatus.ProvisioningPhase).To(Equal(provisioningv1alpha1.StateProgressing))
 			})
 		})
 	})
@@ -4184,10 +4288,10 @@ plan:
 			})
 
 			Context("when ClusterDetails is nil", func() {
-				It("should call checkResourcePreparationStatus and return requeueWithMediumInterval", func() {
+				It("should call checkProvisioningConditionsForFailures and return requeueWithMediumInterval", func() {
 					result, err := deployConfigTask.checkClusterDeployConfigState(ctx)
 
-					// Should call checkResourcePreparationStatus and return requeueWithMediumInterval for monitoring
+					// Should call checkProvisioningConditionsForFailures and return requeueWithMediumInterval for monitoring
 					if err == nil {
 						Expect(result).To(Equal(requeueWithMediumInterval()))
 					} else {
@@ -4197,7 +4301,7 @@ plan:
 				})
 			})
 
-			Context("when checkResourcePreparationStatus returns error", func() {
+			Context("when checkProvisioningConditionsForFailures returns error", func() {
 				It("should handle resource preparation status check appropriately", func() {
 					result, err := deployConfigTask.checkClusterDeployConfigState(ctx)
 
@@ -4333,7 +4437,7 @@ plan:
 				Expect(c.Status().Update(ctx, deployConfigCR)).To(Succeed())
 			})
 
-			Context("when checkResourcePreparationStatus returns error", func() {
+			Context("when checkProvisioningConditionsForFailures returns error", func() {
 				It("should handle final resource preparation check appropriately", func() {
 					result, err := deployConfigTask.checkClusterDeployConfigState(ctx)
 
@@ -4736,7 +4840,7 @@ plan:
 				Expect(getErr).ToNot(HaveOccurred())
 
 				// EXPECTED: The phase should be failed due to the validation failure condition
-				// The fix should make checkClusterDeployConfigState call checkResourcePreparationStatus
+				// The fix should make checkClusterDeployConfigState call checkProvisioningConditionsForFailures
 				// when NodeAllocationRequestRef doesn't exist during initial validation phase
 				Expect(updatedCR.Status.ProvisioningStatus.ProvisioningPhase).To(Equal(provisioningv1alpha1.StateFailed))
 
@@ -5269,6 +5373,90 @@ plan:
 			ctx = context.Background()
 			currentTime = time.Now()
 
+			// Create HardwareTemplate with timeout configuration
+			hwTemplate := &hwmgmtv1alpha1.HardwareTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hw-template",
+					Namespace: utils.InventoryNamespace, // This is "oran-o2ims" namespace
+				},
+				Spec: hwmgmtv1alpha1.HardwareTemplateSpec{
+					HardwareProvisioningTimeout: "30m",
+					HardwarePluginRef:           "test-hw-plugin",
+					BootInterfaceLabel:          "test-label",
+					NodeGroupData: []hwmgmtv1alpha1.NodeGroupData{
+						{
+							Name:           "master",
+							Role:           "master",
+							ResourcePoolId: "test-pool",
+							HwProfile:      "test-profile",
+						},
+					},
+				},
+			}
+
+			clusterInstanceConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ci-defaults",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					utils.ClusterInstallationTimeoutConfigKey: "30m",
+					utils.ClusterInstanceTemplateDefaultsConfigmapKey: `
+baseDomain: example.com
+clusterImageSetNameRef: "4.15.0"
+pullSecretRef:
+  name: "pull-secret"`,
+				},
+			}
+
+			policyTemplateConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pt-defaults",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					utils.ClusterConfigurationTimeoutConfigKey: "15m",
+					utils.PolicyTemplateDefaultsConfigmapKey: `
+clustertemplate-test-policy-v1-cpu-isolated: "2-31"
+clustertemplate-test-policy-v1-cpu-reserved: "0-1"`,
+				},
+			}
+
+			// Create ClusterTemplate that references the ConfigMaps
+			testClusterTemplate := &provisioningv1alpha1.ClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template.v1.0.0",
+					Namespace: "test-namespace",
+				},
+				Spec: provisioningv1alpha1.ClusterTemplateSpec{
+					Name:    "test-template",
+					Version: "v1.0.0",
+					Templates: provisioningv1alpha1.Templates{
+						HwTemplate:              "test-hw-template",
+						ClusterInstanceDefaults: "test-ci-defaults",
+						PolicyTemplateDefaults:  "test-pt-defaults",
+					},
+					TemplateParameterSchema: runtime.RawExtension{
+						Raw: []byte(`{
+							"type": "object",
+							"properties": {
+								"test": {"type": "string"}
+							}
+						}`),
+					},
+				},
+				Status: provisioningv1alpha1.ClusterTemplateStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(provisioningv1alpha1.CTconditionTypes.Validated),
+							Status:  metav1.ConditionTrue,
+							Reason:  string(provisioningv1alpha1.CTconditionReasons.Completed),
+							Message: "ClusterTemplate validation completed successfully",
+						},
+					},
+				},
+			}
+
 			testObject = &provisioningv1alpha1.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-integration-pr",
@@ -5290,6 +5478,13 @@ plan:
 					},
 				},
 			}
+
+			// Create all objects in the fake client
+			Expect(c.Create(ctx, hwTemplate)).To(Succeed())
+			Expect(c.Create(ctx, clusterInstanceConfigMap)).To(Succeed())
+			Expect(c.Create(ctx, policyTemplateConfigMap)).To(Succeed())
+			Expect(c.Create(ctx, testClusterTemplate)).To(Succeed())
+			Expect(c.Create(ctx, testObject)).To(Succeed())
 
 			testTask = &provisioningRequestReconcilerTask{
 				logger:       slog.New(slog.NewTextHandler(os.Stderr, nil)),

--- a/internal/controllers/utils/hardware_utils.go
+++ b/internal/controllers/utils/hardware_utils.go
@@ -533,3 +533,36 @@ func GetBMHNamespace(node *pluginsv1alpha1.AllocatedNode) string {
 	}
 	return node.Spec.HwMgrNodeNs
 }
+
+// MapHardwareReasonToProvisioningReason converts hardware management condition reasons
+// to provisioning request condition reasons with explicit semantic mapping
+func MapHardwareReasonToProvisioningReason(hardwareReason string) provisioningv1alpha1.ConditionReason {
+	switch hardwareReason {
+	case string(hwmgmtv1alpha1.Failed):
+		return provisioningv1alpha1.CRconditionReasons.Failed
+	case string(hwmgmtv1alpha1.TimedOut):
+		return provisioningv1alpha1.CRconditionReasons.TimedOut
+	case string(hwmgmtv1alpha1.InProgress):
+		return provisioningv1alpha1.CRconditionReasons.InProgress
+	case string(hwmgmtv1alpha1.Completed):
+		return provisioningv1alpha1.CRconditionReasons.Completed
+	case string(hwmgmtv1alpha1.InvalidInput):
+		// Hardware InvalidUserInput maps to provisioning Failed
+		return provisioningv1alpha1.CRconditionReasons.Failed
+	case string(hwmgmtv1alpha1.Unprovisioned):
+		// Unexpected unprovisioned state is a failure
+		return provisioningv1alpha1.CRconditionReasons.Failed
+	case string(hwmgmtv1alpha1.NotInitialized):
+		// Initialization failure is a failure
+		return provisioningv1alpha1.CRconditionReasons.Failed
+	case string(hwmgmtv1alpha1.ConfigUpdate):
+		// Configuration update request is in progress
+		return provisioningv1alpha1.CRconditionReasons.InProgress
+	case string(hwmgmtv1alpha1.ConfigApplied):
+		// Configuration applied successfully
+		return provisioningv1alpha1.CRconditionReasons.Completed
+	default:
+		// For unknown hardware reasons, use Unknown
+		return provisioningv1alpha1.CRconditionReasons.Unknown
+	}
+}

--- a/internal/controllers/utils/hardware_utils_test.go
+++ b/internal/controllers/utils/hardware_utils_test.go
@@ -1,0 +1,165 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+)
+
+var _ = Describe("MapHardwareReasonToProvisioningReason", func() {
+	Context("when mapping standard hardware management reasons", func() {
+		It("should correctly map Failed reason", func() {
+			result := MapHardwareReasonToProvisioningReason(string(hwmgmtv1alpha1.Failed))
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Failed))
+		})
+
+		It("should correctly map TimedOut reason", func() {
+			result := MapHardwareReasonToProvisioningReason(string(hwmgmtv1alpha1.TimedOut))
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.TimedOut))
+		})
+
+		It("should correctly map InProgress reason", func() {
+			result := MapHardwareReasonToProvisioningReason(string(hwmgmtv1alpha1.InProgress))
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.InProgress))
+		})
+
+		It("should correctly map Completed reason", func() {
+			result := MapHardwareReasonToProvisioningReason(string(hwmgmtv1alpha1.Completed))
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Completed))
+		})
+	})
+
+	Context("when mapping hardware-specific failure reasons to provisioning Failed", func() {
+		It("should map InvalidInput to Failed", func() {
+			result := MapHardwareReasonToProvisioningReason(string(hwmgmtv1alpha1.InvalidInput))
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Failed))
+		})
+
+		It("should map Unprovisioned to Failed", func() {
+			result := MapHardwareReasonToProvisioningReason(string(hwmgmtv1alpha1.Unprovisioned))
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Failed))
+		})
+
+		It("should map NotInitialized to Failed", func() {
+			result := MapHardwareReasonToProvisioningReason(string(hwmgmtv1alpha1.NotInitialized))
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Failed))
+		})
+	})
+
+	Context("when mapping configuration-specific reasons", func() {
+		It("should map ConfigUpdate to InProgress", func() {
+			result := MapHardwareReasonToProvisioningReason(string(hwmgmtv1alpha1.ConfigUpdate))
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.InProgress))
+		})
+
+		It("should map ConfigApplied to Completed", func() {
+			result := MapHardwareReasonToProvisioningReason(string(hwmgmtv1alpha1.ConfigApplied))
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Completed))
+		})
+	})
+
+	Context("when mapping unknown or invalid reasons", func() {
+		It("should map unknown reason to Unknown", func() {
+			result := MapHardwareReasonToProvisioningReason("UnknownReason")
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Unknown))
+		})
+
+		It("should map empty string to Unknown", func() {
+			result := MapHardwareReasonToProvisioningReason("")
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Unknown))
+		})
+
+		It("should map arbitrary string to Unknown", func() {
+			result := MapHardwareReasonToProvisioningReason("SomeRandomString")
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Unknown))
+		})
+
+		It("should map special characters to Unknown", func() {
+			result := MapHardwareReasonToProvisioningReason("@#$%^&*()")
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Unknown))
+		})
+	})
+
+	Context("when testing all known hardware management reasons comprehensively", func() {
+		type reasonMapping struct {
+			hardwareReason     string
+			expectedProvReason provisioningv1alpha1.ConditionReason
+			description        string
+		}
+
+		DescribeTable("should map hardware reasons correctly",
+			func(mapping reasonMapping) {
+				result := MapHardwareReasonToProvisioningReason(mapping.hardwareReason)
+				Expect(result).To(Equal(mapping.expectedProvReason), mapping.description)
+			},
+			Entry("Failed maps to Failed", reasonMapping{
+				hardwareReason:     string(hwmgmtv1alpha1.Failed),
+				expectedProvReason: provisioningv1alpha1.CRconditionReasons.Failed,
+				description:        "Hardware failure should map to provisioning failure",
+			}),
+			Entry("TimedOut maps to TimedOut", reasonMapping{
+				hardwareReason:     string(hwmgmtv1alpha1.TimedOut),
+				expectedProvReason: provisioningv1alpha1.CRconditionReasons.TimedOut,
+				description:        "Hardware timeout should map to provisioning timeout",
+			}),
+			Entry("InProgress maps to InProgress", reasonMapping{
+				hardwareReason:     string(hwmgmtv1alpha1.InProgress),
+				expectedProvReason: provisioningv1alpha1.CRconditionReasons.InProgress,
+				description:        "Hardware in progress should map to provisioning in progress",
+			}),
+			Entry("Completed maps to Completed", reasonMapping{
+				hardwareReason:     string(hwmgmtv1alpha1.Completed),
+				expectedProvReason: provisioningv1alpha1.CRconditionReasons.Completed,
+				description:        "Hardware completion should map to provisioning completion",
+			}),
+			Entry("InvalidInput maps to Failed", reasonMapping{
+				hardwareReason:     string(hwmgmtv1alpha1.InvalidInput),
+				expectedProvReason: provisioningv1alpha1.CRconditionReasons.Failed,
+				description:        "Invalid hardware input should be treated as provisioning failure",
+			}),
+			Entry("Unprovisioned maps to Failed", reasonMapping{
+				hardwareReason:     string(hwmgmtv1alpha1.Unprovisioned),
+				expectedProvReason: provisioningv1alpha1.CRconditionReasons.Failed,
+				description:        "Unexpected unprovisioned state should be treated as failure",
+			}),
+			Entry("NotInitialized maps to Failed", reasonMapping{
+				hardwareReason:     string(hwmgmtv1alpha1.NotInitialized),
+				expectedProvReason: provisioningv1alpha1.CRconditionReasons.Failed,
+				description:        "Hardware initialization failure should be treated as failure",
+			}),
+			Entry("ConfigUpdate maps to InProgress", reasonMapping{
+				hardwareReason:     string(hwmgmtv1alpha1.ConfigUpdate),
+				expectedProvReason: provisioningv1alpha1.CRconditionReasons.InProgress,
+				description:        "Configuration update request should be treated as in progress",
+			}),
+			Entry("ConfigApplied maps to Completed", reasonMapping{
+				hardwareReason:     string(hwmgmtv1alpha1.ConfigApplied),
+				expectedProvReason: provisioningv1alpha1.CRconditionReasons.Completed,
+				description:        "Configuration applied successfully should be treated as completed",
+			}),
+		)
+	})
+
+	Context("when testing case sensitivity", func() {
+		It("should be case sensitive for known reasons", func() {
+			// Test that the mapping is case-sensitive - uppercase should not match
+			result := MapHardwareReasonToProvisioningReason("FAILED")
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Unknown))
+		})
+
+		It("should be case sensitive for mixed case", func() {
+			result := MapHardwareReasonToProvisioningReason("Failed")
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Failed))
+
+			result = MapHardwareReasonToProvisioningReason("failed")
+			Expect(result).To(Equal(provisioningv1alpha1.CRconditionReasons.Unknown))
+		})
+	})
+})


### PR DESCRIPTION
# Summary

This PR propagates the failed condition status with the corresponding error message to the provisioningState and provisioningDetails.

Problem: ProvisioningRequests would get stuck in a progressing state during hardware provisioning failures because the failure detection logic wasn't properly checking hardware-specific conditions.

Solution: Enhanced the condition failure detection to include hardware provisioning and configuration conditions, and improved the logic to only treat conditions as failed when they have explicit Failed or TimedOut reasons. Additionally, added reason mapping between hardware management conditions and provisioning request conditions to ensure consistent state transitions across all failure scenarios.

ℹ️ Assisted-by: Cursor and claude-4-sonnet

Resolves: [OCPBUGS-61948](https://issues.redhat.com/browse/OCPBUGS-61948)

/cc @donpenney @tliu2021 @irinamihai @Missxiaoguo 