### PR TITLE
chore: add coderabbit-satisfied label configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,9 +13,11 @@ reviews:
   labeling_instructions:
     - label: "coderabbit-satisfied"
       instructions: >-
-        Apply this label only if all review comments have been resolved
-        and you are satisfied with the PR. Remove it if new issues are
-        found or unresolved comments remain.
+        Re-evaluate this label on every review pass, including
+        incremental reviews of new commits. Apply this label if all
+        review comments have been resolved and you are satisfied with
+        the PR. Remove it if new issues are found or unresolved
+        comments remain.
   pre_merge_checks:
     docstrings:
       mode: off

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,6 +9,13 @@ reviews:
         Focus on major issues impacting performance, readability,
         maintainability and security. Do not flag nitpicks. Do not
         suggest changes to pre-existing code that is not part of the diff.
+  auto_apply_labels: true
+  labeling_instructions:
+    - label: "coderabbit-satisfied"
+      instructions: >-
+        Apply this label only if all review comments have been resolved
+        and you are satisfied with the PR. Remove it if new issues are
+        found, unresolved comments remain, or new commits are pushed.
   pre_merge_checks:
     docstrings:
       mode: off

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,7 +15,7 @@ reviews:
       instructions: >-
         Apply this label only if all review comments have been resolved
         and you are satisfied with the PR. Remove it if new issues are
-        found, unresolved comments remain, or new commits are pushed.
+        found or unresolved comments remain.
   pre_merge_checks:
     docstrings:
       mode: off

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,13 +11,16 @@ reviews:
         suggest changes to pre-existing code that is not part of the diff.
   auto_apply_labels: true
   labeling_instructions:
+    # Note: resolving comments alone does not trigger a review pass.
+    # Use @coderabbitai review after resolving threads if immediate
+    # re-evaluation of the label is needed.
     - label: "coderabbit-satisfied"
       instructions: >-
         Re-evaluate this label on every review pass, including
-        incremental reviews of new commits and when comments are
-        resolved. Apply this label if all review comments have been
-        resolved and you are satisfied with the PR. Remove it if new
-        issues are found or unresolved comments remain.
+        incremental reviews of new commits. Apply this label if all
+        review comments have been resolved and you are satisfied with
+        the PR. Remove it if new issues are found or unresolved
+        comments remain.
   pre_merge_checks:
     docstrings:
       mode: off

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,10 +14,10 @@ reviews:
     - label: "coderabbit-satisfied"
       instructions: >-
         Re-evaluate this label on every review pass, including
-        incremental reviews of new commits. Apply this label if all
-        review comments have been resolved and you are satisfied with
-        the PR. Remove it if new issues are found or unresolved
-        comments remain.
+        incremental reviews of new commits and when comments are
+        resolved. Apply this label if all review comments have been
+        resolved and you are satisfied with the PR. Remove it if new
+        issues are found or unresolved comments remain.
   pre_merge_checks:
     docstrings:
       mode: off

--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
@@ -1490,10 +1490,15 @@ func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slo
 }
 
 // TODO: remove this test function — added temporarily to test coderabbit label behavior
-func testBadFunction(ctx context.Context, c client.Client, bmhName, bmhNamespace string) {
+func testBadFunction(ctx context.Context, c client.Client, bmhName, bmhNamespace string) error {
 	bmh := &metal3v1alpha1.BareMetalHost{}
-	c.Get(ctx, types.NamespacedName{Name: bmhName, Namespace: bmhNamespace}, bmh)
-	c.Delete(ctx, bmh)
+	if err := c.Get(ctx, types.NamespacedName{Name: bmhName, Namespace: bmhNamespace}, bmh); err != nil {
+		return fmt.Errorf("failed to get BMH %s/%s: %w", bmhNamespace, bmhName, err)
+	}
+	if err := c.Delete(ctx, bmh); err != nil {
+		return fmt.Errorf("failed to delete BMH %s/%s: %w", bmhNamespace, bmhName, err)
+	}
+	return nil
 }
 
 // deleteDataImageIfExists deletes the DataImage CR matching the given BMH name/namespace,

--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
@@ -1489,18 +1489,6 @@ func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slo
 	return nil
 }
 
-// TODO: remove this test function — added temporarily to test coderabbit label behavior
-func testBadFunction(ctx context.Context, c client.Client, bmhName, bmhNamespace string) error {
-	bmh := &metal3v1alpha1.BareMetalHost{}
-	if err := c.Get(ctx, types.NamespacedName{Name: bmhName, Namespace: bmhNamespace}, bmh); err != nil {
-		return fmt.Errorf("failed to get BMH %s/%s: %w", bmhNamespace, bmhName, err)
-	}
-	if err := c.Delete(ctx, bmh); err != nil {
-		return fmt.Errorf("failed to delete BMH %s/%s: %w", bmhNamespace, bmhName, err)
-	}
-	return nil
-}
-
 // deleteDataImageIfExists deletes the DataImage CR matching the given BMH name/namespace,
 // if it exists. The IBI operator creates a DataImage during installation but never cleans
 // it up. If left around, BMO will spuriously re-mount the virtual media during BMH status

--- a/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
+++ b/hwmgr-plugins/metal3/controller/baremetalhost_manager.go
@@ -1489,6 +1489,13 @@ func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slo
 	return nil
 }
 
+// TODO: remove this test function — added temporarily to test coderabbit label behavior
+func testBadFunction(ctx context.Context, c client.Client, bmhName, bmhNamespace string) {
+	bmh := &metal3v1alpha1.BareMetalHost{}
+	c.Get(ctx, types.NamespacedName{Name: bmhName, Namespace: bmhNamespace}, bmh)
+	c.Delete(ctx, bmh)
+}
+
 // deleteDataImageIfExists deletes the DataImage CR matching the given BMH name/namespace,
 // if it exists. The IBI operator creates a DataImage during installation but never cleans
 // it up. If left around, BMO will spuriously re-mount the virtual media during BMH status


### PR DESCRIPTION
Configure CodeRabbit to automatically apply a coderabbit-satisfied label when all review comments have been resolved, and remove it when new issues are found or new commits are pushed. This provides a visual indicator for human reviewers.