### PR TITLE
CNF-23326: Add .ci-operator.yaml for CI build root

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,5 @@
+---
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-9-release-golang-1.24-openshift-4.22


### PR DESCRIPTION
Add .ci-operator.yaml pointing to the rhel-9-release-golang-1.24-openshift-4.22 release image. This prepares for migrating the CI build root from project_image (Dockerfile.tools) to from_repository mode, which will allow Go version upgrades to be done in a single PR instead of requiring two sequential PRs.

This file has no effect until the openshift/release CI configuration is updated to use build_root.from_repository: true ([CNF-23327](https://redhat.atlassian.net/browse/CNF-23327)).