### PR TITLE
CNF-23666: Go 1.25 Phase 1 — build config, linting, and tooling

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.22
+  tag: rhel-9-release-golang-1.25-openshift-4.22

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,19 +20,3 @@ updates:
     oapi-codegen:
      patterns: ["github.com/oapi-codegen/*"]
      update-types: ["major", "minor", "patch"]
-   ignore:
-    # k8s.io moved to go 1.25 in v0.35, so ignore major/minor updates until this repo is 1.25-based
-    - dependency-name: "k8s.io/*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-    # open-cluster-management.io/api moved to go 1.25 in v1.2.0, so ignore major/minor updates until this repo is 1.25-based
-    - dependency-name: "open-cluster-management.io/api"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-    # open-cluster-management.io/governance-policy-propagator moved to go 1.25 in v0.18.0, so ignore major/minor updates until this repo is 1.25-based
-    - dependency-name: "open-cluster-management.io/governance-policy-propagator"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-    # ignore golang.org major/minor updates until this repo is 1.25-based
-    - dependency-name: "golang.org/*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-    # github.com/jackc/pgx/v5 moved to go 1.25 in v5.9.1, so ignore major/minor updates until this repo is 1.25-based
-    - dependency-name: "github.com/jackc/pgx/v5"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -133,7 +133,7 @@ linters:
         - .WrapPrefixf(
     goconst:
       min-occurrences: 5
-      ignore-string-values: 'get|list|watch|create|update|patch|delete|app|name|master|worker|role|macAddress|nodes|interfaces|label|extraAnnotations|extraLabels|nodeNetwork|apiextensions\.k8s\.io|CustomResourceDefinition|default|true'
+      ignore-string-values: '^(get|list|watch|create|update|patch|delete|app|name|namespace|master|worker|role|macAddress|nodes|interfaces|label|extraAnnotations|extraLabels|nodeNetwork|apiextensions\.k8s\.io|CustomResourceDefinition|default|true|agent-install\.openshift\.io/clusterdeployment-namespace)$'
   exclusions:
     generated: lax
     presets:
@@ -145,7 +145,7 @@ linters:
       - linters: [goconst]
         path: _test\.go$
       - linters: [goconst]
-        path: test/
+        path: (^|/)test/
       - linters: [goconst]
         path: internal/service/.*/api/server\.go$
       - linters: [gosec]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,6 +131,9 @@ linters:
         - .WithMessagef(
         - .WithStack(
         - .WrapPrefixf(
+    goconst:
+      min-occurrences: 5
+      ignore-string-values: 'get|list|watch|create|update|patch|delete|app|name|master|worker|role|macAddress|nodes|interfaces|label|extraAnnotations|extraLabels|nodeNetwork|apiextensions\.k8s\.io|CustomResourceDefinition|default|true'
   exclusions:
     generated: lax
     presets:
@@ -138,6 +141,16 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - linters: [goconst]
+        path: _test\.go$
+      - linters: [goconst]
+        path: test/
+      - linters: [goconst]
+        path: internal/service/.*/api/server\.go$
+      - linters: [gosec]
+        path: _test\.go$
+        text: G101
     paths:
       - third_party$
       - builtin$

--- a/.konflux/Dockerfile
+++ b/.konflux/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24@sha256:c798eefc5d0e7958c8de1444566d8f1d360144f633106adcb30a5886ff70932b AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25@sha256:977bd041377a1367c8b102a460ae8e63f89905f7cf9d8235484ae658c9b47646 AS builder
 
 WORKDIR /app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.hub.docker.com/library/golang:1.24 AS dlvbuilder
+FROM registry.hub.docker.com/library/golang:1.25 AS dlvbuilder
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 FROM dlvbuilder AS builder

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ BASHATE_VERSION ?= 2.1.1
 CONTROLLER_GEN_VERSION ?= v0.18.0
 
 # GOLANGCI_LINT_VERSION defines the golangci-lint version to download from GitHub releases.
-GOLANGCI_LINT_VERSION ?= v2.4.0
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 # KUSTOMIZE_VERSION defines the kustomize version to download from go modules.
 KUSTOMIZE_VERSION ?= v5@v5.7.1
@@ -128,8 +128,8 @@ endif
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.32.0
-ENVTEST_VERSION = release-0.21
+ENVTEST_K8S_VERSION = 1.35.0
+ENVTEST_VERSION = release-0.22
 
 # OCLOUD_MANAGER_NAMESPACE refers to the namespace of the O-Cloud Manager
 OCLOUD_MANAGER_NAMESPACE ?= oran-o2ims

--- a/dev-tools/crd-watcher/formatter.go
+++ b/dev-tools/crd-watcher/formatter.go
@@ -31,6 +31,13 @@ import (
 	controller "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/controller"
 )
 
+// API group and version constants
+const (
+	apiGroupCLCM   = "clcm.openshift.io"
+	apiGroupMetal3 = "metal3.io"
+	apiVersionV1A1 = "v1alpha1"
+)
+
 // CRD type constants
 const (
 	CRDTypeProvisioningRequests   = "provisioningrequests"

--- a/dev-tools/crd-watcher/tui.go
+++ b/dev-tools/crd-watcher/tui.go
@@ -459,9 +459,9 @@ func (t *TUIFormatter) cleanupStaleInventoryObjects() {
 
 	for _, event := range t.events {
 		// Only verify inventory objects during inventory refresh
-		if event.CRDType == "inventory-resources" ||
-			event.CRDType == "inventory-resource-pools" ||
-			event.CRDType == "inventory-node-clusters" ||
+		if event.CRDType == CRDTypeInventoryResources ||
+			event.CRDType == CRDTypeInventoryResourcePools ||
+			event.CRDType == CRDTypeInventoryNodeClusters ||
 			event.CRDType == CRDTypeInventoryAlarms {
 
 			resourceKey := t.getResourceKey(event)

--- a/dev-tools/crd-watcher/watcher.go
+++ b/dev-tools/crd-watcher/watcher.go
@@ -77,9 +77,9 @@ func NewCRDWatcher(clientset kubernetes.Interface, restConfig *rest.Config, sche
 	// Add inventory types if inventory module is enabled
 	if config.EnableInventory {
 		inventoryTypes := []string{
-			"inventory-resource-pools",
-			"inventory-resources",
-			"inventory-node-clusters",
+			CRDTypeInventoryResourcePools,
+			CRDTypeInventoryResources,
+			CRDTypeInventoryNodeClusters,
 		}
 		if config.EnableAlarms {
 			inventoryTypes = append(inventoryTypes, CRDTypeInventoryAlarms)
@@ -152,11 +152,11 @@ func (w *CRDWatcher) verifyResourceExists(event WatchEvent) bool {
 	defer cancel()
 
 	switch event.CRDType {
-	case "inventory-resources":
+	case CRDTypeInventoryResources:
 		return w.verifyInventoryResourceExists(ctx, event)
-	case "inventory-resource-pools":
+	case CRDTypeInventoryResourcePools:
 		return w.verifyInventoryResourcePoolExists(ctx, event)
-	case "inventory-node-clusters":
+	case CRDTypeInventoryNodeClusters:
 		return w.verifyInventoryNodeClusterExists(ctx, event)
 	case CRDTypeInventoryAlarms:
 		return true // Alarms are fully replaced on each refresh
@@ -494,7 +494,7 @@ func (w *CRDWatcher) listInventoryResources(ctx context.Context) ([]WatchEvent, 
 			Type:      watch.Added, // For listing, we treat all as "Added"
 			Object:    resource.ToRuntimeObject(),
 			Timestamp: time.Now(),
-			CRDType:   "inventory-resources",
+			CRDType:   CRDTypeInventoryResources,
 		}
 		events = append(events, event)
 	}
@@ -517,7 +517,7 @@ func (w *CRDWatcher) listInventoryResourcePools(ctx context.Context) ([]WatchEve
 			Type:      watch.Added, // For listing, we treat all as "Added"
 			Object:    resourcePool.ToRuntimeObject(),
 			Timestamp: time.Now(),
-			CRDType:   "inventory-resource-pools",
+			CRDType:   CRDTypeInventoryResourcePools,
 		}
 		events = append(events, event)
 	}
@@ -546,7 +546,7 @@ func (w *CRDWatcher) listInventoryNodeClusters(ctx context.Context) ([]WatchEven
 			Type:      watch.Added, // For listing, we treat all as "Added"
 			Object:    nodeCluster.ToRuntimeObject(),
 			Timestamp: time.Now(),
-			CRDType:   "inventory-node-clusters",
+			CRDType:   CRDTypeInventoryNodeClusters,
 		}
 		events = append(events, event)
 	}
@@ -630,7 +630,7 @@ func (w *CRDWatcher) fetchAndDisplayInventoryResourcePools(ctx context.Context) 
 			Type:      watch.Added,
 			Object:    resourcePool.ToRuntimeObject(),
 			Timestamp: time.Now(),
-			CRDType:   "inventory-resource-pools",
+			CRDType:   CRDTypeInventoryResourcePools,
 		}
 		if err := w.formatter.FormatEvent(event); err != nil {
 			klog.Errorf("Error formatting resource pool event: %v", err)
@@ -652,7 +652,7 @@ func (w *CRDWatcher) fetchAndDisplayInventoryResources(ctx context.Context) erro
 			Type:      watch.Added,
 			Object:    resource.ToRuntimeObject(),
 			Timestamp: time.Now(),
-			CRDType:   "inventory-resources",
+			CRDType:   CRDTypeInventoryResources,
 		}
 		if err := w.formatter.FormatEvent(event); err != nil {
 			klog.Errorf("Error formatting resource event: %v", err)
@@ -681,7 +681,7 @@ func (w *CRDWatcher) fetchAndDisplayInventoryNodeClusters(ctx context.Context) e
 			Type:      watch.Added,
 			Object:    nodeCluster.ToRuntimeObject(),
 			Timestamp: time.Now(),
-			CRDType:   "inventory-node-clusters",
+			CRDType:   CRDTypeInventoryNodeClusters,
 		}
 		if err := w.formatter.FormatEvent(event); err != nil {
 			klog.Errorf("Error formatting node cluster event: %v", err)
@@ -1019,7 +1019,7 @@ func (w *CRDWatcher) refreshInventoryResourcePools(ctx context.Context) error {
 			Type:      watch.Added, // Treat refreshed data as "Added" events
 			Object:    resourcePool.ToRuntimeObject(),
 			Timestamp: time.Now(),
-			CRDType:   "inventory-resource-pools",
+			CRDType:   CRDTypeInventoryResourcePools,
 		}
 		if err := w.formatter.FormatEvent(event); err != nil {
 			klog.Errorf("Error formatting refreshed resource pool event: %v", err)
@@ -1043,7 +1043,7 @@ func (w *CRDWatcher) refreshInventoryResources(ctx context.Context) error {
 			Type:      watch.Added, // Treat refreshed data as "Added" events
 			Object:    resource.ToRuntimeObject(),
 			Timestamp: time.Now(),
-			CRDType:   "inventory-resources",
+			CRDType:   CRDTypeInventoryResources,
 		}
 		if err := w.formatter.FormatEvent(event); err != nil {
 			klog.Errorf("Error formatting refreshed resource event: %v", err)
@@ -1072,7 +1072,7 @@ func (w *CRDWatcher) refreshInventoryNodeClusters(ctx context.Context) error {
 			Type:      watch.Added, // Treat refreshed data as "Added" events
 			Object:    nodeCluster.ToRuntimeObject(),
 			Timestamp: time.Now(),
-			CRDType:   "inventory-node-clusters",
+			CRDType:   CRDTypeInventoryNodeClusters,
 		}
 		if err := w.formatter.FormatEvent(event); err != nil {
 			klog.Errorf("Error formatting refreshed node cluster event: %v", err)
@@ -1414,38 +1414,38 @@ func (w *CRDWatcher) getGVRForCRDType(crdType string) (schema.GroupVersionResour
 	switch crdType {
 	case CRDTypeProvisioningRequests:
 		return schema.GroupVersionResource{
-			Group:    "clcm.openshift.io",
-			Version:  "v1alpha1",
+			Group:    apiGroupCLCM,
+			Version:  apiVersionV1A1,
 			Resource: CRDTypeProvisioningRequests,
 		}, nil
 	case CRDTypeNodeAllocationRequests:
 		return schema.GroupVersionResource{
-			Group:    "clcm.openshift.io",
-			Version:  "v1alpha1",
+			Group:    apiGroupCLCM,
+			Version:  apiVersionV1A1,
 			Resource: CRDTypeNodeAllocationRequests,
 		}, nil
 	case CRDTypeAllocatedNodes:
 		return schema.GroupVersionResource{
-			Group:    "clcm.openshift.io",
-			Version:  "v1alpha1",
+			Group:    apiGroupCLCM,
+			Version:  apiVersionV1A1,
 			Resource: CRDTypeAllocatedNodes,
 		}, nil
 	case CRDTypeBareMetalHosts:
 		return schema.GroupVersionResource{
-			Group:    "metal3.io",
-			Version:  "v1alpha1",
+			Group:    apiGroupMetal3,
+			Version:  apiVersionV1A1,
 			Resource: CRDTypeBareMetalHosts,
 		}, nil
 	case CRDTypeHostFirmwareComponents:
 		return schema.GroupVersionResource{
-			Group:    "metal3.io",
-			Version:  "v1alpha1",
+			Group:    apiGroupMetal3,
+			Version:  apiVersionV1A1,
 			Resource: CRDTypeHostFirmwareComponents,
 		}, nil
 	case CRDTypeHostFirmwareSettings:
 		return schema.GroupVersionResource{
-			Group:    "metal3.io",
-			Version:  "v1alpha1",
+			Group:    apiGroupMetal3,
+			Version:  apiVersionV1A1,
 			Resource: CRDTypeHostFirmwareSettings,
 		}, nil
 	default:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-kni/oran-o2ims
 
-go 1.24.0
+go 1.25.0
 
 // Needed for importing the siteconfig operator, taken from the siteconfig operator repo.
 replace (

--- a/hack/update_deps.sh
+++ b/hack/update_deps.sh
@@ -7,12 +7,17 @@
 
 set -e
 
-PINNED_GO="1.24.0"
+# Read the Go version from go.mod rather than hardcoding it
+GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+if [ -z "${GO_VERSION}" ]; then
+    echo "Error: could not determine Go version from go.mod"
+    exit 1
+fi
 
 # Use of GOTOOLCHAIN=local will cause failure if the local go version doesn't
-# support the pinned go version, rather than automatically downloading a newer
+# support the go.mod go version, rather than automatically downloading a newer
 # go version
-GOFLAGS='' GOTOOLCHAIN=local go mod tidy -go="${PINNED_GO}"
+GOFLAGS='' GOTOOLCHAIN=local go mod tidy -go="${GO_VERSION}"
 GOFLAGS='' GOTOOLCHAIN=local go mod vendor
 
 if grep -q "^toolchain " go.mod; then

--- a/internal/controllers/hardwaremanager_setup.go
+++ b/internal/controllers/hardwaremanager_setup.go
@@ -20,6 +20,12 @@ import (
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
+// API group constants used in RBAC PolicyRules across this package.
+const (
+	apiGroupCLCM   = "clcm.openshift.io"
+	apiGroupMetal3 = "metal3.io"
+)
+
 // setupHardwareManager creates the Kubernetes resources necessary to start the hardware manager.
 func (t *reconcilerTask) setupHardwareManager(ctx context.Context, defaultResult ctrl.Result) (nextReconcile ctrl.Result, err error) {
 
@@ -95,7 +101,7 @@ func (t *reconcilerTask) createHardwareManagerClusterRole(ctx context.Context) e
 			},
 			{
 				APIGroups: []string{
-					"clcm.openshift.io",
+					apiGroupCLCM,
 				},
 				Resources: []string{
 					"hardwareprofiles",
@@ -111,7 +117,7 @@ func (t *reconcilerTask) createHardwareManagerClusterRole(ctx context.Context) e
 			},
 			{
 				APIGroups: []string{
-					"clcm.openshift.io",
+					apiGroupCLCM,
 				},
 				Resources: []string{
 					"hardwareprofiles/status",
@@ -125,7 +131,7 @@ func (t *reconcilerTask) createHardwareManagerClusterRole(ctx context.Context) e
 			// ProvisioningRequest read access for node hostname mapping during Day2 updates
 			{
 				APIGroups: []string{
-					"clcm.openshift.io",
+					apiGroupCLCM,
 				},
 				Resources: []string{
 					"provisioningrequests",
@@ -138,7 +144,7 @@ func (t *reconcilerTask) createHardwareManagerClusterRole(ctx context.Context) e
 			},
 			{
 				APIGroups: []string{
-					"clcm.openshift.io",
+					apiGroupCLCM,
 				},
 				Resources: []string{
 					"nodeallocationrequests",
@@ -156,7 +162,7 @@ func (t *reconcilerTask) createHardwareManagerClusterRole(ctx context.Context) e
 			},
 			{
 				APIGroups: []string{
-					"clcm.openshift.io",
+					apiGroupCLCM,
 				},
 				Resources: []string{
 					"nodeallocationrequests/status",
@@ -170,7 +176,7 @@ func (t *reconcilerTask) createHardwareManagerClusterRole(ctx context.Context) e
 			},
 			{
 				APIGroups: []string{
-					"clcm.openshift.io",
+					apiGroupCLCM,
 				},
 				Resources: []string{
 					"nodeallocationrequests/finalizers",
@@ -213,7 +219,7 @@ func (t *reconcilerTask) createHardwareManagerClusterRole(ctx context.Context) e
 			// Metal3
 			{
 				APIGroups: []string{
-					"metal3.io",
+					apiGroupMetal3,
 				},
 				Resources: []string{
 					"baremetalhosts",
@@ -229,7 +235,7 @@ func (t *reconcilerTask) createHardwareManagerClusterRole(ctx context.Context) e
 			},
 			{
 				APIGroups: []string{
-					"metal3.io",
+					apiGroupMetal3,
 				},
 				Resources: []string{
 					"hostfirmwaresettings",
@@ -247,7 +253,7 @@ func (t *reconcilerTask) createHardwareManagerClusterRole(ctx context.Context) e
 			},
 			{
 				APIGroups: []string{
-					"metal3.io",
+					apiGroupMetal3,
 				},
 				Resources: []string{
 					"dataimages",
@@ -260,7 +266,7 @@ func (t *reconcilerTask) createHardwareManagerClusterRole(ctx context.Context) e
 			},
 			{
 				APIGroups: []string{
-					"metal3.io",
+					apiGroupMetal3,
 				},
 				Resources: []string{
 					"firmwareschemas",

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -970,7 +970,7 @@ func (t *reconcilerTask) createArtifactsServerClusterRole(ctx context.Context) e
 			// We need to read ClusterTemplates and ConfigMaps.
 			{
 				APIGroups: []string{
-					"clcm.openshift.io",
+					apiGroupCLCM,
 				},
 				Resources: []string{
 					"clustertemplates",
@@ -1120,7 +1120,7 @@ func (t *reconcilerTask) createResourceServerClusterRole(ctx context.Context) er
 			// hardware inventory from BMHs, HardwareData, and AllocatedNodes.
 			{
 				APIGroups: []string{
-					"metal3.io",
+					apiGroupMetal3,
 				},
 				Resources: []string{
 					"baremetalhosts",
@@ -1134,7 +1134,7 @@ func (t *reconcilerTask) createResourceServerClusterRole(ctx context.Context) er
 			},
 			{
 				APIGroups: []string{
-					"clcm.openshift.io",
+					apiGroupCLCM,
 				},
 				Resources: []string{
 					"allocatednodes",
@@ -1236,7 +1236,7 @@ func (t *reconcilerTask) createProvisioningServerClusterRole(ctx context.Context
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{
-					"clcm.openshift.io",
+					apiGroupCLCM,
 				},
 				Resources: []string{
 					"provisioningrequests",

--- a/internal/controllers/utils/provision.go
+++ b/internal/controllers/utils/provision.go
@@ -207,7 +207,7 @@ func RemoveLabelFromInterfaces[T any](data T) error {
 	return nil
 }
 
-// removeRequiredFromSchema removes all the requiered properties from a map.
+// removeRequiredFromSchema removes all the required properties from a map.
 func removeRequiredFromSchema(schema map[string]any) {
 	// Check if the current schema level has "properties" defined.
 	if properties, hasProperties := schema["properties"]; hasProperties {

--- a/internal/service/alarms/internal/alertmanager/api.go
+++ b/internal/service/alarms/internal/alertmanager/api.go
@@ -194,7 +194,7 @@ func (c *AMClient) createAlertmanagerClient() (*http.Client, string, error) {
 	}
 
 	// Read token from service account token file
-	token, err := os.ReadFile(tokenPath)
+	token, err := os.ReadFile(tokenPath) //nolint:gosec // tokenPath is from a constant, not user input
 	if err != nil {
 		return nil, "", fmt.Errorf("error reading service account token: %w", err)
 	}
@@ -207,7 +207,7 @@ func (c *AMClient) createAlertmanagerClient() (*http.Client, string, error) {
 
 	// Read service CA certificate
 	// This is automatically mounted by Kubernetes for service-to-service TLS
-	caCrt, err := os.ReadFile(caPath)
+	caCrt, err := os.ReadFile(caPath) //nolint:gosec // caPath is from a constant/env var, not user input
 	if err != nil {
 		return nil, "", fmt.Errorf("error reading service CA certificate: %w", err)
 	}

--- a/internal/service/alarms/internal/alertmanager/api.go
+++ b/internal/service/alarms/internal/alertmanager/api.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
@@ -190,11 +191,11 @@ func (c *AMClient) createAlertmanagerClient() (*http.Client, string, error) {
 	// Determine token file path (allow override for testing/local development)
 	tokenPath := constants.DefaultBackendTokenFile
 	if envPath := os.Getenv("ALARMS_SERVER_TOKEN_FILE"); envPath != "" {
-		tokenPath = envPath
+		tokenPath = filepath.Clean(envPath)
 	}
 
 	// Read token from service account token file
-	token, err := os.ReadFile(tokenPath) //nolint:gosec // tokenPath is from a constant, not user input
+	token, err := os.ReadFile(tokenPath)
 	if err != nil {
 		return nil, "", fmt.Errorf("error reading service account token: %w", err)
 	}
@@ -202,12 +203,12 @@ func (c *AMClient) createAlertmanagerClient() (*http.Client, string, error) {
 	// Determine service CA file path (allow override for testing/local development)
 	caPath := constants.DefaultServiceCAFile
 	if envPath := os.Getenv("ALARMS_SERVER_CA_FILE"); envPath != "" {
-		caPath = envPath
+		caPath = filepath.Clean(envPath)
 	}
 
 	// Read service CA certificate
 	// This is automatically mounted by Kubernetes for service-to-service TLS
-	caCrt, err := os.ReadFile(caPath) //nolint:gosec // caPath is from a constant/env var, not user input
+	caCrt, err := os.ReadFile(caPath)
 	if err != nil {
 		return nil, "", fmt.Errorf("error reading service CA certificate: %w", err)
 	}

--- a/internal/service/common/api/options.go
+++ b/internal/service/common/api/options.go
@@ -112,7 +112,7 @@ func (o *FieldOptions) findFieldByName(v reflect.Type, depth int, fieldName stri
 			}
 			// Check nested objects
 			switch field.Type.Kind() {
-			case reflect.Ptr, reflect.Slice:
+			case reflect.Pointer, reflect.Slice:
 				ft := field.Type.Elem()
 				if ft.Kind() != reflect.Struct {
 					return fmt.Errorf("field %s cannot exist on a primitive data type", fieldName)

--- a/internal/service/common/utils/utils.go
+++ b/internal/service/common/utils/utils.go
@@ -170,7 +170,7 @@ func CompareObjects[T db.Model](a, b T, excluded ...string) DBTag {
 		}
 
 		switch {
-		case field.Type.Kind() != reflect.Ptr:
+		case field.Type.Kind() != reflect.Pointer:
 			// Non-pointer value compare them directly
 			if !reflect.DeepEqual(aFieldValue.Interface(), bFieldValue.Interface()) {
 				tags[fieldName] = tagValue


### PR DESCRIPTION
## Summary

Phase 1 of the Go 1.25 upgrade ([CNF-23329](https://redhat.atlassian.net/browse/CNF-23329)). Build configuration, tooling
updates, and lint fixes only — no dependency or vendor changes.

## Changes

**Build images:**
- `.ci-operator.yaml`: rhel-9-release-golang-1.25-openshift-4.22
- `.konflux/Dockerfile`: openshift-golang-builder rhel_9_golang_1.25
- `Dockerfile`: golang:1.25

**Tooling:**
- `go.mod`: go 1.25.0
- `Makefile`: golangci-lint v2.4.0 → v2.12.2 (old version was built with
  Go 1.24 and cannot lint Go 1.25 code)
- `Makefile`: envtest K8s 1.32 → 1.35, setup-envtest release-0.22
- `hack/update_deps.sh`: read Go version from go.mod instead of hardcoding
  `PINNED_GO`
- `.github/dependabot.yml`: remove ignore list that blocked Go 1.25-dependent
  package updates (k8s.io, ocm, golang.org, pgx)

**Lint fixes for new golangci-lint rules:**
- `govet`: `reflect.Ptr` → `reflect.Pointer` (deprecated constant)
- `misspell`: `requiered` → `required`
- `gosec`: nolint for false-positive path traversal on constant file paths
- `goconst`: configure exclusions for test files, API server files, and
  common K8s/RBAC strings; use existing constants in crd-watcher; create
  `apiGroupCLCM`/`apiGroupMetal3` constants in controllers

## Test plan
- [x] `make ci-job` passes
- [x] Lab tested: operator deployment with Inventory CR update

🤖 Generated with [Claude Code](https://claude.com/claude-code)