### PR TITLE
OCPBUGS-62916: Remove bmcCredentialsDetails from rendered ClusterInstance

### DIFF
--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -164,6 +164,10 @@ func (t *provisioningRequestReconcilerTask) buildClusterInstanceUnstructured() (
 				"name": secretName,
 			}
 		}
+
+		// Remove bmcCredentialsDetails from the ClusterInstance spec as it's not part of the ClusterInstance CRD schema
+		delete(nodeMap, "bmcCredentialsDetails")
+
 		if nodeNetwork, ok := nodeMap["nodeNetwork"]; ok {
 			if interfaces, ok := nodeNetwork.(map[string]interface{})["interfaces"]; ok {
 				if interfaceItems, ok := interfaces.([]interface{}); ok {

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -200,6 +200,8 @@ var (
 		// Node-level ignored fields
 		{"nodes", "*", "bmcAddress"},
 		{"nodes", "*", "bmcCredentialsName"},
+		// The bmcCredentialsDetails field is not part of the ClusterInstance CRD.
+		{"nodes", "*", "bmcCredentialsDetails"},
 		{"nodes", "*", "bootMACAddress"},
 		{"nodes", "*", "hostRef"},
 		{"nodes", "*", "nodeNetwork", "interfaces", "*", "macAddress"},


### PR DESCRIPTION
# Summary

This PR removes the `bmcCredentialsDetails` field from the rendered ClusterInstance nodes as it is not part of the CRD schema. The field is used to create BMC secrets but should not be included in the final ClusterInstance object.

Resolves: [OCPBUGS-62916](https://issues.redhat.com/browse/OCPBUGS-62916)

ℹ️ Assisted-by: Cursor and claude-4.5-sonnet

/cc @Missxiaoguo @donpenney 