### PR TITLE
OCPBUGS-66080: Use url.JoinPath to prevent double slashes in URLs

### DIFF
--- a/hwmgr-plugins/api/client/utils/auth.go
+++ b/hwmgr-plugins/api/client/utils/auth.go
@@ -9,7 +9,7 @@ package utils
 import (
 	"context"
 	"fmt"
-	"strings"
+	"net/url"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -112,17 +112,17 @@ func SetupOAuthConfig(ctx context.Context, c client.Client, authClientConfig *co
 		return fmt.Errorf("failed to get '%s' from OAuth secret: %w", ctlrutils.OAuthClientSecretField, err)
 	}
 
+	tokenURL, err := url.JoinPath(oauthConf.URL, oauthConf.TokenEndpoint)
+	if err != nil {
+		return fmt.Errorf("failed to construct token URL: %w", err)
+	}
+
 	config.OAuthConfig = &ctlrutils.OAuthConfig{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		TokenURL:     BuildTokenURL(oauthConf.URL, oauthConf.TokenEndpoint),
+		TokenURL:     tokenURL,
 		Scopes:       oauthConf.Scopes,
 	}
 
 	return nil
-}
-
-// BuildTokenURL constructs the token URL from base URL and token endpoint
-func BuildTokenURL(baseURL, tokenEndpoint string) string {
-	return strings.TrimSuffix(baseURL, "/") + "/" + strings.TrimPrefix(tokenEndpoint, "/")
 }

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +25,6 @@ import (
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 // createOrUpdateNodeAllocationRequest creates a new NodeAllocationRequest resource if it doesn't exist or updates it if the spec has changed.
@@ -748,7 +748,10 @@ func (t *provisioningRequestReconcilerTask) buildNodeAllocationRequest(clusterIn
 		return nil, fmt.Errorf("failed to get %s from templateParameters: %w", ctlrutils.TemplateParamNodeClusterName, err)
 	}
 
-	callbackURL := t.callbackConfig.BuildCallbackURL(t.object.Name)
+	callbackURL, err := t.callbackConfig.BuildCallbackURL(t.object.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build callback url: %w", err)
+	}
 
 	nodeAllocationRequest := &hwmgrpluginapi.NodeAllocationRequest{}
 	nodeAllocationRequest.Site = siteID.(string)

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -969,9 +969,13 @@ func NewNarCallbackConfig(port int) *NarCallbackConfig {
 }
 
 // BuildCallbackURL constructs the callback URL for a given provisioning request name
-func (c *NarCallbackConfig) BuildCallbackURL(prName string) string {
-	return fmt.Sprintf("https://%s.%s.%s:%d%s/%s",
-		c.ServiceName, c.ServiceNamespace, constants.ClusterLocalDomain, c.Port, constants.NarCallbackServicePath, prName)
+func (c *NarCallbackConfig) BuildCallbackURL(prName string) (string, error) {
+	host := fmt.Sprintf("%s.%s.%s:%d", c.ServiceName, c.ServiceNamespace, constants.ClusterLocalDomain, c.Port)
+	path, err := url.JoinPath(constants.NarCallbackServicePath, prName)
+	if err != nil {
+		return "", err // nolint: wrapcheck
+	}
+	return fmt.Sprintf("https://%s%s", host, path), nil
 }
 
 // ExtractPortFromAddress extracts the port number from an address string like ":8090" or "0.0.0.0:8090"

--- a/internal/service/common/utils/config.go
+++ b/internal/service/common/utils/config.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 
 	"github.com/kelseyhightower/envconfig"
@@ -214,8 +215,13 @@ func (c *CommonServerConfig) CreateOAuthConfig(ctx context.Context) (*ctlrutils.
 		go dynamicClientCert.Run(ctx, 1)
 	}
 
+	tokenURL, err := url.JoinPath(c.OAuth.IssuerURL, c.OAuth.TokenEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct token URL: %w", err)
+	}
+
 	config.OAuthConfig = &ctlrutils.OAuthConfig{
-		TokenURL:     fmt.Sprintf("%s/%s", c.OAuth.IssuerURL, c.OAuth.TokenEndpoint),
+		TokenURL:     tokenURL,
 		ClientID:     c.OAuth.ClientID,
 		ClientSecret: c.OAuth.ClientSecret,
 		Scopes:       c.OAuth.Scopes,


### PR DESCRIPTION
Replace manual URL path concatenation with url.JoinPath to avoid double slash issues when base URLs or path segments have trailing or leading slashes. This affects OAuth token URLs, callback URLs, and API reference URLs across multiple services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)