### PR TITLE
fix: preserve and restore original preprovisioningNetworkDataName

### DIFF
--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
@@ -1173,7 +1173,6 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 						slog.String("original", origValue))
 					patched.Spec.PreprovisioningNetworkDataName = origValue
 				}
-				delete(patched.Annotations, OrigNetworkDataAnnotation)
 			} else if patched.Spec.PreprovisioningNetworkDataName == "" {
 				// Fallback for upgrade scenario: if the annotation doesn't exist (BMH was
 				// allocated by an older operator version that cleared the field), check if
@@ -1197,6 +1196,11 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 			// Clear image reference
 			patched.Spec.Image = nil
 		}
+
+		// Always clear the origNetworkData annotation at the deallocation boundary
+		// to prevent stale values leaking into the next allocation cycle.
+		delete(patched.Annotations, OrigNetworkDataAnnotation)
+
 		if !skipCleanup && (current.Status.Provisioning.State == metal3v1alpha1.StateProvisioned ||
 			current.Status.Provisioning.State == metal3v1alpha1.StateExternallyProvisioned) {
 			// Wipe partition tables using automated cleaning

--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
@@ -59,6 +59,7 @@ const (
 	OpAdd                                    = "add"
 	OpRemove                                 = "remove"
 	BmhServicingErr                          = "BMH Servicing Error"
+	OrigNetworkDataAnnotation                = "clcm.openshift.io/origNetworkData"
 	IBIWarningAnnotation                     = "clcm.openshift.io/ibi-warning"
 	IBIWarningMessage                        = "Warning - this node was used for IBI and has been deprovisioned. BMH deletion and IBI reinstall is required before it can be used in a new cluster"
 )
@@ -1161,10 +1162,23 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 		if !skipCleanup {
 			// Clear CustomDeploy entirely
 			patched.Spec.CustomDeploy = nil
-			// Restore PreprovisioningNetworkDataName if it was cleared by a previous
-			// operator version during allocation. Only restore if the field is empty
-			// and a Secret with the expected name exists.
-			if patched.Spec.PreprovisioningNetworkDataName == "" {
+			// Restore PreprovisioningNetworkDataName from the saved annotation if it
+			// differs from the current value. During IBI provisioning, the field gets
+			// overwritten with a secret that is deleted during deprovisioning.
+			if origValue, exists := patched.Annotations[OrigNetworkDataAnnotation]; exists {
+				if patched.Spec.PreprovisioningNetworkDataName != origValue {
+					logger.InfoContext(ctx, "Restoring PreprovisioningNetworkDataName from annotation",
+						slog.String("bmh", bmh.Name),
+						slog.String("current", patched.Spec.PreprovisioningNetworkDataName),
+						slog.String("original", origValue))
+					patched.Spec.PreprovisioningNetworkDataName = origValue
+				}
+				delete(patched.Annotations, OrigNetworkDataAnnotation)
+			} else if patched.Spec.PreprovisioningNetworkDataName == "" {
+				// Fallback for upgrade scenario: if the annotation doesn't exist (BMH was
+				// allocated by an older operator version that cleared the field), check if
+				// a Secret with the legacy naming convention exists and restore it.
+				// TODO: Remove this fallback once upgrade-breaking changes are introduced.
 				expectedSecretName := BmhNetworkDataPrefx + "-" + bmh.Name
 				secret := &corev1.Secret{}
 				if err := c.Get(ctx, types.NamespacedName{
@@ -1175,7 +1189,7 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 					}
 				} else {
 					patched.Spec.PreprovisioningNetworkDataName = expectedSecretName
-					logger.InfoContext(ctx, "Restored PreprovisioningNetworkDataName",
+					logger.InfoContext(ctx, "Restored PreprovisioningNetworkDataName from legacy secret",
 						slog.String("bmh", bmh.Name),
 						slog.String("secretName", expectedSecretName))
 				}
@@ -1207,6 +1221,25 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 			slog.String("bmh", name.String()))
 		return nil
 	})
+}
+
+// saveOrigNetworkData saves the current PreprovisioningNetworkDataName value in an annotation
+// on the BMH so it can be restored during deprovisioning. IBI provisioning overwrites this
+// field with a secret that gets deleted when the cluster is deprovisioned.
+func saveOrigNetworkData(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
+	// Skip if the annotation already exists (re-entrant safety)
+	if _, exists := bmh.Annotations[OrigNetworkDataAnnotation]; exists {
+		return nil
+	}
+
+	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
+	value := bmh.Spec.PreprovisioningNetworkDataName
+
+	logger.InfoContext(ctx, "Saving original PreprovisioningNetworkDataName",
+		slog.String("bmh", bmh.Name), slog.String("value", value))
+
+	return updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation,
+		OrigNetworkDataAnnotation, value, OpAdd)
 }
 
 // deallocateBMH deallocates a BareMetalHost that is no longer associated with a cluster deployment.

