### PR TITLE
Update markdownlint-cli2 version and resolve warnings

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,12 +1,15 @@
 # See https://github.com/DavidAnson/markdownlint#optionsconfig
 # and https://github.com/DavidAnson/markdownlint-cli2
 
+# https://github.com/DavidAnson/markdownlint-cli2/blob/main/test/markdownlint-cli2-yaml-example/.markdownlint-cli2.yaml
+
 config:
-  line-length:
+  MD013: # line-length
     line_length: 300
     code_blocks: false
-  ul-style: consistent
+  ul-style: true
   emphasis-style: true
   strong-style: true
   no-space-in-emphasis: true
   no-blanks-blockquote: false
+  descriptive-link-text: false

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 # O-RAN O-Cloud Manager
 
 <!-- markdownlint-disable MD033 -->
-<a href="https://github.com/o-ran-sc/it-test/tree/master/test_scripts/O2IMS_Compliance_Test"><img src="https://img.shields.io/badge/O--RAN_SC_O2_IMS_Automated_Test_Compliance-100%25-green"/></a>
+<a href="https://github.com/o-ran-sc/it-test/tree/master/test_scripts/O2IMS_Compliance_Test"><img alt="100%" src="https://img.shields.io/badge/O--RAN_SC_O2_IMS_Automated_Test_Compliance-100%25-green"/></a>
 <!-- markdownlint-enable MD033 -->
 
 <!-- TOC -->
@@ -252,7 +252,7 @@ client present a certificate.
 
 To configure the primary controller to enable mTLS the following attributes must be set in the `clientTLS` section of
 the `spec`. For more information, please refer to the
-documention [here](https://docs.openshift.com/container-platform/4.17/networking/networking_operators/ingress-operator.html#configuring-ingress-controller-tls).
+[Ingress Operator in OpenShift Container Platform documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking_operators/configuring-ingress#configuring-ingress-controller-tls).
 
 ```yaml
 apiVersion: operator.openshift.io/v1
@@ -303,8 +303,8 @@ configuration requirements.
 
    > :warning: Do this only if the cluster proxy isn't currently pointing to some other custom CA bundle. If it is
    > pointing to an existing bundle, then the new private certificates need to be appended to the existing set. Refer to
-   > the OpenShift documentation for more
-   details [here](https://docs.openshift.com/container-platform/4.17/networking/configuring-a-custom-pki.html).
+   > the [OpenShift Configuring a custom PKI documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/configuring_network_settings/configuring-a-custom-pki)
+   > for more details.
 
    ```console
    oc create configmap -n openshift-config custom-ca-certs --from-file=ca-bundle.crt=/some/path/to/ca-bundle.crt

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -26,7 +26,8 @@ This should all be achieved through ArgoCD.
 
 ## Full DU profile
 
-For configuring an SNO with a full DU profile according to the [4.17 RAN RDS](https://docs.openshift.com/container-platform/4.17/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-crs.html), the following main samples can be used as a starting example:
+For configuring an SNO with a full DU profile according to the [4.19 RAN RDS](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-du-reference-configuration-crs),
+the following main samples can be used as a starting example:
 
 * [ClusterInstance defaults ConfigMap](./samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-full-du/clusterinstance-defaults-full-du-v1.yaml)
 * [PolicyTemplate defaults ConfigMap](./samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-full-du/policytemplates-defaults-full-du-v1.yaml)

--- a/docs/enhancements/infrastructure-monitoring-service-api/alarms.md
+++ b/docs/enhancements/infrastructure-monitoring-service-api/alarms.md
@@ -30,10 +30,10 @@ superseded-by:
 
 ## Table of Contents
 
-- [Summary](#Summary)
-- [Goals](#Goals)
-- [Key O-RAN data structures](#key-O-RAN-data-structures)
-- [InfrastructureMonitoring Service API](#Infrastructure-Monitoring-Service-Alarms-API)
+- [Summary](#summary)
+- [Goals](#goals)
+- [Key O-RAN data structures](#key-o-ran-data-structures)
+- [InfrastructureMonitoring Service API](#infrastructure-monitoring-service-alarms-api)
 - [Database schema](#schema)
 - [Init behaviour](#init)
   - [Detailed Steps](#detailed-server-instantiation)
@@ -294,7 +294,7 @@ oc -n open-cluster-management-observability create secret generic alertmanager-c
    - Database interaction is further explained [here](#notification-tracking)
 4. Move all the `status: resolved` rows from `alarm_event_record` to `alarm_event_record_archive`
 
-Eventually data in `alarm_event_record_archive` will be cleared (hardcoded to 24hr) as seen [here](#daily-archive-cleanup-)
+Eventually data in `alarm_event_record_archive` will be cleared (hardcoded to 24hr) as seen [here](#daily-archive-cleanup)
 
 ## Alertmanager Example payload
 

--- a/hack/install-markdownlint.sh
+++ b/hack/install-markdownlint.sh
@@ -9,11 +9,10 @@
 cat /etc/redhat-release || echo "No /etc/redhat-release"
 
 if grep -q 'Red Hat Enterprise Linux' /etc/redhat-release; then
-    # install the config file for the RPM repository with node 14
-    # steps taken from https://rpm.nodesource.com/setup_14.x
+    # https://github.com/nodesource/distributions/blob/master/DEV_README.md#enterprise-linux-based-distributions
     yum module disable -y nodejs
-    curl -sL -o '/tmp/nodesource.rpm' 'https://rpm.nodesource.com/pub_14.x/el/8/x86_64/nodesource-release-el8-1.noarch.rpm'
-    rpm -i --nosignature --force /tmp/nodesource.rpm
+    curl -fsSL https://rpm.nodesource.com/setup_23.x -o nodesource_setup.sh
+    bash nodesource_setup.sh
     yum -y install nodejs
 else
     # Fedora has a module we can use
@@ -21,4 +20,4 @@ else
     dnf -y install nodejs
 fi
 
-npm install -g markdownlint@v0.25.1 markdownlint-cli2@v0.4.0
+npm install -g markdownlint@v0.38.0 markdownlint-cli2@v0.18.1 --save-dev

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -20,4 +20,4 @@ EOF
     fi
 }
 
-markdownlint-cli2 '**/*.md' !'vendor/**/*.md' !'telco5g-konflux/**/*.md'
+markdownlint-cli2 '**/*.md' !'vendor/**/*.md' !'telco5g-konflux/**/*.md' !'bin/**/*.md'


### PR DESCRIPTION
Links in markdown files to RH documentation have been updated to most recent docs