### PR TITLE
fix: delete IBI DataImage CR after cluster provisioning completes

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1599,6 +1599,14 @@ spec:
         - apiGroups:
           - metal3.io
           resources:
+          - dataimages
+          verbs:
+          - delete
+          - get
+          - list
+        - apiGroups:
+          - metal3.io
+          resources:
           - firmwareschemas
           - hardwaredata
           verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -246,6 +246,14 @@ rules:
 - apiGroups:
   - metal3.io
   resources:
+  - dataimages
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
+  - metal3.io
+  resources:
   - firmwareschemas
   - hardwaredata
   verbs:

--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
@@ -1451,3 +1451,32 @@ func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slo
 
 	return nil
 }
+
+// deleteDataImageIfExists deletes the DataImage CR matching the given BMH name/namespace,
+// if it exists. The IBI operator creates a DataImage during installation but never cleans
+// it up. If left around, BMO will spuriously re-mount the virtual media after firmware
+// updates complete, because it sees Spec.URL != Status.AttachedImage.URL and blindly
+// re-attaches. This causes stuck finalizers during deprovisioning.
+func deleteDataImageIfExists(ctx context.Context, c client.Client, logger *slog.Logger, bmhName, bmhNamespace string) error {
+	dataImage := &metal3v1alpha1.DataImage{}
+	key := types.NamespacedName{Name: bmhName, Namespace: bmhNamespace}
+
+	if err := c.Get(ctx, key, dataImage); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get DataImage %s/%s: %w", bmhNamespace, bmhName, err)
+	}
+
+	logger.InfoContext(ctx, "Deleting DataImage to prevent spurious re-mount after firmware updates",
+		slog.String("dataimage", bmhName), slog.String("namespace", bmhNamespace))
+
+	if err := c.Delete(ctx, dataImage); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete DataImage %s/%s: %w", bmhNamespace, bmhName, err)
+	}
+
+	return nil
+}

--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
@@ -1454,22 +1454,16 @@ func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slo
 
 // deleteDataImageIfExists deletes the DataImage CR matching the given BMH name/namespace,
 // if it exists. The IBI operator creates a DataImage during installation but never cleans
-// it up. If left around, BMO will spuriously re-mount the virtual media after firmware
-// updates complete, because it sees Spec.URL != Status.AttachedImage.URL and blindly
-// re-attaches. This causes stuck finalizers during deprovisioning.
+// it up. If left around, BMO will spuriously re-mount the virtual media during BMH status
+// transitions (e.g. day-2 firmware updates). This causes stuck finalizers during
+// deprovisioning.
 func deleteDataImageIfExists(ctx context.Context, c client.Client, logger *slog.Logger, bmhName, bmhNamespace string) error {
-	dataImage := &metal3v1alpha1.DataImage{}
-	key := types.NamespacedName{Name: bmhName, Namespace: bmhNamespace}
-
-	if err := c.Get(ctx, key, dataImage); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to get DataImage %s/%s: %w", bmhNamespace, bmhName, err)
+	dataImage := &metal3v1alpha1.DataImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bmhName,
+			Namespace: bmhNamespace,
+		},
 	}
-
-	logger.InfoContext(ctx, "Deleting DataImage to prevent spurious re-mount after firmware updates",
-		slog.String("dataimage", bmhName), slog.String("namespace", bmhNamespace))
 
 	if err := c.Delete(ctx, dataImage); err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -1477,6 +1471,9 @@ func deleteDataImageIfExists(ctx context.Context, c client.Client, logger *slog.
 		}
 		return fmt.Errorf("failed to delete DataImage %s/%s: %w", bmhNamespace, bmhName, err)
 	}
+
+	logger.InfoContext(ctx, "Deleted DataImage to prevent spurious re-mount after firmware updates",
+		slog.String("dataimage", bmhName), slog.String("namespace", bmhNamespace))
 
 	return nil
 }

--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager_test.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager_test.go
@@ -1421,4 +1421,40 @@ var _ = Describe("BareMetalHost Manager", func() {
 			Expect(updating).To(BeTrue()) // BMHs are not Available yet
 		})
 	})
