### PR TITLE
fix: add macOS compatibility to hack scripts with longopt support

### DIFF
--- a/hack/catalog-undeploy.sh
+++ b/hack/catalog-undeploy.sh
@@ -46,44 +46,78 @@ declare PACKAGE=
 declare NAMESPACE=
 declare CRD_SEARCH=
 
-longopts=(
-    "help"
-    "namespace:"
-    "package:"
-    "crd-search:"
-)
+function parse_args_macos {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --namespace)
+                NAMESPACE="$2"
+                shift 2
+                ;;
+            --package)
+                PACKAGE="$2"
+                shift 2
+                ;;
+            --crd-search)
+                CRD_SEARCH="$2"
+                shift 2
+                ;;
+            --help)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                usage
+                ;;
+        esac
+    done
+}
 
-longopts_str=$(IFS=,; echo "${longopts[*]}")
+function parse_args_linux {
+    longopts=(
+        "help"
+        "namespace:"
+        "package:"
+        "crd-search:"
+    )
 
-if ! OPTS=$(getopt -o "ho:" --long "${longopts_str}" --name "$0" -- "$@"); then
-    usage
+    longopts_str=$(IFS=,; echo "${longopts[*]}")
+
+    if ! OPTS=$(getopt -o "ho:" --long "${longopts_str}" --name "$0" -- "$@"); then
+        usage
+    fi
+
+    eval set -- "${OPTS}"
+
+    while :; do
+        case "$1" in
+            --namespace)
+                NAMESPACE="$2"
+                shift 2
+                ;;
+            --package)
+                PACKAGE="$2"
+                shift 2
+                ;;
+            --crd-search)
+                CRD_SEARCH="$2"
+                shift 2
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                usage
+                ;;
+        esac
+    done
+}
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    parse_args_macos "$@"
+else
+    parse_args_linux "$@"
 fi
-
-eval set -- "${OPTS}"
-
-while :; do
-    case "$1" in
-        --namespace)
-            NAMESPACE="$2"
-            shift 2
-            ;;
-        --package)
-            PACKAGE="$2"
-            shift 2
-            ;;
-        --crd-search)
-            CRD_SEARCH="$2"
-            shift 2
-            ;;
-        --)
-            shift
-            break
-            ;;
-        *)
-            usage
-            ;;
-    esac
-done
 
 if [ -z "${NAMESPACE}" ] || [ -z "${PACKAGE}" ] || [ -z "${CRD_SEARCH}" ]; then
     usage

--- a/hack/generate-catalog-deploy.sh
+++ b/hack/generate-catalog-deploy.sh
@@ -100,54 +100,96 @@ declare CHANNEL=
 declare CATALOG_IMG=
 declare INSTALL_MODE=
 
-longopts=(
-    "help"
-    "namespace:"
-    "package:"
-    "catalog-image:"
-    "channel:"
-    "install-mode:"
-)
+function parse_args_macos {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --namespace)
+                NAMESPACE="$2"
+                shift 2
+                ;;
+            --package)
+                PACKAGE="$2"
+                shift 2
+                ;;
+            --catalog-image)
+                CATALOG_IMG="$2"
+                shift 2
+                ;;
+            --channel)
+                CHANNEL="$2"
+                shift 2
+                ;;
+            --install-mode)
+                INSTALL_MODE="$2"
+                shift 2
+                ;;
+            --help)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                usage
+                ;;
+        esac
+    done
+}
 
-longopts_str=$(IFS=,; echo "${longopts[*]}")
+function parse_args_linux {
+    longopts=(
+        "help"
+        "namespace:"
+        "package:"
+        "catalog-image:"
+        "channel:"
+        "install-mode:"
+    )
 
-if ! OPTS=$(getopt -o "ho:" --long "${longopts_str}" --name "$0" -- "$@"); then
-    usage
+    longopts_str=$(IFS=,; echo "${longopts[*]}")
+
+    if ! OPTS=$(getopt -o "ho:" --long "${longopts_str}" --name "$0" -- "$@"); then
+        usage
+    fi
+
+    eval set -- "${OPTS}"
+
+    while :; do
+        case "$1" in
+            --namespace)
+                NAMESPACE="$2"
+                shift 2
+                ;;
+            --package)
+                PACKAGE="$2"
+                shift 2
+                ;;
+            --catalog-image)
+                CATALOG_IMG="$2"
+                shift 2
+                ;;
+            --channel)
+                CHANNEL="$2"
+                shift 2
+                ;;
+            --install-mode)
+                INSTALL_MODE="$2"
+                shift 2
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                usage
+                ;;
+        esac
+    done
+}
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    parse_args_macos "$@"
+else
+    parse_args_linux "$@"
 fi
