### PR TITLE
fix: set CRD owner reference on runtime cluster-scoped resources

### DIFF
--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -127,6 +127,7 @@ import (
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -224,11 +225,18 @@ func getFakeClientAndMockServer(objs ...client.Object) (client.WithWatch, *MockH
 	// Note: BMC secrets are created by individual tests in their BeforeEach blocks
 	// to avoid resource conflicts between tests
 
+	// Create the Inventory CRD object for CRD ownership of cluster-scoped resources
+	inventoryCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ctlrutils.InventoryCRDName,
+		},
+	}
+
 	// First create the fake client
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objs...).
-		WithObjects([]client.Object{authSecret}...).
+		WithObjects([]client.Object{authSecret, inventoryCRD}...).
 		WithStatusSubresource(&inventoryv1alpha1.Inventory{}).
 		WithStatusSubresource(&provisioningv1alpha1.ClusterTemplate{}).
 		WithStatusSubresource(&provisioningv1alpha1.ProvisioningRequest{}).

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -52,6 +52,11 @@ const (
 	Metal3PluginServerName = Metal3Plugin + serverSuffix
 )
 
+// InventoryCRDName is the fully qualified name of the Inventory CRD, used as the
+// owner reference for runtime-created cluster-scoped resources (ClusterRoles,
+// ClusterRoleBindings) so they are garbage collected on operator uninstall.
+const InventoryCRDName = "inventories.ocloud.openshift.io"
+
 // IngressName defines the name of our ingress controller
 const IngressName = "oran-o2ims-ingress"
 

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -141,8 +141,7 @@ func CreateK8sCR(ctx context.Context, c client.Client,
 		} else if key.Namespace == "" {
 			// Cluster-scoped resource with namespace-scoped owner — use CRD ownership
 			if err := SetCRDOwnerRef(ctx, c, newObject, InventoryCRDName); err != nil {
-				oranUtilsLog.Error(err, "Failed to set CRD owner reference, continuing without it",
-					"name", newObject.GetName())
+				return fmt.Errorf("failed to set CRD owner reference for %s: %w", newObject.GetName(), err)
 			}
 		}
 	}

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -79,6 +79,45 @@ func UpdateK8sCRStatus(ctx context.Context, c client.Client, object client.Objec
 	return nil
 }
 
