### PR TITLE
CNF-22981: fix renovate labels and git-submodules configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,23 +7,16 @@
         "packageRules": [
             {
                 "addLabels": [
-                    "approved",
-                    "lgtm"
+                    "allow-automatic-merge"
                 ],
                 "additionalBranchPrefix": "telco5g-konflux-",
                 "autoApprove": true,
                 "automerge": true,
-                "matchFileNames": [
-                    "telco5g-konflux/**"
+                "matchPackageNames": [
+                    "https://github.com/openshift-kni/telco5g-konflux.git"
                 ],
                 "schedule": [
                     "at any time"
-                ]
-            },
-            {
-                "additionalBranchPrefix": "telco5g-konflux-",
-                "matchFileNames": [
-                    "telco5g-konflux/**"
                 ]
             }
         ]
@@ -34,8 +27,7 @@
     "packageRules": [
         {
             "addLabels": [
-                "approved",
-                "lgtm"
+                "allow-automatic-merge"
             ],
             "autoApprove": true,
             "automerge": true,
@@ -65,6 +57,11 @@
     "prConcurrentLimit": 0,
     "pruneBranchAfterAutomerge": true,
     "tekton": {
+        "addLabels": [
+            "allow-automatic-merge"
+        ],
+        "autoApprove": true,
+        "automerge": true,
         "enabled": true,
         "ignoreTests": false,
         "includePaths": [


### PR DESCRIPTION
Replace "approved"/"lgtm" labels with "allow-automatic-merge" across all rules, and update git-submodules to use matchPackageNames with actual repo URLs instead of matchFileNames. Add automerge config to tekton section and complete the second submodule rule for oran-o2ims.

Made-with: Cursor