### PR TITLE
OCPBUGS-65758: Use service account token for alertmanager API authentication

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1694,14 +1694,6 @@ spec:
           - update
           - watch
         - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
           - siteconfig.open-cluster-management.io
           resources:
           - clusterinstances

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -376,14 +376,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - siteconfig.open-cluster-management.io
   resources:
   - clusterinstances

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -73,7 +73,6 @@ import (
 //+kubebuilder:rbac:urls="/o2ims-infrastructureCluster/v1/alarmDictionaries/*",verbs=get
 //+kubebuilder:rbac:urls="/hardware-manager/inventory/*",verbs=get;list
 //+kubebuilder:rbac:groups="batch",resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=clcm.openshift.io,resources=hardwareplugins,verbs=get;list;watch;create;update;patch;delete
@@ -1284,6 +1283,22 @@ func (t *reconcilerTask) createAlarmServerClusterRole(ctx context.Context) error
 				},
 			},
 			{
+				// Required for ACM Observability API authentication.
+				// The oauth-proxy in front of alertmanager validates that the service account
+				// token has at least "get namespaces" permission before granting API access.
+				// This is an ACM authentication requirement - our code doesn't actually call
+				// Get on namespace resources.
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"namespaces",
+				},
+				Verbs: []string{
+					"get",
+				},
+			},
+			{
 				APIGroups: []string{
 					"",
 				},
@@ -1341,22 +1356,6 @@ func (t *reconcilerTask) createAlarmServerClusterRole(ctx context.Context) error
 					"delete",
 					"update",
 					"patch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"route.openshift.io",
-				},
-				Resources: []string{
-					"routes",
-				},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-				ResourceNames: []string{
-					"alertmanager",
 				},
 			},
 			{


### PR DESCRIPTION
Switch from ACM's observability-alertmanager-accessor secret to pod's own service account token for alertmanager API access. Add required "get namespaces" RBAC permission for ACM oauth-proxy authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

/cc @alegacy 