### PR TITLE
feat: add per-package code coverage threshold checks

### DIFF
--- a/.coverage-thresholds.yaml
+++ b/.coverage-thresholds.yaml
@@ -1,4 +1,4 @@
-# Code coverage thresholds per package.
+# Code coverage thresholds per package (statement-weighted).
 # These are minimum coverage percentages that must be maintained.
 # The check-coverage.sh script will fail if any package drops below its threshold.
 # Increase thresholds as coverage improves over time.
@@ -8,29 +8,29 @@ overall: 53
 
 # Per-package minimum thresholds
 packages:
-  api/hardwaremanagement/v1alpha1: 9
-  api/provisioning/v1alpha1: 51
+  api/hardwaremanagement/v1alpha1: 3
+  api/provisioning/v1alpha1: 64
   hwmgr-plugins/controller/utils: 0
-  hwmgr-plugins/metal3/controller: 69
-  hwmgr-plugins/metal3/server: 88
-  internal: 42
-  internal/cmd/server: 89
-  internal/controllers: 62
-  internal/controllers/utils: 21
-  internal/logging: 74
-  internal/search: 82
-  internal/service/alarms/api: 7
-  internal/service/alarms/internal/alertmanager: 85
-  internal/service/alarms/internal/db/repo: 85
-  internal/service/alarms/internal/infrastructure: 58
-  internal/service/artifacts/api: 12
-  internal/service/cluster/api: 16
-  internal/service/cluster/collector: 12
-  internal/service/common/api: 70
-  internal/service/common/api/middleware: 44
-  internal/service/common/async: 99
-  internal/service/common/auth: 41
-  internal/service/common/utils: 24
-  internal/service/provisioning/api: 24
-  internal/service/resources/listener: 41
-  internal/typed-errors: 40
+  hwmgr-plugins/metal3/controller: 63
+  hwmgr-plugins/metal3/server: 46
+  internal: 16
+  internal/cmd/server: 40
+  internal/controllers: 32
+  internal/controllers/utils: 19
+  internal/logging: 39
+  internal/search: 38
+  internal/service/alarms/api: 2
+  internal/service/alarms/internal/alertmanager: 42
+  internal/service/alarms/internal/db/repo: 40
+  internal/service/alarms/internal/infrastructure: 30
+  internal/service/artifacts/api: 10
+  internal/service/cluster/api: 11
+  internal/service/cluster/collector: 5
+  internal/service/common/api: 74
+  internal/service/common/api/middleware: 31
+  internal/service/common/async: 48
+  internal/service/common/auth: 29
+  internal/service/common/utils: 12
+  internal/service/provisioning/api: 17
+  internal/service/resources/listener: 15
+  internal/typed-errors: 38

--- a/.coverage-thresholds.yaml
+++ b/.coverage-thresholds.yaml
@@ -1,0 +1,36 @@
+# Code coverage thresholds per package.
+# These are minimum coverage percentages that must be maintained.
+# The check-coverage.sh script will fail if any package drops below its threshold.
+# Increase thresholds as coverage improves over time.
+
+# Overall minimum coverage across all packages
+overall: 53
+
+# Per-package minimum thresholds
+packages:
+  api/hardwaremanagement/v1alpha1: 9
+  api/provisioning/v1alpha1: 51
+  hwmgr-plugins/controller/utils: 0
+  hwmgr-plugins/metal3/controller: 69
+  hwmgr-plugins/metal3/server: 88
+  internal: 42
+  internal/cmd/server: 89
+  internal/controllers: 62
+  internal/controllers/utils: 21
+  internal/logging: 74
+  internal/search: 82
+  internal/service/alarms/api: 7
+  internal/service/alarms/internal/alertmanager: 85
+  internal/service/alarms/internal/db/repo: 85
+  internal/service/alarms/internal/infrastructure: 58
+  internal/service/artifacts/api: 12
+  internal/service/cluster/api: 16
+  internal/service/cluster/collector: 12
+  internal/service/common/api: 70
+  internal/service/common/api/middleware: 44
+  internal/service/common/async: 99
+  internal/service/common/auth: 41
+  internal/service/common/utils: 24
+  internal/service/provisioning/api: 24
+  internal/service/resources/listener: 41
+  internal/typed-errors: 40

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 
 # ginkgo code coverage
 coverprofile.out
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -610,10 +610,16 @@ go-generate:
 	done
 	@echo "All generated files are up-to-date."
 
