### PR TITLE
CNF-22946: Upstream catalog-template update — O-Cloud 4.21.6

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,3 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-4-21@sha256:08546866948a7bb9731a1b9dbb8dbbadfa65bc21e44bf906d50e10501661156d
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-4-21@sha256:2fc07855e4366374a9acb8e245f4458ba61d2b5414b7279620e49a4fba39df98
 

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -35,6 +35,10 @@ entries:
       - name: o-cloud-manager.v4.21.6
         replaces: o-cloud-manager.v4.21.5
         skipRange: '>=4.9.0 <4.21.6'
+      # v4.21.7
+      - name: o-cloud-manager.v4.21.7
+        replaces: o-cloud-manager.v4.21.6
+        skipRange: '>=4.9.0 <4.21.7'
     name: stable
     package: o-cloud-manager
     schema: olm.channel
@@ -67,6 +71,10 @@ entries:
       - name: o-cloud-manager.v4.21.6
         replaces: o-cloud-manager.v4.21.5
         skipRange: '>=4.9.0 <4.21.6'
+      # v4.21.7
+      - name: o-cloud-manager.v4.21.7
+        replaces: o-cloud-manager.v4.21.6
+        skipRange: '>=4.9.0 <4.21.7'
     name: "4.21"
     package: o-cloud-manager
     schema: olm.channel
@@ -89,6 +97,9 @@ entries:
   - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:ccae35ceb7fd1197a8072a4dfdff64a701dbd8d207430b812cd1cdfea9361f0c
     schema: olm.bundle
   # v4.21.6
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:08546866948a7bb9731a1b9dbb8dbbadfa65bc21e44bf906d50e10501661156d
+    schema: olm.bundle
+  # v4.21.7 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for O-Cloud 4.21.6 → 4.21.7.

Generated by release-automator-konflux.