-
-eval set -- "${OPTS}"
-
-while :; do
-    case "$1" in
-        --namespace)
-            NAMESPACE="$2"
-            shift 2
-            ;;
-        --package)
-            PACKAGE="$2"
-            shift 2
-            ;;
-        --catalog-image)
-            CATALOG_IMG="$2"
-            shift 2
-            ;;
-        --channel)
-            CHANNEL="$2"
-            shift 2
-            ;;
-        --install-mode)
-            INSTALL_MODE="$2"
-            shift 2
-            ;;
-        --)
-            shift
-            break
-            ;;
-        *)
-            usage
-            ;;
-    esac
-done
 
 if [ -z "${NAMESPACE}" ] || [ -z "${PACKAGE}" ] || [ -z "${CATALOG_IMG}" ] || [ -z "${CHANNEL}" ] || [ -z "${INSTALL_MODE}" ]; then
     usage

--- a/hack/generate-catalog-index.sh
+++ b/hack/generate-catalog-index.sh
@@ -32,49 +32,87 @@ declare NAME=
 declare CHANNEL=
 declare VERSION=
 
-longopts=(
-    "help"
-    "opm:"
-    "name:"
-    "channel:"
-    "version:"
-)
+function parse_args_macos {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --opm)
+                OPM="$2"
+                shift 2
+                ;;
+            --name)
+                NAME="$2"
+                shift 2
+                ;;
+            --channel)
+                CHANNEL="$2"
+                shift 2
+                ;;
+            --version)
+                VERSION="$2"
+                shift 2
+                ;;
+            --help)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                usage
+                ;;
+        esac
+    done
+}
 
-longopts_str=$(IFS=,; echo "${longopts[*]}")
+function parse_args_linux {
+    longopts=(
+        "help"
+        "opm:"
+        "name:"
+        "channel:"
+        "version:"
+    )
 
-if ! OPTS=$(getopt -o "h" --long "${longopts_str}" --name "$0" -- "$@"); then
-    usage
+    longopts_str=$(IFS=,; echo "${longopts[*]}")
+
+    if ! OPTS=$(getopt -o "h" --long "${longopts_str}" --name "$0" -- "$@"); then
+        usage
+    fi
+
+    eval set -- "${OPTS}"
+
+    while :; do
+        case "$1" in
+            --opm)
+                OPM="$2"
+                shift 2
+                ;;
+            --name)
+                NAME="$2"
+                shift 2
+                ;;
+            --channel)
+                CHANNEL="$2"
+                shift 2
+                ;;
+            --version)
+                VERSION="$2"
+                shift 2
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                usage
+                ;;
+        esac
+    done
+}
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    parse_args_macos "$@"
+else
+    parse_args_linux "$@"
 fi
-
-eval set -- "${OPTS}"
-
-while :; do
-    case "$1" in
-        --opm)
-            OPM="$2"
-            shift 2
-            ;;
-        --name)
-            NAME="$2"
-            shift 2
-            ;;
-        --channel)
-            CHANNEL="$2"
-            shift 2
-            ;;
-        --version)
-            VERSION="$2"
-            shift 2
-            ;;
-        --)
-            shift
-            break
-            ;;
-        *)
-            usage
-            ;;
-    esac
-done
 
 if [ -z "${OPM}" ] || [ -z "${NAME}" ] || [ -z "${CHANNEL}" ] || [ -z "${VERSION}" ]; then
     usage


### PR DESCRIPTION
The hack scripts using GNU getopt with longopts failed on macOS due to BSD getopt differences. Added OS detection and dual parsing functions to support both platforms while preserving longopt functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)