### PR TITLE
Clear managedFields when reusing ClusterInstance for SSA

### DIFF
--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -1001,6 +1001,10 @@ func (t *provisioningRequestReconcilerTask) canSkipClusterInstanceRendering(ctx 
 		return nil, false
 	}
 
+	// Prepare the existing ClusterInstance for Server-Side Apply by clearing metadata
+	// that must not be present in SSA requests
+	ctlrutils.PrepareClusterInstanceForServerSideApply(existingCI)
+
 	return existingCI, true
 }
 


### PR DESCRIPTION
# Summary

When `canSkipClusterInstanceRendering` returns an existing ClusterInstance, certain `metadata` fields need to be cleared to avoid Server-Side Apply errors. Without this fix, PRs could remain stuck in the "progressing" state even after cluster provisioning has completed.

/cc @donpenney @Missxiaoguo 