### PR TITLE
CNF-22946: Upstream release-config version bump — O-Cloud 4.21.6

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -5,6 +5,6 @@ variables:
   description: |
       O-cloud manager operator
   display_name: "o-cloud manager"
-  manager_version: "o-cloud-manager.v4.21.6"
+  manager_version: "o-cloud-manager.v4.21.7"
   min_kube_version: "1.32.0"
-  version: "4.21.6"
+  version: "4.21.7"


### PR DESCRIPTION
Automated post-release update for O-Cloud 4.21.6 → 4.21.7.

Generated by release-automator-konflux.