### PR TITLE
CNF-23100: feat: replace NAR REST API with direct K8s client operations (Phase 1)

### DIFF
--- a/hwmgr-plugins/metal3/controller/helpers.go
+++ b/hwmgr-plugins/metal3/controller/helpers.go
@@ -481,9 +481,6 @@ func createNode(ctx context.Context,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodename,
 			Namespace: pluginNamespace,
-			Labels: map[string]string{
-				hwmgrutils.HardwarePluginLabel: hwmgrutils.Metal3HardwarePluginID,
-			},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         nodeAllocationRequest.APIVersion,
 				Kind:               nodeAllocationRequest.Kind,

--- a/hwmgr-plugins/metal3/controller/helpers_test.go
+++ b/hwmgr-plugins/metal3/controller/helpers_test.go
@@ -361,7 +361,6 @@ var _ = Describe("Helpers", func() {
 			Expect(createdNode.Spec.HwProfile).To(Equal("test-profile"))
 			Expect(createdNode.Spec.HwMgrNodeId).To(Equal("test-node-id"))
 			Expect(createdNode.Spec.HwMgrNodeNs).To(Equal("test-node-ns"))
-			Expect(createdNode.Labels[hwmgrutils.HardwarePluginLabel]).To(Equal(hwmgrutils.Metal3HardwarePluginID))
 		})
 
 		It("should skip creation if AllocatedNode already exists", func() {

--- a/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller.go
+++ b/hwmgr-plugins/metal3/controller/metal3_allocatednode_controller.go
@@ -16,15 +16,12 @@ import (
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
@@ -121,23 +118,8 @@ func (r *AllocatedNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AllocatedNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
-	// Create a label selector for filtering AllocatedNode pertaining to the Metal3 HardwarePlugin
-	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			hwmgrutils.HardwarePluginLabel: hwmgrutils.Metal3HardwarePluginID,
-		},
-	}
-
-	// Create a predicate to filter AllocatedNode with the specified metal3 H/W plugin label
-	pred, err := predicate.LabelSelectorPredicate(labelSelector)
-	if err != nil {
-		return fmt.Errorf("failed to create label selector predicate: %w", err)
-	}
-
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&pluginsv1alpha1.AllocatedNode{}).
-		WithEventFilter(pred).
 		Complete(r); err != nil {
 		return fmt.Errorf("failed to create allocated node controller: %w", err)
 	}

--- a/hwmgr-plugins/metal3/controller/metal3_nodeallocationrequest_controller.go
+++ b/hwmgr-plugins/metal3/controller/metal3_nodeallocationrequest_controller.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
@@ -309,23 +308,8 @@ func (r *NodeAllocationRequestReconciler) Reconcile(ctx context.Context, req ctr
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeAllocationRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
-	// Create a label selector for filtering NodeAllocationRequests pertaining to the Metal3 HardwarePlugin
-	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			hwmgrutils.HardwarePluginLabel: hwmgrutils.Metal3HardwarePluginID,
-		},
-	}
-
-	// Create a predicate to filter NodeAllocationRequests with the specified metal3 H/W plugin label
-	pred, err := predicate.LabelSelectorPredicate(labelSelector)
-	if err != nil {
-		return fmt.Errorf("failed to create label selector predicate: %w", err)
-	}
-
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&pluginsv1alpha1.NodeAllocationRequest{}).
-		WithEventFilter(pred).
 		Complete(r); err != nil {
 		return fmt.Errorf("failed to create controller: %w", err)
 	}

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -13,46 +13,32 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
-	hwmgrpluginapi "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/provisioning"
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
 // collectNodeDetails collects BMC and node interfaces details
