### PR TITLE
Use MatchingFields for AllocatedNode lookups in PR controller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,15 +87,6 @@ This project has not reached GA, so there are no production databases to migrate
 The following are accepted design decisions. Do not flag these patterns as
 issues during code review.
 
-- **DD-001: In-memory filtering for AllocatedNode lookups.**
-  `listAllocatedNodesForNAR` in the PR controller uses in-memory filtering
-  instead of server-side `MatchingFields` because the e2e tests use a
-  non-caching K8s client that does not support field selectors. This is a
-  known scaling issue — with many clusters the function walks all
-  AllocatedNodes across all clusters. A field indexer exists in the
-  hardware manager controller and should be used here too once the e2e
-  test framework is updated to use a caching client.
-
 - **DD-002: Cluster-scoped ProvisioningRequest watch mappers.**
   Watch mappers that enqueue ProvisioningRequests (e.g.,
   `enqueueProvisioningRequestForNAR`) intentionally omit the namespace from

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -14,6 +14,7 @@ import (
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
 )
 
 // collectNodeDetails collects BMC and node interfaces details
@@ -91,19 +92,16 @@ func newNodeGroup(group hwmgmtv1alpha1.NodeGroupData, roleCounts map[string]int)
 	return nodeGroup
 }
 
-// listAllocatedNodesForNAR lists AllocatedNodes that belong to the given NodeAllocationRequest.
+// listAllocatedNodesForNAR lists AllocatedNodes that belong to the given NodeAllocationRequest
+// using a field index on spec.nodeAllocationRequest. The client must have the field indexer
+// registered (via RegisterAllocatedNodeFieldIndexer or SetupWithManager).
 func listAllocatedNodesForNAR(ctx context.Context, c client.Client, narName, narNS string) (*hwmgmtv1alpha1.AllocatedNodeList, error) {
-	allNodes := &hwmgmtv1alpha1.AllocatedNodeList{}
-	if err := c.List(ctx, allNodes, client.InNamespace(narNS)); err != nil {
+	nodes := &hwmgmtv1alpha1.AllocatedNodeList{}
+	if err := c.List(ctx, nodes, client.InNamespace(narNS),
+		client.MatchingFields{hwmgrutils.AllocatedNodeSpecNodeAllocationRequestKey: narName}); err != nil {
 		return nil, fmt.Errorf("failed to list AllocatedNodes: %w", err)
 	}
-	filtered := &hwmgmtv1alpha1.AllocatedNodeList{}
-	for i := range allNodes.Items {
-		if allNodes.Items[i].Spec.NodeAllocationRequest == narName {
-			filtered.Items = append(filtered.Items, allNodes.Items[i])
-		}
-	}
-	return filtered, nil
+	return nodes, nil
 }
 
 // getRoleToGroupNameMap creates a mapping of Role to Group Name from NodeAllocationRequest

--- a/internal/controllers/provisioningrequest_setup.go
+++ b/internal/controllers/provisioningrequest_setup.go
@@ -8,6 +8,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -26,6 +27,7 @@ import (
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -34,6 +36,10 @@ import (
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ProvisioningRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := hwmgrutils.RegisterAllocatedNodeFieldIndexer(context.Background(), mgr.GetFieldIndexer()); err != nil {
+		return fmt.Errorf("failed to register AllocatedNode field indexer: %w", err)
+	}
+
 	//nolint:wrapcheck
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("o2ims-cluster-request").

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -41,12 +41,7 @@ type NodeAllocationRequestReconciler struct {
 
 func (r *NodeAllocationRequestReconciler) SetupIndexer(ctx context.Context) error {
 	r.Logger.Info("SetupIndexer Start")
-	// Setup AllocatedNode CRD indexer. This field indexer allows us to query a list of AllocatedNode CRs, filtered by the spec.nodeAllocationRequest field.
-	nodeIndexFunc := func(obj client.Object) []string {
-		return []string{obj.(*hwmgmtv1alpha1.AllocatedNode).Spec.NodeAllocationRequest}
-	}
-
-	if err := r.Manager.GetFieldIndexer().IndexField(ctx, &hwmgmtv1alpha1.AllocatedNode{}, hwmgrutils.AllocatedNodeSpecNodeAllocationRequestKey, nodeIndexFunc); err != nil {
+	if err := hwmgrutils.RegisterAllocatedNodeFieldIndexer(ctx, r.Manager.GetFieldIndexer()); err != nil {
 		return fmt.Errorf("failed to setup node indexer: %w", err)
 	}
 	return nil

--- a/internal/hardwaremanager/utils/allocated_node.go
+++ b/internal/hardwaremanager/utils/allocated_node.go
@@ -32,6 +32,20 @@ const (
 	AllocatedNodeFinalizer                    = "clcm.openshift.io/allocatednode-finalizer"
 )
 
+// RegisterAllocatedNodeFieldIndexer registers a field indexer for
+// spec.nodeAllocationRequest on AllocatedNode CRs. This allows efficient
+// filtering by NAR name via client.MatchingFields.
+func RegisterAllocatedNodeFieldIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx, &hwmgmtv1alpha1.AllocatedNode{},
+		AllocatedNodeSpecNodeAllocationRequestKey,
+		func(obj client.Object) []string {
+			return []string{obj.(*hwmgmtv1alpha1.AllocatedNode).Spec.NodeAllocationRequest}
+		}); err != nil {
+		return fmt.Errorf("failed to register AllocatedNode field indexer: %w", err)
+	}
+	return nil
+}
+
 // GetNode get a node resource for a provided name
 func GetNode(
 	ctx context.Context,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -178,8 +178,10 @@ var _ = BeforeSuite(func() {
 	hwmgrcontrollers.OverrideNoncachedClient(K8SClient)
 
 	// Setup the ProvisioningRequest Reconciler on main manager.
+	// Use the manager's cached client so field indexers (e.g., AllocatedNode
+	// spec.nodeAllocationRequest) work correctly during reconciliation.
 	ProvReqTestReconciler := &provisioningcontrollers.ProvisioningRequestReconciler{
-		Client: K8SClient,
+		Client: ProvisioningManager.GetClient(),
 		Logger: logger,
 	}
 	err = ProvReqTestReconciler.SetupWithManager(ProvisioningManager)

--- a/test/e2e/mno_hw_configuration_test.go
+++ b/test/e2e/mno_hw_configuration_test.go
@@ -309,7 +309,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 
 		By("Waiting for all 11 AllocatedNodes to be created")
 		Eventually(func() int {
-			return len(listAllocatedNodesForNAR(testCtx, prName).Items)
+			return len(testNonCachingListAllocatedNodesForNAR(testCtx, prName).Items)
 		}, timeout, interval).Should(Equal(masterCount + workerCount))
 
 		By("Waiting for day0 to complete (NAR Provisioned=True)")
@@ -328,7 +328,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 
 		By("Simulating AllocatedNodeHostMap on PR")
 		Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
-		nodeList := listAllocatedNodesForNAR(testCtx, prName)
+		nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 		hostMap := make(map[string]string)
 		masterIdx, workerIdx := 1, 1
 		hostnames := []string{}
@@ -401,7 +401,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			_ = K8SClient.Update(testCtx, narObj)
 			_ = K8SClient.Delete(testCtx, narObj)
 		}
-		anList := listAllocatedNodesForNAR(testCtx, prName)
+		anList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 		for i := range anList.Items {
 			_ = K8SClient.Delete(testCtx, &anList.Items[i])
 		}
@@ -475,7 +475,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			By("Polling and advancing BMH state transitions for each node")
 			Eventually(func() bool {
 				allComplete := true
-				nodeList := listAllocatedNodesForNAR(testCtx, prName)
+				nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 
 				// Track rolling-update invariants
 				mastersAllDone := true
@@ -594,7 +594,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		It("Should fail when one worker BMH enters error state during update", func() {
 			By("Failing one worker BMH and waiting for NAR to reach Failed")
 			Eventually(func() bool {
-				nodeList := listAllocatedNodesForNAR(testCtx, prName)
+				nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 				for i := range nodeList.Items {
 					node := &nodeList.Items[i]
 
@@ -706,7 +706,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			By("Waiting for at least 3 workers in ConfigUpdate with v1 profile")
 			Eventually(func() int {
 				count := 0
-				nodeList := listAllocatedNodesForNAR(testCtx, prName)
+				nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 				for i := range nodeList.Items {
 					node := &nodeList.Items[i]
 					if node.Spec.GroupName != worker || node.Spec.HwProfile != v1Profile {
@@ -722,7 +722,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 				"At least 3 workers should be in ConfigUpdate with v1 profile")
 
 			By("Picking one worker and advancing its BMH to Servicing with config-in-progress")
-			nodeList := listAllocatedNodesForNAR(testCtx, prName)
+			nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 			for i := range nodeList.Items {
 				node := &nodeList.Items[i]
 				if node.Spec.GroupName != worker || node.Spec.HwProfile != v1Profile {
@@ -790,7 +790,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			// The 1 Servicing worker can't be abandoned (BMH Servicing) -> stays in ConfigUpdate.
 			Eventually(func() int {
 				count := 0
-				nodeList := listAllocatedNodesForNAR(testCtx, prName)
+				nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 				for _, node := range nodeList.Items {
 					if node.Spec.GroupName != worker {
 						continue
@@ -832,7 +832,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			}, timeout, interval).Should(BeTrue(), "NAR should reach ConfigApplied")
 
 			By("Verifying all 8 worker nodes converged to v2 profile")
-			nodeList := listAllocatedNodesForNAR(testCtx, prName)
+			nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 			for _, node := range nodeList.Items {
 				if node.Spec.GroupName != worker {
 					continue
@@ -855,13 +855,18 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 
 func intPtr(v int) *int { return &v }
 
-func listAllocatedNodesForNAR(ctx context.Context, narName string) *hwmgmtv1alpha1.AllocatedNodeList {
+// testNonCachingListAllocatedNodesForNAR is a test-only helper that lists AllocatedNodes
+// for a NAR using the non-caching K8SClient with in-memory filtering. This is
+// intentionally different from the production testNonCachingListAllocatedNodesForNAR which
+// uses MatchingFields on a cached client — the non-caching client is needed
+// here so test assertions see the latest API server state without cache delay.
+func testNonCachingListAllocatedNodesForNAR(ctx context.Context, narName string) *hwmgmtv1alpha1.AllocatedNodeList {
 	all := &hwmgmtv1alpha1.AllocatedNodeList{}
 	Expect(K8SClient.List(ctx, all, client.InNamespace(constants.DefaultNamespace))).To(Succeed())
 	filtered := &hwmgmtv1alpha1.AllocatedNodeList{}
-	for _, n := range all.Items {
-		if n.Spec.NodeAllocationRequest == narName {
-			filtered.Items = append(filtered.Items, n)
+	for i := range all.Items {
+		if all.Items[i].Spec.NodeAllocationRequest == narName {
+			filtered.Items = append(filtered.Items, all.Items[i])
 		}
 	}
 	return filtered

--- a/test/e2e/sno_provisioning_test.go
+++ b/test/e2e/sno_provisioning_test.go
@@ -444,7 +444,7 @@ defaultHugepagesSize: "1G"`,
 				_ = K8SClient.Update(testCtx, nar)
 				_ = K8SClient.Delete(testCtx, nar)
 			}
-			anList := listAllocatedNodesForNAR(testCtx, crName)
+			anList := testNonCachingListAllocatedNodesForNAR(testCtx, crName)
 			for i := range anList.Items {
 				_ = K8SClient.Delete(testCtx, &anList.Items[i])
 			}


### PR DESCRIPTION
## Summary
- Replace in-memory filtering in `listAllocatedNodesForNAR` with server-side
  `MatchingFields` using the `spec.nodeAllocationRequest` field indexer
- This avoids walking all AllocatedNodes across all clusters on every
  reconciliation — at scale (e.g., 1000 clusters x 5 nodes), this was
  iterating through 5000 CRs instead of returning only the relevant ones

## Changes
- `listAllocatedNodesForNAR` now uses `MatchingFields` filter
- Register AllocatedNode field indexer in PR controller `SetupWithManager`
- Extract shared `RegisterAllocatedNodeFieldIndexer` helper used by both
  the PR controller and hardware manager NAR controller
- Use `ProvisioningManager.GetClient()` (cached) for the PR reconciler in
  e2e tests so field indexers work during reconciliation
- Rename e2e test helper to `testNonCachingListAllocatedNodesForNAR` to
  distinguish from the production function and clarify that it uses the
  non-caching client for fresh reads in test assertions
- Remove DD-001 from AGENTS.md (design decision resolved)

## Test plan
- [x] `make ci-job` passes (all unit, e2e, envtest, coverage)
- [x] CodeRabbit CLI review: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)