--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager_test.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager_test.go
@@ -865,8 +865,58 @@ var _ = Describe("BareMetalHost Manager", func() {
 			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(Equal("old-network-data"))
 		})
 
-		It("should restore PreprovisioningNetworkDataName when empty and secret exists", func() {
+		It("should restore PreprovisioningNetworkDataName from annotation when overwritten", func() {
+			// Simulate IBI overwriting the field while the annotation holds the original
+			bmh.Spec.PreprovisioningNetworkDataName = "ibi-generated-secret"
+			bmh.Annotations[OrigNetworkDataAnnotation] = "original-network-data"
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
+
+			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			var updatedBMH metal3v1alpha1.BareMetalHost
+			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
+			err = fakeClient.Get(ctx, name, &updatedBMH)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(Equal("original-network-data"))
+			_, hasAnnotation := updatedBMH.Annotations[OrigNetworkDataAnnotation]
+			Expect(hasAnnotation).To(BeFalse())
+		})
+
+		It("should restore empty PreprovisioningNetworkDataName from annotation", func() {
+			// Simulate IBI overwriting a field that was originally empty
+			bmh.Spec.PreprovisioningNetworkDataName = "ibi-generated-secret"
+			bmh.Annotations[OrigNetworkDataAnnotation] = ""
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
+
+			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			var updatedBMH metal3v1alpha1.BareMetalHost
+			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
+			err = fakeClient.Get(ctx, name, &updatedBMH)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(BeEmpty())
+		})
+
+		It("should not modify PreprovisioningNetworkDataName when no annotation exists", func() {
+			bmh.Spec.PreprovisioningNetworkDataName = "some-network-data"
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
+
+			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			var updatedBMH metal3v1alpha1.BareMetalHost
+			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
+			err = fakeClient.Get(ctx, name, &updatedBMH)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(Equal("some-network-data"))
+		})
+
+		It("should restore PreprovisioningNetworkDataName from legacy secret when no annotation and field is empty", func() {
+			// Upgrade scenario: allocated by older operator that cleared the field
 			bmh.Spec.PreprovisioningNetworkDataName = ""
+			delete(bmh.Annotations, OrigNetworkDataAnnotation)
 			expectedSecretName := BmhNetworkDataPrefx + "-" + bmh.Name
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -886,8 +936,9 @@ var _ = Describe("BareMetalHost Manager", func() {
 			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(Equal(expectedSecretName))
 		})
 
-		It("should leave PreprovisioningNetworkDataName empty when empty and no secret exists", func() {
+		It("should leave PreprovisioningNetworkDataName empty when no annotation and no legacy secret", func() {
 			bmh.Spec.PreprovisioningNetworkDataName = ""
+			delete(bmh.Annotations, OrigNetworkDataAnnotation)
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
@@ -1419,6 +1470,57 @@ var _ = Describe("BareMetalHost Manager", func() {
 			updating, err := handleBMHCompletion(ctx, fakeClient, fakeClient, logger, pluginNs, nodelist)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updating).To(BeTrue()) // BMHs are not Available yet
+		})
+	})
+
+	Describe("saveOrigNetworkData", func() {
+		const testNs = "test-save-networkdata-ns"
+		var fakeClient client.Client
+
+		BeforeEach(func() {
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+		})
+
+		It("should save the current PreprovisioningNetworkDataName as an annotation", func() {
+			bmh := createBMH("test-bmh", testNs, nil, map[string]string{}, metal3v1alpha1.StateAvailable)
+			bmh.Spec.PreprovisioningNetworkDataName = "my-network-data"
+			Expect(fakeClient.Create(ctx, bmh)).To(Succeed())
+
+			err := saveOrigNetworkData(ctx, fakeClient, logger, bmh)
+			Expect(err).ToNot(HaveOccurred())
+
+			var updated metal3v1alpha1.BareMetalHost
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: testNs}, &updated)).To(Succeed())
+			Expect(updated.Annotations[OrigNetworkDataAnnotation]).To(Equal("my-network-data"))
+		})
+
+		It("should save empty string when PreprovisioningNetworkDataName is not set", func() {
+			bmh := createBMH("test-bmh", testNs, nil, map[string]string{}, metal3v1alpha1.StateAvailable)
+			Expect(fakeClient.Create(ctx, bmh)).To(Succeed())
+
+			err := saveOrigNetworkData(ctx, fakeClient, logger, bmh)
+			Expect(err).ToNot(HaveOccurred())
+
+			var updated metal3v1alpha1.BareMetalHost
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: testNs}, &updated)).To(Succeed())
+			val, exists := updated.Annotations[OrigNetworkDataAnnotation]
+			Expect(exists).To(BeTrue())
+			Expect(val).To(BeEmpty())
+		})
+
+		It("should not overwrite annotation if already set", func() {
+			bmh := createBMH("test-bmh", testNs, nil, map[string]string{
+				OrigNetworkDataAnnotation: "original-value",
+			}, metal3v1alpha1.StateAvailable)
+			bmh.Spec.PreprovisioningNetworkDataName = "new-value"
+			Expect(fakeClient.Create(ctx, bmh)).To(Succeed())
+
+			err := saveOrigNetworkData(ctx, fakeClient, logger, bmh)
+			Expect(err).ToNot(HaveOccurred())
+
+			var updated metal3v1alpha1.BareMetalHost
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: testNs}, &updated)).To(Succeed())
+			Expect(updated.Annotations[OrigNetworkDataAnnotation]).To(Equal("original-value"))
 		})
 	})
 

