### PR TITLE
OCPBUGS-63350: Consolidate plugin and operator namespaces under OCLOUD_MANAGER_NAMESPACE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,6 @@ ENVTEST_VERSION = release-0.21
 # OCLOUD_MANAGER_NAMESPACE refers to the namespace of the O-Cloud Manager
 OCLOUD_MANAGER_NAMESPACE ?= oran-o2ims
 
-# HWMGR_PLUGIN_NAMESPACE refers to the namespace of the hardware manager plugin.
-HWMGR_PLUGIN_NAMESPACE ?= oran-o2ims
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -265,7 +262,6 @@ uninstall: manifests kustomize kubectl ## Uninstall CRDs from the K8s cluster sp
 .PHONY: deploy
 deploy: install manifests kustomize kubectl ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	@$(KUBECTL) create configmap env-config \
-		--from-literal=HWMGR_PLUGIN_NAMESPACE=$(HWMGR_PLUGIN_NAMESPACE) \
 		--from-literal=imagePullPolicy=$(IMAGE_PULL_POLICY) \
 		--dry-run=client -o yaml > config/manager/env-config.yaml
 	cd config/manager \
@@ -352,7 +348,6 @@ endif
 bundle: operator-sdk manifests kustomize kubectl ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests --apis-dir api/ -q
 	@$(KUBECTL) create configmap env-config \
-		--from-literal=HWMGR_PLUGIN_NAMESPACE=$(HWMGR_PLUGIN_NAMESPACE) \
 		--from-literal=imagePullPolicy=$(IMAGE_PULL_POLICY) \
 		--dry-run=client -o yaml > config/manager/env-config.yaml
 	cd config/manager \
@@ -601,7 +596,7 @@ go-generate:
 .PHONY: test tests
 test tests:
 	@echo "Run ginkgo"
-	HWMGR_PLUGIN_NAMESPACE=hwmgr ginkgo run -r ./internal ./api ./hwmgr-plugins $(ginkgo_flags)
+	ginkgo run -r ./internal ./api ./hwmgr-plugins $(ginkgo_flags)
 
 .PHONY: test-e2e
 test-e2e: envtest kubectl

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1754,8 +1754,6 @@ spec:
                   value: quay.io/openshift-kni/oran-o2ims-operator:4.21.0
                 - name: POSTGRES_IMAGE
                   value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
-                - name: HWMGR_PLUGIN_NAMESPACE
-                  value: oran-o2ims
                 - name: OCLOUD_MANAGER_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -30,16 +30,6 @@ replacements:
       kind: Deployment
       name: controller-manager
 - source:
-    fieldPath: data.HWMGR_PLUGIN_NAMESPACE
-    kind: ConfigMap
-    name: env-config
-  targets:
-  - fieldPaths:
-    - spec.template.spec.containers.[name=manager].env.[name=HWMGR_PLUGIN_NAMESPACE].value
-    select:
-      kind: Deployment
-      name: controller-manager
-- source:
     fieldPath: data.imagePullPolicy
     kind: ConfigMap
     name: env-config

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,9 +79,6 @@ spec:
           value: controller:latest
         - name: POSTGRES_IMAGE
           value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
-        - name: HWMGR_PLUGIN_NAMESPACE
-          # A placeholder for the replacement kustomization that will inject the value from the config map
-          value: plugin-namespace-placeholder
         - name: OCLOUD_MANAGER_NAMESPACE
           valueFrom:
             fieldRef:

