### PR TITLE
CNF-20721: Fix spurious quotes around CPE label

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -262,7 +262,7 @@ spec:
             - distribution-scope=public
             - io.k8s.description=o-cloud-manager
             - release=4.21
-            - cpe="cpe:/a:redhat:openshift:4.21::el9"
+            - cpe=cpe:/a:redhat:openshift:4.21::el9
             - 'url=https://github.com/openshift-kni/oran-o2ims'
             - 'vendor=Red Hat, Inc.'
             - io.k8s.display-name=o-cloud-manager


### PR DESCRIPTION
- We should not use additional quotes when adding labels in the .tekton yaml files
- This causes additional escaped quotes to be incorrectly added to the strings