### PR TITLE
Add config and hwmgr-plugins dirs to o-cloud-manager tekton on-cel-ex…

### DIFF
--- a/.tekton/o-cloud-manager-4-21-pull-request.yaml
+++ b/.tekton/o-cloud-manager-4-21-pull-request.yaml
@@ -16,9 +16,11 @@ metadata:
         '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.tekton/o-cloud-manager-4-21-pull-request.yaml'.pathChanged() ||
         'api/***'.pathChanged() ||
+        'config/***'.pathChanged() ||
         'go.mod'.pathChanged() ||
         'go.sum'.pathChanged() ||
         'hack/***'.pathChanged() ||
+        'hwmgr-plugins/***'.pathChanged() ||
         'internal/***'.pathChanged() ||
         'main.go'.pathChanged() ||
         'pkg/***'.pathChanged() ||

--- a/.tekton/o-cloud-manager-4-21-push.yaml
+++ b/.tekton/o-cloud-manager-4-21-push.yaml
@@ -15,9 +15,11 @@ metadata:
         '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.tekton/o-cloud-manager-4-21-push.yaml'.pathChanged() ||
         'api/***'.pathChanged() ||
+        'config/***'.pathChanged() ||
         'go.mod'.pathChanged() ||
         'go.sum'.pathChanged() ||
         'hack/***'.pathChanged() ||
+        'hwmgr-plugins/***'.pathChanged() ||
         'internal/***'.pathChanged() ||
         'main.go'.pathChanged() ||
         'pkg/***'.pathChanged() ||


### PR DESCRIPTION
…pression

Include 'config/***' and 'hwmgr-plugins/***' pathChanged() triggers in both pull-request and push pipeline definitions so that changes to these directories trigger Konflux builds.

Made-with: Cursor