### PR TITLE
CNF-20351: Handle Thanos rules edge cases

### DIFF
--- a/internal/service/cluster/db/repo/generated/mock_repo.generated.go
+++ b/internal/service/cluster/db/repo/generated/mock_repo.generated.go
@@ -466,6 +466,21 @@ func (mr *MockRepositoryInterfaceMockRecorder) GetSubscriptions(arg0 any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubscriptions", reflect.TypeOf((*MockRepositoryInterface)(nil).GetSubscriptions), arg0)
 }
 
+// GetThanosAlarmDefinitions mocks base method.
+func (m *MockRepositoryInterface) GetThanosAlarmDefinitions(arg0 context.Context) ([]models.AlarmDefinition, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetThanosAlarmDefinitions", arg0)
+	ret0, _ := ret[0].([]models.AlarmDefinition)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetThanosAlarmDefinitions indicates an expected call of GetThanosAlarmDefinitions.
+func (mr *MockRepositoryInterfaceMockRecorder) GetThanosAlarmDefinitions(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThanosAlarmDefinitions", reflect.TypeOf((*MockRepositoryInterface)(nil).GetThanosAlarmDefinitions), arg0)
+}
+
 // SetNodeClusterID mocks base method.
 func (m *MockRepositoryInterface) SetNodeClusterID(arg0 context.Context, arg1 string, arg2 uuid.UUID) (int, error) {
 	m.ctrl.T.Helper()

--- a/internal/service/cluster/db/repo/repository_interface.go
+++ b/internal/service/cluster/db/repo/repository_interface.go
@@ -35,6 +35,7 @@ type RepositoryInterface interface {
 	UpsertAlarmDefinitions(context.Context, []models.AlarmDefinition) ([]models.AlarmDefinition, error)
 	DeleteAlarmDefinitionsNotIn(context.Context, []any, uuid.UUID) (int64, error)
 	GetAlarmDefinitionsByAlarmDictionaryID(context.Context, uuid.UUID) ([]models.AlarmDefinition, error)
+	GetThanosAlarmDefinitions(context.Context) ([]models.AlarmDefinition, error)
 	FindStaleAlarmDictionaries(context.Context, uuid.UUID, int) ([]models.AlarmDictionary, error)
 	GetNodeClusterTypeAlarmDictionary(context.Context, uuid.UUID) ([]models.AlarmDictionary, error)
 	GetAlarmDictionaries(context.Context) ([]models.AlarmDictionary, error)


### PR DESCRIPTION
Thanos rules are applicable for all clusters (unlike the usual PromRules) which gets propagated and handled by ACM. 

  - Add clusterID label fallback for Thanos/ACM alerts that don't use managed_cluster label
  - Add ACM severity mappings: "important" -> MAJOR, "moderate" -> WARNING
  - Expand templated severity rules (e.g., ViolatedPolicyReport) into static alarm definitions for each severity level
  - Include Thanos alarm definitions in GetAlarmDictionary/GetAlarmDictionaries API responses so alarms-server can lookup alarm_definition_id
  - Document getFilteredRules deduplication logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)