+COVERAGE_DIR := $(PROJECT_DIR)/coverage
+COVERAGE_UNIT := $(COVERAGE_DIR)/unit.out
+COVERAGE_ENVTEST := $(COVERAGE_DIR)/envtest.out
+COVERAGE_MERGED := $(COVERAGE_DIR)/merged.out
+
 .PHONY: test tests
 test tests:
 	@echo "Run ginkgo excluding envtest tests"
-	ginkgo run -r --label-filter="!envtest" ./internal ./api ./hwmgr-plugins $(ginkgo_flags)
+	@mkdir -p $(COVERAGE_DIR)
+	ginkgo run -r --label-filter="!envtest" --coverprofile=unit.out --output-dir=$(COVERAGE_DIR) ./internal ./api ./hwmgr-plugins $(ginkgo_flags)
 
 .PHONY: test-e2e
 test-e2e: envtest kubectl
@@ -628,12 +634,33 @@ ifeq ($(shell uname -s),Linux)
 	@chmod -R u+w $(LOCALBIN)
 endif
 	@echo "Run ginkgo envtest tests"
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -i --bin-dir $(LOCALBIN) -p path)" ginkgo run -r --label-filter="envtest" ./internal $(ginkgo_flags)
+	@mkdir -p $(COVERAGE_DIR)
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -i --bin-dir $(LOCALBIN) -p path)" ginkgo run -r --label-filter="envtest" --coverprofile=envtest.out --output-dir=$(COVERAGE_DIR) ./internal $(ginkgo_flags)
 
 .PHONY: test-crd-watcher
 test-crd-watcher:
 	@echo "Run crd-watcher unit tests"
 	cd dev-tools/crd-watcher && go test -v $(ginkgo_flags)
+
+.PHONY: test-coverage-check
+test-coverage-check: ## Check code coverage against per-package thresholds
+	@echo "Merging coverage profiles"
+	@mkdir -p $(COVERAGE_DIR)
+	@# Merge unit and envtest profiles if both exist; use whichever is available
+	@if [ -f $(COVERAGE_UNIT) ] && [ -f $(COVERAGE_ENVTEST) ]; then \
+		head -1 $(COVERAGE_UNIT) > $(COVERAGE_MERGED); \
+		tail -n +2 $(COVERAGE_UNIT) >> $(COVERAGE_MERGED); \
+		tail -n +2 $(COVERAGE_ENVTEST) >> $(COVERAGE_MERGED); \
+	elif [ -f $(COVERAGE_UNIT) ]; then \
+		cp $(COVERAGE_UNIT) $(COVERAGE_MERGED); \
+	elif [ -f $(COVERAGE_ENVTEST) ]; then \
+		cp $(COVERAGE_ENVTEST) $(COVERAGE_MERGED); \
+	else \
+		echo "ERROR: No coverage profiles found. Run 'make test' and/or 'make test-envtest' first."; \
+		exit 1; \
+	fi
+	@echo "Checking coverage thresholds"
+	@$(PROJECT_DIR)/hack/check-coverage.sh $(COVERAGE_MERGED)
 
 .PHONY: fmt
 fmt:
@@ -653,7 +680,7 @@ deps-update: mock-gen golangci-lint-download
 # TODO: add back `test-e2e` to ci-job
 # NOTE: `bundle-check` should be the last job in the list for `ci-job`
 .PHONY: ci-job
-ci-job: deps-update go-generate generate fmt vet lint test test-e2e test-envtest test-crd-watcher bundle-check
+ci-job: deps-update go-generate generate fmt vet lint test test-e2e test-envtest test-crd-watcher test-coverage-check bundle-check
 
 .PHONY: clean
 clean:

--- a/hack/check-coverage.sh
+++ b/hack/check-coverage.sh
@@ -98,7 +98,7 @@ for pkg in "${!pkg_total_stmts[@]}"; do
     total="${pkg_total_stmts[${pkg}]}"
     covered="${pkg_covered_stmts[${pkg}]:-0}"
     if [[ "${total}" -gt 0 ]]; then
-        pkg_avg[${pkg}]=$(echo "scale=1; ${covered} * 100 / ${total}" | bc)
+        pkg_avg[${pkg}]=$(awk "BEGIN {printf \"%.1f\", ${covered} * 100 / ${total}}")
     else
         pkg_avg[${pkg}]="0"
     fi
@@ -153,8 +153,8 @@ while IFS= read -r line; do
             continue
         fi
 