-func collectNodeDetails(ctx context.Context, c client.Client, nodes *[]hwmgrpluginapi.AllocatedNode) (map[string][]ctlrutils.NodeInfo, error) {
+func collectNodeDetails(_ context.Context, _ client.Client, nodeList *pluginsv1alpha1.AllocatedNodeList) (map[string][]ctlrutils.NodeInfo, error) {
 	// hwNodes maps a group name to a slice of NodeInfo
 	hwNodes := make(map[string][]ctlrutils.NodeInfo)
-	for _, node := range *nodes {
-		if node.Bmc.CredentialsName == "" {
-			return nil, fmt.Errorf("the AllocatedNode does not have BMC details")
-		}
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
 
-		interfaces := []*pluginsv1alpha1.Interface{}
-		for _, ifc := range node.Interfaces {
-			interfaces = append(interfaces, &pluginsv1alpha1.Interface{
-				Name:       ifc.Name,
-				MACAddress: ifc.MacAddress,
-				Label:      ifc.Label,
-			})
+		if node.Status.BMC == nil || node.Status.BMC.CredentialsName == "" {
+			return nil, fmt.Errorf("allocatedNode %s does not have BMC details", node.Name)
 		}
 
 		tmpNode := ctlrutils.NodeInfo{
-			BmcAddress:     node.Bmc.Address,
-			BmcCredentials: node.Bmc.CredentialsName,
-			NodeID:         node.Id,
-			Interfaces:     interfaces,
-		}
-
-		bmh, err := ctlrutils.GetBareMetalHostForAllocatedNode(ctx, c, node.Id)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get BareMetalHost: %w", err)
-		}
-		if bmh != nil {
-			tmpNode.HwMgrNodeId = bmh.Name
-			tmpNode.HwMgrNodeNs = bmh.Namespace
+			BmcAddress:     node.Status.BMC.Address,
+			BmcCredentials: node.Status.BMC.CredentialsName,
+			NodeID:         node.Name,
+			Interfaces:     node.Status.Interfaces,
+			HwMgrNodeId:    node.Spec.HwMgrNodeId,
+			HwMgrNodeNs:    node.Spec.HwMgrNodeNs,
 		}
 
 		// Store the nodeInfo per group
-		hwNodes[node.GroupName] = append(hwNodes[node.GroupName], tmpNode)
+		hwNodes[node.Spec.GroupName] = append(hwNodes[node.Spec.GroupName], tmpNode)
 	}
 
 	return hwNodes, nil
@@ -60,7 +46,7 @@ func collectNodeDetails(ctx context.Context, c client.Client, nodes *[]hwmgrplug
 
 // validateNodeGroupsMatchNAR verifies that every node group in the existing
 // NodeAllocationRequest has a corresponding entry in the merged hwMgmt data.
-func validateNodeGroupsMatchNAR(hwMgmtData map[string]any, nodeAllocationRequest *hwmgrpluginapi.NodeAllocationRequest) error {
+func validateNodeGroupsMatchNAR(hwMgmtData map[string]any, narSpec *pluginsv1alpha1.NodeAllocationRequestSpec) error {
 	// Build set of valid group names from merged hwMgmt data
 	validNames := make(map[string]bool)
 	if ngData, ok := hwMgmtData["nodeGroupData"].([]any); ok {
@@ -75,7 +61,7 @@ func validateNodeGroupsMatchNAR(hwMgmtData map[string]any, nodeAllocationRequest
 
 	// Check NAR groups exist in hwMgmt data
 	narNames := make(map[string]bool)
-	for _, specNodeGroup := range nodeAllocationRequest.NodeGroup {
+	for _, specNodeGroup := range narSpec.NodeGroup {
 		narNames[specNodeGroup.NodeGroupData.Name] = true
 		if !validNames[specNodeGroup.NodeGroupData.Name] {
 			return fmt.Errorf("node group %s found in NodeAllocationRequest but not in hwMgmt data", specNodeGroup.NodeGroupData.Name)
@@ -93,24 +79,38 @@ func validateNodeGroupsMatchNAR(hwMgmtData map[string]any, nodeAllocationRequest
 }
 
 // newNodeGroup populates NodeGroup
-func newNodeGroup(group hwmgrpluginapi.NodeGroupData, roleCounts map[string]int) hwmgrpluginapi.NodeGroup {
-	var nodeGroup hwmgrpluginapi.NodeGroup
-
-	// Populate embedded NodeAllocationRequestData fields
-	nodeGroup.NodeGroupData = group
+func newNodeGroup(group hwmgmtv1alpha1.NodeGroupData, roleCounts map[string]int) pluginsv1alpha1.NodeGroup {
+	nodeGroup := pluginsv1alpha1.NodeGroup{
+		NodeGroupData: group,
+	}
 
 	// Assign size if available in roleCounts
 	if count, ok := roleCounts[group.Role]; ok {
-		nodeGroup.NodeGroupData.Size = count
+		nodeGroup.Size = count
 	}
 
 	return nodeGroup
 }
 
+// listAllocatedNodesForNAR lists AllocatedNodes that belong to the given NodeAllocationRequest.
+func listAllocatedNodesForNAR(ctx context.Context, c client.Client, narName, narNS string) (*pluginsv1alpha1.AllocatedNodeList, error) {
+	allNodes := &pluginsv1alpha1.AllocatedNodeList{}
+	if err := c.List(ctx, allNodes, client.InNamespace(narNS)); err != nil {
+		return nil, fmt.Errorf("failed to list AllocatedNodes: %w", err)
+	}
+	filtered := &pluginsv1alpha1.AllocatedNodeList{}
+	for i := range allNodes.Items {
+		if allNodes.Items[i].Spec.NodeAllocationRequest == narName {
+			filtered.Items = append(filtered.Items, allNodes.Items[i])
+		}
+	}
+	return filtered, nil
+}
+
 // getRoleToGroupNameMap creates a mapping of Role to Group Name from NodeAllocationRequest
-func getRoleToGroupNameMap(nodeAllocationRequest *hwmgrpluginapi.NodeAllocationRequest) map[string]string {
+func getRoleToGroupNameMap(narSpec *pluginsv1alpha1.NodeAllocationRequestSpec) map[string]string {
 	roleToNodeGroupName := make(map[string]string)
-	for _, nodeGroup := range nodeAllocationRequest.NodeGroup {
+	for _, nodeGroup := range narSpec.NodeGroup {
 
 		if _, exists := roleToNodeGroupName[nodeGroup.NodeGroupData.Role]; !exists {
 			roleToNodeGroupName[nodeGroup.NodeGroupData.Role] = nodeGroup.NodeGroupData.Name

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -18,7 +18,7 @@ import (
 )
 
 // collectNodeDetails collects BMC and node interfaces details
-func collectNodeDetails(_ context.Context, _ client.Client, nodeList *pluginsv1alpha1.AllocatedNodeList) (map[string][]ctlrutils.NodeInfo, error) {
+func collectNodeDetails(nodeList *pluginsv1alpha1.AllocatedNodeList) (map[string][]ctlrutils.NodeInfo, error) {
 	// hwNodes maps a group name to a slice of NodeInfo
 	hwNodes := make(map[string][]ctlrutils.NodeInfo)
 	for i := range nodeList.Items {

--- a/internal/controllers/provisioningrequest_clusterconfig.go
+++ b/internal/controllers/provisioningrequest_clusterconfig.go
@@ -16,8 +16,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
-	hwprovisioningapi "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/provisioning"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -439,14 +440,13 @@ func (t *provisioningRequestReconcilerTask) addPostProvisioningLabels(ctx contex
 	}
 
 	// Get AllocatedNodes if hardware provisioning is not skipped.
-	nodes := &[]hwprovisioningapi.AllocatedNode{}
+	narNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
+	allocatedNodeList := &pluginsv1alpha1.AllocatedNodeList{}
 	if !t.isHardwareProvisionSkipped() {
-		nodeAllocationRequestID := t.getNodeAllocationRequestID()
-		if nodeAllocationRequestID != "" {
-			nodes, err = t.hwpluginClient.GetAllocatedNodesFromNodeAllocationRequest(ctx, nodeAllocationRequestID)
-			if err != nil {
-				return fmt.Errorf("failed to get AllocatedNodes for NodeAllocationRequest '%s': %w", nodeAllocationRequestID, err)
-			}
+		var err error
+		allocatedNodeList, err = listAllocatedNodesForNAR(ctx, t.client, t.object.Name, narNS)
+		if err != nil {
+			return fmt.Errorf("failed to list AllocatedNodes for NodeAllocationRequest '%s': %w", t.object.Name, err)
 		}
 	}
 
@@ -467,9 +467,10 @@ func (t *provisioningRequestReconcilerTask) addPostProvisioningLabels(ctx contex
 		// hostname assigned during cluster installation (not the BMH inspected hostname).
 		foundNode := false
 
-		for _, node := range *nodes {
+		for i := range allocatedNodeList.Items {
+			node := &allocatedNodeList.Items[i]
 
-			hostName := t.object.Status.Extensions.AllocatedNodeHostMap[node.Id]
+			hostName := t.object.Status.Extensions.AllocatedNodeHostMap[node.Name]
 			if hostName == "" {
 				continue
 			}
@@ -481,14 +482,14 @@ func (t *provisioningRequestReconcilerTask) addPostProvisioningLabels(ctx contex
 			// Look up the BMH via the allocated-node label rather than by
 			// BMH status hostname, because the inspected hostname on the BMH
 			// may differ from the hostname actually assigned to the node.
-			bmh, err := ctlrutils.GetBareMetalHostForAllocatedNode(ctx, t.client, node.Id)
+			bmh, err := ctlrutils.GetBareMetalHostForAllocatedNode(ctx, t.client, node.Name)
 			if err != nil {
 				return fmt.Errorf("failed to get BareMetalHost: %w", err)
 			}
 			if bmh == nil {
 				t.logger.WarnContext(ctx,
 					"BareMetalHost not found for AllocatedNode",
-					"allocatedNodeId", node.Id,
+					"allocatedNodeId", node.Name,
 					"hostname", hostName,
 				)
 				continue
@@ -496,7 +497,8 @@ func (t *provisioningRequestReconcilerTask) addPostProvisioningLabels(ctx contex
 
 			foundNode = true
 
-			err = t.setLabelValue(ctx, &agent, ctlrutils.HardwarePluginRefLabel, t.hwpluginClient.GetHardwarePluginRef())
+			hwPluginRef := t.ctDetails.templates.HwMgmtDefaults.GetHardwarePluginRef()
+			err = t.setLabelValue(ctx, &agent, ctlrutils.HardwarePluginRefLabel, hwPluginRef)
 			if err != nil {
 				return err
 			}

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -80,7 +80,6 @@ import (
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
-	hwmgrpluginapi "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/provisioning"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
@@ -1780,7 +1779,6 @@ var _ = Describe("addPostProvisioningLabels", func() {
 		ProvReqTask           *provisioningRequestReconcilerTask
 		managedCluster        = &clusterv1.ManagedCluster{}
 		nodeAllocationRequest = &pluginsv1alpha1.NodeAllocationRequest{}
-		mockHwPluginServer    *MockHardwarePluginServer
 	)
 
 	BeforeEach(func() {
@@ -1895,7 +1893,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 			},
 		}
 
-		c, mockHwPluginServer = getFakeClientAndMockServer(crs...)
+		c = getFakeClientFromObjects(crs...)
 
 		// Populate the NodeAllocationRequest without creating it.
 		nodeAllocationRequest = &pluginsv1alpha1.NodeAllocationRequest{
@@ -1946,28 +1944,10 @@ var _ = Describe("addPostProvisioningLabels", func() {
 			Logger: logger,
 		}
 
-		// Get hwpluginClient for the test
-		hwpluginKey := types.NamespacedName{
-			Name:      utils.UnitTestHwPluginRef,
-			Namespace: constants.DefaultNamespace,
-		}
-		hwplugin := &hwmgmtv1alpha1.HardwarePlugin{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      hwpluginKey.Name,
-				Namespace: hwpluginKey.Namespace,
-			},
-		}
-		err := c.Get(ctx, hwpluginKey, hwplugin)
-		Expect(err).ToNot(HaveOccurred())
-
-		hwpluginClient, err := hwmgrpluginapi.NewHardwarePluginClient(ctx, c, ProvReqReconciler.Logger, hwplugin)
-		Expect(err).ToNot(HaveOccurred())
-
 		ProvReqTask = &provisioningRequestReconcilerTask{
-			logger:         ProvReqReconciler.Logger,
-			client:         ProvReqReconciler.Client,
-			object:         provisioningRequest, // cluster-1 request
-			hwpluginClient: hwpluginClient,
+			logger: ProvReqReconciler.Logger,
+			client: ProvReqReconciler.Client,
+			object: provisioningRequest, // cluster-1 request
 			ctDetails: &clusterTemplateDetails{
 				namespace: ctNamespace,
 				templates: provisioningv1alpha1.TemplateDefaults{
@@ -1991,12 +1971,10 @@ var _ = Describe("addPostProvisioningLabels", func() {
 	})
 
 	Context("When the HW template is provided and the HW CRs do not exist", func() {
-		It("Returns error for the NodeAllocationRequest missing", func() {
-			// Set a NodeAllocationRequestID that doesn't exist in the mock server
-			ProvReqTask.object.Status.Extensions.NodeAllocationRequestRef = &provisioningv1alpha1.NodeAllocationRequestRef{
-				NodeAllocationRequestID: "non-existent-cluster", // Use an ID that doesn't exist in mock server
-			}
-			// Update the status in the fake client so the change persists
+		It("Succeeds with no AllocatedNodes when Agents exist", func() {
+			// No AllocatedNodes exist for this PR — the function should succeed
+			// but log warnings about missing nodes for each Agent.
+			ProvReqTask.object.Status.Extensions.NodeAllocationRequestRef = &provisioningv1alpha1.NodeAllocationRequestRef{}
 			Expect(c.Status().Update(ctx, ProvReqTask.object)).To(Succeed())
 
 			// Create an Agent so the function proceeds beyond the Agent check
@@ -2018,11 +1996,9 @@ var _ = Describe("addPostProvisioningLabels", func() {
 			}
 			Expect(c.Create(ctx, agent)).To(Succeed())
 
-			// Run the function.
+			// Run the function — should succeed (no AllocatedNodes → warning, not error)
 			err := ProvReqTask.addPostProvisioningLabels(ctx, managedCluster)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(
-				"empty or unexpected error response for AllocatedNodesFromNodeAllocationRequest 'non-existent-cluster'"))
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Succeeds with no Agents (IBI cluster case)", func() {
@@ -2209,23 +2185,20 @@ var _ = Describe("addPostProvisioningLabels", func() {
 				},
 			}
 
-			// Configure mock server to return 3 allocated nodes.
-			mockAllocatedNodes := make([]hwmgrpluginapi.AllocatedNode, len(nodes))
-			for i, n := range nodes {
-				mockAllocatedNodes[i] = hwmgrpluginapi.AllocatedNode{
-					Id:        n.allocatedNodeID,
-					GroupName: "controller",
-					HwProfile: "dell-r740-bios-v1",
-					Bmc: hwmgrpluginapi.BMC{
-						Address:         n.bmcAddress,
-						CredentialsName: n.bmcCredentialName,
+			// Create AllocatedNode CRs in the fake client.
+			for _, n := range nodes {
+				allocatedNode := &pluginsv1alpha1.AllocatedNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      n.allocatedNodeID,
+						Namespace: constants.DefaultNamespace,
 					},
-					Interfaces: []hwmgrpluginapi.Interface{
-						{Name: "eno1", MacAddress: fmt.Sprintf("AA:BB:CC:DD:EE:%02d", i), Label: constants.BootInterfaceLabel},
+					Spec: pluginsv1alpha1.AllocatedNodeSpec{
+						NodeAllocationRequest: "cluster-1",
+						GroupName:             "controller",
 					},
 				}
+				Expect(c.Create(ctx, allocatedNode)).To(Succeed())
 			}
-			mockHwPluginServer.SetAllocatedNodes("cluster-1", mockAllocatedNodes)
 
 			// Set up AllocatedNodeHostMap: allocated-node-id -> assigned hostname.
 			hostMap := make(map[string]string, len(nodes))

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -8,7 +8,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -19,14 +18,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
-	hwmgrpluginapi "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/provisioning"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	observabilityv1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
@@ -45,7 +44,6 @@ type ProvisioningRequestReconciler struct {
 type provisioningRequestReconcilerTask struct {
 	logger         *slog.Logger
 	client         client.Client
-	hwpluginClient hwmgrpluginapi.HardwarePluginClientInterface
 	object         *provisioningv1alpha1.ProvisioningRequest
 	clusterInput   *clusterInput
 	ctDetails      *clusterTemplateDetails
@@ -77,9 +75,7 @@ type timeouts struct {
 
 // Hardware plugin client retry configuration constants
 const (
-	maxHardwareClientRetries = 3
-	baseRetryDelay           = 5 * time.Second
-	timedOutMessage          = "timed out"
+	timedOutMessage = "timed out"
 )
 
 func GetClusterTemplateRefName(name, version string) string {
@@ -235,12 +231,6 @@ func (t *provisioningRequestReconcilerTask) executePreProvisioningPhase(ctx cont
 	ctx = ctlrutils.LogPhaseStart(ctx, t.logger, "pre_provisioning")
 	phaseStartTime := time.Now()
 
-	// Initialize hardware plugin client if needed
-	if err := t.initializeHardwarePluginIfNeeded(ctx); err != nil {
-		result, _ := requeueWithError(err)
-		return nil, nil, result, err
-	}
-
 	// Handle validation, rendering and creation of required resources
 	renderedClusterInstance, res, err := t.handlePreProvisioning(ctx)
 	if renderedClusterInstance == nil {
@@ -274,11 +264,6 @@ func (t *provisioningRequestReconcilerTask) executeHardwareProvisioningPhase(ctx
 
 	ctx = ctlrutils.LogPhaseStart(ctx, t.logger, "hardware_provisioning")
 	phaseStartTime := time.Now()
-
-	if t.hwpluginClient == nil {
-		result, _ := requeueWithError(errors.New("hwpluginClient is not initialized"))
-		return result, errors.New("hwpluginClient is not initialized")
-	}
 
 	res, proceed, err := t.handleNodeAllocationRequestProvisioning(ctx, unstructuredClusterInstance)
 	if err != nil || (res == doNotRequeue() && !proceed) || res.RequeueAfter > 0 {
@@ -448,36 +433,6 @@ func (t *provisioningRequestReconcilerTask) checkOverallProvisioningTimeout(ctx 
 	return ctrl.Result{}
 }
 
-// initializeHardwarePluginIfNeeded initializes the hardware plugin client if hardware template is present
-func (t *provisioningRequestReconcilerTask) initializeHardwarePluginIfNeeded(ctx context.Context) error {
-	clusterTemplate, err := t.object.GetClusterTemplateRef(ctx, t.client)
-	if err != nil {
-		return nil
-	}
-
-	// Check if hardware provisioning might be needed: either the CT has default
-	// nodeGroupData, or the PR supplies hwMgmtParameters with nodeGroupData.
-	needsHwPlugin := len(clusterTemplate.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData) > 0
-	if !needsHwPlugin {
-		hwMgmtParams, extractErr := provisioningv1alpha1.ExtractMatchingInput(
-			t.object.Spec.TemplateParameters.Raw, ctlrutils.TemplateParamHwMgmt)
-		if extractErr == nil && hwMgmtParams != nil {
-			if m, ok := hwMgmtParams.(map[string]any); ok {
-				if ng, ok := m["nodeGroupData"].([]any); ok && len(ng) > 0 {
-					needsHwPlugin = true
-				}
-			}
-		}
-	}
-
-	if needsHwPlugin && t.hwpluginClient == nil {
-		if err := t.initializeHardwarePluginClientWithRetry(ctx); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // handleClusterUpgrades handles cluster upgrade logic
 func (t *provisioningRequestReconcilerTask) handleClusterUpgrades(ctx context.Context, clusterName string) (ctrl.Result, error) {
 	shouldUpgrade, result, err := t.IsUpgradeRequested(ctx, clusterName)
@@ -517,7 +472,7 @@ func (t *provisioningRequestReconcilerTask) shouldStopReconciliation() bool {
 //
 //nolint:unparam // Kept for API compatibility, always returns empty Result
 func (t *provisioningRequestReconcilerTask) checkHardwareProvisioningTimeout() ctrl.Result {
-	if t.isHardwareProvisionSkipped() || t.object.Status.Extensions.NodeAllocationRequestRef == nil {
+	if t.isHardwareProvisionSkipped() {
 		return ctrl.Result{}
 	}
 
@@ -620,7 +575,7 @@ func (t *provisioningRequestReconcilerTask) handleNodeAllocationRequestProvision
 		return requeueWithMediumInterval(), false, err
 	}
 
-	nodeAllocationRequestID := t.getNodeAllocationRequestID()
+	nodeAllocationRequestID := t.object.Name
 	if nodeAllocationRequestID == "" {
 		t.logger.WarnContext(ctx, "Missing NodeAllocationRequest identifier, will retry")
 		return requeueWithShortInterval(), false, fmt.Errorf("missing nodeAllocationRequest identifier")
@@ -670,17 +625,13 @@ func (t *provisioningRequestReconcilerTask) checkClusterDeployConfigState(ctx co
 	if !t.isHardwareProvisionSkipped() {
 		// Check the NodeAllocationRequest status if exists
 		nodeAllocationRequestResponse, exists, err := t.getNodeAllocationRequestResponse(ctx)
-		if err != nil || !exists {
-			// If NodeAllocationRequest doesn't exist and this is likely initial validation phase,
-			// skip hardware status checks and proceed to resource preparation status check
-			if t.object.Status.Extensions.NodeAllocationRequestRef == nil {
-				// No NodeAllocationRequestRef means this is initial phase, skip hardware checks
-				t.logger.InfoContext(ctx, "NodeAllocationRequestRef is nil, skipping hardware status checks during initial phase")
-			} else {
-				// NodeAllocationRequestRef exists but getNodeAllocationRequestResponse failed,
-				// this indicates a real hardware plugin error
-				return requeueWithError(err)
-			}
+		if err != nil {
+			return requeueWithError(err)
+		}
+		if !exists {
+			// NAR not found — either not yet created or already deleted.
+			// Skip hardware status checks and proceed to resource preparation status check.
+			t.logger.InfoContext(ctx, "NodeAllocationRequest not found, skipping hardware status checks")
 		} else {
 			hwProvisioned, timedOutOrFailed, err := t.checkNodeAllocationRequestStatus(ctx, nodeAllocationRequestResponse, hwmgmtv1alpha1.Provisioned)
 			if err != nil {
@@ -793,7 +744,7 @@ func (t *provisioningRequestReconcilerTask) handleFulfilledStateMonitoring(ctx c
 	// Sync skip-cleanup annotation to the NAR for fulfilled PRs.
 	// During provisioning this is handled by createOrUpdateNodeAllocationRequest,
 	// but after fulfillment that path is no longer called.
-	if !t.isHardwareProvisionSkipped() && t.hwpluginClient != nil {
+	if !t.isHardwareProvisionSkipped() {
 		if err := t.syncNARSkipCleanup(ctx); err != nil {
 			return requeueWithError(fmt.Errorf("failed to sync skipCleanup on NAR: %w", err))
 		}
@@ -1064,7 +1015,7 @@ func (t *provisioningRequestReconcilerTask) handleClusterResources(ctx context.C
 }
 
 func (t *provisioningRequestReconcilerTask) renderHardwareTemplate(ctx context.Context,
-	clusterInstance *unstructured.Unstructured) (*hwmgrpluginapi.NodeAllocationRequest, error) {
+	clusterInstance *unstructured.Unstructured) (*pluginsv1alpha1.NodeAllocationRequest, error) {
 	renderedNodeAllocationRequest, err := t.handleRenderHardwareTemplate(ctx, clusterInstance)
 	if err != nil {
 		hardwareTemplateFailureMsg := "Failed to render the Hardware template"
@@ -1182,36 +1133,28 @@ func (r *ProvisioningRequestReconciler) handleProvisioningRequestDeletion(
 		}
 	}
 
-	// Delete the NodeAllocationRequest CR first
-	if provisioningRequest.Status.Extensions.NodeAllocationRequestRef != nil {
-		// Get hwplugin client for the HardwarePlugin
-		hwpluginClient, err := getHardwarePluginClient(ctx, r.Client, r.Logger, provisioningRequest)
-		if err != nil {
-			return false, fmt.Errorf("failed to get HardwarePlugin client: %w", err)
+	// Delete the NodeAllocationRequest CR first.
+	// The NAR name matches the ProvisioningRequest name (1:1 relationship).
+	narNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
+	nar := &pluginsv1alpha1.NodeAllocationRequest{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: provisioningRequest.Name, Namespace: narNS}, nar); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to get NodeAllocationRequest %s: %w", provisioningRequest.Name, err)
 		}
-
-		nodeAllocationRequestID := provisioningRequest.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID
-		if nodeAllocationRequestID != "" {
+		// NAR not found — already deleted or never created
+	} else {
+		// NAR exists — initiate deletion if not already deleting
+		if nar.DeletionTimestamp.IsZero() {
 			r.Logger.InfoContext(ctx, "Deleting NodeAllocationRequest",
-				slog.String("nodeAllocationRequestID", nodeAllocationRequestID))
-			// Create adapter for the hardware plugin client
-			clientAdapter := hwmgrpluginapi.NewHardwarePluginClientAdapter(hwpluginClient)
-			resp, narExists, err := clientAdapter.DeleteNodeAllocationRequest(ctx, nodeAllocationRequestID)
-			if err != nil {
-				return false, fmt.Errorf("failed to delete NodeAllocationRequest '%s': %w", nodeAllocationRequestID, err)
-			}
-
-			if resp == nodeAllocationRequestID {
-				r.Logger.InfoContext(ctx, "Deletion request for NodeAllocationRequest successful",
-					slog.String("nodeAllocationRequestID", nodeAllocationRequestID))
-			}
-
-			if narExists {
-				r.Logger.InfoContext(ctx, "Waiting for NodeAllocationRequest to be deleted",
-					slog.String("nodeAllocationRequestID", nodeAllocationRequestID))
-				return false, nil
+				slog.String("nar", provisioningRequest.Name))
+			deletePolicy := metav1.DeletePropagationForeground
+			if err := r.Client.Delete(ctx, nar, &client.DeleteOptions{PropagationPolicy: &deletePolicy}); err != nil {
+				return false, fmt.Errorf("failed to delete NodeAllocationRequest %s: %w", provisioningRequest.Name, err)
 			}
 		}
+		r.Logger.InfoContext(ctx, "Waiting for NodeAllocationRequest to be deleted",
+			slog.String("nar", provisioningRequest.Name))
+		return false, nil
 	}
 
 	// Delete the ClusterInstance CR next
@@ -1384,7 +1327,7 @@ func (t *provisioningRequestReconcilerTask) finalizeProvisioningIfComplete(ctx c
 		// enabling BMO management of IBI-provisioned nodes.
 		// Done after persisting FULFILLED state so a transient plugin failure
 		// does not block fulfillment. Returns error to trigger retry via requeue.
-		if !t.isHardwareProvisionSkipped() && t.hwpluginClient != nil {
+		if !t.isHardwareProvisionSkipped() {
 			if err := t.setNARClusterProvisioned(ctx); err != nil {
 				return fmt.Errorf("failed to set clusterProvisioned on NAR: %w", err)
 			}
@@ -1397,138 +1340,19 @@ func (t *provisioningRequestReconcilerTask) finalizeProvisioningIfComplete(ctx c
 	return nil
 }
 
-// initializeHardwarePluginClientWithRetry attempts to initialize the hardware plugin client
-// with synchronous exponential backoff retry logic to handle temporary failures.
-func (t *provisioningRequestReconcilerTask) initializeHardwarePluginClientWithRetry(ctx context.Context) error {
-	var lastErr error
-
-	for attempt := 1; attempt <= maxHardwareClientRetries; attempt++ {
-		hwclient, err := getHardwarePluginClient(ctx, t.client, t.logger, t.object)
-		if err == nil {
-			// Success - initialize client and return
-			t.hwpluginClient = hwmgrpluginapi.NewHardwarePluginClientAdapter(hwclient)
-
-			if attempt > 1 {
-				t.logger.InfoContext(ctx,
-					"Hardware plugin client initialized successfully after retries",
-					slog.String("provisioningRequest", t.object.Name),
-					slog.Int("attempts", attempt))
-			} else {
-				t.logger.InfoContext(ctx,
-					"Hardware plugin client initialized successfully",
-					slog.String("provisioningRequest", t.object.Name))
-			}
-
-			return nil
-		}
-
-		lastErr = err
-
-		if attempt == maxHardwareClientRetries {
-			// Maximum retries exceeded, fail permanently
-			t.logger.ErrorContext(ctx,
-				"Failed to initialize hardware plugin client after maximum retries",
-				slog.String("provisioningRequest", t.object.Name),
-				slog.Int("maxRetries", maxHardwareClientRetries),
-				slog.String("error", err.Error()))
-			break
-		}
-
-		// Calculate exponential backoff delay: baseRetryDelay * 2^(attempt-1)
-		delay := baseRetryDelay * time.Duration(1<<(attempt-1))
-
-		t.logger.WarnContext(ctx,
-			"Hardware plugin client initialization failed, retrying",
-			slog.String("provisioningRequest", t.object.Name),
-			slog.Int("attempt", attempt),
-			slog.Int("maxRetries", maxHardwareClientRetries),
-			slog.Duration("retryDelay", delay),
-			slog.String("error", err.Error()))
-
-		// Sleep before retry (except for the last attempt)
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("context cancelled during retry: %w", ctx.Err())
-		case <-time.After(delay):
-			// Continue to next attempt
-		}
-	}
-
-	return fmt.Errorf("hardware plugin client initialization failed after %d retries: %w",
-		maxHardwareClientRetries, lastErr)
-}
-
-// getHardwarePluginClient is a convenience wrapper function to get the HardwarePluginClient object
-func getHardwarePluginClient(
-	ctx context.Context,
-	c client.Client,
-	logger *slog.Logger,
-	pr *provisioningv1alpha1.ProvisioningRequest,
-) (*hwmgrpluginapi.HardwarePluginClient, error) {
-	// Get the HardwarePlugin CR
-	hwplugin, err := ctlrutils.GetHardwarePluginFromProvisioningRequest(ctx, c, pr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve HardwarePlugin: %w", err)
-	}
-
-	// Validate that the HardwarePlugin CR is registered successfully
-	validated := meta.FindStatusCondition(hwplugin.Status.Conditions, string(hwmgmtv1alpha1.ConditionTypes.Registration))
-	if validated == nil || validated.Status != metav1.ConditionTrue {
-		return nil, fmt.Errorf("hardwarePlugin '%s' is not registered", hwplugin.Name)
-	}
-
-	// Get hwplugin client for the HardwarePlugin
-	// nolint: wrapcheck
-	return hwmgrpluginapi.NewHardwarePluginClient(ctx, c, logger, hwplugin)
-}
-
-// getNodeAllocationRequestID returns the NodeAllocationRequest identifier associated with the ProvisioningRequest CR.
-// If no identifier is set, a null string is returned.
-func (t *provisioningRequestReconcilerTask) getNodeAllocationRequestID() string {
-	if t.object.Status.Extensions.NodeAllocationRequestRef != nil {
-		return t.object.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID
-	}
-	return ""
-}
-
 // getNodeAllocationRequestResponse retrieves the NodeAllocationRequest from the HardwarePlugin server.
 // It returns the NodeAllocationRequestResponse, boolean value indicating whether the NodeAllocationRequest object was found (exists),
 // and any error encountered while attempting to fetch the NodeAllocationRequest.
-func (t *provisioningRequestReconcilerTask) getNodeAllocationRequestResponse(ctx context.Context) (*hwmgrpluginapi.NodeAllocationRequestResponse, bool, error) {
-	nodeAllocationRequestID := t.getNodeAllocationRequestID()
-	if nodeAllocationRequestID == "" {
-		return nil, false, fmt.Errorf("missing status.nodeAllocationRequestRef.NodeAllocationRequestID")
-	}
-
-	// Check if hardware plugin client is available
-	if t.hwpluginClient == nil {
-		return nil, false, fmt.Errorf("hardware plugin client is not available")
-	}
-
-	var (
-		nodeAllocationRequestResponse *hwmgrpluginapi.NodeAllocationRequestResponse
-		exists                        bool
-		err                           error
-	)
-	// Get the generated NodeAllocationRequest and its status.
-	if err = ctlrutils.RetryOnConflictOrRetriableOrNotFound(retry.DefaultRetry, func() error {
-		nodeAllocationRequestResponse, exists, err = t.hwpluginClient.GetNodeAllocationRequest(ctx, nodeAllocationRequestID)
-		if err != nil {
-			return fmt.Errorf("failed to get NodeAllocationRequest '%s': %w", nodeAllocationRequestID, err)
-		}
-		if !exists {
-			return fmt.Errorf("nodeAllocationRequest '%s' does not exist", nodeAllocationRequestID)
-		}
-		return nil
-	}); err != nil {
-		if strings.Contains(err.Error(), "does not exist") {
+func (t *provisioningRequestReconcilerTask) getNodeAllocationRequestResponse(ctx context.Context) (*pluginsv1alpha1.NodeAllocationRequest, bool, error) {
+	nar, err := t.getNAR(ctx)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
 			return nil, false, nil
 		}
-		// nolint: wrapcheck
-		return nil, false, err
+		return nil, false, fmt.Errorf("failed to get NodeAllocationRequest %s: %w", t.object.Name, err)
 	}
 
-	return nodeAllocationRequestResponse, true, nil
+	return nar, true, nil
 }
 
 func (t *provisioningRequestReconcilerTask) resetHardwareTimers() {

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -1340,9 +1340,9 @@ func (t *provisioningRequestReconcilerTask) finalizeProvisioningIfComplete(ctx c
 	return nil
 }
 
-// getNodeAllocationRequestResponse retrieves the NodeAllocationRequest from the HardwarePlugin server.
-// It returns the NodeAllocationRequestResponse, boolean value indicating whether the NodeAllocationRequest object was found (exists),
-// and any error encountered while attempting to fetch the NodeAllocationRequest.
+// getNodeAllocationRequestResponse retrieves the NodeAllocationRequest CR by PR name.
+// It returns the NodeAllocationRequest, a boolean indicating whether it exists,
+// and any error encountered.
 func (t *provisioningRequestReconcilerTask) getNodeAllocationRequestResponse(ctx context.Context) (*pluginsv1alpha1.NodeAllocationRequest, bool, error) {
 	nar, err := t.getNAR(ctx)
 	if err != nil {

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -172,8 +172,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -184,10 +182,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ibgu "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
+	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
-	hwmgrpluginapi "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/provisioning"
-	"github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/provisioning/mocks"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
@@ -1116,22 +1113,19 @@ plan:
 			})
 		})
 
-		Context("when NodeAllocationRequestRef exists but ID is empty", func() {
-			It("should handle hardware plugin client error gracefully", func() {
-				// Set NodeAllocationRequestRef with empty ID
-				deletionCR.Status.Extensions.NodeAllocationRequestRef = &provisioningv1alpha1.NodeAllocationRequestRef{
-					NodeAllocationRequestID: "", // Empty ID
-				}
+		Context("when NodeAllocationRequestRef exists but NAR does not exist", func() {
+			It("should proceed gracefully when NAR is not found", func() {
+				// Set NodeAllocationRequestRef (NAR looked up by PR name, not by ID)
+				deletionCR.Status.Extensions.NodeAllocationRequestRef = &provisioningv1alpha1.NodeAllocationRequestRef{}
 				deletionCR.Status.Extensions.ClusterDetails = &provisioningv1alpha1.ClusterDetails{
 					Name: testClusterName,
 				}
 				Expect(c.Status().Update(ctx, deletionCR)).To(Succeed())
 
-				// This will fail due to missing HardwarePlugin resource, which is expected behavior
-				// when the test setup doesn't include proper hardware plugin dependencies
-				_, err := deletionReconciler.handleProvisioningRequestDeletion(ctx, deletionCR)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to get HardwarePlugin client"))
+				// NAR not found is handled gracefully — deletion proceeds to ClusterInstance
+				deleteCompleted, err := deletionReconciler.handleProvisioningRequestDeletion(ctx, deletionCR)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deleteCompleted).To(BeFalse()) // Should wait for ClusterInstance deletion
 			})
 		})
 
@@ -2857,23 +2851,17 @@ nodes:
 
 	Describe("getNodeAllocationRequestResponse", func() {
 		var (
-			narResponseTask    *provisioningRequestReconcilerTask
-			narResponseCR      *provisioningv1alpha1.ProvisioningRequest
-			testNARID          = "cluster-1" // Use mock server's default NodeAllocationRequest ID
-			testClusterName    = "test-nar-response-cluster"
-			mockCtrl           *gomock.Controller
-			mockHwPluginClient *mocks.MockHardwarePluginClientInterface
+			narResponseTask *provisioningRequestReconcilerTask
+			narResponseCR   *provisioningv1alpha1.ProvisioningRequest
+			testPRName      = "test-nar-response-pr"
+			testClusterName = "test-nar-response-cluster"
 		)
 
 		BeforeEach(func() {
 			// Create a ProvisioningRequest for NAR response testing
 			narResponseCR = &provisioningv1alpha1.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-nar-response-pr",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						"test-type": "nar-response",
-					},
+					Name: testPRName,
 				},
 				Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 					TemplateName:    "test-nar-response-template",
@@ -2882,22 +2870,8 @@ nodes:
 						Raw: []byte(`{"clusterName": "` + testClusterName + `"}`),
 					},
 				},
-				Status: provisioningv1alpha1.ProvisioningRequestStatus{
-					ProvisioningStatus: provisioningv1alpha1.ProvisioningStatus{
-						ProvisioningPhase: provisioningv1alpha1.StateProgressing,
-					},
-					Extensions: provisioningv1alpha1.Extensions{
-						NodeAllocationRequestRef: &provisioningv1alpha1.NodeAllocationRequestRef{
-							NodeAllocationRequestID: testNARID,
-						},
-					},
-				},
 			}
 			Expect(c.Create(ctx, narResponseCR)).To(Succeed())
-
-			// Create the mock controller and hardware plugin client
-			mockCtrl = gomock.NewController(GinkgoT())
-			mockHwPluginClient = mocks.NewMockHardwarePluginClientInterface(mockCtrl)
 
 			// Create the reconciler task
 			narResponseTask = &provisioningRequestReconcilerTask{
@@ -2908,259 +2882,45 @@ nodes:
 				ctDetails:      &clusterTemplateDetails{},
 				timeouts:       &timeouts{},
 				callbackConfig: utils.NewNarCallbackConfig(constants.DefaultNarCallbackServicePort),
-				hwpluginClient: mockHwPluginClient,
 			}
-
-		})
-
-		AfterEach(func() {
-			// Clean up the mock controller
-			if mockCtrl != nil {
-				mockCtrl.Finish()
-			}
-		})
-
-		Context("when NodeAllocationRequestID is missing", func() {
-			BeforeEach(func() {
-				// Remove the NodeAllocationRequestID to test missing identifier
-				narResponseCR.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID = ""
-				Expect(c.Status().Update(ctx, narResponseCR)).To(Succeed())
-			})
-
-			It("should return error for missing nodeAllocationRequestID", func() {
-				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
-
-				// Should return error for missing ID
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("missing status.nodeAllocationRequestRef.NodeAllocationRequestID"))
-				Expect(response).To(BeNil())
-				Expect(exists).To(BeFalse())
-			})
-		})
-
-		Context("when hwpluginClient is nil", func() {
-			BeforeEach(func() {
-				// Set hwpluginClient to nil to test error handling
-				narResponseTask.hwpluginClient = nil
-			})
-
-			It("should return error when hardware plugin client is not available", func() {
-				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
-
-				// Should return error due to nil hwpluginClient - no panic expected
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("hardware plugin client is not available"))
-				Expect(response).To(BeNil())
-				Expect(exists).To(BeFalse())
-			})
-		})
-
-		Context("when hwpluginClient.GetNodeAllocationRequest returns error", func() {
-			It("should return error from hardware plugin client", func() {
-				// Set up mock to return an error
-				expectedError := fmt.Errorf("hardware plugin error")
-				mockHwPluginClient.EXPECT().
-					GetNodeAllocationRequest(gomock.Any(), testNARID).
-					Return(nil, false, expectedError)
-
-				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
-
-				// Should return the error from the mock (may be wrapped)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("hardware plugin error"))
-				Expect(response).To(BeNil())
-				Expect(exists).To(BeFalse())
-			})
 		})
 
 		Context("when NodeAllocationRequest does not exist", func() {
 			It("should return nil response and false exists", func() {
-				// Set up mock to return not found (no error, but not exists)
-				mockHwPluginClient.EXPECT().
-					GetNodeAllocationRequest(gomock.Any(), testNARID).
-					Return(nil, false, nil)
-
 				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
 
-				// Should return no error, but exists should be false
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response).To(BeNil())
 				Expect(exists).To(BeFalse())
 			})
 		})
 
-		Context("when retry mechanism is triggered", func() {
-			It("should retry on retriable errors and eventually succeed", func() {
-				// Import k8s errors for proper retry simulation
-				k8sErrors := metav1.Status{
-					Reason: metav1.StatusReasonServiceUnavailable,
-					Code:   503,
-				}
-				retriableError := &errors.StatusError{ErrStatus: k8sErrors}
-
-				// Simulate retry scenario: first call fails with retriable error, second call succeeds
-				gomock.InOrder(
-					mockHwPluginClient.EXPECT().
-						GetNodeAllocationRequest(gomock.Any(), testNARID).
-						Return(nil, false, retriableError).
-						Times(1),
-					mockHwPluginClient.EXPECT().
-						GetNodeAllocationRequest(gomock.Any(), testNARID).
-						Return(&hwmgrpluginapi.NodeAllocationRequestResponse{
-							NodeAllocationRequest: &hwmgrpluginapi.NodeAllocationRequest{
-								ClusterId: testClusterName,
-								Site:      "test-site",
-							},
-						}, true, nil).
-						Times(1),
-				)
-
-				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
-
-				// Should eventually succeed after retry
-				Expect(err).ToNot(HaveOccurred())
-				Expect(response).ToNot(BeNil())
-				Expect(exists).To(BeTrue())
-				Expect(response.NodeAllocationRequest.ClusterId).To(Equal(testClusterName))
-			})
-
-			It("should stop retrying after persistent errors", func() {
-				// Return the same error multiple times to simulate persistent failure
-				mockHwPluginClient.EXPECT().
-					GetNodeAllocationRequest(gomock.Any(), testNARID).
-					Return(nil, false, fmt.Errorf("persistent hardware error")).
-					MinTimes(1) // Should be called at least once, potentially more due to retries
-
-				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
-
-				// Should eventually give up and return the error
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("persistent hardware error"))
-				Expect(response).To(BeNil())
-				Expect(exists).To(BeFalse())
-			})
-		})
-
-		Context("when GetNodeAllocationRequest returns different error types", func() {
-			It("should handle timeout errors appropriately", func() {
-				timeoutError := fmt.Errorf("context deadline exceeded")
-				mockHwPluginClient.EXPECT().
-					GetNodeAllocationRequest(gomock.Any(), testNARID).
-					Return(nil, false, timeoutError)
-
-				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
-
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("context deadline exceeded"))
-				Expect(response).To(BeNil())
-				Expect(exists).To(BeFalse())
-			})
-
-			It("should handle authentication errors appropriately", func() {
-				authError := fmt.Errorf("unauthorized: invalid credentials")
-				mockHwPluginClient.EXPECT().
-					GetNodeAllocationRequest(gomock.Any(), testNARID).
-					Return(nil, false, authError)
-
-				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
-
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("unauthorized"))
-				Expect(response).To(BeNil())
-				Expect(exists).To(BeFalse())
-			})
-		})
-
-		Context("when NodeAllocationRequest exists and is retrieved successfully", func() {
-			It("should return response, true exists, and nil error", func() {
-				// Set up mock to return a successful response
-				mockResponse := &hwmgrpluginapi.NodeAllocationRequestResponse{
-					NodeAllocationRequest: &hwmgrpluginapi.NodeAllocationRequest{
-						ClusterId: testClusterName,
-						Site:      "test-site",
+		Context("when NodeAllocationRequest exists", func() {
+			BeforeEach(func() {
+				// Create a NAR CR with the same name as the PR
+				nar := &pluginsv1alpha1.NodeAllocationRequest{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testPRName,
+						Namespace: constants.DefaultNamespace,
 					},
-				}
-				mockHwPluginClient.EXPECT().
-					GetNodeAllocationRequest(gomock.Any(), testNARID).
-					Return(mockResponse, true, nil)
-
-				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
-
-				// Should successfully retrieve the NodeAllocationRequest
-				Expect(err).ToNot(HaveOccurred())
-				Expect(response).ToNot(BeNil())
-				Expect(exists).To(BeTrue())
-				Expect(response.NodeAllocationRequest.ClusterId).To(Equal(testClusterName))
-			})
-		})
-
-		Context("integration with getNodeAllocationRequestID", func() {
-			It("should use the correct NodeAllocationRequestID from the CR", func() {
-				// Test that the method calls the hardware plugin with the correct ID
-				customNARID := "custom-nar-id-123"
-
-				// Update the CR with a custom NAR ID
-				narResponseCR.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID = customNARID
-				Expect(c.Status().Update(ctx, narResponseCR)).To(Succeed())
-
-				// Set up mock to expect the custom ID
-				mockResponse := &hwmgrpluginapi.NodeAllocationRequestResponse{
-					NodeAllocationRequest: &hwmgrpluginapi.NodeAllocationRequest{
-						ClusterId: testClusterName,
-						Site:      "test-site",
-					},
-				}
-				mockHwPluginClient.EXPECT().
-					GetNodeAllocationRequest(gomock.Any(), customNARID). // Should use the custom ID
-					Return(mockResponse, true, nil)
-
-				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
-
-				// Should successfully retrieve using the custom ID
-				Expect(err).ToNot(HaveOccurred())
-				Expect(response).ToNot(BeNil())
-				Expect(exists).To(BeTrue())
-				Expect(response.NodeAllocationRequest.ClusterId).To(Equal(testClusterName))
-			})
-		})
-
-		Context("response structure validation", func() {
-			It("should handle responses with complete NodeAllocationRequest data", func() {
-				// Set up mock to return a comprehensive response
-				mockResponse := &hwmgrpluginapi.NodeAllocationRequestResponse{
-					NodeAllocationRequest: &hwmgrpluginapi.NodeAllocationRequest{
+					Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
 						ClusterId:           testClusterName,
-						Site:                "test-site",
+						LocationSpec:        pluginsv1alpha1.LocationSpec{Site: "test-site"},
 						ConfigTransactionId: 12345,
 					},
-					Status: &hwmgrpluginapi.NodeAllocationRequestStatus{
-						Conditions: &[]hwmgrpluginapi.Condition{
-							{
-								Type:   "Ready",
-								Status: "True",
-							},
-						},
-					},
 				}
-				mockHwPluginClient.EXPECT().
-					GetNodeAllocationRequest(gomock.Any(), testNARID).
-					Return(mockResponse, true, nil)
+				Expect(c.Create(ctx, nar)).To(Succeed())
+			})
 
+			It("should return response, true exists, and nil error", func() {
 				response, exists, err := narResponseTask.getNodeAllocationRequestResponse(ctx)
 
-				// Should handle complete response data
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response).ToNot(BeNil())
 				Expect(exists).To(BeTrue())
-
-				// Verify response structure
-				Expect(response.NodeAllocationRequest.ClusterId).To(Equal(testClusterName))
-				Expect(response.NodeAllocationRequest.Site).To(Equal("test-site"))
-				Expect(response.NodeAllocationRequest.ConfigTransactionId).To(Equal(int64(12345)))
-				Expect(response.Status).ToNot(BeNil())
-				Expect(response.Status.Conditions).ToNot(BeNil())
-				Expect(*response.Status.Conditions).To(HaveLen(1))
-				Expect((*response.Status.Conditions)[0].Type).To(Equal("Ready"))
+				Expect(response.Spec.ClusterId).To(Equal(testClusterName))
+				Expect(response.Spec.LocationSpec.Site).To(Equal("test-site"))
+				Expect(response.Spec.ConfigTransactionId).To(Equal(int64(12345)))
 			})
 		})
 	})
@@ -3665,7 +3425,10 @@ plan:
 		// Create fake client with all objects
 		c = fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 			cr, clusterTemplate, upgradeDefaults,
-		).WithStatusSubresource(&provisioningv1alpha1.ProvisioningRequest{}).Build()
+		).WithStatusSubresource(
+			&provisioningv1alpha1.ProvisioningRequest{},
+			&pluginsv1alpha1.NodeAllocationRequest{},
+		).Build()
 		reconciler.Client = c
 
 		// Create task
@@ -4833,23 +4596,6 @@ plan:
 				callbackConfig: utils.NewNarCallbackConfig(constants.DefaultNarCallbackServicePort),
 			}
 
-			// Set up hwpluginClient using the test Metal3 hardware plugin for deploy config tests
-			hwplugin := &hwmgmtv1alpha1.HardwarePlugin{}
-			hwpluginKey := client.ObjectKey{
-				Name:      testMetal3HardwarePluginRef,
-				Namespace: testHwMgrPluginNameSpace,
-			}
-			err := c.Get(ctx, hwpluginKey, hwplugin)
-			if err != nil {
-				reconciler.Logger.Warn("Could not get hwplugin for deploy config test", "error", err)
-			} else {
-				hwpluginClient, err := hwmgrpluginapi.NewHardwarePluginClient(ctx, c, reconciler.Logger, hwplugin)
-				if err != nil {
-					reconciler.Logger.Warn("Could not create hwpluginClient for deploy config test", "error", err)
-				} else {
-					deployConfigTask.hwpluginClient = hwpluginClient
-				}
-			}
 		})
 
 		Context("when hardware provisioning is not skipped", func() {
@@ -4900,25 +4646,37 @@ plan:
 			})
 
 			Context("when hardware provisioning times out or fails", func() {
-				It("should return doNotRequeue without error", func() {
-					defer func() {
-						if r := recover(); r != nil {
-							// Panic is expected when hardware plugin client is not fully functional in unit tests
-							// This validates that the method reaches the hardware plugin integration point
-							return
-						}
-					}()
-
-					result, err := deployConfigTask.checkClusterDeployConfigState(ctx)
-
-					// In test environment, will likely error before reaching timeout logic
-					if err == nil {
-						// If method reaches timeout logic, should not requeue
-						Expect(result).To(Equal(doNotRequeue()))
-					} else {
-						// Error is expected in test environment
-						Expect(result).ToNot(BeNil())
+				BeforeEach(func() {
+					// Create a NAR with a timed-out provisioning condition
+					nar := &pluginsv1alpha1.NodeAllocationRequest{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      deployConfigCR.Name,
+							Namespace: constants.DefaultNamespace,
+						},
+						Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+							ClusterId: deployConfigCR.Name,
+						},
 					}
+					Expect(c.Create(ctx, nar)).To(Succeed())
+
+					// Set status after creation (fake client strips status on Create)
+					nar.Status.Conditions = []metav1.Condition{
+						{
+							Type:               string(hwmgmtv1alpha1.Provisioned),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(hwmgmtv1alpha1.Failed),
+							Message:            "Hardware provisioning timed out",
+							LastTransitionTime: metav1.Now(),
+						},
+					}
+					Expect(c.Status().Update(ctx, nar)).To(Succeed())
+				})
+
+				It("should return requeueWithMediumInterval without error", func() {
+					result, err := deployConfigTask.checkClusterDeployConfigState(ctx)
+					Expect(err).ToNot(HaveOccurred())
+					// Hardware timed out or failed → requeue to allow recovery
+					Expect(result.RequeueAfter).To(Equal(requeueWithMediumInterval().RequeueAfter))
 				})
 			})
 
@@ -5252,74 +5010,19 @@ plan:
 			})
 		})
 
-		Context("when getNodeAllocationRequestResponse returns error", func() {
+		Context("when NAR does not exist", func() {
 			BeforeEach(func() {
-				// Ensure Extensions are initialized before modifying NodeAllocationRequestID
-				if deployConfigCR.Status.Extensions.NodeAllocationRequestRef == nil {
-					deployConfigCR.Status.Extensions = provisioningv1alpha1.Extensions{
-						NodeAllocationRequestRef: &provisioningv1alpha1.NodeAllocationRequestRef{},
-					}
-				}
-				// Use empty NodeAllocationRequest ID to trigger missing ID error
-				deployConfigCR.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID = ""
+				// Set NodeAllocationRequestRef but don't create NAR in client
+				deployConfigCR.Status.Extensions.NodeAllocationRequestRef = &provisioningv1alpha1.NodeAllocationRequestRef{}
 				Expect(c.Status().Update(ctx, deployConfigCR)).To(Succeed())
 			})
 
-			It("should return error and valid result", func() {
+			It("should skip hardware checks and not return error", func() {
 				result, err := deployConfigTask.checkClusterDeployConfigState(ctx)
 
-				// Should error due to missing NodeAllocationRequest ID
-				Expect(err).To(HaveOccurred())
-				Expect(result).ToNot(BeNil()) // Should return a valid ctrl.Result
-			})
-		})
-
-		Context("when checkNodeAllocationRequestStatus returns error", func() {
-			BeforeEach(func() {
-				// Remove hardware plugin client to cause checkNodeAllocationRequestStatus to fail
-				deployConfigTask.hwpluginClient = nil
-				deployConfigCR.Status.Extensions.NodeAllocationRequestRef = &provisioningv1alpha1.NodeAllocationRequestRef{
-					NodeAllocationRequestID: "test-node-allocation-request-id",
-				}
-				Expect(c.Status().Update(ctx, deployConfigCR)).To(Succeed())
-			})
-
-			It("should return error and valid result", func() {
-				result, err := deployConfigTask.checkClusterDeployConfigState(ctx)
-
-				// Should not error due to missing hardware plugin client for status check
-				Expect(err).To(HaveOccurred())
-				Expect(result).ToNot(BeNil()) // Should return a valid ctrl.Result
-			})
-		})
-
-		Context("when checkNodeAllocationRequestStatus returns error", func() {
-			BeforeEach(func() {
-				// Ensure Extensions are initialized to prevent panic in BeforeEach
-				if deployConfigCR.Status.Extensions.NodeAllocationRequestRef == nil {
-					deployConfigCR.Status.Extensions = provisioningv1alpha1.Extensions{
-						NodeAllocationRequestRef: &provisioningv1alpha1.NodeAllocationRequestRef{},
-					}
-				}
-				// Use empty NodeAllocationRequest ID to trigger error in getNodeAllocationRequestResponse
-				deployConfigCR.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID = ""
-				Expect(c.Status().Update(ctx, deployConfigCR)).To(Succeed())
-			})
-
-			It("should return error and valid result", func() {
-				defer func() {
-					if r := recover(); r != nil {
-						// Panic is expected when hardware plugin client is not fully functional in unit tests
-						// This validates that the method attempts to call hardware plugin
-						return
-					}
-				}()
-
-				result, err := deployConfigTask.checkClusterDeployConfigState(ctx)
-
-				// Should error due to missing NodeAllocationRequest ID
-				Expect(err).To(HaveOccurred())
-				Expect(result).ToNot(BeNil()) // Should return a valid ctrl.Result
+				// NAR not found is not an error — hardware checks are skipped
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).ToNot(BeNil())
 			})
 		})
 	})
@@ -5413,23 +5116,6 @@ plan:
 				callbackConfig: utils.NewNarCallbackConfig(constants.DefaultNarCallbackServicePort),
 			}
 
-			// Set up hwpluginClient using the test Metal3 hardware plugin
-			hwplugin := &hwmgmtv1alpha1.HardwarePlugin{}
-			hwpluginKey := client.ObjectKey{
-				Name:      testMetal3HardwarePluginRef,
-				Namespace: testHwMgrPluginNameSpace,
-			}
-			err := c.Get(ctx, hwpluginKey, hwplugin)
-			if err != nil {
-				reconciler.Logger.Warn("Could not get hwplugin for validation test", "error", err)
-			} else {
-				hwpluginClient, err := hwmgrpluginapi.NewHardwarePluginClient(ctx, c, reconciler.Logger, hwplugin)
-				if err != nil {
-					reconciler.Logger.Warn("Could not create hwpluginClient for validation test", "error", err)
-				} else {
-					validationTask.hwpluginClient = hwpluginClient
-				}
-			}
 		})
 
 		Context("when validation fails during initial provisioning", func() {
@@ -5513,96 +5199,8 @@ plan:
 		})
 	})
 
-	Describe("initializeHardwarePluginClientWithRetry", func() {
-		var (
-			retryTask *provisioningRequestReconcilerTask
-			ctx       context.Context
-			logger    *slog.Logger
-		)
-
-		BeforeEach(func() {
-			ctx = context.TODO()
-			logger = slog.New(slog.DiscardHandler)
-
-			// Create a minimal test ProvisioningRequest
-			testCR := &provisioningv1alpha1.ProvisioningRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-retry-cr",
-					Namespace: "test-namespace",
-				},
-				Spec: provisioningv1alpha1.ProvisioningRequestSpec{
-					TemplateName:    "test-template",
-					TemplateVersion: "v1.0.0",
-				},
-			}
-
-			retryTask = &provisioningRequestReconcilerTask{
-				logger: logger,
-				client: c,
-				object: testCR,
-			}
-		})
-
-		Context("when hardware plugin client initialization fails", func() {
-			It("should fail after maximum retries", func() {
-				Skip("Skipping timing tests as they would take 15+ seconds and slow down test suite")
-
-				// This test would verify:
-				// - Exponential backoff with 5s base delay (5s, 10s, 20s)
-				// - Total delay of at least 15 seconds
-				// - Final error message indicating 3 retries attempted
-
-				err := retryTask.initializeHardwarePluginClientWithRetry(ctx)
-
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("hardware plugin client initialization failed after 3 retries"))
-				Expect(retryTask.hwpluginClient).To(BeNil())
-			})
-
-			It("should respect context cancellation during retries", func() {
-				Skip("Skipping timing tests as they would take 2+ seconds and slow down test suite")
-
-				// This test would verify:
-				// - Context cancellation is respected during sleep periods
-				// - Returns context error when cancelled
-				// - Does not complete all retries when cancelled early
-			})
-		})
-
-		Context("retry configuration", func() {
-			It("should have correct retry parameters", func() {
-				// Test the configuration constants without actually running retries
-				Expect(maxHardwareClientRetries).To(Equal(3))
-				Expect(baseRetryDelay).To(Equal(5 * time.Second))
-			})
-
-			It("should calculate correct exponential backoff delays", func() {
-				// Verify the mathematical correctness of delay calculation
-				// without actually sleeping
-
-				// Expected delays: 5s * 2^0 = 5s, 5s * 2^1 = 10s, 5s * 2^2 = 20s
-				expectedDelays := []time.Duration{
-					5 * time.Second,  // First retry
-					10 * time.Second, // Second retry
-					20 * time.Second, // Third retry (not used since it's the final attempt)
-				}
-
-				for attempt := 1; attempt <= 2; attempt++ { // Only test first 2 delays
-					expectedDelay := baseRetryDelay * time.Duration(1<<(attempt-1))
-					Expect(expectedDelay).To(Equal(expectedDelays[attempt-1]))
-				}
-			})
-		})
-
-		Context("successful initialization", func() {
-			// Note: This test would require setting up a valid hardware plugin,
-			// which is complex in a unit test environment. The success path is
-			// tested implicitly in integration tests.
-			It("should be tested in integration tests with real hardware plugin setup", func() {
-				Skip("Success path requires complex hardware plugin setup, tested in integration tests")
-			})
-		})
-	})
+	// initializeHardwarePluginClientWithRetry tests removed — function eliminated
+	// in NAR API re-architecture (Phase 1). Hardware plugin REST client is no longer used.
 
 	Describe("checkOverallProvisioningTimeout", func() {
 		var (
@@ -6105,19 +5703,12 @@ clustertemplate-test-policy-v1-cpu-reserved: "0-1"`,
 			}
 		})
 
-		Context("when provisioning phases fail and timeout is exceeded", func() {
-			It("should trigger timeout check and continue reconciling", func() {
-				// This test simulates the integration point at line 191 in the controller
-				// executeProvisioningPhases will fail (due to missing templates), triggering the timeout check
+		Context("when provisioning is pending and timeout is exceeded", func() {
+			It("should trigger timeout check and set failed state", func() {
+				// Verify the state is Pending with old UpdateTime (set in BeforeEach)
+				Expect(testObject.Status.ProvisioningStatus.ProvisioningPhase).To(Equal(provisioningv1alpha1.StatePending))
 
-				renderedClusterInstance, _, err := testTask.executeProvisioningPhases(ctx)
-
-				// Should get an error from the provisioning phases
-				Expect(err).To(HaveOccurred())
-				Expect(renderedClusterInstance).To(BeNil())
-
-				// The error should be related to provisioning failure, not timeout
-				// But if we now run the timeout check manually (as done at line 191), it should trigger
+				// Run the timeout check directly — it should trigger
 				timeoutResult := testTask.checkOverallProvisioningTimeout(ctx)
 
 				// Should continue reconciling after timeout
@@ -6129,19 +5720,13 @@ clustertemplate-test-policy-v1-cpu-reserved: "0-1"`,
 			})
 		})
 
-		Context("when provisioning phases fail but timeout is not exceeded", func() {
+		Context("when provisioning is pending but timeout is not exceeded", func() {
 			BeforeEach(func() {
 				// Set recent UpdateTime to avoid timeout
 				testObject.Status.ProvisioningStatus.UpdateTime = metav1.Time{Time: currentTime.Add(-5 * time.Minute)}
 			})
 
-			It("should not trigger timeout and return original error", func() {
-				renderedClusterInstance, _, err := testTask.executeProvisioningPhases(ctx)
-
-				// Should get an error from the provisioning phases
-				Expect(err).To(HaveOccurred())
-				Expect(renderedClusterInstance).To(BeNil())
-
+			It("should not trigger timeout and keep pending state", func() {
 				// Timeout check should not trigger
 				timeoutResult := testTask.checkOverallProvisioningTimeout(ctx)
 				Expect(timeoutResult).To(Equal(ctrl.Result{}))

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -261,17 +261,21 @@ func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestStatus(
 	var timedOutOrFailed bool
 	var err error
 
-	// Guard against consuming stale terminal status from the NAR during day-2 retries.
-	// After a PR spec change, the NAR may still carry a Failed/TimedOut condition from the
-	// previous attempt until the plugin processes the new ConfigTransactionId. Skip the
-	// update and requeue until the plugin has observed the new transaction.
-	if nodeAllocationRequestResponse.Spec.ConfigTransactionId != 0 &&
+	// Guard against consuming stale Configured status during day-2 retries.
+	// After a PR spec change, the NAR may still carry a Configured condition
+	// from the previous attempt (Failed, TimedOut, or True from a prior success)
+	// until the plugin processes the new ConfigTransactionId. Skip the update
+	// and requeue until the plugin has observed the new transaction.
+	// This only applies to Configured — the Provisioned condition transitions
+	// once during initial provisioning and is not affected by spec changes.
+	if condition == hwmgmtv1alpha1.Configured &&
+		nodeAllocationRequestResponse.Spec.ConfigTransactionId != 0 &&
 		nodeAllocationRequestResponse.Status.ObservedConfigTransactionId != nodeAllocationRequestResponse.Spec.ConfigTransactionId {
 		for _, c := range nodeAllocationRequestResponse.Status.Conditions {
-			if c.Type == string(condition) &&
-				(c.Reason == string(hwmgmtv1alpha1.Failed) || c.Reason == string(hwmgmtv1alpha1.TimedOut)) {
-				t.logger.InfoContext(ctx, "Skipping stale terminal NAR status — plugin has not observed new transaction",
+			if c.Type == string(condition) {
+				t.logger.InfoContext(ctx, "Skipping stale NAR status — plugin has not observed new transaction",
 					slog.String("condition", string(condition)),
+					slog.String("reason", c.Reason),
 					slog.Int64("specTransaction", nodeAllocationRequestResponse.Spec.ConfigTransactionId),
 					slog.Int64("observedTransaction", nodeAllocationRequestResponse.Status.ObservedConfigTransactionId))
 				return false, false, nil

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -14,51 +14,55 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/meta"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
+	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
-	hwmgrpluginapi "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/provisioning"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/controller/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// getNAR retrieves the NodeAllocationRequest CR for this ProvisioningRequest.
+// The NAR name matches the ProvisioningRequest name (1:1 relationship).
+func (t *provisioningRequestReconcilerTask) getNAR(ctx context.Context) (*pluginsv1alpha1.NodeAllocationRequest, error) {
+	narNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
+	nar := &pluginsv1alpha1.NodeAllocationRequest{}
+	if err := t.client.Get(ctx, types.NamespacedName{Name: t.object.Name, Namespace: narNS}, nar); err != nil {
+		return nil, fmt.Errorf("failed to get NodeAllocationRequest %s/%s: %w", narNS, t.object.Name, err)
+	}
+	return nar, nil
+}
 
 // setNARClusterProvisioned sets the ClusterProvisioned field on the NodeAllocationRequest
 // to signal to the hardware plugin that the cluster is fully provisioned and operational.
 func (t *provisioningRequestReconcilerTask) setNARClusterProvisioned(ctx context.Context) error {
-	if t.object.Status.Extensions.NodeAllocationRequestRef == nil {
-		return nil
-	}
-	nodeAllocationRequestID := t.object.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID
-	if nodeAllocationRequestID == "" {
-		return nil
-	}
-
-	existingNAR, exists, err := t.hwpluginClient.GetNodeAllocationRequest(ctx, nodeAllocationRequestID)
+	nar, err := t.getNAR(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get NodeAllocationRequest %s: %w", nodeAllocationRequestID, err)
-	}
-	if !exists || existingNAR.NodeAllocationRequest == nil {
-		return nil
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get NodeAllocationRequest %s: %w", t.object.Name, err)
 	}
 
 	// Skip if already set
-	if existingNAR.NodeAllocationRequest.ClusterProvisioned != nil && *existingNAR.NodeAllocationRequest.ClusterProvisioned {
+	if nar.Spec.ClusterProvisioned {
 		return nil
 	}
 
-	// Set ClusterProvisioned on the existing NAR and update
-	clusterProvisioned := true
-	existingNAR.NodeAllocationRequest.ClusterProvisioned = &clusterProvisioned
-	if _, err := t.hwpluginClient.UpdateNodeAllocationRequest(ctx, nodeAllocationRequestID, *existingNAR.NodeAllocationRequest); err != nil {
-		return fmt.Errorf("failed to set clusterProvisioned on NodeAllocationRequest %s: %w", nodeAllocationRequestID, err)
+	// Set ClusterProvisioned and update
+	patch := client.MergeFrom(nar.DeepCopy())
+	nar.Spec.ClusterProvisioned = true
+	if err := t.client.Patch(ctx, nar, patch); err != nil {
+		return fmt.Errorf("failed to set clusterProvisioned on NodeAllocationRequest %s: %w", t.object.Name, err)
 	}
 
-	t.logger.InfoContext(ctx, "Set clusterProvisioned on NodeAllocationRequest", slog.String("narID", nodeAllocationRequestID))
+	t.logger.InfoContext(ctx, "Set clusterProvisioned on NodeAllocationRequest", slog.String("nar", t.object.Name))
 	return nil
 }
 
@@ -66,36 +70,28 @@ func (t *provisioningRequestReconcilerTask) setNARClusterProvisioned(ctx context
 // to the SkipCleanup field on the NodeAllocationRequest. This is used for fulfilled PRs
 // where createOrUpdateNodeAllocationRequest is no longer called.
 func (t *provisioningRequestReconcilerTask) syncNARSkipCleanup(ctx context.Context) error {
-	if t.object.Status.Extensions.NodeAllocationRequestRef == nil {
-		return nil
-	}
-	nodeAllocationRequestID := t.object.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID
-	if nodeAllocationRequestID == "" {
-		return nil
-	}
-
-	existingNAR, exists, err := t.hwpluginClient.GetNodeAllocationRequest(ctx, nodeAllocationRequestID)
+	nar, err := t.getNAR(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get NodeAllocationRequest %s: %w", nodeAllocationRequestID, err)
-	}
-	if !exists || existingNAR.NodeAllocationRequest == nil {
-		return nil
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get NodeAllocationRequest %s: %w", t.object.Name, err)
 	}
 
 	_, hasAnnotation := t.object.Annotations[ctlrutils.SkipCleanupAnnotation]
-	currentValue := existingNAR.NodeAllocationRequest.SkipCleanup != nil && *existingNAR.NodeAllocationRequest.SkipCleanup
 
-	if hasAnnotation == currentValue {
+	if hasAnnotation == nar.Spec.SkipCleanup {
 		return nil // Already in sync
 	}
 
-	existingNAR.NodeAllocationRequest.SkipCleanup = &hasAnnotation
-	if _, err := t.hwpluginClient.UpdateNodeAllocationRequest(ctx, nodeAllocationRequestID, *existingNAR.NodeAllocationRequest); err != nil {
-		return fmt.Errorf("failed to sync skipCleanup on NodeAllocationRequest %s: %w", nodeAllocationRequestID, err)
+	patch := client.MergeFrom(nar.DeepCopy())
+	nar.Spec.SkipCleanup = hasAnnotation
+	if err := t.client.Patch(ctx, nar, patch); err != nil {
+		return fmt.Errorf("failed to sync skipCleanup on NodeAllocationRequest %s: %w", t.object.Name, err)
 	}
 
 	t.logger.InfoContext(ctx, "Synced skipCleanup on NodeAllocationRequest",
-		slog.String("narID", nodeAllocationRequestID),
+		slog.String("nar", t.object.Name),
 		slog.Bool("skipCleanup", hasAnnotation))
 	return nil
 }
@@ -103,56 +99,37 @@ func (t *provisioningRequestReconcilerTask) syncNARSkipCleanup(ctx context.Conte
 // createOrUpdateNodeAllocationRequest creates a new NodeAllocationRequest resource if it doesn't exist or updates it if the spec has changed.
 func (t *provisioningRequestReconcilerTask) createOrUpdateNodeAllocationRequest(ctx context.Context,
 	clusterNamespace string,
-	nodeAllocationRequest *hwmgrpluginapi.NodeAllocationRequest) error {
+	nodeAllocationRequest *pluginsv1alpha1.NodeAllocationRequest) error {
 
-	var (
-		nodeAllocationRequestID       string
-		existingNodeAllocationRequest *hwmgrpluginapi.NodeAllocationRequestResponse
-		err                           error
-	)
-
-	if t.object.Status.Extensions.NodeAllocationRequestRef != nil {
-		nodeAllocationRequestID = t.object.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID
-	}
-
-	if nodeAllocationRequestID == "" {
+	// Check if the NAR already exists
+	existingNAR, err := t.getNAR(ctx)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get NodeAllocationRequest %s: %w", t.object.Name, err)
+		}
+		// NAR doesn't exist — create it
 		return t.createNodeAllocationRequestResources(ctx, clusterNamespace, nodeAllocationRequest)
-	} else {
-		existingNodeAllocationRequest, _, err = t.hwpluginClient.GetNodeAllocationRequest(ctx, nodeAllocationRequestID)
-		if err != nil {
-			return fmt.Errorf("failed to get NodeAllocationRequest %s: %w", nodeAllocationRequestID, err)
-		}
 	}
 
-	// Compare the fields managed by the PR controller and update if any have changed.
-	// We compare against a copy of the existing NAR with server-managed fields (like
-	// ClusterProvisioned) carried over to avoid false-positive change detection.
-	nodeAllocationRequest.ClusterProvisioned = existingNodeAllocationRequest.NodeAllocationRequest.ClusterProvisioned
-	if !equality.Semantic.DeepEqual(existingNodeAllocationRequest.NodeAllocationRequest, nodeAllocationRequest) {
-		narID, err := t.hwpluginClient.UpdateNodeAllocationRequest(ctx, nodeAllocationRequestID, *nodeAllocationRequest)
-		if err != nil {
-			return fmt.Errorf("failed to update NodeAllocationRequest '%s': %w", nodeAllocationRequestID, err)
-		}
-
-		if narID != nodeAllocationRequestID {
-			return fmt.Errorf("received nodeAllocationRequestID '%s' != expected nodeAllocationRequestID '%s'", narID, nodeAllocationRequestID)
-		}
-
-		// Update the ProvisioningRequest status after updating the NodeAllocationRequest
-		err = ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object)
-		if err != nil {
-			return fmt.Errorf("failed to update status for ProvisioningRequest %s: %w", t.object.Name, err)
+	// NAR exists — compare spec and update if changed.
+	// Carry over fields managed by the plugin to avoid false-positive change detection.
+	nodeAllocationRequest.Spec.ClusterProvisioned = existingNAR.Spec.ClusterProvisioned
+	if !equality.Semantic.DeepEqual(existingNAR.Spec, nodeAllocationRequest.Spec) {
+		patch := client.MergeFrom(existingNAR.DeepCopy())
+		existingNAR.Spec = nodeAllocationRequest.Spec
+		if err := t.client.Patch(ctx, existingNAR, patch); err != nil {
+			return fmt.Errorf("failed to update NodeAllocationRequest %s: %w", t.object.Name, err)
 		}
 
 		t.logger.InfoContext(ctx,
-			fmt.Sprintf("NodeAllocationRequest (%s) spec changes have been detected", nodeAllocationRequestID))
+			fmt.Sprintf("NodeAllocationRequest (%s) spec changes have been detected", t.object.Name))
 	}
 	return nil
 }
 
 func (t *provisioningRequestReconcilerTask) createNodeAllocationRequestResources(ctx context.Context,
 	clusterNamespace string,
-	nodeAllocationRequest *hwmgrpluginapi.NodeAllocationRequest) error {
+	nodeAllocationRequest *pluginsv1alpha1.NodeAllocationRequest) error {
 
 	// Create/update the clusterInstance namespace, adding ProvisioningRequest labels to the namespace
 	err := t.createClusterInstanceNamespace(ctx, clusterNamespace)
@@ -160,26 +137,13 @@ func (t *provisioningRequestReconcilerTask) createNodeAllocationRequestResources
 		return err
 	}
 
-	// Create the node allocation request resource
-	nodeAllocationRequestID, err := t.hwpluginClient.CreateNodeAllocationRequest(ctx, *nodeAllocationRequest)
-	if err != nil {
+	// Create the NodeAllocationRequest CR
+	if err := t.client.Create(ctx, nodeAllocationRequest); err != nil {
 		t.logger.ErrorContext(ctx, "Failed to create the NodeAllocationRequest", slog.String("error", err.Error()))
-		return fmt.Errorf("failed to create/update the NodeAllocationRequest: %w", err)
+		return fmt.Errorf("failed to create NodeAllocationRequest %s: %w", t.object.Name, err)
 	}
 
-	// Set NodeAllocationRequestRef
-	if t.object.Status.Extensions.NodeAllocationRequestRef == nil {
-		t.object.Status.Extensions.NodeAllocationRequestRef = &provisioningv1alpha1.NodeAllocationRequestRef{}
-	}
-	t.object.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID = nodeAllocationRequestID
-
-	// Update the ProvisioningRequest status after creating the NodeAllocationRequest
-	err = ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object)
-	if err != nil {
-		return fmt.Errorf("failed to update status for ProvisioningRequest %s: %w", t.object.Name, err)
-	}
-
-	t.logger.InfoContext(ctx, fmt.Sprintf("Created NodeAllocationRequest (%s) if not already exist", nodeAllocationRequestID))
+	t.logger.InfoContext(ctx, fmt.Sprintf("Created NodeAllocationRequest (%s)", t.object.Name))
 
 	return nil
 }
@@ -189,7 +153,7 @@ func (t *provisioningRequestReconcilerTask) createNodeAllocationRequestResources
 func (t *provisioningRequestReconcilerTask) waitForHardwareData(
 	ctx context.Context,
 	clusterInstance *unstructured.Unstructured,
-	nodeAllocationRequestResponse *hwmgrpluginapi.NodeAllocationRequestResponse) (bool, *bool, bool, error) {
+	nodeAllocationRequestResponse *pluginsv1alpha1.NodeAllocationRequest) (bool, *bool, bool, error) {
 
 	var configured *bool
 	provisioned, timedOutOrFailed, err := t.checkNodeAllocationRequestProvisionStatus(ctx, clusterInstance, nodeAllocationRequestResponse)
@@ -226,21 +190,17 @@ func (t *provisioningRequestReconcilerTask) waitForHardwareData(
 
 // updateClusterInstance updates the given ClusterInstance object based on the provisioned nodeAllocationRequest.
 func (t *provisioningRequestReconcilerTask) updateClusterInstance(ctx context.Context,
-	clusterInstance *unstructured.Unstructured, nodeAllocationRequest *hwmgrpluginapi.NodeAllocationRequestResponse) error {
+	clusterInstance *unstructured.Unstructured, nodeAllocationRequest *pluginsv1alpha1.NodeAllocationRequest) error {
 
-	nodeAllocationRequestID := t.getNodeAllocationRequestID()
-	if nodeAllocationRequestID == "" {
-		return fmt.Errorf("missing nodeAllocationRequest identifier")
+	narNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
+	allocatedNodeList, err := listAllocatedNodesForNAR(ctx, t.client, t.object.Name, narNS)
+	if err != nil {
+		return fmt.Errorf("failed to list AllocatedNodes for NodeAllocationRequest '%s': %w", t.object.Name, err)
 	}
 
-	nodes, err := t.hwpluginClient.GetAllocatedNodesFromNodeAllocationRequest(ctx, nodeAllocationRequestID)
+	hwNodes, err := collectNodeDetails(ctx, t.client, allocatedNodeList)
 	if err != nil {
-		return fmt.Errorf("failed to get AllocatedNodes for NodeAllocationRequest '%s': %w", nodeAllocationRequestID, err)
-	}
-
-	hwNodes, err := collectNodeDetails(ctx, t.client, nodes)
-	if err != nil {
-		return fmt.Errorf("failed to collect hardware node %s details for node allocation request: %w", nodeAllocationRequestID, err)
+		return fmt.Errorf("failed to collect hardware node %s details for node allocation request: %w", t.object.Name, err)
 	}
 
 	hwpluginRef, err := ctlrutils.GetHardwarePluginRefFromProvisioningRequest(ctx, t.client, t.object)
@@ -285,69 +245,33 @@ func (t *provisioningRequestReconcilerTask) updateClusterInstance(ctx context.Co
 	}
 
 	if configErr != nil {
-		return fmt.Errorf("failed to apply node configuration for NodeAllocationRequest '%s': %w", nodeAllocationRequestID, configErr)
+		return fmt.Errorf("failed to apply node configuration for NodeAllocationRequest '%s': %w", t.object.Name, configErr)
 	}
 	return nil
-}
-
-// getHardwareStatusFromConditions reads hardware status from existing ProvisioningRequest conditions
-func (t *provisioningRequestReconcilerTask) getHardwareStatusFromConditions(condition hwmgmtv1alpha1.ConditionType) (bool, bool) {
-	var conditionType string
-	switch condition {
-	case hwmgmtv1alpha1.Provisioned:
-		conditionType = string(provisioningv1alpha1.PRconditionTypes.HardwareProvisioned)
-	case hwmgmtv1alpha1.Configured:
-		conditionType = string(provisioningv1alpha1.PRconditionTypes.HardwareConfigured)
-	default:
-		return false, false
-	}
-
-	hwCondition := meta.FindStatusCondition(t.object.Status.Conditions, conditionType)
-	if hwCondition == nil {
-		return false, false
-	}
-
-	status := hwCondition.Status == metav1.ConditionTrue
-	timedOutOrFailed := hwCondition.Reason == string(provisioningv1alpha1.CRconditionReasons.TimedOut) ||
-		hwCondition.Reason == string(provisioningv1alpha1.CRconditionReasons.Failed)
-
-	return status, timedOutOrFailed
 }
 
 // checkNodeAllocationRequestStatus checks the NodeAllocationRequest status of a given condition type
 // and updates the provisioning request status accordingly.
 func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestStatus(
 	ctx context.Context,
-	nodeAllocationRequestResponse *hwmgrpluginapi.NodeAllocationRequestResponse,
+	nodeAllocationRequestResponse *pluginsv1alpha1.NodeAllocationRequest,
 	condition hwmgmtv1alpha1.ConditionType) (bool, bool, error) {
 
 	var status bool
 	var timedOutOrFailed bool
 	var err error
 
-	// Only update hardware status on callback notifications or initial setup
-	// This eliminates the read-after-write race condition
-	if t.shouldUpdateHardwareStatus(condition) {
-		t.logger.InfoContext(ctx, "Updating hardware status",
-			slog.String("condition", string(condition)))
-
-		// Update the provisioning request Status with status from the NodeAllocationRequest object.
-		status, timedOutOrFailed, err = t.updateHardwareStatus(ctx, nodeAllocationRequestResponse, condition)
-		if err != nil && !ctlrutils.IsConditionDoesNotExistsErr(err) {
-			t.logger.ErrorContext(
-				ctx,
-				"Failed to update the NodeAllocationRequest status for ProvisioningRequest",
-				slog.String("name", t.object.Name),
-				slog.String("error", err.Error()),
-			)
-		}
-	} else {
-		// For non-callback reconciliation, read current status from PR conditions instead of querying plugin
-		status, timedOutOrFailed = t.getHardwareStatusFromConditions(condition)
-		t.logger.InfoContext(ctx, "Skipping hardware status update - not callback triggered",
-			slog.String("condition", string(condition)),
-			slog.Bool("currentStatus", status),
-			slog.Bool("timedOut", timedOutOrFailed))
+	// Update the provisioning request Status with status from the NodeAllocationRequest object.
+	// With direct K8s client access (no REST API), there is no read-after-write race,
+	// so we always read the latest NAR status.
+	status, timedOutOrFailed, err = t.updateHardwareStatus(ctx, nodeAllocationRequestResponse, condition)
+	if err != nil && !ctlrutils.IsConditionDoesNotExistsErr(err) {
+		t.logger.ErrorContext(
+			ctx,
+			"Failed to update the NodeAllocationRequest status for ProvisioningRequest",
+			slog.String("name", t.object.Name),
+			slog.String("error", err.Error()),
+		)
 	}
 
 	return status, timedOutOrFailed, err
@@ -357,10 +281,10 @@ func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestStatus(
 func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestProvisionStatus(
 	ctx context.Context,
 	clusterInstance *unstructured.Unstructured,
-	nodeAllocationRequestResponse *hwmgrpluginapi.NodeAllocationRequestResponse,
+	nodeAllocationRequestResponse *pluginsv1alpha1.NodeAllocationRequest,
 ) (bool, bool, error) {
 
-	nodeAllocationRequestID := t.getNodeAllocationRequestID()
+	nodeAllocationRequestID := t.object.Name
 	if nodeAllocationRequestID == "" {
 		return false, false, fmt.Errorf("missing NodeAllocationRequest identifier")
 	}
@@ -379,7 +303,7 @@ func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestProvisionS
 // checkNodeAllocationRequestConfigStatus checks the Configured status of the node allocation request.
 func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestConfigStatus(
 	ctx context.Context,
-	nodeAllocationRequestResponse *hwmgrpluginapi.NodeAllocationRequestResponse,
+	nodeAllocationRequestResponse *pluginsv1alpha1.NodeAllocationRequest,
 ) (*bool, bool, error) {
 
 	status, timedOutOrFailed, err := t.checkNodeAllocationRequestStatus(ctx, nodeAllocationRequestResponse, hwmgmtv1alpha1.Configured)
@@ -397,14 +321,14 @@ func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestConfigStat
 func (t *provisioningRequestReconcilerTask) applyNodeConfiguration(
 	ctx context.Context,
 	hwNodes map[string][]ctlrutils.NodeInfo,
-	nar *hwmgrpluginapi.NodeAllocationRequestResponse,
+	nar *pluginsv1alpha1.NodeAllocationRequest,
 	clusterInstance *unstructured.Unstructured,
 ) error {
 
 	// Create a map to track unmatched nodes
 	unmatchedNodes := make(map[int]string)
 
-	roleToNodeGroupName := getRoleToGroupNameMap(nar.NodeAllocationRequest)
+	roleToNodeGroupName := getRoleToGroupNameMap(&nar.Spec)
 
 	// Extract the nodes slice
 	nodes, found, err := unstructured.NestedSlice(clusterInstance.Object, "spec", "nodes")
@@ -521,10 +445,10 @@ func (t *provisioningRequestReconcilerTask) updateAllocatedNodeHostMap(ctx conte
 
 // processExistingHardwareCondition processes an existing hardware condition and returns the appropriate status
 func (t *provisioningRequestReconcilerTask) processExistingHardwareCondition(
-	hwCondition *hwmgrpluginapi.Condition,
+	hwCondition *metav1.Condition,
 	condition hwmgmtv1alpha1.ConditionType,
 ) (metav1.ConditionStatus, string, string, bool) {
-	status := metav1.ConditionStatus(hwCondition.Status)
+	status := hwCondition.Status
 	reason := hwCondition.Reason
 	message := hwCondition.Message
 	timedOutOrFailed := false
@@ -581,11 +505,11 @@ func (t *provisioningRequestReconcilerTask) processExistingHardwareCondition(
 //   - error: any error that occurred during status processing
 func (t *provisioningRequestReconcilerTask) updateHardwareStatus(
 	ctx context.Context,
-	nodeAllocationRequest *hwmgrpluginapi.NodeAllocationRequestResponse,
+	nodeAllocationRequest *pluginsv1alpha1.NodeAllocationRequest,
 	condition hwmgmtv1alpha1.ConditionType,
 ) (bool, bool, error) {
 
-	nodeAllocationRequestID := t.getNodeAllocationRequestID()
+	nodeAllocationRequestID := t.object.Name
 	if nodeAllocationRequestID == "" {
 		return false, false, fmt.Errorf("missing NodeAllocationRequest identifier")
 	}
@@ -599,12 +523,10 @@ func (t *provisioningRequestReconcilerTask) updateHardwareStatus(
 	timedOutOrFailed := false // Default to false unless explicitly needed
 
 	// Retrieve the given hardware condition(Provisioned or Configured) from the nodeAllocationRequest status.
-	var hwCondition *hwmgrpluginapi.Condition
-	if nodeAllocationRequest.Status.Conditions != nil {
-		for _, cond := range *nodeAllocationRequest.Status.Conditions {
-			if cond.Type == string(condition) {
-				hwCondition = &cond
-			}
+	var hwCondition *metav1.Condition
+	for i := range nodeAllocationRequest.Status.Conditions {
+		if nodeAllocationRequest.Status.Conditions[i].Type == string(condition) {
+			hwCondition = &nodeAllocationRequest.Status.Conditions[i]
 		}
 	}
 
@@ -682,102 +604,6 @@ func (t *provisioningRequestReconcilerTask) updateHardwareStatus(
 	return status == metav1.ConditionTrue, timedOutOrFailed, err
 }
 
-// isCallbackTriggeredReconciliation checks if this reconciliation was triggered by a hardware plugin callback
-func (t *provisioningRequestReconcilerTask) isCallbackTriggeredReconciliation() bool {
-	ann := t.object.GetAnnotations()
-	if ann == nil {
-		return false
-	}
-
-	// Must have a non-empty "callback received" marker
-	if ann[ctlrutils.CallbackReceivedAnnotation] == "" {
-		return false
-	}
-
-	// If the callback specified a NAR ID, ensure it matches
-	if narFromCallback := ann[ctlrutils.CallbackNodeAllocationRequestIdAnnotation]; narFromCallback != "" {
-		var narFromStatus string
-		if t.object.Status.Extensions.NodeAllocationRequestRef != nil {
-			narFromStatus = t.object.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID
-		}
-		if narFromStatus != "" && narFromCallback != narFromStatus {
-			return false
-		}
-	}
-
-	return true
-}
-
-// shouldUpdateHardwareStatus decides whether to update hardware status during reconciliation.
-// Rules:
-// - Always update on callback-triggered reconciliations.
-// - During polling (non-callback), for Provisioned/Configured:
-//   - If no prior condition exists, update.
-//   - If prior condition is terminal (TimedOut/Failed), do not update.
-//   - Otherwise, update only if prior Status != True.
-func (t *provisioningRequestReconcilerTask) shouldUpdateHardwareStatus(
-	condition hwmgmtv1alpha1.ConditionType,
-) bool {
-	// Callbacks always allowed to update.
-	if shouldAllowCallbackUpdate(t) {
-		return true
-	}
-
-	// During polling, check if updates are allowed based on current condition state.
-	return shouldAllowPollingUpdate(t, condition)
-}
-
-// shouldAllowCallbackUpdate returns true if the reconciliation is callback-triggered.
-// Callbacks are always allowed to update hardware status.
-func shouldAllowCallbackUpdate(t *provisioningRequestReconcilerTask) bool {
-	return t.isCallbackTriggeredReconciliation()
-}
-
-// shouldAllowPollingUpdate determines if hardware status updates are allowed during polling
-// (non-callback reconciliations). Updates are allowed if:
-// - The condition type is supported (Provisioned/Configured)
-// - No prior condition exists (first write)
-// - Prior condition is not terminal (TimedOut/Failed)
-// - Prior condition status is not True (allows updates for False/Unknown)
-func shouldAllowPollingUpdate(t *provisioningRequestReconcilerTask, condition hwmgmtv1alpha1.ConditionType) bool {
-	// Map HW condition → PR condition type stored in Status.Conditions.
-	prTypeByHW := map[hwmgmtv1alpha1.ConditionType]string{
-		hwmgmtv1alpha1.Provisioned: string(provisioningv1alpha1.PRconditionTypes.HardwareProvisioned),
-		hwmgmtv1alpha1.Configured:  string(provisioningv1alpha1.PRconditionTypes.HardwareConfigured),
-	}
-
-	prCondType, ok := prTypeByHW[condition]
-	if !ok {
-		// Unknown/non-actionable condition types: do not update during polling.
-		return false
-	}
-
-	hwCond := meta.FindStatusCondition(t.object.Status.Conditions, prCondType)
-	if hwCond == nil {
-		// No status yet → allow first write.
-		return true
-	}
-
-	// Do not update if condition is in terminal state.
-	if isTerminalState(hwCond) {
-		return false
-	}
-
-	// Update only if not already True (i.e., False or Unknown).
-	return hwCond.Status != metav1.ConditionTrue
-}
-
-// isTerminalState returns true if the condition is in a terminal state (TimedOut or Failed).
-// Terminal states should not be overwritten by polling updates.
-func isTerminalState(condition *metav1.Condition) bool {
-	return isTerminalReason(condition.Reason)
-}
-
-func isTerminalReason(reason string) bool {
-	return reason == string(provisioningv1alpha1.CRconditionReasons.TimedOut) ||
-		reason == string(provisioningv1alpha1.CRconditionReasons.Failed)
-}
-
 // isConfigTransactionObserved checks if the observed config transaction ID matches the expected generation.
 // Returns true if the transaction has been observed (not zero and matches generation).
 // A value of 0 indicates the transaction has not been observed yet.
@@ -794,29 +620,27 @@ func isConfigTransactionObserved(observedID, expectedGeneration int64) bool {
 func (t *provisioningRequestReconcilerTask) checkExistingNodeAllocationRequest(
 	ctx context.Context,
 	hwMgmtData map[string]any,
-	nodeAllocationRequestId string) (*hwmgrpluginapi.NodeAllocationRequestResponse, error) {
+	nodeAllocationRequestId string) (*pluginsv1alpha1.NodeAllocationRequest, error) {
 
-	if t.hwpluginClient == nil {
-		return nil, fmt.Errorf("hwpluginClient is nil")
-	}
-
-	nodeAllocationRequestResponse, exist, err := t.hwpluginClient.GetNodeAllocationRequest(ctx, nodeAllocationRequestId)
+	nar, err := t.getNAR(ctx)
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil //nolint:nilnil // NAR not found is not an error
+		}
 		return nil, fmt.Errorf("failed to get NodeAllocationRequest '%s': %w", nodeAllocationRequestId, err)
 	}
-	if exist {
-		err = validateNodeGroupsMatchNAR(hwMgmtData, nodeAllocationRequestResponse.NodeAllocationRequest)
-		if err != nil {
-			return nil, ctlrutils.NewInputError("%w", err)
-		}
+
+	err = validateNodeGroupsMatchNAR(hwMgmtData, &nar.Spec)
+	if err != nil {
+		return nil, ctlrutils.NewInputError("%w", err)
 	}
 
-	return nodeAllocationRequestResponse, nil
+	return nar, nil
 }
 
 // buildNodeAllocationRequest builds the NodeAllocationRequest from the pre-merged hwMgmt data and cluster instance
 func (t *provisioningRequestReconcilerTask) buildNodeAllocationRequest(
-	clusterInstance *unstructured.Unstructured) (*hwmgrpluginapi.NodeAllocationRequest, error) {
+	clusterInstance *unstructured.Unstructured) (*pluginsv1alpha1.NodeAllocationRequest, error) {
 
 	hwMgmtData := t.clusterInput.hwMgmtData
 
@@ -851,7 +675,7 @@ func (t *provisioningRequestReconcilerTask) buildNodeAllocationRequest(
 
 	// Node group validation (name, role, duplicates) is handled by validateMergedNodeGroups
 	// which runs before this function. Here we only extract values to build the NAR.
-	nodeGroups := []hwmgrpluginapi.NodeGroup{}
+	nodeGroups := []pluginsv1alpha1.NodeGroup{}
 	for _, ngRaw := range nodeGroupDataSlice {
 		ngMap, ok := ngRaw.(map[string]any)
 		if !ok {
@@ -872,10 +696,10 @@ func (t *provisioningRequestReconcilerTask) buildNodeAllocationRequest(
 			}
 		}
 
-		ngd := hwmgrpluginapi.NodeGroupData{
+		ngd := hwmgmtv1alpha1.NodeGroupData{
 			HwProfile:        hwProfile,
 			Name:             name,
-			ResourceGroupId:  resourcePoolId,
+			ResourcePoolId:   resourcePoolId,
 			ResourceSelector: resourceSelector,
 			Role:             role,
 		}
@@ -883,16 +707,24 @@ func (t *provisioningRequestReconcilerTask) buildNodeAllocationRequest(
 		nodeGroups = append(nodeGroups, nodeGroup)
 	}
 
-	siteID, err := provisioningv1alpha1.ExtractMatchingInput(
+	siteIDRaw, err := provisioningv1alpha1.ExtractMatchingInput(
 		t.object.Spec.TemplateParameters.Raw, ctlrutils.TemplateParamOCloudSiteId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get %s from templateParameters: %w", ctlrutils.TemplateParamOCloudSiteId, err)
 	}
+	siteID, ok := siteIDRaw.(string)
+	if !ok {
+		return nil, fmt.Errorf("%s is not a string", ctlrutils.TemplateParamOCloudSiteId)
+	}
 
-	clusterId, err := provisioningv1alpha1.ExtractMatchingInput(
+	clusterIdRaw, err := provisioningv1alpha1.ExtractMatchingInput(
 		t.object.Spec.TemplateParameters.Raw, ctlrutils.TemplateParamNodeClusterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get %s from templateParameters: %w", ctlrutils.TemplateParamNodeClusterName, err)
+	}
+	clusterId, ok := clusterIdRaw.(string)
+	if !ok {
+		return nil, fmt.Errorf("%s is not a string", ctlrutils.TemplateParamNodeClusterName)
 	}
 
 	callbackURL, err := t.callbackConfig.BuildCallbackURL(t.object.Name)
@@ -900,51 +732,48 @@ func (t *provisioningRequestReconcilerTask) buildNodeAllocationRequest(
 		return nil, fmt.Errorf("failed to build callback url: %w", err)
 	}
 
-	nodeAllocationRequest := &hwmgrpluginapi.NodeAllocationRequest{}
-	nodeAllocationRequest.Site = siteID.(string)
-	nodeAllocationRequest.ClusterId = clusterId.(string)
-	nodeAllocationRequest.NodeGroup = nodeGroups
-	nodeAllocationRequest.ConfigTransactionId = t.object.Generation
+	// Get the hardware plugin reference, defaulting to metal3
+	hwPluginRef := t.ctDetails.templates.HwMgmtDefaults.GetHardwarePluginRef()
+	narNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
 
 	// Set HardwareProvisioningTimeout from merged data, or use default
 	timeoutStr := ctlrutils.DefaultHardwareProvisioningTimeout.String()
 	if ts, ok := hwMgmtData["hardwareProvisioningTimeout"].(string); ok && ts != "" {
 		timeoutStr = ts
 	}
-	nodeAllocationRequest.HardwareProvisioningTimeout = &timeoutStr
 
-	// Always set SkipCleanup explicitly based on annotation presence,
-	// so the server knows to clear it when the annotation is removed.
 	_, hasSkipCleanup := t.object.Annotations[ctlrutils.SkipCleanupAnnotation]
-	nodeAllocationRequest.SkipCleanup = &hasSkipCleanup
 
-	// Create callback configuration with the callback URL
-	nodeAllocationRequest.Callback = &hwmgrpluginapi.Callback{
-		CallbackURL: callbackURL,
+	nar := &pluginsv1alpha1.NodeAllocationRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.object.Name,
+			Namespace: narNS,
+		},
+		Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+			ClusterId:                   clusterId,
+			HardwarePluginRef:           hwPluginRef,
+			NodeGroup:                   nodeGroups,
+			LocationSpec:                pluginsv1alpha1.LocationSpec{Site: siteID},
+			ConfigTransactionId:         t.object.Generation,
+			HardwareProvisioningTimeout: timeoutStr,
+			SkipCleanup:                 hasSkipCleanup,
+			Callback: &pluginsv1alpha1.Callback{
+				CallbackURL: callbackURL,
+			},
+		},
 	}
 
-	return nodeAllocationRequest, nil
+	return nar, nil
 }
 
 func (t *provisioningRequestReconcilerTask) handleRenderHardwareTemplate(ctx context.Context,
-	clusterInstance *unstructured.Unstructured) (*hwmgrpluginapi.NodeAllocationRequest, error) {
+	clusterInstance *unstructured.Unstructured) (*pluginsv1alpha1.NodeAllocationRequest, error) {
 
 	hwMgmtData := t.clusterInput.hwMgmtData
 
-	if t.object.Status.Extensions.NodeAllocationRequestRef != nil {
-		nodeAllocationRequestID := t.object.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID
-		if _, err := t.checkExistingNodeAllocationRequest(ctx, hwMgmtData, nodeAllocationRequestID); err != nil {
-			return nil, err
-		}
-	}
-
-	// Get the hardware plugin reference, defaulting to metal3
-	hwPluginRef := t.ctDetails.templates.HwMgmtDefaults.GetHardwarePluginRef()
-
-	hwplugin := &hwmgmtv1alpha1.HardwarePlugin{}
-	hwpluginNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
-	if err := t.client.Get(ctx, types.NamespacedName{Namespace: hwpluginNS, Name: hwPluginRef}, hwplugin); err != nil {
-		return nil, fmt.Errorf("could not find specified HardwarePlugin: %s/%s, err=%w", hwpluginNS, hwPluginRef, err)
+	// Check if an existing NAR needs validation against current hw config
+	if _, err := t.checkExistingNodeAllocationRequest(ctx, hwMgmtData, t.object.Name); err != nil {
+		return nil, err
 	}
 
 	nodeAllocationRequest, err := t.buildNodeAllocationRequest(clusterInstance)

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -198,7 +198,7 @@ func (t *provisioningRequestReconcilerTask) updateClusterInstance(ctx context.Co
 		return fmt.Errorf("failed to list AllocatedNodes for NodeAllocationRequest '%s': %w", t.object.Name, err)
 	}
 
-	hwNodes, err := collectNodeDetails(ctx, t.client, allocatedNodeList)
+	hwNodes, err := collectNodeDetails(allocatedNodeList)
 	if err != nil {
 		return fmt.Errorf("failed to collect hardware node %s details for node allocation request: %w", t.object.Name, err)
 	}
@@ -261,9 +261,25 @@ func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestStatus(
 	var timedOutOrFailed bool
 	var err error
 
+	// Guard against consuming stale terminal status from the NAR during day-2 retries.
+	// After a PR spec change, the NAR may still carry a Failed/TimedOut condition from the
+	// previous attempt until the plugin processes the new ConfigTransactionId. Skip the
+	// update and requeue until the plugin has observed the new transaction.
+	if nodeAllocationRequestResponse.Spec.ConfigTransactionId != 0 &&
+		nodeAllocationRequestResponse.Status.ObservedConfigTransactionId != nodeAllocationRequestResponse.Spec.ConfigTransactionId {
+		for _, c := range nodeAllocationRequestResponse.Status.Conditions {
+			if c.Type == string(condition) &&
+				(c.Reason == string(hwmgmtv1alpha1.Failed) || c.Reason == string(hwmgmtv1alpha1.TimedOut)) {
+				t.logger.InfoContext(ctx, "Skipping stale terminal NAR status — plugin has not observed new transaction",
+					slog.String("condition", string(condition)),
+					slog.Int64("specTransaction", nodeAllocationRequestResponse.Spec.ConfigTransactionId),
+					slog.Int64("observedTransaction", nodeAllocationRequestResponse.Status.ObservedConfigTransactionId))
+				return false, false, nil
+			}
+		}
+	}
+
 	// Update the provisioning request Status with status from the NodeAllocationRequest object.
-	// With direct K8s client access (no REST API), there is no read-after-write race,
-	// so we always read the latest NAR status.
 	status, timedOutOrFailed, err = t.updateHardwareStatus(ctx, nodeAllocationRequestResponse, condition)
 	if err != nil && !ctlrutils.IsConditionDoesNotExistsErr(err) {
 		t.logger.ErrorContext(

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -2472,6 +2472,35 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			Expect(timedOutOrFailed).To(BeFalse())
 		})
 
+		It("skips update when NAR has stale True condition from previous success", func() {
+			narWithStaleSuccess := &pluginsv1alpha1.NodeAllocationRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-1",
+					Namespace: constants.DefaultNamespace,
+				},
+				Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+					ConfigTransactionId: 3,
+				},
+				Status: pluginsv1alpha1.NodeAllocationRequestStatus{
+					ObservedConfigTransactionId: 2,
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(hwmgmtv1alpha1.Configured),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(hwmgmtv1alpha1.ConfigApplied),
+							Message:            "Previous config applied",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			}
+
+			status, timedOutOrFailed, err := task.checkNodeAllocationRequestStatus(ctx, narWithStaleSuccess, hwmgmtv1alpha1.Configured)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeFalse())
+			Expect(timedOutOrFailed).To(BeFalse())
+		})
+
 		It("allows update when plugin has observed the current transaction", func() {
 			narWithCurrentFailure := &pluginsv1alpha1.NodeAllocationRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2499,6 +2528,35 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(status).To(BeFalse())
 			Expect(timedOutOrFailed).To(BeTrue())
+		})
+
+		It("does not apply guard to Provisioned condition during initial provisioning", func() {
+			narInitialProvisioning := &pluginsv1alpha1.NodeAllocationRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-1",
+					Namespace: constants.DefaultNamespace,
+				},
+				Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+					ConfigTransactionId: 1,
+				},
+				Status: pluginsv1alpha1.NodeAllocationRequestStatus{
+					ObservedConfigTransactionId: 0,
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(hwmgmtv1alpha1.Provisioned),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(hwmgmtv1alpha1.Completed),
+							Message:            "Hardware provisioning completed",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			}
+
+			status, timedOutOrFailed, err := task.checkNodeAllocationRequestStatus(ctx, narInitialProvisioning, hwmgmtv1alpha1.Provisioned)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeTrue())
+			Expect(timedOutOrFailed).To(BeFalse())
 		})
 	})
 

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -75,20 +75,17 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
-	hwmgrpluginapi "github.com/openshift-kni/oran-o2ims/hwmgr-plugins/api/client/provisioning"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
-	"github.com/openshift-kni/oran-o2ims/internal/controllers/mocks"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
 	"github.com/openshift/assisted-service/api/v1beta1"
@@ -192,22 +189,6 @@ var _ = Describe("handleRenderHardwareTemplate", func() {
 		}
 
 		// Set up hwpluginClient using the test Metal3 hardware plugin
-		hwplugin := &hwmgmtv1alpha1.HardwarePlugin{}
-		hwpluginKey := client.ObjectKey{
-			Name:      testMetal3HardwarePluginRef,
-			Namespace: testHwMgrPluginNameSpace,
-		}
-		err := c.Get(ctx, hwpluginKey, hwplugin)
-		if err != nil {
-			reconciler.Logger.Warn("Could not get hwplugin for test", "error", err)
-		} else {
-			hwpluginClient, err := hwmgrpluginapi.NewHardwarePluginClient(ctx, c, reconciler.Logger, hwplugin)
-			if err != nil {
-				reconciler.Logger.Warn("Could not create hwpluginClient for test", "error", err)
-			} else {
-				task.hwpluginClient = hwpluginClient
-			}
-		}
 	})
 
 	It("returns no error when handleRenderHardwareTemplate succeeds", func() {
@@ -234,7 +215,7 @@ var _ = Describe("handleRenderHardwareTemplate", func() {
 			// Count the nodes per group
 			roleCounts[node.Role]++
 		}
-		Expect(nodeAllocationRequest.NodeGroup).To(HaveLen(2))
+		Expect(nodeAllocationRequest.Spec.NodeGroup).To(HaveLen(2))
 		expectedNodeGroups := map[string]struct {
 			size int
 		}{
@@ -242,10 +223,10 @@ var _ = Describe("handleRenderHardwareTemplate", func() {
 			groupNameWorker:     {size: roleCounts["worker"]},
 		}
 
-		for _, group := range nodeAllocationRequest.NodeGroup {
+		for _, group := range nodeAllocationRequest.Spec.NodeGroup {
 			expected, found := expectedNodeGroups[group.NodeGroupData.Name]
 			Expect(found).To(BeTrue())
-			Expect(group.NodeGroupData.Size).To(Equal(expected.size))
+			Expect(group.Size).To(Equal(expected.size))
 		}
 	})
 
@@ -283,52 +264,52 @@ var _ = Describe("handleRenderHardwareTemplate", func() {
 
 // createMockNodeAllocationRequestResponse creates a mock NodeAllocationRequestResponse for testing
 // By default, it creates a mock with current transaction ID (both spec and status match)
-func createMockNodeAllocationRequestResponse(conditionStatus, conditionReason, conditionMessage string) *hwmgrpluginapi.NodeAllocationRequestResponse {
+func createMockNodeAllocationRequestResponse(conditionStatus, conditionReason, conditionMessage string) *pluginsv1alpha1.NodeAllocationRequest {
 	return createMockNodeAllocationRequestResponseWithTransactionId(conditionStatus, conditionReason, conditionMessage, 0, 0)
 }
 
-// createMockNodeAllocationRequestResponseWithTransactionId creates a mock with specific transaction IDs
-func createMockNodeAllocationRequestResponseWithTransactionId(conditionStatus, conditionReason, conditionMessage string, specTransactionId, statusTransactionId int64) *hwmgrpluginapi.NodeAllocationRequestResponse {
-	nodeNames := []string{"test-node-1", "test-node-2"}
-
-	conditions := []hwmgrpluginapi.Condition{
-		{
-			Type:               "Provisioned",
-			Status:             conditionStatus,
-			Reason:             conditionReason,
-			Message:            conditionMessage,
-			LastTransitionTime: time.Now(),
+// createMockNodeAllocationRequestResponseWithTransactionId creates a mock NAR with specific transaction IDs
+func createMockNodeAllocationRequestResponseWithTransactionId(conditionStatus, conditionReason, conditionMessage string, specTransactionId, statusTransactionId int64) *pluginsv1alpha1.NodeAllocationRequest {
+	return &pluginsv1alpha1.NodeAllocationRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-nar",
+			Namespace: constants.DefaultNamespace,
 		},
-	}
-
-	return &hwmgrpluginapi.NodeAllocationRequestResponse{
-		NodeAllocationRequest: &hwmgrpluginapi.NodeAllocationRequest{
+		Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
 			ClusterId:           "test-cluster",
 			ConfigTransactionId: specTransactionId,
-			NodeGroup: []hwmgrpluginapi.NodeGroup{
+			NodeGroup: []pluginsv1alpha1.NodeGroup{
 				{
-					NodeGroupData: hwmgrpluginapi.NodeGroupData{
+					NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
 						Name:      "controller",
 						Role:      "master",
 						HwProfile: "profile-spr-single-processor-64G",
-						Size:      1,
 					},
+					Size: 1,
 				},
 				{
-					NodeGroupData: hwmgrpluginapi.NodeGroupData{
+					NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
 						Name:      "worker",
 						Role:      "worker",
 						HwProfile: "profile-spr-dual-processor-128G",
-						Size:      1,
 					},
+					Size: 1,
 				},
 			},
 		},
-		Status: &hwmgrpluginapi.NodeAllocationRequestStatus{
-			Conditions:                  &conditions,
+		Status: pluginsv1alpha1.NodeAllocationRequestStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               "Provisioned",
+					Status:             metav1.ConditionStatus(conditionStatus),
+					Reason:             conditionReason,
+					Message:            conditionMessage,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
 			ObservedConfigTransactionId: statusTransactionId,
-			Properties: &hwmgrpluginapi.Properties{
-				NodeNames: &nodeNames,
+			Properties: pluginsv1alpha1.Properties{
+				NodeNames: []string{"test-node-1", "test-node-2"},
 			},
 		},
 	}
@@ -542,13 +523,15 @@ var _ = Describe("waitForNodeAllocationRequestProvision", func() {
 		// This should still update status because configuration was started but not completed
 		completedMock := createMockNodeAllocationRequestResponse("True", "Completed", "Hardware configured successfully")
 		// Add configured condition to the mock
-		configuredCond := hwmgrpluginapi.Condition{
-			Type:    "Configured",
-			Status:  "True",
-			Reason:  "Completed",
-			Message: "Hardware configured successfully",
+		completedMock.Status.Conditions = []metav1.Condition{
+			{
+				Type:               "Configured",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Completed",
+				Message:            "Hardware configured successfully",
+				LastTransitionTime: metav1.Now(),
+			},
 		}
-		completedMock.Status.Conditions = &[]hwmgrpluginapi.Condition{configuredCond}
 
 		configured, timedOutOrFailed, err := task.checkNodeAllocationRequestConfigStatus(ctx, completedMock)
 		Expect(err).ToNot(HaveOccurred())
@@ -599,14 +582,15 @@ var _ = Describe("waitForNodeAllocationRequestProvision", func() {
 		// Simulate non-callback reconciliation with stale failed state
 		// This should NOT update status because the condition reason is Failed (terminal state)
 		staleMock := createMockNodeAllocationRequestResponse("False", "Failed", "Old failure message")
-		detailedError := "Old failure message"
-		failedCond := hwmgrpluginapi.Condition{
-			Type:    "Configured",
-			Status:  "False",
-			Reason:  "Failed",
-			Message: detailedError,
+		staleMock.Status.Conditions = []metav1.Condition{
+			{
+				Type:               "Configured",
+				Status:             metav1.ConditionFalse,
+				Reason:             "Failed",
+				Message:            "Old failure message",
+				LastTransitionTime: metav1.Now(),
+			},
 		}
-		staleMock.Status.Conditions = &[]hwmgrpluginapi.Condition{failedCond}
 
 		configured, timedOutOrFailed, err := task.checkNodeAllocationRequestConfigStatus(ctx, staleMock)
 
@@ -622,7 +606,7 @@ var _ = Describe("waitForNodeAllocationRequestProvision", func() {
 		condition := meta.FindStatusCondition(updatedCR.Status.Conditions, string(provisioningv1alpha1.PRconditionTypes.HardwareConfigured))
 		Expect(condition).ToNot(BeNil())
 		Expect(condition.Reason).To(Equal(string(provisioningv1alpha1.CRconditionReasons.Failed))) // Should remain as original failed state
-		Expect(condition.Message).To(Equal("Hardware configuring failed: " + detailedError))       // Reflects the current plugin response with the detailed error
+		Expect(condition.Message).To(Equal("Hardware configuring failed: Old failure message"))    // Reflects the current plugin response with the detailed error
 	})
 
 	It("returns false when NodeAllocationRequest is not provisioned", func() {
@@ -706,35 +690,25 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 		}
 
 		// Set up hwpluginClient using the test Metal3 hardware plugin
-		hwplugin := &hwmgmtv1alpha1.HardwarePlugin{}
-		hwpluginKey := client.ObjectKey{
-			Name:      testMetal3HardwarePluginRef,
-			Namespace: testHwMgrPluginNameSpace,
-		}
-		err := c.Get(ctx, hwpluginKey, hwplugin)
-		if err != nil {
-			reconciler.Logger.Warn("Could not get hwplugin for test", "error", err)
-		} else {
-			hwpluginClient, err := hwmgrpluginapi.NewHardwarePluginClient(ctx, c, reconciler.Logger, hwplugin)
-			if err != nil {
-				reconciler.Logger.Warn("Could not create hwpluginClient for test", "error", err)
-			} else {
-				task.hwpluginClient = hwpluginClient
-			}
-		}
 	})
 
 	It("creates new NodeAllocationRequest when none exists", func() {
-		nodeAllocationRequest := &hwmgrpluginapi.NodeAllocationRequest{
-			ClusterId: crName,
-			Site:      "test-site",
-			NodeGroup: []hwmgrpluginapi.NodeGroup{
-				{
-					NodeGroupData: hwmgrpluginapi.NodeGroupData{
-						Name:      "controller",
-						Role:      "master",
-						HwProfile: "profile-spr-single-processor-64G",
-						Size:      1,
+		nodeAllocationRequest := &pluginsv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cr.Name,
+				Namespace: constants.DefaultNamespace,
+			},
+			Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+				ClusterId:    crName,
+				LocationSpec: pluginsv1alpha1.LocationSpec{Site: "test-site"},
+				NodeGroup: []pluginsv1alpha1.NodeGroup{
+					{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+							Name:      "controller",
+							Role:      "master",
+							HwProfile: "profile-spr-single-processor-64G",
+						},
+						Size: 1,
 					},
 				},
 			},
@@ -743,28 +717,54 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 		err := task.createOrUpdateNodeAllocationRequest(ctx, ctNamespace, nodeAllocationRequest)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Verify NodeAllocationRequestRef is set
-		Expect(cr.Status.Extensions.NodeAllocationRequestRef).ToNot(BeNil())
-		Expect(cr.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID).To(Equal("cluster-1"))
+		// Verify the NAR was created in the cluster
+		createdNAR := &pluginsv1alpha1.NodeAllocationRequest{}
+		err = c.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: constants.DefaultNamespace}, createdNAR)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(createdNAR.Spec.ClusterId).To(Equal(crName))
 	})
 
 	It("updates existing NodeAllocationRequest when spec changes", func() {
-		// Set up existing NodeAllocationRequest
-		existingID := crName
-		task.object.Status.Extensions.NodeAllocationRequestRef = &provisioningv1alpha1.NodeAllocationRequestRef{
-			NodeAllocationRequestID: existingID,
+		// Create existing NAR CR
+		existingNAR := &pluginsv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cr.Name,
+				Namespace: constants.DefaultNamespace,
+			},
+			Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+				ClusterId:    crName,
+				LocationSpec: pluginsv1alpha1.LocationSpec{Site: "test-site"},
+				NodeGroup: []pluginsv1alpha1.NodeGroup{
+					{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+							Name:      "controller",
+							Role:      "master",
+							HwProfile: "profile-spr-single-processor-64G",
+						},
+						Size: 1,
+					},
+				},
+			},
 		}
+		Expect(c.Create(ctx, existingNAR)).To(Succeed())
 
-		nodeAllocationRequest := &hwmgrpluginapi.NodeAllocationRequest{
-			ClusterId: crName,
-			Site:      "test-site",
-			NodeGroup: []hwmgrpluginapi.NodeGroup{
-				{
-					NodeGroupData: hwmgrpluginapi.NodeGroupData{
-						Name:      "controller",
-						Role:      "master",
-						HwProfile: "profile-spr-single-processor-64G",
-						Size:      2, // Changed size to trigger update
+		// New NAR with changed size
+		nodeAllocationRequest := &pluginsv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cr.Name,
+				Namespace: constants.DefaultNamespace,
+			},
+			Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+				ClusterId:    crName,
+				LocationSpec: pluginsv1alpha1.LocationSpec{Site: "test-site"},
+				NodeGroup: []pluginsv1alpha1.NodeGroup{
+					{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+							Name:      "controller",
+							Role:      "master",
+							HwProfile: "profile-spr-single-processor-64G",
+						},
+						Size: 2, // Changed size
 					},
 				},
 			},
@@ -775,51 +775,46 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 	})
 
 	It("updates configuring timer when NAR spec changes", func() {
-		// Set up existing NodeAllocationRequest
-		existingID := crName
-		task.object.Status.Extensions.NodeAllocationRequestRef = &provisioningv1alpha1.NodeAllocationRequestRef{
-			NodeAllocationRequestID: existingID,
-		}
-
-		// Update the CR to persist the old timers
-		Expect(c.Status().Update(ctx, cr)).To(Succeed())
-
-		// Update task object to reflect the updated CR status
-		task.object = cr
-
-		// Set up mock hwpluginClient that returns existing NAR with different NodeGroup
-		existingNAR := &hwmgrpluginapi.NodeAllocationRequestResponse{
-			NodeAllocationRequest: &hwmgrpluginapi.NodeAllocationRequest{
-				ClusterId: crName,
-				Site:      "test-site",
-				NodeGroup: []hwmgrpluginapi.NodeGroup{
+		// Create existing NAR CR in fake client with original profile
+		existingNAR := &pluginsv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cr.Name,
+				Namespace: constants.DefaultNamespace,
+			},
+			Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+				ClusterId:    crName,
+				LocationSpec: pluginsv1alpha1.LocationSpec{Site: "test-site"},
+				NodeGroup: []pluginsv1alpha1.NodeGroup{
 					{
-						NodeGroupData: hwmgrpluginapi.NodeGroupData{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
 							Name:      "controller",
 							Role:      "master",
-							HwProfile: "profile-spr-single-processor-64G", // Different profile to trigger update
-							Size:      1,
+							HwProfile: "profile-spr-single-processor-64G",
 						},
+						Size: 1,
 					},
 				},
 			},
 		}
-		ctrl := gomock.NewController(GinkgoT())
-		mockClient := mocks.NewMockHardwarePluginClientInterface(ctrl)
-		mockClient.EXPECT().GetNodeAllocationRequest(gomock.Any(), existingID).Return(existingNAR, true, nil)
-		mockClient.EXPECT().UpdateNodeAllocationRequest(gomock.Any(), existingID, gomock.Any()).Return(existingID, nil)
-		task.hwpluginClient = mockClient
+		Expect(c.Create(ctx, existingNAR)).To(Succeed())
 
-		nodeAllocationRequest := &hwmgrpluginapi.NodeAllocationRequest{
-			ClusterId: crName,
-			Site:      "test-site",
-			NodeGroup: []hwmgrpluginapi.NodeGroup{
-				{
-					NodeGroupData: hwmgrpluginapi.NodeGroupData{
-						Name:      "controller",
-						Role:      "master",
-						HwProfile: "profile-spr-single-processor-128G", // Changed profile to trigger update
-						Size:      1,
+		// New NAR with changed profile to trigger update
+		nodeAllocationRequest := &pluginsv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cr.Name,
+				Namespace: constants.DefaultNamespace,
+			},
+			Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+				ClusterId:    crName,
+				LocationSpec: pluginsv1alpha1.LocationSpec{Site: "test-site"},
+				NodeGroup: []pluginsv1alpha1.NodeGroup{
+					{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+							Name:      "controller",
+							Role:      "master",
+							HwProfile: "profile-spr-single-processor-128G", // Changed profile
+						},
+						Size: 1,
 					},
 				},
 			},
@@ -828,13 +823,10 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 		err := task.createOrUpdateNodeAllocationRequest(ctx, ctNamespace, nodeAllocationRequest)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Read the updated CR to get the latest status
-		var updatedCR provisioningv1alpha1.ProvisioningRequest
-		Expect(c.Get(ctx, client.ObjectKeyFromObject(cr), &updatedCR)).To(Succeed())
-
-		// Verify NodeAllocationRequestRef is updated
-		Expect(updatedCR.Status.Extensions.NodeAllocationRequestRef).ToNot(BeNil())
-		Expect(updatedCR.Status.Extensions.NodeAllocationRequestRef.NodeAllocationRequestID).To(Equal("cluster-1"))
+		// Verify the NAR spec was updated in the cluster
+		updatedNAR := &pluginsv1alpha1.NodeAllocationRequest{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: constants.DefaultNamespace}, updatedNAR)).To(Succeed())
+		Expect(updatedNAR.Spec.NodeGroup[0].NodeGroupData.HwProfile).To(Equal("profile-spr-single-processor-128G"))
 	})
 })
 
@@ -912,26 +904,26 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		nar, err := task.buildNodeAllocationRequest(clusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(nar).ToNot(BeNil())
-		Expect(nar.Site).To(Equal("local-123"))
-		Expect(nar.ClusterId).To(Equal("exampleCluster"))
-		Expect(nar.NodeGroup).To(HaveLen(2))
+		Expect(nar.Spec.LocationSpec.Site).To(Equal("local-123"))
+		Expect(nar.Spec.ClusterId).To(Equal("exampleCluster"))
+		Expect(nar.Spec.NodeGroup).To(HaveLen(2))
 
 		// Check master nodes
-		var masterGroup, workerGroup *hwmgrpluginapi.NodeGroup
-		for i := range nar.NodeGroup {
-			if nar.NodeGroup[i].NodeGroupData.Name == "controller" {
-				masterGroup = &nar.NodeGroup[i]
-			} else if nar.NodeGroup[i].NodeGroupData.Name == groupNameWorker {
-				workerGroup = &nar.NodeGroup[i]
+		var masterGroup, workerGroup *pluginsv1alpha1.NodeGroup
+		for i := range nar.Spec.NodeGroup {
+			if nar.Spec.NodeGroup[i].NodeGroupData.Name == "controller" {
+				masterGroup = &nar.Spec.NodeGroup[i]
+			} else if nar.Spec.NodeGroup[i].NodeGroupData.Name == groupNameWorker {
+				workerGroup = &nar.Spec.NodeGroup[i]
 			}
 		}
 
 		Expect(masterGroup).ToNot(BeNil())
-		Expect(masterGroup.NodeGroupData.Size).To(Equal(2)) // 2 master nodes
+		Expect(masterGroup.Size).To(Equal(2)) // 2 master nodes
 		Expect(masterGroup.NodeGroupData.Role).To(Equal("master"))
 
 		Expect(workerGroup).ToNot(BeNil())
-		Expect(workerGroup.NodeGroupData.Size).To(Equal(1)) // 1 worker node
+		Expect(workerGroup.Size).To(Equal(1)) // 1 worker node
 		Expect(workerGroup.NodeGroupData.Role).To(Equal("worker"))
 	})
 
@@ -967,9 +959,9 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		nar, err := task.buildNodeAllocationRequest(clusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(nar).ToNot(BeNil())
-		Expect(nar.ConfigTransactionId).To(Equal(int64(1))) // Should match PR generation
-		Expect(nar.HardwareProvisioningTimeout).ToNot(BeNil())
-		Expect(*nar.HardwareProvisioningTimeout).To(Equal("60m"))
+		Expect(nar.Spec.ConfigTransactionId).To(Equal(int64(1))) // Should match PR generation
+		Expect(nar.Spec.HardwareProvisioningTimeout).ToNot(BeNil())
+		Expect(nar.Spec.HardwareProvisioningTimeout).To(Equal("60m"))
 	})
 
 	It("should use default timeout when template timeout is empty", func() {
@@ -1004,8 +996,8 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		nar, err := task.buildNodeAllocationRequest(clusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(nar).ToNot(BeNil())
-		Expect(nar.HardwareProvisioningTimeout).ToNot(BeNil())
-		Expect(*nar.HardwareProvisioningTimeout).To(Equal("1h30m0s")) // Default timeout
+		Expect(nar.Spec.HardwareProvisioningTimeout).ToNot(BeNil())
+		Expect(nar.Spec.HardwareProvisioningTimeout).To(Equal("1h30m0s")) // Default timeout
 	})
 
 	It("returns error when spec.nodes not found", func() {
@@ -1054,15 +1046,15 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		nar, err := task.buildNodeAllocationRequest(clusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(nar).ToNot(BeNil())
-		Expect(nar.NodeGroup).To(HaveLen(2))
+		Expect(nar.Spec.NodeGroup).To(HaveLen(2))
 
 		// Check that controller group uses the overridden profile
-		var controllerGroup, workerGroup *hwmgrpluginapi.NodeGroup
-		for i := range nar.NodeGroup {
-			if nar.NodeGroup[i].NodeGroupData.Name == "controller" {
-				controllerGroup = &nar.NodeGroup[i]
-			} else if nar.NodeGroup[i].NodeGroupData.Name == groupNameWorker {
-				workerGroup = &nar.NodeGroup[i]
+		var controllerGroup, workerGroup *pluginsv1alpha1.NodeGroup
+		for i := range nar.Spec.NodeGroup {
+			if nar.Spec.NodeGroup[i].NodeGroupData.Name == "controller" {
+				controllerGroup = &nar.Spec.NodeGroup[i]
+			} else if nar.Spec.NodeGroup[i].NodeGroupData.Name == groupNameWorker {
+				workerGroup = &nar.Spec.NodeGroup[i]
 			}
 		}
 
@@ -1097,8 +1089,8 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		nar, err := task.buildNodeAllocationRequest(clusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(nar).ToNot(BeNil())
-		Expect(nar.NodeGroup).To(HaveLen(1))
-		Expect(nar.NodeGroup[0].NodeGroupData.HwProfile).To(Equal("template-profile-1"))
+		Expect(nar.Spec.NodeGroup).To(HaveLen(1))
+		Expect(nar.Spec.NodeGroup[0].NodeGroupData.HwProfile).To(Equal("template-profile-1"))
 	})
 
 	It("succeeds when nodeGroup has no hwProfile, resourcePoolId, or resourceSelector", func() {
@@ -1124,9 +1116,9 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		nar, err := task.buildNodeAllocationRequest(clusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(nar).ToNot(BeNil())
-		Expect(nar.NodeGroup).To(HaveLen(1))
-		Expect(nar.NodeGroup[0].NodeGroupData.Name).To(Equal("controller"))
-		Expect(nar.NodeGroup[0].NodeGroupData.Role).To(Equal("master"))
+		Expect(nar.Spec.NodeGroup).To(HaveLen(1))
+		Expect(nar.Spec.NodeGroup[0].NodeGroupData.Name).To(Equal("controller"))
+		Expect(nar.Spec.NodeGroup[0].NodeGroupData.Role).To(Equal("master"))
 	})
 })
 
@@ -1314,49 +1306,19 @@ var _ = Describe("waitForHardwareData", func() {
 		}
 
 		// Set up hwpluginClient using the test Metal3 hardware plugin
-		hwplugin := &hwmgmtv1alpha1.HardwarePlugin{}
-		hwpluginKey := client.ObjectKey{
-			Name:      testMetal3HardwarePluginRef,
-			Namespace: testHwMgrPluginNameSpace,
-		}
-		err := c.Get(ctx, hwpluginKey, hwplugin)
-		if err != nil {
-			reconciler.Logger.Warn("Could not get hwplugin for test", "error", err)
-		} else {
-			hwpluginClient, err := hwmgrpluginapi.NewHardwarePluginClient(ctx, c, reconciler.Logger, hwplugin)
-			if err != nil {
-				reconciler.Logger.Warn("Could not create hwpluginClient for test", "error", err)
-			} else {
-				task.hwpluginClient = hwpluginClient
-			}
-		}
 	})
 
 	It("returns provisioned=true and configured=true when both conditions are met", func() {
-		// Create mock with both provisioned and configured true
-		provisionedConfiguredMock := &hwmgrpluginapi.NodeAllocationRequestResponse{
-			Status: &hwmgrpluginapi.NodeAllocationRequestStatus{
-				Conditions: &[]hwmgrpluginapi.Condition{
-					{
-						Type:               "Provisioned",
-						Status:             "True",
-						Reason:             "Completed",
-						Message:            "Hardware provisioned",
-						LastTransitionTime: time.Now(),
-					},
-					{
-						Type:               "Configured",
-						Status:             "True",
-						Reason:             "Completed",
-						Message:            "Hardware configured",
-						LastTransitionTime: time.Now(),
-					},
+		provisionedConfiguredMock := &pluginsv1alpha1.NodeAllocationRequest{
+			Status: pluginsv1alpha1.NodeAllocationRequestStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Provisioned", Status: metav1.ConditionTrue, Reason: "Completed", Message: "Hardware provisioned", LastTransitionTime: metav1.Now()},
+					{Type: "Configured", Status: metav1.ConditionTrue, Reason: "Completed", Message: "Hardware configured", LastTransitionTime: metav1.Now()},
 				},
 				ObservedConfigTransactionId: cr.Generation,
 			},
 		}
 
-		// Test just the status checking, not the full flow
 		provisioned, timedOutOrFailed, err := task.checkNodeAllocationRequestStatus(ctx, provisionedConfiguredMock, hwmgmtv1alpha1.Provisioned)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(provisioned).To(BeTrue())
@@ -1370,17 +1332,10 @@ var _ = Describe("waitForHardwareData", func() {
 	})
 
 	It("returns provisioned=false when provisioning is not complete", func() {
-		// Create mock with provisioned false
-		notProvisionedMock := &hwmgrpluginapi.NodeAllocationRequestResponse{
-			Status: &hwmgrpluginapi.NodeAllocationRequestStatus{
-				Conditions: &[]hwmgrpluginapi.Condition{
-					{
-						Type:               "Provisioned",
-						Status:             "False",
-						Reason:             "InProgress",
-						Message:            "Hardware provisioning in progress",
-						LastTransitionTime: time.Now(),
-					},
+		notProvisionedMock := &pluginsv1alpha1.NodeAllocationRequest{
+			Status: pluginsv1alpha1.NodeAllocationRequestStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Provisioned", Status: metav1.ConditionFalse, Reason: "InProgress", Message: "Hardware provisioning in progress", LastTransitionTime: metav1.Now()},
 				},
 			},
 		}
@@ -1393,30 +1348,22 @@ var _ = Describe("waitForHardwareData", func() {
 	})
 
 	It("returns configured=nil when configured condition does not exist", func() {
-		// Create mock with only provisioned condition
-		onlyProvisionedMock := &hwmgrpluginapi.NodeAllocationRequestResponse{
-			Status: &hwmgrpluginapi.NodeAllocationRequestStatus{
-				Conditions: &[]hwmgrpluginapi.Condition{
-					{
-						Type:               "Provisioned",
-						Status:             "True",
-						Reason:             "Completed",
-						Message:            "Hardware provisioned",
-						LastTransitionTime: time.Now(),
-					},
+		onlyProvisionedMock := &pluginsv1alpha1.NodeAllocationRequest{
+			Status: pluginsv1alpha1.NodeAllocationRequestStatus{
+				Conditions: []metav1.Condition{
+					{Type: "Provisioned", Status: metav1.ConditionTrue, Reason: "Completed", Message: "Hardware provisioned", LastTransitionTime: metav1.Now()},
 				},
 			},
 		}
 
-		// Test just the status checking, not the full flow
 		provisioned, timedOutOrFailed, err := task.checkNodeAllocationRequestStatus(ctx, onlyProvisionedMock, hwmgmtv1alpha1.Provisioned)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(provisioned).To(BeTrue())
 		Expect(timedOutOrFailed).To(BeFalse())
 
 		configured, timedOutOrFailed, err := task.checkNodeAllocationRequestConfigStatus(ctx, onlyProvisionedMock)
-		Expect(err).ToNot(HaveOccurred()) // Function returns nil error when condition doesn't exist
-		Expect(configured).To(BeNil())    // But configured should be nil
+		Expect(err).ToNot(HaveOccurred())
+		Expect(configured).To(BeNil())
 		Expect(timedOutOrFailed).To(BeFalse())
 	})
 })
@@ -1462,37 +1409,42 @@ var _ = Describe("checkExistingNodeAllocationRequest", func() {
 		}
 
 		// Set up hwpluginClient using the test Metal3 hardware plugin
-		hwplugin := &hwmgmtv1alpha1.HardwarePlugin{}
-		hwpluginKey := client.ObjectKey{
-			Name:      testMetal3HardwarePluginRef,
-			Namespace: testHwMgrPluginNameSpace,
-		}
-		err := c.Get(ctx, hwpluginKey, hwplugin)
-		if err != nil {
-			reconciler.Logger.Warn("Could not get hwplugin for test", "error", err)
-		} else {
-			hwpluginClient, err := hwmgrpluginapi.NewHardwarePluginClient(ctx, c, reconciler.Logger, hwplugin)
-			if err != nil {
-				reconciler.Logger.Warn("Could not create hwpluginClient for test", "error", err)
-			} else {
-				task.hwpluginClient = hwpluginClient
-			}
-		}
 	})
 
-	It("returns error when hwpluginClient is nil", func() {
-		task.hwpluginClient = nil
-
+	It("returns nil when NAR does not exist", func() {
 		hwMgmtData := map[string]any{}
 		nodeAllocationRequestId := "test-id"
 
 		response, err := task.checkExistingNodeAllocationRequest(ctx, hwMgmtData, nodeAllocationRequestId)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(response).To(BeNil())
-		Expect(err.Error()).To(ContainSubstring("hwpluginClient is nil"))
 	})
 
 	It("returns response when NodeAllocationRequest exists and matches", func() {
+		// Create a NAR CR in the fake client
+		nar := &pluginsv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      crName,
+				Namespace: constants.DefaultNamespace,
+			},
+			Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+				ClusterId: crName,
+				NodeGroup: []pluginsv1alpha1.NodeGroup{
+					{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+							Name: "controller", Role: "master", HwProfile: "profile-spr-single-processor-64G",
+						},
+					},
+					{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+							Name: "worker", Role: "worker", HwProfile: "profile-spr-dual-processor-128G",
+						},
+					},
+				},
+			},
+		}
+		Expect(c.Create(ctx, nar)).To(Succeed())
+
 		hwMgmtData := map[string]any{
 			"hardwarePluginRef": testMetal3HardwarePluginRef,
 			"nodeGroupData": []any{
@@ -1517,7 +1469,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 		cr          *provisioningv1alpha1.ProvisioningRequest
 		ci          *unstructured.Unstructured
 		hwNodes     map[string][]utils.NodeInfo
-		nar         *hwmgrpluginapi.NodeAllocationRequestResponse
+		nar         *pluginsv1alpha1.NodeAllocationRequest
 		crName      = "cluster-1"
 		ctNamespace = "clustertemplate-a-v4-16"
 		tName       = "clustertemplate-a"
@@ -1652,18 +1604,18 @@ var _ = Describe("applyNodeConfiguration", func() {
 			},
 		}
 
-		// Set up node allocation request response
-		nar = &hwmgrpluginapi.NodeAllocationRequestResponse{
-			NodeAllocationRequest: &hwmgrpluginapi.NodeAllocationRequest{
-				NodeGroup: []hwmgrpluginapi.NodeGroup{
+		// Set up node allocation request
+		nar = &pluginsv1alpha1.NodeAllocationRequest{
+			Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+				NodeGroup: []pluginsv1alpha1.NodeGroup{
 					{
-						NodeGroupData: hwmgrpluginapi.NodeGroupData{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
 							Name: "controller",
 							Role: "master",
 						},
 					},
 					{
-						NodeGroupData: hwmgrpluginapi.NodeGroupData{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
 							Name: "worker",
 							Role: "worker",
 						},
@@ -2282,9 +2234,9 @@ var _ = Describe("processExistingHardwareCondition", func() {
 	Context("when HardwareProvisioned condition fails", func() {
 		It("preserves detailed NAR error message in PR condition", func() {
 			detailedError := "Creation request failed: not enough free resources matching nodegroup=controller criteria: freenodes=0, required=1"
-			hwCondition := &hwmgrpluginapi.Condition{
+			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Provisioned),
-				Status:  string(metav1.ConditionFalse),
+				Status:  metav1.ConditionFalse,
 				Reason:  string(hwmgmtv1alpha1.Failed),
 				Message: detailedError,
 			}
@@ -2302,9 +2254,9 @@ var _ = Describe("processExistingHardwareCondition", func() {
 	Context("when HardwareConfigured condition fails", func() {
 		It("preserves detailed NAR error message in PR condition", func() {
 			detailedError := "Configuration failed: unable to apply BIOS settings on node controller-0"
-			hwCondition := &hwmgrpluginapi.Condition{
+			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Configured),
-				Status:  string(metav1.ConditionFalse),
+				Status:  metav1.ConditionFalse,
 				Reason:  string(hwmgmtv1alpha1.Failed),
 				Message: detailedError,
 			}
@@ -2324,9 +2276,9 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			// With the new timeout handling approach, timeouts are detected at the NodeAllocationRequest level
 			// and propagated via callbacks. The ProvisioningRequest controller no longer detects timeouts directly.
 			// Instead, it receives timeout status via callbacks from the hardware plugin.
-			hwCondition := &hwmgrpluginapi.Condition{
+			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Provisioned),
-				Status:  string(metav1.ConditionFalse),
+				Status:  metav1.ConditionFalse,
 				Reason:  string(hwmgmtv1alpha1.TimedOut), // Hardware plugin reports timeout via callback
 				Message: "Hardware provisioning timed out",
 			}
@@ -2345,9 +2297,9 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			// With the new timeout handling approach, timeouts are detected at the NodeAllocationRequest level
 			// and propagated via callbacks. The ProvisioningRequest controller no longer detects timeouts directly.
 			// Instead, it receives timeout status via callbacks from the hardware plugin.
-			hwCondition := &hwmgrpluginapi.Condition{
+			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Configured),
-				Status:  string(metav1.ConditionFalse),
+				Status:  metav1.ConditionFalse,
 				Reason:  string(hwmgmtv1alpha1.TimedOut), // Hardware plugin reports timeout via callback
 				Message: "Hardware configuration timed out",
 			}
@@ -2362,9 +2314,9 @@ var _ = Describe("processExistingHardwareCondition", func() {
 
 	Context("when HardwareProvisioned completes successfully", func() {
 		It("updates provisioningStatus with success message", func() {
-			hwCondition := &hwmgrpluginapi.Condition{
+			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Provisioned),
-				Status:  string(metav1.ConditionTrue),
+				Status:  metav1.ConditionTrue,
 				Reason:  string(hwmgmtv1alpha1.Completed),
 				Message: "Created",
 			}
@@ -2383,9 +2335,9 @@ var _ = Describe("processExistingHardwareCondition", func() {
 
 	Context("when HardwareConfigured completes successfully", func() {
 		It("updates provisioningStatus with success message", func() {
-			hwCondition := &hwmgrpluginapi.Condition{
+			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Configured),
-				Status:  string(metav1.ConditionTrue),
+				Status:  metav1.ConditionTrue,
 				Reason:  string(hwmgmtv1alpha1.Completed),
 				Message: "Configuration applied",
 			}
@@ -2405,9 +2357,9 @@ var _ = Describe("processExistingHardwareCondition", func() {
 	Context("when HardwareProvisioned is in progress with context", func() {
 		It("preserves NAR context message", func() {
 			narContextMessage := "Handling creation"
-			hwCondition := &hwmgrpluginapi.Condition{
+			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Provisioned),
-				Status:  string(metav1.ConditionFalse),
+				Status:  metav1.ConditionFalse,
 				Reason:  string(hwmgmtv1alpha1.InProgress),
 				Message: narContextMessage,
 			}
@@ -2424,9 +2376,9 @@ var _ = Describe("processExistingHardwareCondition", func() {
 
 	Context("when HardwareProvisioned is in progress without context", func() {
 		It("uses generic in-progress message", func() {
-			hwCondition := &hwmgrpluginapi.Condition{
+			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Provisioned),
-				Status:  string(metav1.ConditionFalse),
+				Status:  metav1.ConditionFalse,
 				Reason:  string(hwmgmtv1alpha1.InProgress),
 				Message: "", // Empty message
 			}
@@ -2444,9 +2396,9 @@ var _ = Describe("processExistingHardwareCondition", func() {
 	Context("when HardwareConfigured is in progress with context", func() {
 		It("preserves NAR context message", func() {
 			narContextMessage := "AwaitConfig"
-			hwCondition := &hwmgrpluginapi.Condition{
+			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Configured),
-				Status:  string(metav1.ConditionFalse),
+				Status:  metav1.ConditionFalse,
 				Reason:  string(hwmgmtv1alpha1.InProgress),
 				Message: narContextMessage,
 			}
@@ -2458,149 +2410,6 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			Expect(timedOutOrFailed).To(BeFalse())
 			// Verify the NAR context is preserved with "configuring" (verb form)
 			Expect(message).To(Equal("Hardware configuring is in progress: " + narContextMessage))
-		})
-	})
-
-	Context("shouldUpdateHardwareStatus day 2 retry logic", func() {
-		var task *provisioningRequestReconcilerTask
-		var cr *provisioningv1alpha1.ProvisioningRequest
-
-		BeforeEach(func() {
-			cr = &provisioningv1alpha1.ProvisioningRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-pr",
-					Namespace:  "default",
-					Generation: 2,
-				},
-				Status: provisioningv1alpha1.ProvisioningRequestStatus{
-					ObservedGeneration: 1, // Different from generation, indicating spec change
-					ProvisioningStatus: provisioningv1alpha1.ProvisioningStatus{
-						ProvisioningPhase: provisioningv1alpha1.StatePending,
-					},
-				},
-			}
-			Expect(c.Create(ctx, cr)).To(Succeed())
-
-			task = &provisioningRequestReconcilerTask{
-				logger: reconciler.Logger,
-				client: reconciler.Client,
-				object: cr,
-			}
-		})
-
-		Context("when Configured condition is in terminal state and PR is pending", func() {
-			BeforeEach(func() {
-				// Set up terminal state (TimedOut) for HardwareConfigured condition
-				utils.SetStatusCondition(&cr.Status.Conditions,
-					provisioningv1alpha1.PRconditionTypes.HardwareConfigured,
-					provisioningv1alpha1.CRconditionReasons.TimedOut,
-					metav1.ConditionFalse,
-					"Hardware configuration timed out")
-				Expect(c.Status().Update(ctx, cr)).To(Succeed())
-			})
-
-			It("should NOT allow status update for terminal Configured condition", func() {
-				// This should return false because:
-				// 1. isTerminalState = true (TimedOut reason)
-				// 2. condition = hwmgmtv1alpha1.Configured
-				// 3. With new implementation, terminal states always return false
-				result := task.shouldUpdateHardwareStatus(hwmgmtv1alpha1.Configured)
-				Expect(result).To(BeFalse())
-			})
-
-			It("should NOT allow status update for Provisioned condition", func() {
-				// Set up terminal state (TimedOut) for HardwareProvisioned condition
-				utils.SetStatusCondition(&cr.Status.Conditions,
-					provisioningv1alpha1.PRconditionTypes.HardwareProvisioned,
-					provisioningv1alpha1.CRconditionReasons.TimedOut,
-					metav1.ConditionFalse,
-					"Hardware provisioning timed out")
-				Expect(c.Status().Update(ctx, cr)).To(Succeed())
-
-				// This should return false because:
-				// 1. isTerminalState = true (TimedOut reason)
-				// 2. condition = hwmgmtv1alpha1.Provisioned (not Configured)
-				// 3. Day 2 retry exception only applies to Configured condition
-				result := task.shouldUpdateHardwareStatus(hwmgmtv1alpha1.Provisioned)
-				Expect(result).To(BeFalse())
-			})
-
-			It("should NOT allow status update when PR is not pending", func() {
-				// Change PR phase to progressing
-				cr.Status.ProvisioningStatus.ProvisioningPhase = provisioningv1alpha1.StateProgressing
-				Expect(c.Status().Update(ctx, cr)).To(Succeed())
-
-				// This should return false because ProvisioningPhase is not StatePending
-				result := task.shouldUpdateHardwareStatus(hwmgmtv1alpha1.Configured)
-				Expect(result).To(BeFalse())
-			})
-		})
-
-		Context("when Configured condition is in terminal state (Failed) and PR is pending", func() {
-			BeforeEach(func() {
-				// Set up terminal state (Failed) for HardwareConfigured condition
-				utils.SetStatusCondition(&cr.Status.Conditions,
-					provisioningv1alpha1.PRconditionTypes.HardwareConfigured,
-					provisioningv1alpha1.CRconditionReasons.Failed,
-					metav1.ConditionFalse,
-					"Hardware configuration failed")
-				Expect(c.Status().Update(ctx, cr)).To(Succeed())
-			})
-
-			It("should NOT allow status update for terminal Configured condition", func() {
-				result := task.shouldUpdateHardwareStatus(hwmgmtv1alpha1.Configured)
-				Expect(result).To(BeFalse())
-			})
-		})
-
-		Context("when Configured condition is NOT in terminal state", func() {
-			BeforeEach(func() {
-				// Set up non-terminal state (InProgress) for HardwareConfigured condition
-				utils.SetStatusCondition(&cr.Status.Conditions,
-					provisioningv1alpha1.PRconditionTypes.HardwareConfigured,
-					provisioningv1alpha1.CRconditionReasons.InProgress,
-					metav1.ConditionFalse,
-					"Hardware configuration in progress")
-				Expect(c.Status().Update(ctx, cr)).To(Succeed())
-			})
-
-			It("should allow status update regardless of PR phase", func() {
-				// Should return true because condition is not in terminal state
-				result := task.shouldUpdateHardwareStatus(hwmgmtv1alpha1.Configured)
-				Expect(result).To(BeTrue())
-			})
-		})
-
-		Context("when no condition exists yet", func() {
-			It("should allow status update", func() {
-				// Should return true because no condition exists yet
-				result := task.shouldUpdateHardwareStatus(hwmgmtv1alpha1.Configured)
-				Expect(result).To(BeTrue())
-			})
-		})
-
-		Context("when callback-triggered reconciliation", func() {
-			BeforeEach(func() {
-				// Set up callback annotations
-				cr.Annotations = map[string]string{
-					utils.CallbackReceivedAnnotation: "test-callback",
-				}
-				Expect(c.Update(ctx, cr)).To(Succeed())
-
-				// Set up terminal state
-				utils.SetStatusCondition(&cr.Status.Conditions,
-					provisioningv1alpha1.PRconditionTypes.HardwareConfigured,
-					provisioningv1alpha1.CRconditionReasons.TimedOut,
-					metav1.ConditionFalse,
-					"Hardware configuration timed out")
-				Expect(c.Status().Update(ctx, cr)).To(Succeed())
-			})
-
-			It("should always allow status update", func() {
-				// Should return true because it's callback-triggered, regardless of terminal state
-				result := task.shouldUpdateHardwareStatus(hwmgmtv1alpha1.Configured)
-				Expect(result).To(BeTrue())
-			})
 		})
 	})
 
@@ -2712,10 +2521,10 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			// Create NAR response without Configured condition and ObservedConfigTransactionId not matching
 			// This simulates waiting for a new configuration transaction to start
 			observedID := int64(3) // Different from PR Generation (5)
-			mockResponse := &hwmgrpluginapi.NodeAllocationRequestResponse{
-				Status: &hwmgrpluginapi.NodeAllocationRequestStatus{
+			mockResponse := &pluginsv1alpha1.NodeAllocationRequest{
+				Status: pluginsv1alpha1.NodeAllocationRequestStatus{
 					ObservedConfigTransactionId: observedID,
-					Conditions:                  &[]hwmgrpluginapi.Condition{}, // No Configured condition
+					Conditions:                  []metav1.Condition{}, // No Configured condition
 				},
 			}
 
@@ -2730,10 +2539,10 @@ var _ = Describe("processExistingHardwareCondition", func() {
 		It("should return ConditionDoesNotExistsErr when ObservedConfigTransactionId is zero", func() {
 			// Create NAR response without Configured condition and zero ObservedConfigTransactionId
 			// Zero indicates the transaction has not been observed yet
-			mockResponse := &hwmgrpluginapi.NodeAllocationRequestResponse{
-				Status: &hwmgrpluginapi.NodeAllocationRequestStatus{
+			mockResponse := &pluginsv1alpha1.NodeAllocationRequest{
+				Status: pluginsv1alpha1.NodeAllocationRequestStatus{
 					ObservedConfigTransactionId: 0,
-					Conditions:                  &[]hwmgrpluginapi.Condition{}, // No Configured condition
+					Conditions:                  []metav1.Condition{}, // No Configured condition
 				},
 			}
 
@@ -2748,16 +2557,16 @@ var _ = Describe("processExistingHardwareCondition", func() {
 		It("should proceed normally when ObservedConfigTransactionId matches Generation", func() {
 			// Create NAR response with matching ObservedConfigTransactionId
 			observedID := int64(5) // Matches PR Generation
-			configuredCondition := hwmgrpluginapi.Condition{
+			configuredCondition := metav1.Condition{
 				Type:    "Configured",
 				Status:  "True",
 				Reason:  "Completed",
 				Message: "Hardware configured successfully",
 			}
-			mockResponse := &hwmgrpluginapi.NodeAllocationRequestResponse{
-				Status: &hwmgrpluginapi.NodeAllocationRequestStatus{
+			mockResponse := &pluginsv1alpha1.NodeAllocationRequest{
+				Status: pluginsv1alpha1.NodeAllocationRequestStatus{
 					ObservedConfigTransactionId: observedID,
-					Conditions:                  &[]hwmgrpluginapi.Condition{configuredCondition},
+					Conditions:                  []metav1.Condition{configuredCondition},
 				},
 			}
 
@@ -2808,10 +2617,10 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			// Simulate a race condition: PR Generation changes during reconciliation
 			// Step 1: Start reconciliation with Generation=5
 			observedID := int64(5) // Matches initial Generation
-			mockResponse1 := &hwmgrpluginapi.NodeAllocationRequestResponse{
-				Status: &hwmgrpluginapi.NodeAllocationRequestStatus{
+			mockResponse1 := &pluginsv1alpha1.NodeAllocationRequest{
+				Status: pluginsv1alpha1.NodeAllocationRequestStatus{
 					ObservedConfigTransactionId: observedID,
-					Conditions:                  &[]hwmgrpluginapi.Condition{}, // No Configured condition yet
+					Conditions:                  []metav1.Condition{}, // No Configured condition yet
 				},
 			}
 
@@ -2840,16 +2649,16 @@ var _ = Describe("processExistingHardwareCondition", func() {
 
 			// Step 2: Plugin eventually processes the new transaction (Generation 6)
 			observedID := int64(6) // Matches new Generation
-			configuredCondition := hwmgrpluginapi.Condition{
+			configuredCondition := metav1.Condition{
 				Type:    "Configured",
 				Status:  "True",
 				Reason:  "Completed",
 				Message: "Hardware configured successfully",
 			}
-			mockResponse := &hwmgrpluginapi.NodeAllocationRequestResponse{
-				Status: &hwmgrpluginapi.NodeAllocationRequestStatus{
+			mockResponse := &pluginsv1alpha1.NodeAllocationRequest{
+				Status: pluginsv1alpha1.NodeAllocationRequestStatus{
 					ObservedConfigTransactionId: observedID,
-					Conditions:                  &[]hwmgrpluginapi.Condition{configuredCondition},
+					Conditions:                  []metav1.Condition{configuredCondition},
 				},
 			}
 

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -2413,6 +2413,95 @@ var _ = Describe("processExistingHardwareCondition", func() {
 		})
 	})
 
+	Context("stale terminal NAR status guard", func() {
+		It("skips update when NAR has Failed condition and plugin has not observed new transaction", func() {
+			narWithStaleFailure := &pluginsv1alpha1.NodeAllocationRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-1",
+					Namespace: constants.DefaultNamespace,
+				},
+				Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+					ConfigTransactionId: 3,
+				},
+				Status: pluginsv1alpha1.NodeAllocationRequestStatus{
+					ObservedConfigTransactionId: 2,
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(hwmgmtv1alpha1.Configured),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(hwmgmtv1alpha1.Failed),
+							Message:            "Previous attempt failed",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			}
+
+			status, timedOutOrFailed, err := task.checkNodeAllocationRequestStatus(ctx, narWithStaleFailure, hwmgmtv1alpha1.Configured)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeFalse())
+			Expect(timedOutOrFailed).To(BeFalse())
+		})
+
+		It("skips update when NAR has TimedOut condition and plugin has not observed new transaction", func() {
+			narWithStaleTimeout := &pluginsv1alpha1.NodeAllocationRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-1",
+					Namespace: constants.DefaultNamespace,
+				},
+				Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+					ConfigTransactionId: 3,
+				},
+				Status: pluginsv1alpha1.NodeAllocationRequestStatus{
+					ObservedConfigTransactionId: 2,
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(hwmgmtv1alpha1.Configured),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(hwmgmtv1alpha1.TimedOut),
+							Message:            "Previous attempt timed out",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			}
+
+			status, timedOutOrFailed, err := task.checkNodeAllocationRequestStatus(ctx, narWithStaleTimeout, hwmgmtv1alpha1.Configured)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeFalse())
+			Expect(timedOutOrFailed).To(BeFalse())
+		})
+
+		It("allows update when plugin has observed the current transaction", func() {
+			narWithCurrentFailure := &pluginsv1alpha1.NodeAllocationRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-1",
+					Namespace: constants.DefaultNamespace,
+				},
+				Spec: pluginsv1alpha1.NodeAllocationRequestSpec{
+					ConfigTransactionId: 3,
+				},
+				Status: pluginsv1alpha1.NodeAllocationRequestStatus{
+					ObservedConfigTransactionId: 3,
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(hwmgmtv1alpha1.Configured),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(hwmgmtv1alpha1.Failed),
+							Message:            "Current attempt failed",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			}
+
+			status, timedOutOrFailed, err := task.checkNodeAllocationRequestStatus(ctx, narWithCurrentFailure, hwmgmtv1alpha1.Configured)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeFalse())
+			Expect(timedOutOrFailed).To(BeTrue())
+		})
+	})
+
 	Context("integration test: updateHardwareStatus with callback for failed condition", func() {
 		It("propagates detailed error through the full flow", func() {
 			detailedError := "Creation request failed: not enough free resources matching nodegroup=controller criteria: freenodes=0, required=1"

--- a/internal/controllers/provisioningrequest_setup.go
+++ b/internal/controllers/provisioningrequest_setup.go
@@ -8,7 +8,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -24,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ibgu "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
-	pluginsv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/plugins/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
@@ -35,14 +33,6 @@ import (
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ProvisioningRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Setup Node CRD indexer. This field indexer allows us to query a list of Node CRs, filtered by the spec.nodeAllocationRequest field.
-	nodeIndexFunc := func(obj client.Object) []string {
-		return []string{obj.(*pluginsv1alpha1.AllocatedNode).Spec.NodeAllocationRequest}
-	}
-
-	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &pluginsv1alpha1.AllocatedNode{}, "spec.nodeAllocationRequest", nodeIndexFunc); err != nil {
-		return fmt.Errorf("failed to setup indexer for clcm.openshift.io/v1alpha1 AllocatedNode: %w", err)
-	}
 	//nolint:wrapcheck
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("o2ims-cluster-request").

--- a/test/e2e/mno_hw_configuration_test.go
+++ b/test/e2e/mno_hw_configuration_test.go
@@ -306,12 +306,12 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		By("Waiting for NAR creation")
 		Eventually(func() error {
 			return K8SClient.Get(testCtx, types.NamespacedName{
-				Name: clusterName, Namespace: constants.DefaultNamespace}, nar)
+				Name: prName, Namespace: constants.DefaultNamespace}, nar)
 		}, timeout, interval).Should(Succeed())
 
 		By("Waiting for all 11 AllocatedNodes to be created")
 		Eventually(func() int {
-			return len(listAllocatedNodesForNAR(testCtx, clusterName).Items)
+			return len(listAllocatedNodesForNAR(testCtx, prName).Items)
 		}, timeout, interval).Should(Equal(masterCount + workerCount))
 
 		By("Waiting for day0 to complete (NAR Provisioned=True)")
@@ -333,7 +333,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 
 		By("Simulating AllocatedNodeHostMap on PR")
 		Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
-		nodeList := listAllocatedNodesForNAR(testCtx, clusterName)
+		nodeList := listAllocatedNodesForNAR(testCtx, prName)
 		hostMap := make(map[string]string)
 		masterIdx, workerIdx := 1, 1
 		hostnames := []string{}
@@ -400,13 +400,13 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		// Clean up NARs and AllocatedNodes (not cascade-deleted since PR finalizer was stripped)
 		narObj := &pluginsv1alpha1.NodeAllocationRequest{}
 		if err := K8SClient.Get(testCtx, types.NamespacedName{
-			Name: clusterName, Namespace: constants.DefaultNamespace,
+			Name: prName, Namespace: constants.DefaultNamespace,
 		}, narObj); err == nil {
 			narObj.Finalizers = nil
 			_ = K8SClient.Update(testCtx, narObj)
 			_ = K8SClient.Delete(testCtx, narObj)
 		}
-		anList := listAllocatedNodesForNAR(testCtx, clusterName)
+		anList := listAllocatedNodesForNAR(testCtx, prName)
 		for i := range anList.Items {
 			_ = K8SClient.Delete(testCtx, &anList.Items[i])
 		}
@@ -482,7 +482,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			By("Polling and advancing BMH state transitions for each node")
 			Eventually(func() bool {
 				allComplete := true
-				nodeList := listAllocatedNodesForNAR(testCtx, clusterName)
+				nodeList := listAllocatedNodesForNAR(testCtx, prName)
 
 				// Track rolling-update invariants
 				mastersAllDone := true
@@ -606,7 +606,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		It("Should fail when one worker BMH enters error state during update", func() {
 			By("Failing one worker BMH and waiting for NAR to reach Failed")
 			Eventually(func() bool {
-				nodeList := listAllocatedNodesForNAR(testCtx, clusterName)
+				nodeList := listAllocatedNodesForNAR(testCtx, prName)
 				for i := range nodeList.Items {
 					node := &nodeList.Items[i]
 
@@ -720,7 +720,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			By("Waiting for at least 3 workers in ConfigUpdate with v1 profile")
 			Eventually(func() int {
 				count := 0
-				nodeList := listAllocatedNodesForNAR(testCtx, clusterName)
+				nodeList := listAllocatedNodesForNAR(testCtx, prName)
 				for i := range nodeList.Items {
 					node := &nodeList.Items[i]
 					if node.Spec.GroupName != worker || node.Spec.HwProfile != v1Profile {
@@ -736,7 +736,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 				"At least 3 workers should be in ConfigUpdate with v1 profile")
 
 			By("Picking one worker and advancing its BMH to Servicing with config-in-progress")
-			nodeList := listAllocatedNodesForNAR(testCtx, clusterName)
+			nodeList := listAllocatedNodesForNAR(testCtx, prName)
 			for i := range nodeList.Items {
 				node := &nodeList.Items[i]
 				if node.Spec.GroupName != worker || node.Spec.HwProfile != v1Profile {
@@ -806,7 +806,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			// The 1 Servicing worker can't be abandoned (BMH Servicing) -> stays in ConfigUpdate.
 			Eventually(func() int {
 				count := 0
-				nodeList := listAllocatedNodesForNAR(testCtx, clusterName)
+				nodeList := listAllocatedNodesForNAR(testCtx, prName)
 				for _, node := range nodeList.Items {
 					if node.Spec.GroupName != worker {
 						continue
@@ -849,7 +849,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			Expect(simulateCallback(testCtx, prName, string(hwmgmtv1alpha1.ConfigApplied))).To(Succeed())
 
 			By("Verifying all 8 worker nodes converged to v2 profile")
-			nodeList := listAllocatedNodesForNAR(testCtx, clusterName)
+			nodeList := listAllocatedNodesForNAR(testCtx, prName)
 			for _, node := range nodeList.Items {
 				if node.Spec.GroupName != worker {
 					continue


### PR DESCRIPTION
Replace the REST API layer between the ProvisioningRequest controller and the NodeAllocationRequest CRs with direct Kubernetes client operations. This eliminates the hardware plugin REST client, the HardwarePluginClientAdapter, and the mock REST interface from tests.

Key changes:

NAR naming: Use the ProvisioningRequest name as the NAR name (1:1 relationship), eliminating NAR name generation and the need for NodeAllocationRequestRef.NodeAllocationRequestID.

Production code:
- Add getNAR helper for direct K8s Get by PR name
- Rewrite setNARClusterProvisioned/syncNARSkipCleanup with client.Patch
- Rewrite createOrUpdateNodeAllocationRequest with client.Create/Patch
- Rewrite handleProvisioningRequestDeletion with client.Get/Delete using foreground deletion propagation
- Rewrite buildNodeAllocationRequest to return CRD type with ObjectMeta
- Replace AllocatedNode REST queries with in-memory filtering via listAllocatedNodesForNAR helper
- Rewrite collectNodeDetails to use CRD AllocatedNode types
- Update addPostProvisioningLabels to use direct AllocatedNode CR list
- Remove hwpluginClient field, getHardwarePluginClient, initializeHardwarePluginIfNeeded
- Remove shouldUpdateHardwareStatus gating and related functions (isCallbackTriggeredReconciliation, shouldAllowCallbackUpdate, shouldAllowPollingUpdate, getHardwareStatusFromConditions, isTerminalState) — always read latest NAR status directly
- Remove HardwarePluginLabel from NAR/AllocatedNode creation and Metal3 controller watch predicates (single hardware manager)
- Remove field index registration from PR controller SetupWithManager
- Remove all hwmgrpluginapi imports from production code

Tests:
- Rewrite getNodeAllocationRequestResponse tests with fake K8s client
- Rewrite mock helpers to return CRD types (pluginsv1alpha1)
- Remove initializeHardwarePluginClientWithRetry tests
- Remove shouldUpdateHardwareStatus tests
- Remove all hwpluginClient setup blocks from test BeforeEach
- Replace mock REST interface with direct CRD object creation
- Update e2e tests: NAR lookups use prName not clusterName
- Remove unused gomock, mocks, and hwmgrpluginapi imports

Net change: 586 additions, 1620 deletions across 14 files