### PR TITLE
Add design decisions to AGENTS.md for AI code review tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,25 @@ This project has not reached GA, so there are no production databases to migrate
 - `ocloud.openshift.io` - Inventory
 - `plugins.clcm.openshift.io` - NodeAllocationRequest, AllocatedNode
 
+### Design Decisions
+
+The following are accepted design decisions. Do not flag these patterns as
+issues during code review.
+
+- **DD-001: In-memory filtering for AllocatedNode lookups.**
+  `listAllocatedNodesForNAR` in the PR controller uses in-memory filtering
+  instead of server-side `MatchingFields` because the fake Kubernetes client
+  in unit tests does not support field selectors. Per-cluster node counts are
+  small (1-11 nodes), so the cost is negligible. The Metal3 NAR controller
+  uses a proper field index (`spec.nodeAllocationRequest`) since it runs with
+  a real manager cache.
+
+- **DD-002: Cluster-scoped ProvisioningRequest watch mappers.**
+  Watch mappers that enqueue ProvisioningRequests (e.g.,
+  `enqueueProvisioningRequestForNAR`) intentionally omit the namespace from
+  `NamespacedName`. `ProvisioningRequest` is cluster-scoped (`scope: Cluster`
+  in the CRD) and has no namespace.
+
 ## Contributing Requirements
 
 - All commits must be signed off with DCO: `git commit -s`


### PR DESCRIPTION
## Summary
- Inline accepted design decisions (DD-001, DD-002) directly in `AGENTS.md`
  so both CodeRabbit (auto-detects AGENTS.md) and Claude Code (imports via
  CLAUDE.md) apply them during code reviews
- Single source of truth — no separate design-decisions doc to maintain

## Background
CodeRabbit was repeatedly flagging two accepted patterns:
1. In-memory AllocatedNode filtering (DD-001)
2. Namespace-less NamespacedName for cluster-scoped CRs (DD-002)

After discussion with CodeRabbit on this PR, we confirmed that:
- CodeRabbit auto-detects `AGENTS.md` and uses it as review guidelines
- Inlining the rules in `AGENTS.md` serves all consumers (CodeRabbit,
  Claude Code, human readers) from a single source of truth
- `path_instructions` does not support `@filename` imports, so the
  original approach was non-functional

## Test plan
- [ ] Verify CodeRabbit no longer flags DD-001/DD-002 patterns in future PRs
- [ ] Verify markdownlint passes: `make markdownlint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)