### PR TITLE
OCPBUGS-56702: Improve PR status accuracy during Day-2 policy configuration changes

### DIFF
--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/sno-ran-du/sno-ran-du-pg-v4-Y-Z+1-v1.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/sno-ran-du/sno-ran-du-pg-v4-Y-Z+1-v1.yaml
@@ -11,6 +11,10 @@ policyDefaults:
     labelSelector:
       cluster-version: "v4-Y-Z+1"
       sno-ran-du-policy: "v1"
+  policyAnnotations:
+    # This annotation contains a comma-separated list of ClusterTemplates (metadata.name) this PG is associated with.
+    # This is used for linking the generated root policies to the ClusterTemplate used by the ProvisioningRequest.
+    clustertemplates.clcm.openshift.io/templates: "sno-ran-du.v4-Y-Z+1-1"
   remediationAction: enforce
   severity: low
   namespaceSelector:

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v1.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v1.yaml
@@ -11,6 +11,10 @@ policyDefaults:
     labelSelector:
       cluster-version: "v4-Y-Z"
       sno-ran-du-policy: "v1"
+  policyAnnotations:
+    # This annotation contains a comma-separated list of ClusterTemplates (metadata.name) this PG is associated with.
+    # This is used for linking the generated root policies to the ClusterTemplate used by the ProvisioningRequest.
+    clustertemplates.clcm.openshift.io/templates: "sno-ran-du.v4-Y-Z-1,sno-ran-du.v4-Y-Z-1-no-hwtemplate,sno-ran-du-ibi.v4-Y-Z-1"
   remediationAction: enforce
   severity: low
   namespaceSelector:

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v2.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v2.yaml
@@ -11,6 +11,10 @@ policyDefaults:
     labelSelector:
       cluster-version: "v4-Y-Z"
       sno-ran-du-policy: "v2"
+  policyAnnotations:
+    # This annotation contains a comma-separated list of ClusterTemplates (metadata.name) this PG is associated with.
+    # This is used for linking the generated root policies to the ClusterTemplate used by the ProvisioningRequest.
+    clustertemplates.clcm.openshift.io/templates: "sno-ran-du.v4-Y-Z-3"
   remediationAction: enforce
   severity: low
   namespaceSelector:

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v3.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v3.yaml
@@ -11,6 +11,10 @@ policyDefaults:
     labelSelector:
       cluster-version: "v4-Y-Z"
       sno-ran-du-policy: "v3"
+  policyAnnotations:
+    # This annotation contains a comma-separated list of ClusterTemplates (metadata.name) this PG is associated with.
+    # This is used for linking the generated root policies to the ClusterTemplate used by the ProvisioningRequest.
+    clustertemplates.clcm.openshift.io/templates: "sno-ran-du.v4-Y-Z-4"
   remediationAction: enforce
   severity: low
   namespaceSelector:

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-full-du/sno-ran-full-du-pg-v4-Y-Z-v1.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-full-du/sno-ran-full-du-pg-v4-Y-Z-v1.yaml
@@ -13,6 +13,10 @@ policyDefaults:
     labelSelector:
       cluster-version: "v4-Y-Z"
       sno-ran-full-du-policy: "v1"
+  policyAnnotations:
+    # This annotation contains a comma-separated list of ClusterTemplates (metadata.name) this PG is associated with.
+    # This is used for linking the generated root policies to the ClusterTemplate used by the ProvisioningRequest.
+    clustertemplates.clcm.openshift.io/templates: "sno-ran-full-du.v4-Y-Z-1"
   remediationAction: enforce
   severity: low
   namespaceSelector:

--- a/docs/user-guide/cluster-configuration.md
+++ b/docs/user-guide/cluster-configuration.md
@@ -242,6 +242,7 @@ For updating a manifest in an existing ACM PolicyGenerator, the following steps 
     * Create a new version of the ACM PG - [sno-ran-du-pg-v4-Y-Z-v2](../samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v2.yaml):
         * The name is updated to `sno-ran-du-pg-v4-Y-Z-v2` (the `ztp-sno-ran-du-v4-Y-Z` namespace is kept).
         * `policyDefaults.placement.labelSelector.sno-ran-du-policy` is updated from `v1` to `v2` such that the policy binding is updated.
+        * The annotation `clustertemplates.clcm.openshift.io/templates` under `policyAnnotations` is updated to `sno-ran-du.v4-Y-Z-3`, which is the name of new ClusterTemplate that will be created in the following step.
         * All policy names are updated from `v1` to `v2` (example: `v1-subscriptions-policy` -> `v2-subscriptions-policy`).
         * The desired manifest section is updated. The current [sno-ran-du-pg-v4-Y-Z-v2](../samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v2.yaml) sample adds a `sysctl` section to the `TunedPerformancePatch` section under the `v2-tuned-configuration-policy` policy.
     * Create a new version of the [clusterinstance-defaults-v2](../samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v2.yaml) `ConfigMap` - [clusterinstance-defaults-v3](../samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v3.yaml):