+// SetCRDOwnerRef sets an ownerReference on a cluster-scoped resource, using the
+// specified CRD as the owner. This ensures the resource is garbage collected when
+// the CRD is deleted (e.g., on operator uninstall). The owner reference is set
+// with controller=false and blockOwnerDeletion=false, matching the pattern used
+// by OLM for CRD-owned ClusterRoles.
+func SetCRDOwnerRef(ctx context.Context, c client.Client, object metav1.Object, crdName string) error {
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+	if err := c.Get(ctx, types.NamespacedName{Name: crdName}, crd); err != nil {
+		return fmt.Errorf("failed to get CRD %s: %w", crdName, err)
+	}
+
+	isController := false
+	blockOwnerDeletion := false
+	ownerRef := metav1.OwnerReference{
+		APIVersion:         "apiextensions.k8s.io/v1",
+		Kind:               "CustomResourceDefinition",
+		Name:               crdName,
+		UID:                crd.GetUID(),
+		Controller:         &isController,
+		BlockOwnerDeletion: &blockOwnerDeletion,
+	}
+
+	// Check if the owner reference already exists
+	for _, ref := range object.GetOwnerReferences() {
+		if ref.UID == ownerRef.UID {
+			return nil
+		}
+	}
+
+	refs := append(object.GetOwnerReferences(), ownerRef)
+	object.SetOwnerReferences(refs)
+	return nil
+}
+
 // CreateK8sCR creates/updates/patches an object.
 func CreateK8sCR(ctx context.Context, c client.Client,
 	newObject client.Object, ownerObject client.Object,
@@ -87,14 +126,24 @@ func CreateK8sCR(ctx context.Context, c client.Client,
 	// Get the name and namespace of the object:
 	key := client.ObjectKeyFromObject(newObject)
 
-	// We can set the owner reference only for objects that live in the same namespace, as cross
-	// namespace owners are forbidden. This also applies to non-namespaced objects like cluster
-	// roles or cluster role bindings; those have empty namespaces, so the equals comparison
-	// should also work.
-	if ownerObject != nil && (ownerObject.GetNamespace() == key.Namespace || ownerObject.GetNamespace() == "") {
-		err = controllerutil.SetControllerReference(ownerObject, newObject, c.Scheme())
-		if err != nil {
-			return fmt.Errorf("failed to set controller reference: %w", err)
+	// Set owner references for garbage collection:
+	// - For namespace-scoped resources: set the ownerObject as the controller owner
+	//   (only when both are in the same namespace).
+	// - For cluster-scoped resources with a namespace-scoped owner: set the Inventory
+	//   CRD as a non-controller owner so the resource is cleaned up on operator uninstall.
+	if ownerObject != nil {
+		if ownerObject.GetNamespace() == key.Namespace || ownerObject.GetNamespace() == "" {
+			// Same namespace or both cluster-scoped — use controller reference
+			err = controllerutil.SetControllerReference(ownerObject, newObject, c.Scheme())
+			if err != nil {
+				return fmt.Errorf("failed to set controller reference: %w", err)
+			}
+		} else if key.Namespace == "" {
+			// Cluster-scoped resource with namespace-scoped owner — use CRD ownership
+			if err := SetCRDOwnerRef(ctx, c, newObject, InventoryCRDName); err != nil {
+				oranUtilsLog.Error(err, "Failed to set CRD owner reference, continuing without it",
+					"name", newObject.GetName())
+			}
 		}
 	}
 

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -20,7 +20,10 @@ import (
 	openshiftv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1291,5 +1294,122 @@ var _ = Describe("IsHardwareConfigCompleted", func() {
 			result := IsHardwareConfigCompleted(pr)
 			Expect(result).To(BeTrue())
 		})
+	})
+})
+
+var _ = Describe("SetCRDOwnerRef", func() {
+	var fakeClient client.Client
+	var crd *unstructured.Unstructured
+	const crdName = "inventories.ocloud.openshift.io"
+	const crdUID = "test-crd-uid-12345"
+
+	BeforeEach(func() {
+		crd = &unstructured.Unstructured{}
+		crd.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "apiextensions.k8s.io",
+			Version: "v1",
+			Kind:    "CustomResourceDefinition",
+		})
+		crd.SetName(crdName)
+		crd.SetUID(types.UID(crdUID))
+
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(suitescheme).
+			WithObjects(crd).
+			Build()
+	})
+
+	It("should set CRD owner reference on a ClusterRole", func() {
+		role := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-clusterrole",
+			},
+		}
+		err := SetCRDOwnerRef(context.TODO(), fakeClient, role, crdName)
+		Expect(err).ToNot(HaveOccurred())
+
+		refs := role.GetOwnerReferences()
+		Expect(refs).To(HaveLen(1))
+		Expect(refs[0].Kind).To(Equal("CustomResourceDefinition"))
+		Expect(refs[0].Name).To(Equal(crdName))
+		Expect(refs[0].UID).To(Equal(types.UID(crdUID)))
+		Expect(*refs[0].Controller).To(BeFalse())
+		Expect(*refs[0].BlockOwnerDeletion).To(BeFalse())
+	})
+
+	It("should not duplicate owner reference if already set", func() {
+		role := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-clusterrole",
+			},
+		}
+		err := SetCRDOwnerRef(context.TODO(), fakeClient, role, crdName)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Call again
+		err = SetCRDOwnerRef(context.TODO(), fakeClient, role, crdName)
+		Expect(err).ToNot(HaveOccurred())
+
+		refs := role.GetOwnerReferences()
+		Expect(refs).To(HaveLen(1))
+	})
+
+	It("should return error when CRD does not exist", func() {
+		role := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-clusterrole",
+			},
+		}
+		err := SetCRDOwnerRef(context.TODO(), fakeClient, role, "nonexistent.crd.io")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to get CRD"))
+	})
+})
+
+var _ = Describe("CreateK8sCR with cluster-scoped resources", func() {
+	var fakeClient client.Client
+	var crd *unstructured.Unstructured
+	const crdUID = "test-crd-uid-12345"
+
+	BeforeEach(func() {
+		crd = &unstructured.Unstructured{}
+		crd.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "apiextensions.k8s.io",
+			Version: "v1",
+			Kind:    "CustomResourceDefinition",
+		})
+		crd.SetName(InventoryCRDName)
+		crd.SetUID(types.UID(crdUID))
+
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(suitescheme).
+			WithObjects(crd).
+			Build()
+	})
+
+	It("should set CRD owner on cluster-scoped resource with namespace-scoped owner", func() {
+		owner := &inventoryv1alpha1.Inventory{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-inventory",
+				Namespace: "oran-o2ims",
+			},
+		}
+		role := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-role",
+			},
+		}
+		err := CreateK8sCR(context.TODO(), fakeClient, role, owner, UPDATE)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Fetch the created role and check owner references
+		created := &rbacv1.ClusterRole{}
+		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "test-role"}, created)
+		Expect(err).ToNot(HaveOccurred())
+
+		refs := created.GetOwnerReferences()
+		Expect(refs).To(HaveLen(1))
+		Expect(refs[0].Kind).To(Equal("CustomResourceDefinition"))
+		Expect(refs[0].Name).To(Equal(InventoryCRDName))
 	})
 })


### PR DESCRIPTION
Runtime-created ClusterRoles and ClusterRoleBindings were orphaned on operator uninstall because Kubernetes prevents namespace-scoped owners (the Inventory CR) from owning cluster-scoped resources.

Set the Inventory CRD as a non-controller owner reference on cluster- scoped resources created by CreateK8sCR, matching the pattern used by OLM for CRD-owned ClusterRoles. When the CRD is deleted during operator uninstall, Kubernetes garbage collection cleans up the associated ClusterRoles and ClusterRoleBindings.