--- a/hwmgr-plugins/metal3/controller/helpers.go
+++ b/hwmgr-plugins/metal3/controller/helpers.go
@@ -1533,6 +1533,13 @@ func allocateBMHToNodeAllocationRequest(
 		return "", fmt.Errorf("failed to add allocated label to BMH (%s): %w", bmh.Name, err)
 	}
 
+	// Save the original PreprovisioningNetworkDataName so it can be restored during
+	// deprovisioning. IBI provisioning overwrites this field with a secret that gets
+	// deleted when the cluster is deprovisioned, leaving a stale reference.
+	if err := saveOrigNetworkData(ctx, c, logger, bmh); err != nil {
+		return "", fmt.Errorf("failed to save original network data annotation on BMH (%s): %w", bmh.Name, err)
+	}
+
 	// Allow Host Management
 	if err := allowHostManagement(ctx, c, logger, bmh); err != nil {
 		return "", fmt.Errorf("failed to add host management annotation to BMH (%s): %w", bmh.Name, err)


### PR DESCRIPTION
During IBI provisioning, the BMH preprovisioningNetworkDataName field gets overwritten with a secret that is deleted during deprovisioning, leaving a stale reference that puts the BMH in an error state.

Save the original preprovisioningNetworkDataName value in a clcm.openshift.io/origNetworkData annotation on the BMH during resource allocation. During deprovisioning, restore the original value from the annotation if it differs from the current field value.

Includes a fallback for the upgrade scenario where the annotation doesn't exist (BMH was allocated by an older operator version): check for a legacy network-data-<bmhname> secret and restore from that.