### PR TITLE
CNF-19760: Add alarm dictionary endpoints to resource server (infrastructureInventory)

### DIFF
--- a/internal/service/resources/api/openapi.yaml
+++ b/internal/service/resources/api/openapi.yaml
@@ -49,6 +49,9 @@ tags:
 - name: resources
   description: |
     Information about resources.
+- name: alarmDictionaries
+  description: |
+    Information about alarm dictionaries.
 
 security:
 - oauth2:
@@ -601,7 +604,6 @@ paths:
               schema:
                 $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
 
-
   /o2ims-infrastructureInventory/v1/resourcePools:
     get:
       operationId: getResourcePools
@@ -791,6 +793,164 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Resource"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '404':
+          description: The specified entity was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '500':
+          description: Internal server error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+
+  /o2ims-infrastructureInventory/v1/alarmDictionaries:
+    get:
+      operationId: getAlarmDictionaries
+      summary: Get alarm dictionaries
+      security:
+      - oauth2:
+        - role:o2ims-admin
+        - role:o2ims-reader
+      description: |
+        Returns the list of alarm dictionaries.
+      parameters:
+        - $ref: "../../common/api/openapi.yaml#/components/parameters/allFields"
+        - $ref: "../../common/api/openapi.yaml#/components/parameters/excludeFields"
+        - $ref: "../../common/api/openapi.yaml#/components/parameters/fields"
+        - $ref: "../../common/api/openapi.yaml#/components/parameters/filter"
+      tags:
+        - alarmDictionaries
+      responses:
+        '200':
+          description: |
+            Successfully obtained the list of alarm dictionaries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "../../common/api/openapi.yaml#/components/schemas/AlarmDictionary"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '500':
+          description: Internal server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+
+  /o2ims-infrastructureInventory/v1/alarmDictionaries/{alarmDictionaryId}:
+    get:
+      operationId: getAlarmDictionary
+      summary: Get an alarm dictionary
+      security:
+      - oauth2:
+        - role:o2ims-admin
+        - role:o2ims-reader
+      description: |
+        Returns the details of an alarm dictionary.
+      parameters:
+        - $ref: "../../common/api/openapi.yaml#/components/parameters/alarmDictionaryId"
+      tags:
+        - alarmDictionaries
+      responses:
+        '200':
+          description: |
+            Successfully obtained the details of an alarm dictionary.
+          content:
+            application/json:
+              schema:
+                $ref: "../../common/api/openapi.yaml#/components/schemas/AlarmDictionary"
+        '400':
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '404':
+          description: The specified entity was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+        '500':
+          description: Internal server error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../../common/api/openapi.yaml#/components/schemas/ProblemDetails'
+
+  /o2ims-infrastructureInventory/v1/resourceTypes/{resourceTypeId}/alarmDictionary:
+    get:
+      operationId: getResourceTypeAlarmDictionary
+      summary: Get an alarm dictionary for a resource type
+      security:
+      - oauth2:
+        - role:o2ims-admin
+        - role:o2ims-reader
+      description: |
+        Returns the alarm dictionary for a resource type.
+      parameters:
+        - $ref: "#/components/parameters/resourceTypeId"
+      tags:
+        - alarmDictionaries
+      responses:
+        '200':
+          description: |
+            Successfully obtained the details of the alarm dictionary.
+          content:
+            application/json:
+              schema:
+                $ref: "../../common/api/openapi.yaml#/components/schemas/AlarmDictionary"
         '400':
           description: Bad request
           content:

--- a/internal/service/resources/api/server.go
+++ b/internal/service/resources/api/server.go
@@ -46,6 +46,30 @@ type ResourceServer struct {
 	SubscriptionEventHandler notifier.SubscriptionEventHandler
 }
 
+func (r *ResourceServer) GetAlarmDictionaries(ctx context.Context, request api.GetAlarmDictionariesRequestObject) (api.GetAlarmDictionariesResponseObject, error) {
+	// TODO: implement actual logic to fetch alarm dictionaries from database
+	// For now, return an empty array
+	return api.GetAlarmDictionaries200JSONResponse{}, nil
+}
+
+func (r *ResourceServer) GetAlarmDictionary(ctx context.Context, request api.GetAlarmDictionaryRequestObject) (api.GetAlarmDictionaryResponseObject, error) {
+	// TODO: implement actual logic to fetch alarm dictionary by ID from database
+	// For now, return 404 not found
+	return api.GetAlarmDictionary404ApplicationProblemPlusJSONResponse{
+		Detail: "Alarm dictionary not found (not implemented yet)",
+		Status: http.StatusNotFound,
+	}, nil
+}
+
+func (r *ResourceServer) GetResourceTypeAlarmDictionary(ctx context.Context, request api.GetResourceTypeAlarmDictionaryRequestObject) (api.GetResourceTypeAlarmDictionaryResponseObject, error) {
+	// TODO: implement actual logic to fetch alarm dictionary for resource type from database
+	// For now, return 404 not found
+	return api.GetResourceTypeAlarmDictionary404ApplicationProblemPlusJSONResponse{
+		Detail: "Resource type alarm dictionary not found (not implemented yet)",
+		Status: http.StatusNotFound,
+	}, nil
+}
+
 // GetAllVersions receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ResourceServer) GetAllVersions(ctx context.Context, request api.GetAllVersionsRequestObject) (api.GetAllVersionsResponseObject, error) {
 	// We currently only support a single version


### PR DESCRIPTION
Based on: O-RAN.WG6.TS.O2IMS-INTERFACE-R004-v09.00 

```
# 1. GET /alarmDictionaries
curl -k -s --header "Authorization: Bearer $(cat /tmp/token.txt)" \
  "https://hub.com/o2ims-infrastructureInventory/v1/alarmDictionaries"

# 2. GET /alarmDictionaries/{alarmDictionaryId}
curl -k -s --header "Authorization: Bearer $(cat /tmp/token.txt)" \
  "https://hub.com/o2ims-infrastructureInventory/v1/alarmDictionaries/00000000-0000-0000-0000-000000000001"

# 3. GET /resourceTypes/{resourceTypeId}/alarmDictionary
curl -k -s --header "Authorization: Bearer $(cat /tmp/token.txt)" \
  "https://hub.com/o2ims-infrastructureInventory/v1/resourceTypes/00000000-0000-0000-0000-000000000001/alarmDictionary"
```