### PR TITLE
OCPBUGS-61673: fix(metal3-plugin): Handle AllocatedNode deletion when BMH is manuall…

### DIFF
--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager_test.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager_test.go
@@ -74,7 +74,8 @@ import (
 )
 
 const (
-	nonexistentBMHID = "nonexistent-bmh"
+	nonexistentBMHID        = "nonexistent-bmh"
+	nonexistentBMHNamespace = "nonexistent-namespace"
 )
 
 var _ = Describe("BareMetalHost Manager", func() {

--- a/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller.go
+++ b/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller.go
@@ -151,6 +151,13 @@ func (r *AllocatedNodeReconciler) handleAllocatedNodeDeletion(ctx context.Contex
 	r.Logger.InfoContext(ctx, "handleAllocatedNodeDeletion", slog.String("node", allocatednode.Name))
 	bmh, err := getBMHForNode(ctx, r.NoncachedClient, allocatednode)
 	if err != nil {
+		// If BMH is not found (e.g., manually deleted), allow the AllocatedNode deletion to proceed
+		if errors.IsNotFound(err) {
+			r.Logger.InfoContext(ctx, "BMH not found, assuming manually deleted — proceeding with AllocatedNode deletion",
+				slog.String("node", allocatednode.Name),
+				slog.String("bmh", allocatednode.Spec.HwMgrNodeId))
+			return true, nil
+		}
 		return true, fmt.Errorf("failed to get BMH for node %s: %w", allocatednode.Name, err)
 	}
 

--- a/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller_test.go
+++ b/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller_test.go
@@ -630,28 +630,28 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 		})
 
 		Context("when BMH does not exist", func() {
-			It("should return error", func() {
-				// Delete the BMH
+			It("should proceed with deletion gracefully", func() {
+				// Delete the BMH to simulate it being manually deleted
 				Expect(fakeClient.Delete(ctx, bmh)).To(Succeed())
 
 				completed, err := reconciler.handleAllocatedNodeDeletion(ctx, allocatedNode)
 
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to get BMH for node"))
+				// Should complete successfully without error when BMH is not found
+				Expect(err).NotTo(HaveOccurred())
 				Expect(completed).To(BeTrue()) // Returns true to indicate we should proceed with finalizer removal
 			})
 		})
 
 		Context("when node has invalid BMH reference", func() {
-			It("should return error", func() {
-				// Set invalid BMH reference
+			It("should proceed with deletion gracefully", func() {
+				// Set invalid BMH reference to a non-existent BMH
 				allocatedNode.Spec.HwMgrNodeId = nonexistentBMHID
-				allocatedNode.Spec.HwMgrNodeNs = "nonexistent-namespace"
+				allocatedNode.Spec.HwMgrNodeNs = nonexistentBMHNamespace
 
 				completed, err := reconciler.handleAllocatedNodeDeletion(ctx, allocatedNode)
 
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to get BMH for node"))
+				// Should complete successfully without error when BMH is not found
+				Expect(err).NotTo(HaveOccurred())
 				Expect(completed).To(BeTrue())
 			})
 		})


### PR DESCRIPTION
…y deleted

When an AllocatedNode is being deleted, the controller now gracefully handles the case where the associated BareMetalHost (BMH) has already been manually deleted. Previously, the deletion would fail with an error when the BMH could not be found.

Changes:
- Updated handleAllocatedNodeDeletion() to check for NotFound errors when retrieving the BMH and proceed with deletion gracefully
- Added informative logging when BMH is not found during deletion
- Updated test cases to verify deletion succeeds when BMH is missing
- Defined test constants nonexistentBMHID and nonexistentBMHNamespace in baremetalhost_manager_test.go for reuse across test files

This fix ensures that AllocatedNode resources can be properly cleaned up even when their associated BMH resources have been removed out-of-band.

Fixes: AllocatedNode deletion failures when BMH is manually deleted

Assisted-By: Claude <noreply@anthropic.com>