-        # Compare (using bc for float comparison)
-        if (( $(echo "${actual} < ${threshold}" | bc -l) )); then
+        # Compare using awk for float comparison
+        if (( $(awk "BEGIN {print (${actual} < ${threshold})}") )); then
             printf "%-65s %7s%% %7s%% %s\n" "${pkg}" "${actual}" "${threshold}" "✗ FAIL"
             FAILURES=$((FAILURES + 1))
         else
@@ -173,7 +173,7 @@ done
 
 echo ""
 printf "%-65s %7s%% %7s%% " "OVERALL" "${OVERALL_COVERAGE}" "${OVERALL_THRESHOLD}"
-if (( $(echo "${OVERALL_COVERAGE} < ${OVERALL_THRESHOLD}" | bc -l) )); then
+if (( $(awk "BEGIN {print (${OVERALL_COVERAGE} < ${OVERALL_THRESHOLD})}") )); then
     echo "✗ FAIL"
     FAILURES=$((FAILURES + 1))
 else

--- a/hack/check-coverage.sh
+++ b/hack/check-coverage.sh
@@ -35,40 +35,63 @@ OVERALL_COVERAGE=$(go tool cover -func="${COVERAGE_FILE}" | grep '^total:' | awk
 echo "=== Code Coverage Report ==="
 echo ""
 
-# Collect per-package coverage from the profile
-declare -A pkg_coverage
+# Calculate per-package statement-weighted coverage from the raw profile.
+# Each line in the profile (after the mode: header) has the format:
+#   file.go:startline.col,endline.col numStatements count
+# When merging unit and envtest profiles, the same block may appear multiple
+# times. We deduplicate by taking the max count per block, so a block covered
+# by either test suite counts as covered.
+declare -A block_stmts
+declare -A block_count
 while IFS= read -r line; do
-    # Each line from go tool cover -func is: file:line func coverage%
-    # We want to aggregate by package
-    file=$(echo "${line}" | awk '{print $1}')
-    cov=$(echo "${line}" | awk '{gsub(/%/,""); print $NF}')
+    # Skip the mode: header
+    [[ "${line}" == mode:* ]] && continue
+
+    # Parse: location numStatements count
+    location="${line%% *}"
+    rest="${line#* }"
+    num_stmts="${rest%% *}"
+    count="${rest##* }"
+
+    # Deduplicate: keep the max count for each block
+    block_stmts["${location}"]="${num_stmts}"
+    if [[ -z "${block_count["${location}"]+x}" ]] || [[ "${count}" -gt "${block_count["${location}"]}" ]]; then
+        block_count["${location}"]="${count}"
+    fi
+done < "${COVERAGE_FILE}"
+
+# Aggregate per-package from deduplicated blocks
+declare -A pkg_total_stmts
+declare -A pkg_covered_stmts
+for location in "${!block_stmts[@]}"; do
+    num_stmts="${block_stmts[${location}]}"
+    count="${block_count[${location}]}"
+
+    # Extract file path from location (before the colon with line info)
+    file="${location%%:*}"
 
     # Extract package path (strip module prefix and filename)
     pkg="${file#"${MODULE}"/}"
     pkg="${pkg%/*}"
 
-    if [[ -n "${pkg}" && "${pkg}" != "total:" ]]; then
-        # Accumulate for averaging
-        if [[ -z "${pkg_coverage[${pkg}]+x}" ]]; then
-            pkg_coverage[${pkg}]="${cov}"
-        else
-            pkg_coverage[${pkg}]="${pkg_coverage[${pkg}]} ${cov}"
+    if [[ -n "${pkg}" ]]; then
+        pkg_total_stmts[${pkg}]=$(( ${pkg_total_stmts[${pkg}]:-0} + num_stmts ))
+        if [[ "${count}" -gt 0 ]]; then
+            pkg_covered_stmts[${pkg}]=$(( ${pkg_covered_stmts[${pkg}]:-0} + num_stmts ))
         fi
     fi
-done < <(go tool cover -func="${COVERAGE_FILE}" | grep -v '^total:')
+done
 
-# Calculate per-package averages
+# Calculate per-package coverage percentages
 declare -A pkg_avg
-for pkg in "${!pkg_coverage[@]}"; do
-    values="${pkg_coverage[${pkg}]}"
-    sum=0
-    count=0
-    for v in ${values}; do
-        sum=$(echo "${sum} + ${v}" | bc)
-        count=$((count + 1))
-    done
-    avg=$(echo "scale=1; ${sum} / ${count}" | bc)
-    pkg_avg[${pkg}]="${avg}"
+for pkg in "${!pkg_total_stmts[@]}"; do
+    total="${pkg_total_stmts[${pkg}]}"
+    covered="${pkg_covered_stmts[${pkg}]:-0}"
+    if [[ "${total}" -gt 0 ]]; then
+        pkg_avg[${pkg}]=$(echo "scale=1; ${covered} * 100 / ${total}" | bc)
+    else
+        pkg_avg[${pkg}]="0"
+    fi
 done
 
 # Collect known packages from thresholds file
@@ -115,7 +138,8 @@ while IFS= read -r line; do
         actual="${pkg_avg[${pkg}]:-N/A}"
 
         if [[ "${actual}" == "N/A" ]]; then
-            printf "%-65s %7s%% %7s%% %s\n" "${pkg}" "${actual}" "${threshold}" "⚠ NOT FOUND"
+            printf "%-65s %7s%% %7s%% %s\n" "${pkg}" "${actual}" "${threshold}" "✗ NOT FOUND"
+            FAILURES=$((FAILURES + 1))
             continue
         fi
 

--- a/hack/check-coverage.sh
+++ b/hack/check-coverage.sh
@@ -70,9 +70,19 @@ for location in "${!block_stmts[@]}"; do
     # Extract file path from location (before the colon with line info)
     file="${location%%:*}"
 
+    # Skip files outside the module
+    if [[ "${file}" != "${MODULE}"/* ]]; then
+        continue
+    fi
+
     # Extract package path (strip module prefix and filename)
-    pkg="${file#"${MODULE}"/}"
-    pkg="${pkg%/*}"
+    rel="${file#"${MODULE}"/}"
+    if [[ "${rel}" == */* ]]; then
+        pkg="${rel%/*}"
+    else
+        # Root-level file (e.g. main.go) — skip
+        continue
+    fi
 
     if [[ -n "${pkg}" ]]; then
         pkg_total_stmts[${pkg}]=$(( ${pkg_total_stmts[${pkg}]:-0} + num_stmts ))

--- a/hack/check-coverage.sh
+++ b/hack/check-coverage.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# check-coverage.sh - Verify code coverage meets per-package thresholds
+#
+# Usage: ./hack/check-coverage.sh <coverage-profile>
+#
+# Reads thresholds from .coverage-thresholds.yaml and checks the coverage
+# profile against them. Exits with 1 if any threshold is violated or if
+# new packages are found that are not listed in the thresholds file.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+THRESHOLDS_FILE="${REPO_ROOT}/.coverage-thresholds.yaml"
+COVERAGE_FILE="${1:?Usage: $0 <coverage-profile>}"
+
+if [[ ! -f "${COVERAGE_FILE}" ]]; then
+    echo "ERROR: Coverage profile not found: ${COVERAGE_FILE}"
+    exit 1
+fi
+
+if [[ ! -f "${THRESHOLDS_FILE}" ]]; then
+    echo "ERROR: Thresholds file not found: ${THRESHOLDS_FILE}"
+    exit 1
+fi
+
+# Module path prefix to strip from coverage output
+MODULE="github.com/openshift-kni/oran-o2ims"
+
+# Parse the overall threshold
+OVERALL_THRESHOLD=$(grep '^overall:' "${THRESHOLDS_FILE}" | awk '{print $2}')
+
+# Get overall coverage from the profile
+OVERALL_COVERAGE=$(go tool cover -func="${COVERAGE_FILE}" | grep '^total:' | awk '{gsub(/%/,""); print $NF}')
+
+echo "=== Code Coverage Report ==="
+echo ""
+
+# Collect per-package coverage from the profile
+declare -A pkg_coverage
+while IFS= read -r line; do
+    # Each line from go tool cover -func is: file:line func coverage%
+    # We want to aggregate by package
+    file=$(echo "${line}" | awk '{print $1}')
+    cov=$(echo "${line}" | awk '{gsub(/%/,""); print $NF}')
+
+    # Extract package path (strip module prefix and filename)
+    pkg="${file#"${MODULE}"/}"
+    pkg="${pkg%/*}"
+
+    if [[ -n "${pkg}" && "${pkg}" != "total:" ]]; then
+        # Accumulate for averaging
+        if [[ -z "${pkg_coverage[${pkg}]+x}" ]]; then
+            pkg_coverage[${pkg}]="${cov}"
+        else
+            pkg_coverage[${pkg}]="${pkg_coverage[${pkg}]} ${cov}"
+        fi
+    fi
+done < <(go tool cover -func="${COVERAGE_FILE}" | grep -v '^total:')
+
+# Calculate per-package averages
+declare -A pkg_avg
+for pkg in "${!pkg_coverage[@]}"; do
+    values="${pkg_coverage[${pkg}]}"
+    sum=0
+    count=0
+    for v in ${values}; do
+        sum=$(echo "${sum} + ${v}" | bc)
+        count=$((count + 1))
+    done
+    avg=$(echo "scale=1; ${sum} / ${count}" | bc)
+    pkg_avg[${pkg}]="${avg}"
+done
+
+# Collect known packages from thresholds file
+declare -A known_packages
+in_pkgs=false
+while IFS= read -r line; do
+    [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line}" ]] && continue
+    if [[ "${line}" == "packages:" ]]; then
+        in_pkgs=true
+        continue
+    fi
+    if ${in_pkgs}; then
+        kpkg=$(echo "${line}" | sed 's/^[[:space:]]*//' | cut -d: -f1)
+        known_packages[${kpkg}]=1
+    fi
+done < "${THRESHOLDS_FILE}"
+
+# Check thresholds
+FAILURES=0
+
+# Print header
+printf "%-65s %8s %8s %s\n" "Package" "Coverage" "Min" "Status"
+printf "%-65s %8s %8s %s\n" "-------" "--------" "---" "------"
+
+# Read per-package thresholds and check
+in_packages=false
+while IFS= read -r line; do
+    # Skip comments and empty lines
+    [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line}" ]] && continue
+    [[ "${line}" =~ ^overall: ]] && continue
+
+    if [[ "${line}" == "packages:" ]]; then
+        in_packages=true
+        continue
+    fi
+
+    if ${in_packages}; then
+        # Parse "  package/path: threshold"
+        pkg=$(echo "${line}" | sed 's/^[[:space:]]*//' | cut -d: -f1)
+        threshold=$(echo "${line}" | cut -d: -f2 | tr -d ' ')
+
+        actual="${pkg_avg[${pkg}]:-N/A}"
+
+        if [[ "${actual}" == "N/A" ]]; then
+            printf "%-65s %7s%% %7s%% %s\n" "${pkg}" "${actual}" "${threshold}" "⚠ NOT FOUND"
+            continue
+        fi
+
+        # Compare (using bc for float comparison)
+        if (( $(echo "${actual} < ${threshold}" | bc -l) )); then
+            printf "%-65s %7s%% %7s%% %s\n" "${pkg}" "${actual}" "${threshold}" "✗ FAIL"
+            FAILURES=$((FAILURES + 1))
+        else
+            printf "%-65s %7s%% %7s%% %s\n" "${pkg}" "${actual}" "${threshold}" "✓ OK"
+        fi
+    fi
+done < "${THRESHOLDS_FILE}"
+
+# Check for packages in coverage profile that are not in thresholds file
+for pkg in "${!pkg_avg[@]}"; do
+    if [[ -z "${known_packages[${pkg}]+x}" ]]; then
+        printf "%-65s %7s%%          %s\n" "${pkg}" "${pkg_avg[${pkg}]}" "✗ NOT IN THRESHOLDS"
+        FAILURES=$((FAILURES + 1))
+    fi
+done
+
+echo ""
+printf "%-65s %7s%% %7s%% " "OVERALL" "${OVERALL_COVERAGE}" "${OVERALL_THRESHOLD}"
+if (( $(echo "${OVERALL_COVERAGE} < ${OVERALL_THRESHOLD}" | bc -l) )); then
+    echo "✗ FAIL"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "✓ OK"
+fi
+
+echo ""
+if [[ ${FAILURES} -gt 0 ]]; then
+    echo "FAILED: ${FAILURES} coverage threshold(s) violated"
+    exit 1
+else
+    echo "PASSED: All coverage thresholds met"
+fi


### PR DESCRIPTION
Add a coverage gating mechanism to CI that ensures test coverage does not regress as new code is added. Coverage profiling is added to the existing test runs with no additional execution time.

- Add --coverprofile to ginkgo test and test-envtest targets
- Add hack/check-coverage.sh to check coverage against thresholds
- Add .coverage-thresholds.yaml with per-package minimum thresholds based on current coverage levels
- Add test-coverage-check target to ci-job pipeline