### PR TITLE
Update minimum required OCP Platform and ACM release versions in prereqs.md

### DIFF
--- a/docs/user-guide/prereqs.md
+++ b/docs/user-guide/prereqs.md
@@ -16,12 +16,12 @@ SPDX-License-Identifier: Apache-2.0
 ### Platform
 
 - OpenShift Container Platform
-  - 4.20: 4.20.15 or newer
-  - 4.21: 4.21.2 or newer
+  - 4.20: 4.20.18 or newer
+  - 4.21: 4.21.9 or newer
 
 ### Required operators and add‑ons on the hub
 
-- Advanced Cluster Management (ACM) v2.14 or newer
+- Advanced Cluster Management (ACM) v2.15 or newer
   - SiteConfig Operator
 
     Enable SiteConfig in ACM by running the following command:


### PR DESCRIPTION
Updating minimum required OCP Platform release version, to versions with required change in BMO to enable IBI provisioning.
Also, as ACM 2.15 is available for both OCP 4.20 and 4.21, this minimum version has also been updated.