### PR TITLE
feat(auth): add server-side logging for authentication failures

### DIFF
--- a/internal/service/common/auth/auth.go
+++ b/internal/service/common/auth/auth.go
@@ -36,11 +36,13 @@ func Authenticator(oauthHandler, kubernetesHandler authenticator.Request) middle
 
 			response, ok, err := handler.AuthenticateRequest(req)
 			if err != nil {
+				slog.Warn("authentication error", "method", req.Method, "path", req.URL.Path, "error", err)
 				middleware.ProblemDetails(w, fmt.Sprintf("failed to authenticate request: %v", err), http.StatusUnauthorized)
 				return
 			}
 
 			if !ok {
+				slog.Warn("authentication rejected", "method", req.Method, "path", req.URL.Path)
 				middleware.ProblemDetails(w, "unable to authenticate request", http.StatusUnauthorized)
 				return
 			}

--- a/internal/service/common/auth/auth_rfc8705.go
+++ b/internal/service/common/auth/auth_rfc8705.go
@@ -163,7 +163,7 @@ func (w *withClientVerification) AuthenticateRequest(req *http.Request) (*authen
 	}
 
 	if tokenFingerprintValues[0] != "" && tokenFingerprintValues[0] != clientFingerprint {
-		slog.Debug("fingerprint values do not match", "client", clientFingerprint, "token", tokenFingerprintValues[0])
+		slog.Warn("fingerprint values do not match", "client", clientFingerprint, "token", tokenFingerprintValues[0])
 		return nil, false, fmt.Errorf("client certificate fingerprint mismatch")
 	}
 

--- a/internal/service/common/auth/auth_rfc8705_test.go
+++ b/internal/service/common/auth/auth_rfc8705_test.go
@@ -7,10 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package auth
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -156,6 +158,21 @@ var _ = Describe("WithClientVerification", func() {
 		Expect(response).To(BeNil())
 		Expect(request.Header.Get(sslClientCertKey)).To(Equal(""))
 		Expect(request.Header.Get(sslClientChainKey)).To(Equal(""))
+	})
+
+	It("logs fingerprint mismatch at Warn level", func() {
+		var logBuf bytes.Buffer
+		originalLogger := slog.Default()
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, nil)))
+		DeferCleanup(func() { slog.SetDefault(originalLogger) })
+
+		noopAuthenticator.Response.User.GetExtra()[fingerprintKey] = []string{"other"}
+		_, _, err := tokenAuthenticator.AuthenticateRequest(&request)
+		Expect(err).ToNot(BeNil())
+
+		logOutput := logBuf.String()
+		Expect(logOutput).To(ContainSubstring(`"level":"WARN"`))
+		Expect(logOutput).To(ContainSubstring("fingerprint values do not match"))
 	})
 
 	It("reject a request with multiple fingerprints", func() {

--- a/internal/service/common/auth/auth_test.go
+++ b/internal/service/common/auth/auth_test.go
@@ -7,8 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package auth
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -87,7 +89,7 @@ var _ = Describe("Authenticator", func() {
 			Ok:    true,
 			Error: nil,
 		}
-		req = http.Request{Header: http.Header{}}
+		req = http.Request{Header: http.Header{}, Method: http.MethodGet, URL: &url.URL{Path: "/test/path"}}
 		next = &NoopHandler{}
 		recorder = httptest.NewRecorder()
 		handler = Authenticator(&oauthAuthenticator, &k8sAuthenticator)(next)
@@ -148,6 +150,41 @@ var _ = Describe("Authenticator", func() {
 		Expect(next.(*NoopHandler).called).To(BeFalse())
 		Expect(recorder.Code).To(Equal(http.StatusUnauthorized))
 		Expect(recorder.Body.String()).To(ContainSubstring("unable to authenticate request"))
+	})
+
+	It("Logs authentication errors with method and path", func() {
+		var logBuf bytes.Buffer
+		originalLogger := slog.Default()
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, nil)))
+		DeferCleanup(func() { slog.SetDefault(originalLogger) })
+
+		k8sAuthenticator.Error = errors.New("token expired")
+		handler.ServeHTTP(recorder, &req)
+
+		Expect(recorder.Code).To(Equal(http.StatusUnauthorized))
+		logOutput := logBuf.String()
+		Expect(logOutput).To(ContainSubstring(`"level":"WARN"`))
+		Expect(logOutput).To(ContainSubstring(`"msg":"authentication error"`))
+		Expect(logOutput).To(ContainSubstring(`"method":"GET"`))
+		Expect(logOutput).To(ContainSubstring(`"path":"/test/path"`))
+		Expect(logOutput).To(ContainSubstring("token expired"))
+	})
+
+	It("Logs authentication rejections with method and path", func() {
+		var logBuf bytes.Buffer
+		originalLogger := slog.Default()
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, nil)))
+		DeferCleanup(func() { slog.SetDefault(originalLogger) })
+
+		k8sAuthenticator.Ok = false
+		handler.ServeHTTP(recorder, &req)
+
+		Expect(recorder.Code).To(Equal(http.StatusUnauthorized))
+		logOutput := logBuf.String()
+		Expect(logOutput).To(ContainSubstring(`"level":"WARN"`))
+		Expect(logOutput).To(ContainSubstring(`"msg":"authentication rejected"`))
+		Expect(logOutput).To(ContainSubstring(`"method":"GET"`))
+		Expect(logOutput).To(ContainSubstring(`"path":"/test/path"`))
 	})
 })
 


### PR DESCRIPTION
## Summary

Add structured `slog.Warn` logging to all authentication failure paths in the `Authenticator` middleware, and upgrade the RFC 8705 certificate fingerprint mismatch log from `Debug` to `Warn` level. This provides server-side visibility into auth failures for forensic analysis and attacker correlation.

**Requirement**: REQ-033 — Token validation failures must be logged
**Obligation**: mandatory
**Source**: O-Cloud-22

## Changes

### WI-REQ-033-01: Add server-side logging for all authentication failure paths
- Added `slog.Warn("authentication error", ...)` to the `AuthenticateRequest` error path in `Authenticator()` with `method`, `path`, and `error` fields
- Added `slog.Warn("authentication rejected", ...)` to the `ok==false` path in `Authenticator()` with `method` and `path` fields
- Upgraded fingerprint mismatch log in `WithClientVerification` from `slog.Debug` to `slog.Warn`

## Acceptance Criteria

- [x] All auth failure paths produce structured slog.Warn entries
- [x] Log includes method and path fields
- [x] No token content or bearer values logged
- [x] RFC 8705 fingerprint mismatch at Warn level

## Test Plan

Three new unit tests added to `internal/service/common/auth/`:
- **Auth error log verification** — confirms `slog.Warn` output contains `level:WARN`, message, method, path, and error fields
- **Auth rejection log verification** — confirms `slog.Warn` output contains `level:WARN`, message, method, and path fields
- **Fingerprint mismatch log level** — confirms the RFC 8705 mismatch log is at `WARN` level

All 22 auth package tests pass. golangci-lint clean. go vet clean.

Assisted-By: Claude Code <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)