--- a/hwmgr-plugins/api/server/provisioning/helpers.go
+++ b/hwmgr-plugins/api/server/provisioning/helpers.go
@@ -20,15 +20,13 @@ import (
 
 	"github.com/openshift-kni/oran-o2ims/api/common"
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
-func GetLoopbackHWPluginNamespace() string {
-	return ctlrutils.GetHwMgrPluginNS()
-}
-
 func GetMetal3HWPluginNamespace() string {
-	return ctlrutils.GetHwMgrPluginNS()
+	// HardwarePlugins are co-located with the operator in OCLOUD_MANAGER_NAMESPACE
+	return ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
 }
 
 func GenerateResourceIdentifier(baseName string) (string, error) {

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -1516,7 +1516,7 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (c
 	// Build the deployment's metadata.
 	deploymentMeta := metav1.ObjectMeta{
 		Name:      serverName,
-		Namespace: ctlrutils.InventoryNamespace,
+		Namespace: t.object.Namespace,
 		Labels: map[string]string{
 			"oran/o2ims": t.object.Name,
 			"app":        serverName,
@@ -1602,12 +1602,16 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (c
 			},
 		},
 		{
-			Name:  constants.InternalServicePortName,
-			Value: fmt.Sprintf("%d", constants.DefaultServicePort),
+			Name: constants.DefaultNamespaceEnvName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
 		},
 		{
-			Name:  ctlrutils.HwMgrPluginNameSpace,
-			Value: ctlrutils.GetHwMgrPluginNS(),
+			Name:  constants.InternalServicePortName,
+			Value: fmt.Sprintf("%d", constants.DefaultServicePort),
 		},
 	}...)
 
@@ -1891,7 +1895,7 @@ func (t *reconcilerTask) createIngress(ctx context.Context) error {
 
 func (t *reconcilerTask) updateInventoryStatusConditions(ctx context.Context, deploymentName string) {
 	deployment := &appsv1.Deployment{}
-	err := t.client.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: ctlrutils.InventoryNamespace}, deployment)
+	err := t.client.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: t.object.Namespace}, deployment)
 
 	if err != nil {
 		reason := string(ctlrutils.InventoryConditionReasons.ErrorGettingDeploymentInformation)

--- a/internal/controllers/mock_hardware_plugin_server.go
+++ b/internal/controllers/mock_hardware_plugin_server.go
@@ -70,7 +70,7 @@ import (
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	hwmgrpluginapi "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/provisioning"
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 )
 
 const (
@@ -308,7 +308,7 @@ func (m *MockHardwarePluginServer) handleNodeAllocationRequests(w http.ResponseW
 				fmt.Printf("DEBUG: Failed to create K8s NodeAllocationRequest %s: %v\n", requestID, err)
 			} else {
 				// Success case - log for debugging
-				fmt.Printf("DEBUG: Successfully created K8s NodeAllocationRequest %s in namespace %s\n", requestID, ctlrutils.UnitTestHwmgrNamespace)
+				fmt.Printf("DEBUG: Successfully created K8s NodeAllocationRequest %s in namespace %s\n", requestID, constants.DefaultNamespace)
 			}
 		}
 
@@ -598,7 +598,7 @@ func (m *MockHardwarePluginServer) checkForAllocatedNodes(requestID string) bool
 
 	// Check if any AllocatedNode resources exist for this NodeAllocationRequest
 	allocatedNodeList := &pluginsv1alpha1.AllocatedNodeList{}
-	err := m.k8sClient.List(context.Background(), allocatedNodeList, client.InNamespace(ctlrutils.UnitTestHwmgrNamespace))
+	err := m.k8sClient.List(context.Background(), allocatedNodeList, client.InNamespace(constants.DefaultNamespace))
 	if err != nil {
 		return false
 	}
@@ -617,7 +617,7 @@ func (m *MockHardwarePluginServer) createKubernetesNodeAllocationRequest(ctx con
 	k8sNodeAllocationRequest := &pluginsv1alpha1.NodeAllocationRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      requestID,
-			Namespace: ctlrutils.UnitTestHwmgrNamespace,
+			Namespace: constants.DefaultNamespace,
 		},
 		Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
 			ClusterId:          request.ClusterId,

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -350,12 +350,12 @@ defaultHugepagesSize: "1G"`,
 
 		// Create the provisioned NodeAllocationRequest
 		hwPluginNs := &corev1.Namespace{}
-		hwPluginNs.SetName(utils.UnitTestHwmgrNamespace)
+		hwPluginNs.SetName(constants.DefaultNamespace)
 		Expect(c.Create(ctx, hwPluginNs)).To(Succeed())
 		nodeAllocationRequest := &pluginsv1alpha1.NodeAllocationRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cluster-1",
-				Namespace: utils.UnitTestHwmgrNamespace,
+				Namespace: constants.DefaultNamespace,
 				Annotations: map[string]string{
 					pluginsv1alpha1.BootInterfaceLabelAnnotation: "bootable-interface",
 				},
@@ -1782,7 +1782,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 		}
 
 		hwPluginNs := &corev1.Namespace{}
-		hwPluginNs.SetName(utils.UnitTestHwmgrNamespace)
+		hwPluginNs.SetName(constants.DefaultNamespace)
 
 		crs := []client.Object{
 			// Cluster Template Namespace.
@@ -1793,7 +1793,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 			},
 			&corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: utils.UnitTestHwmgrNamespace,
+					Name: constants.DefaultNamespace,
 				},
 			},
 			// ManagedCluster Namespace.
@@ -1850,7 +1850,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 		nodeAllocationRequest = &pluginsv1alpha1.NodeAllocationRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      mclName,
-				Namespace: utils.UnitTestHwmgrNamespace,
+				Namespace: constants.DefaultNamespace,
 				Annotations: map[string]string{
 					pluginsv1alpha1.BootInterfaceLabelAnnotation: "bootable-interface",
 				},
@@ -1901,7 +1901,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 		// Get hwpluginClient for the test
 		hwpluginKey := types.NamespacedName{
 			Name:      utils.UnitTestHwPluginRef,
-			Namespace: utils.UnitTestHwmgrNamespace,
+			Namespace: constants.DefaultNamespace,
 		}
 		hwplugin := &hwmgmtv1alpha1.HardwarePlugin{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1990,7 +1990,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 	Context("When the HW template is provided and the expected HW CRs exist", func() {
 		BeforeEach(func() {
 			hwPluginNs := &corev1.Namespace{}
-			hwPluginNs.SetName(utils.UnitTestHwmgrNamespace)
+			hwPluginNs.SetName(constants.DefaultNamespace)
 
 			// Create the NodeAllocationRequest.
 			Expect(c.Create(ctx, nodeAllocationRequest)).To(Succeed())
@@ -2098,9 +2098,9 @@ var _ = Describe("addPostProvisioningLabels", func() {
 			bmcSecretName2 := "bmc-secret-2"
 			node := testutils.CreateNode(
 				masterNodeName2, "idrac-virtualmedia+https://10.16.2.1/redfish/v1/Systems/System.Embedded.1",
-				"bmc-secret", "controller", utils.UnitTestHwmgrNamespace, mclName, nil)
+				"bmc-secret", "controller", constants.DefaultNamespace, mclName, nil)
 			node.Status.Hostname = agent2Hostname
-			secrets := testutils.CreateSecrets([]string{bmcSecretName2}, utils.UnitTestHwmgrNamespace)
+			secrets := testutils.CreateSecrets([]string{bmcSecretName2}, constants.DefaultNamespace)
 			testutils.CreateResources(ctx, c, []*pluginsv1alpha1.AllocatedNode{node}, secrets)
 
 			// Create the corresponding BareMetalHost that the function will look for
@@ -2108,7 +2108,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 			bmh := &metal3v1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      masterNodeName2,
-					Namespace: utils.UnitTestHwmgrNamespace,
+					Namespace: constants.DefaultNamespace,
 					UID:       types.UID(bmhUID),
 				},
 				Spec: metal3v1alpha1.BareMetalHostSpec{
@@ -2188,9 +2188,9 @@ var _ = Describe("addPostProvisioningLabels", func() {
 			bmcSecretName2 := "bmc-secret-2"
 			node := testutils.CreateNode(
 				masterNodeName2, "idrac-virtualmedia+https://10.16.2.1/redfish/v1/Systems/System.Embedded.1",
-				"bmc-secret", "controller", utils.UnitTestHwmgrNamespace, mclName, nil)
+				"bmc-secret", "controller", constants.DefaultNamespace, mclName, nil)
 			node.Status.Hostname = "some-other-cluster.lab.example.com"
-			secrets := testutils.CreateSecrets([]string{bmcSecretName2}, utils.UnitTestHwmgrNamespace)
+			secrets := testutils.CreateSecrets([]string{bmcSecretName2}, constants.DefaultNamespace)
 			testutils.CreateResources(ctx, c, []*pluginsv1alpha1.AllocatedNode{node}, secrets)
 
 			// Run the function.

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -126,7 +126,7 @@ import (
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -137,7 +137,7 @@ func TestControllers(t *testing.T) {
 	RunSpecs(t, "Controllers")
 }
 
-const testHwMgrPluginNameSpace = "hwmgr"
+const testHwMgrPluginNameSpace = constants.DefaultNamespace
 const testMetal3HardwarePluginRef = "hwmgr"
 
 // SSACompatibleClient wraps a fake client and converts Server-Side Apply operations
@@ -307,7 +307,7 @@ var _ = BeforeSuite(func() {
 	ctrl.SetLogger(adapter)
 	klog.SetLogger(adapter)
 
-	os.Setenv(ctlrutils.HwMgrPluginNameSpace, testHwMgrPluginNameSpace)
+	os.Setenv(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
 
 	// Add all the required types to the scheme used by the tests:
 	scheme.AddKnownTypes(inventoryv1alpha1.GroupVersion, &inventoryv1alpha1.Inventory{})

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -262,20 +262,13 @@ const (
 
 // Hardware Manager plugin constants
 const (
-	UnitTestHwPluginRef    = "hwmgr"
-	UnitTestHwmgrNamespace = "hwmgr"
-	DefaultPluginNamespace = constants.DefaultNamespace
+	UnitTestHwPluginRef = "hwmgr"
 )
 
 // POD Port Values
 const (
 	DefaultServiceTargetPort = "https"
 	DatabaseTargetPort       = "database"
-)
-
-// Environment values
-const (
-	HwMgrPluginNameSpace = "HWMGR_PLUGIN_NAMESPACE"
 )
 
 // ClusterVersionName is the name given to the default ClusterVersion object

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -47,7 +47,6 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
-const testHwMgrPluginNameSpace = "hwmgr"
 const testHardwarePluginRef = "hwmgr"
 
 var (
@@ -85,8 +84,8 @@ var _ = BeforeSuite(func() {
 	ctrl.SetLogger(adapter)
 	klog.SetLogger(adapter)
 
-	// Set the hardware manager plugin details.
-	os.Setenv(ctlrutils.HwMgrPluginNameSpace, testHwMgrPluginNameSpace)
+	// Set the operator namespace for tests
+	os.Setenv(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
 
 	// Set the scheme.
 	testScheme := runtime.NewScheme()
@@ -171,13 +170,7 @@ var _ = BeforeSuite(func() {
 	mockServer := provisioningcontrollers.NewMockHardwarePluginServerWithClient(K8SClient)
 
 	suiteCrs := []client.Object{
-		// HW plugin test namespace
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ctlrutils.UnitTestHwmgrNamespace,
-			},
-		},
-		// oran-o2ims
+		// oran-o2ims operator namespace
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: constants.DefaultNamespace,
@@ -187,7 +180,7 @@ var _ = BeforeSuite(func() {
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-hwmgr-auth-secret",
-				Namespace: testHwMgrPluginNameSpace,
+				Namespace: constants.DefaultNamespace,
 			},
 			Type: corev1.SecretTypeOpaque,
 			Data: map[string][]byte{
@@ -198,7 +191,7 @@ var _ = BeforeSuite(func() {
 		// HardwarePlugin CRs
 		&hwmgmtv1alpha1.HardwarePlugin{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: testHwMgrPluginNameSpace,
+				Namespace: constants.DefaultNamespace,
 				Name:      testHardwarePluginRef,
 			},
 			Spec: hwmgmtv1alpha1.HardwarePluginSpec{
@@ -219,7 +212,7 @@ var _ = BeforeSuite(func() {
 	// Update HardwarePlugin status to mark it as registered
 	mockHwPlugin := &hwmgmtv1alpha1.HardwarePlugin{}
 	err = K8SClient.Get(context.Background(), types.NamespacedName{
-		Namespace: testHwMgrPluginNameSpace,
+		Namespace: constants.DefaultNamespace,
 		Name:      testHardwarePluginRef,
 	}, mockHwPlugin)
 	Expect(err).ToNot(HaveOccurred())
@@ -631,7 +624,7 @@ defaultHugepagesSize: "1G"`,
 
 			// Now provision the NodeAllocationRequest to complete hardware provisioning
 			currentNp := &pluginsv1alpha1.NodeAllocationRequest{}
-			Expect(K8SClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ctlrutils.UnitTestHwmgrNamespace}, currentNp)).To(Succeed())
+			Expect(K8SClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: constants.DefaultNamespace}, currentNp)).To(Succeed())
 			currentNp.Status.Conditions = []metav1.Condition{
 				{
 					Status:             metav1.ConditionTrue,

--- a/test/utils/functions.go
+++ b/test/utils/functions.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
@@ -182,10 +183,10 @@ func DownloadFile(rawUrl, filename, dirpath string) error {
 }
 
 func CreateNodeResources(ctx context.Context, c client.Client, npName string) {
-	node := CreateNode(MasterNodeName, "idrac-virtualmedia+https://10.16.2.1/redfish/v1/Systems/System.Embedded.1", "bmc-secret", "controller", ctlrutils.UnitTestHwmgrNamespace, npName, nil)
+	node := CreateNode(MasterNodeName, "idrac-virtualmedia+https://10.16.2.1/redfish/v1/Systems/System.Embedded.1", "bmc-secret", "controller", constants.DefaultNamespace, npName, nil)
 	// Create both the standard secret and the mock server expected secrets
 	secretNames := []string{BmcSecretName, "test-node-1-bmc-secret", "master-node-2-bmc-secret"}
-	secrets := CreateSecrets(secretNames, ctlrutils.UnitTestHwmgrNamespace)
+	secrets := CreateSecrets(secretNames, constants.DefaultNamespace)
 	CreateResources(ctx, c, []*pluginsv1alpha1.AllocatedNode{node}, secrets)
 }
 


### PR DESCRIPTION
# Summary

This PR refactors namespace handling in the oran-o2ims project by consolidating `HWMGR_PLUGIN_NAMESPACE` into `OCLOUD_MANAGER_NAMESPACE`. It removes hardcoded namespace references and cleans up deprecated namespace utility functions to ensure all operator resources are consistently deployed in the same namespace.

Resolves: [OCPBUGS-63350](https://issues.redhat.com/browse/OCPBUGS-63350)

/cc @donpenney @browsell