### PR TITLE
Use map[string]any for hostRef in ClusterInstance nodes

### DIFF
--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -616,10 +616,14 @@ func extractNodeDetails(existingCI *unstructured.Unstructured) map[string]nodeIn
 			}
 		}
 
-		hostRef, ok := nodeMap["hostRef"].(map[string]string)
+		hostRef, ok := nodeMap["hostRef"].(map[string]any)
 		if ok {
-			extractedNodeInfo.HwMgrNodeId = hostRef["name"]
-			extractedNodeInfo.HwMgrNodeNs = hostRef["namespace"]
+			hwMgrNodeId, okId := hostRef["name"].(string)
+			hwMgrNodeNs, okNs := hostRef["namespace"].(string)
+			if okId && okNs {
+				extractedNodeInfo.HwMgrNodeId = hwMgrNodeId
+				extractedNodeInfo.HwMgrNodeNs = hwMgrNodeNs
+			}
 		}
 
 		// Extract interface macAddress by interface name
@@ -680,7 +684,7 @@ func assignNodeDetails(renderedCI *unstructured.Unstructured, nodesInfo map[stri
 				}
 			}
 			if extractedNode.HwMgrNodeId != "" && extractedNode.HwMgrNodeNs != "" {
-				nodeMap["hostRef"] = map[string]string{
+				nodeMap["hostRef"] = map[string]any{
 					"name":      extractedNode.HwMgrNodeId,
 					"namespace": extractedNode.HwMgrNodeNs,
 				}

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -753,7 +753,7 @@ func TestAssignNodeDetails(t *testing.T) {
 							"bmcCredentialsName": map[string]any{
 								"name": "bmc-secret",
 							},
-							"hostRef": map[string]string{
+							"hostRef": map[string]any{
 								"name":      "test",
 								"namespace": "test",
 							},


### PR DESCRIPTION
# Summary

This PR updates the extraction and assignment of `hostRef` from `map[string]string` to `map[string]any` to address the following error post cluster provisioning:
```
{"time":"2025-10-22T15:23:58Z","level":"ERROR","msg":"Failed to render and validate ClusterInstance","controller":"ProvisioningRequest","error":"failed to validate the rendered ClusterInstance with dry-run: failed to apply ClusterInstance: admission webhook \"clusterinstances.siteconfig.open-cluster-management.io\" denied the request: invalid spec changes detected: detected unauthorized node modifications: [node cnfdg6.ptp.eng.rdu2.dc.redhat.com: unauthorized change to /hostRef]","name":"67549398-f7a9-41e8-9943-2246b976ff99","resource":"ProvisioningRequest","name":"67549398-f7a9-41e8-9943-2246b976ff99","namespace":"","action":"reconcile_start","resourceVersion":"149460537","generation":1,"phase":"pre_provisioning"}
```

/cc @Missxiaoguo @browsell 