@@ -406,6 +407,7 @@ The following steps need to be taken:
     * A new ACM PG is created - [sno-ran-du-pg-v4-Y-Z-v3](../samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v3.yaml):
         * `metadata.name` is updated from `sno-ran-du-pg-v4-Y-Z-v2` to `sno-ran-du-pg-v4-Y-Z-v3` (the `ztp-sno-ran-du-v4-Y-Z` namespace is kept).
         * `policyDefaults.placement.labelSelector.sno-ran-du-policy` is updated from `v2` to `v3` such that the policy binding is updated.
+        * The annotation `clustertemplates.clcm.openshift.io/templates` under `policyAnnotations` is updated to `sno-ran-du.v4-Y-Z-4`, which is the name of new ClusterTemplate that will be created in the following step.
         * All policy names are updated from `v2` to `v3` (example: `v2-subscriptions-policy` -> `v3-subscriptions-policy`).
         * The following manifests are added under the `v3-subscriptions-policy`:
 

--- a/docs/user-guide/gitops-layout-and-setup.md
+++ b/docs/user-guide/gitops-layout-and-setup.md
@@ -48,6 +48,11 @@ or extracted from the [ztp-site-generate](https://catalog.redhat.com/software/co
   * The ACM PGs will reference the source CRs to generate the ACM Policies that will be applied on the spoke cluster(s).
 * Make sure to bring over the `extra-manifest` and `source-crs` corresponding to the OCP release provided in the ClusterTemplate CR.
 * ACM policies must be created under the namespace `ztp-<cluster-template-namespace>`. See the [example](../samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/ns.yaml).
+* In the ACM PGs, set `policyAnnotations` to include the annotation `clustertemplates.clcm.openshift.io/templates` with a comma-separated
+  list of ClusterTemplates that PG is associated with. Use the ClusterTemplate metadata.name for each entry. This annotation is propagated to
+  each generated root Policy. It enables the O‑Cloud Manager to identify which root policies are associated with the
+  ClusterTemplate used by a ProvisioningRequest, determine the expected child policies, and accurately detect when configuration
+  is complete - ensuring correct provisioning status reporting during Day-2 policy configuration changes. See the [example](../samples/git-setup/policytemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-pg-v4-Y-Z-v1.yaml).
 
 ## Full DU profile
 

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -251,6 +251,15 @@ const (
 	ChildPolicyClusterNamespaceLabel = "policy.open-cluster-management.io/cluster-namespace"
 )
 
+// Policy annotation keys
+const (
+	// CTPolicyTemplatesAnnotation is an optional annotation on root Policy objects.
+	// It contains a comma-separated list of ClusterTemplate refs (metadata.name = spec.name + "." + spec.version)
+	// that this root policy is associated with. When present, the controller will use it to
+	// determine the expected set of child policies for a ProvisioningRequest using that template.
+	CTPolicyTemplatesAnnotation = "clustertemplates.clcm.openshift.io/templates"
+)
+
 // Hardware Manager plugin constants
 const (
 	UnitTestHwPluginRef    = "hwmgr"

--- a/internal/controllers/utils/provision.go
+++ b/internal/controllers/utils/provision.go
@@ -315,6 +315,26 @@ func IsParentPolicyInZtpClusterTemplateNs(policyNamespace, ctNamespace string) b
 	return policyNamespace == fmt.Sprintf("ztp-%s", ctNamespace)
 }
 
+// RootPolicyMatchesClusterTemplate returns true if the root policy annotations include the given
+// ClusterTemplate reference string. The annotation value is a comma-separated list
+// of ClusterTemplate refs using metadata.name (name.version).
+func RootPolicyMatchesClusterTemplate(annotations map[string]string, ctRef string) bool {
+	if annotations == nil || ctRef == "" {
+		return false
+	}
+	raw, ok := annotations[CTPolicyTemplatesAnnotation]
+	if !ok || raw == "" {
+		return false
+	}
+	// Split comma-separated list and match exact ref after trimming spaces
+	for _, item := range strings.Split(raw, ",") {
+		if strings.EqualFold(strings.TrimSpace(item), ctRef) {
+			return true
+		}
+	}
+	return false
+}
+
 func ConvertToUnstructured(ci siteconfig.ClusterInstance) (*unstructured.Unstructured, error) {
 	objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&ci)
 	if err != nil {


### PR DESCRIPTION
**Problem**
When a ProvisioningRequest switches to a ClusterTemplate that targets a different set of policies, there’s a delay before new child policies are generated. During this gap, old child policies remain bound and compliant, so the PR is marked fulfilled too early; however, the new child policies haven't been created yet.

**Solution**
Introduce an annotation on root policies (added via PolicyGenerator) to link policies to specific ClusterTemplates. The controller uses this to determine the expected child policies for the PR’s template and gate completion until expected policies are present, and all bound policies are compliant.

**Behavior**
When the annotation is present, the controller identifies the root policies associated with the PR’s ClusterTemplate, determines the expected child policies, and:
- Sets to Missing and no requeue if there are missing policies but all expected policies are inform - this aligins with current inform-only handling (without timeout handling).
- Sets to Progressing and requeue while expected policies (enforce/enforce+inform) are missing (with timeout handling).

If no annotation is found, or no root policies match the current ClusterTemplate, behavior remains unchanged (evaluation is based on bound policies only).

Added unit tests and consolidated common reconciler task setup into BeforeEach in provisioningrequest_clusterconfig_test.go.