### PR TITLE
Fix additional-labels for o-cloud builds

### DIFF
--- a/.tekton/o-cloud-manager-4-21-push.yaml
+++ b/.tekton/o-cloud-manager-4-21-push.yaml
@@ -57,7 +57,7 @@ spec:
       value: ['latest']
     - name: additional-labels
       value:
-        - name=openshift4/o-cloud-manager-operator-bundle
+        - name=openshift4/o-cloud-manager-rhel9-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/o-cloud-manager-bundle-4-21-push.yaml
+++ b/.tekton/o-cloud-manager-bundle-4-21-push.yaml
@@ -55,6 +55,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: ["latest"]
+    - name: additional-labels
+      value:
+        - name=openshift4/o-cloud-manager-operator-bundle
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
- the operator on-push build was using the bundle label
- the bundle on-push build was missing a label

AI-attribution: AIA,Entirely human-created,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/