+
+	Describe("deleteDataImageIfExists", func() {
+		const testNs = "test-dataimage-ns"
+		var fakeClient client.Client
+
+		BeforeEach(func() {
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+		})
+
+		It("should delete an existing DataImage", func() {
+			dataImage := &metal3v1alpha1.DataImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bmh",
+					Namespace: testNs,
+				},
+				Spec: metal3v1alpha1.DataImageSpec{
+					URL: "https://example.com/image.iso",
+				},
+			}
+			Expect(fakeClient.Create(ctx, dataImage)).To(Succeed())
+
+			err := deleteDataImageIfExists(ctx, fakeClient, logger, "test-bmh", testNs)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify it was deleted
+			result := &metal3v1alpha1.DataImage{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: testNs}, result)
+			Expect(err).To(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
+		})
+
+		It("should succeed when no DataImage exists", func() {
+			err := deleteDataImageIfExists(ctx, fakeClient, logger, "nonexistent-bmh", testNs)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })

--- a/hwmgr-plugins/metal3/controller/helpers.go
+++ b/hwmgr-plugins/metal3/controller/helpers.go
@@ -128,6 +128,14 @@ func enableBMOManagementForIBINodes(
 
 		bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 
+		// Delete the DataImage CR (if it exists) before removing the detached annotation.
+		// The IBI operator creates a DataImage during installation but never deletes it.
+		// If left around, BMO will spuriously re-mount the virtual media after firmware
+		// updates, which causes stuck finalizers during deprovisioning.
+		if err := deleteDataImageIfExists(ctx, c, logger, bmh.Name, bmh.Namespace); err != nil {
+			return fmt.Errorf("failed to delete DataImage for BMH %s: %w", bmh.Name, err)
+		}
+
 		if !bmh.Spec.Online {
 			logger.InfoContext(ctx, "Setting BMH online=true for IBI post-provisioning",
 				slog.String("bmh", bmh.Name))

--- a/hwmgr-plugins/metal3/controller/metal3_nodeallocationrequest_controller.go
+++ b/hwmgr-plugins/metal3/controller/metal3_nodeallocationrequest_controller.go
@@ -214,6 +214,7 @@ func (r *NodeAllocationRequestReconciler) SetupIndexer(ctx context.Context) erro
 //+kubebuilder:rbac:groups=metal3.io,resources=hostfirmwaresettings,verbs=get;create;list;watch;update;patch
 //+kubebuilder:rbac:groups=metal3.io,resources=hostfirmwarecomponents,verbs=get;create;list;watch;update;patch
 //+kubebuilder:rbac:groups=metal3.io,resources=hostupdatepolicies,verbs=get;create;list;watch;update;patch
+//+kubebuilder:rbac:groups=metal3.io,resources=dataimages,verbs=get;list;delete
 //+kubebuilder:rbac:groups=metal3.io,resources=firmwareschemas,verbs=get;list;watch
 //+kubebuilder:rbac:groups=metal3.io,resources=hardwaredata,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;create;update;patch;watch

--- a/internal/controllers/metal3plugin_server_setup.go
+++ b/internal/controllers/metal3plugin_server_setup.go
@@ -259,6 +259,19 @@ func (t *reconcilerTask) createMetal3PluginServerClusterRole(ctx context.Context
 					"metal3.io",
 				},
 				Resources: []string{
+					"dataimages",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"delete",
+				},
+			},
+			{
+				APIGroups: []string{
+					"metal3.io",
+				},
+				Resources: []string{
 					"firmwareschemas",
 					"hardwaredata",
 				},


### PR DESCRIPTION
The IBI operator creates a DataImage CR during installation but never deletes it. When BMO reconciles BMH status changes during day-2 firmware updates, it re-mounts the DataImage virtual media ISO. This causes stuck finalizers during deprovisioning because BMO never ejects the re-mounted media.

Delete the DataImage CR (if it exists) during IBI post-provisioning setup, before removing the detached annotation. This prevents the spurious re-mount without requiring upstream BMO changes.