### PR TITLE
Refactor IsUpgradeRequested and improve error handling

### DIFF
--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -464,10 +464,12 @@ func (t *provisioningRequestReconcilerTask) initializeHardwarePluginIfNeeded(ctx
 
 // handleClusterUpgrades handles cluster upgrade logic
 func (t *provisioningRequestReconcilerTask) handleClusterUpgrades(ctx context.Context, clusterName string) (ctrl.Result, error) {
-	shouldUpgrade, err := t.IsUpgradeRequested(ctx, clusterName)
+	shouldUpgrade, result, err := t.IsUpgradeRequested(ctx, clusterName)
 	if err != nil {
-		result, _ := requeueWithError(err)
-		return result, err
+		return requeueWithError(err)
+	}
+	if result.RequeueAfter > 0 {
+		return result, nil
 	}
 
 	// An upgrade is requested or upgrade has started but not completed


### PR DESCRIPTION
# Summary

This PR refactors the `IsUpgradeRequested` function with improved handling of missing `openshiftVersion` label on ManagedCluster. Previously, the reconciler failed repeatedly and delayed marking the PR as "fulfilled" when this label was absent (it’s only added after successful ACM import). This change ensures the absence is handled gracefully, avoiding unnecessary errors and with potential exponential backoff delays.

Partially resolves: [OCPBUGS-62300](https://issues.redhat.com/browse/OCPBUGS-62300) 

/cc @Missxiaoguo @donpenney 