### PR TITLE
Update OCP documentation links to latest versions

### DIFF
--- a/docs/user-guide/environment-setup.md
+++ b/docs/user-guide/environment-setup.md
@@ -213,7 +213,7 @@ configuration requirements.
 
    > :warning: Do this only if the cluster proxy isn't currently pointing to some other custom CA bundle. If it is
    > pointing to an existing bundle, then the new private certificates need to be appended to the existing set. Refer to
-   > the [OpenShift Configuring a custom PKI documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/configuring_network_settings/configuring-a-custom-pki)
+   > the [OpenShift Configuring a custom PKI documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/configuring_network_settings/configuring-a-custom-pki)
    > for more details.
 
    ```console

--- a/docs/user-guide/gitops-layout-and-setup.md
+++ b/docs/user-guide/gitops-layout-and-setup.md
@@ -51,7 +51,7 @@ or extracted from the [ztp-site-generate](https://catalog.redhat.com/software/co
 
 ## Full DU profile
 
-For configuring an SNO with a full DU profile according to the [4.19 RAN RDS](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-du-reference-configuration-crs),
+For configuring an SNO with a full DU profile according to the [4.19 RAN RDS](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-du-reference-configuration-crs),
 the following main samples can be used as a starting example:
 
 * [ClusterInstance defaults ConfigMap](./samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-full-du/clusterinstance-defaults-full-du-v1.yaml)

--- a/docs/user-guide/ibi-based-cluster-provisioning.md
+++ b/docs/user-guide/ibi-based-cluster-provisioning.md
@@ -37,7 +37,7 @@ Some of the key benefits of using IBI provisioning are:
 * Reduced network bandwidth requirements for remote deployments
 * Simplified deployment process for edge environments
 
-For additional details, see the [Red Hat OpenShift Image-Based Installation documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/edge_computing/image-based-installation-for-single-node-openshift).
+For additional details, see the [Red Hat OpenShift Image-Based Installation documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/edge_computing/image-based-installation-for-single-node-openshift).
 
 ## IBI Workflow Overview
 

--- a/docs/user-guide/prereqs.md
+++ b/docs/user-guide/prereqs.md
@@ -52,7 +52,7 @@ client present a certificate.
 
 To configure the primary controller to enable mTLS the following attributes must be set in the `clientTLS` section of
 the `spec`. For more information, please refer to the
-[Ingress Operator in OpenShift Container Platform documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking_operators/configuring-ingress#configuring-ingress-controller-tls).
+[Ingress Operator in OpenShift Container Platform documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/networking_operators/configuring-ingress#configuring-ingress-controller-tls).
 
 ```yaml
 apiVersion: operator.openshift.io/v1


### PR DESCRIPTION
This PR updates OpenShift Container Platform documentation URLs to point to the latest available versions.

## Changes
- Automatically updated OCP documentation links using [ocp-doc-checker](https://github.com/sebrandon1/ocp-doc-checker)
- All documentation URLs now point to current versions

## Tool Information
This PR was created automatically by scanning the repository with `ocp-doc-checker`, which identifies and updates outdated OpenShift documentation links.

Repository: https://github.com/sebrandon1/ocp-doc-checker

---

**Tracking Issue:** https://github.com/sebrandon1/ocp-doc-checker/issues/21