### PR TITLE
CNF-23688: replace hardware inventory polling with K8s watches

### DIFF
--- a/docs/user-guide/inventory-api.md
+++ b/docs/user-guide/inventory-api.md
@@ -162,8 +162,8 @@ curl -ks -H "Authorization: Bearer ${MY_TOKEN}" \
 ## Resources
 
 Resources represent individual physical servers (BareMetalHosts) within a
-resource pool. Resource data is collected by polling the hardware manager on
-a configurable interval (default: 1 minute).
+resource pool. Resource data is collected via K8s watches on BareMetalHost,
+HardwareData, and AllocatedNode CRs and reflected in the API within seconds.
 
 Resources are accessed as sub-resources of a resource pool.
 
@@ -171,8 +171,7 @@ Resources are accessed as sub-resources of a resource pool.
 > A BMH will only appear in the Resources API if it has a
 > `resources.clcm.openshift.io/resourcePoolName` label and has completed
 > hardware inspection (i.e., it has reached the `available` provisioning
-> state or later). Resource data is polled every minute, so newly labeled
-> or newly inspected BMHs may take up to 1 minute to appear.
+> state or later).
 
 ### List Resources in a Resource Pool
 

--- a/docs/user-guide/server-onboarding.md
+++ b/docs/user-guide/server-onboarding.md
@@ -556,13 +556,9 @@ After the collector processes the CRs, verify via the Inventory API.
 
 > **Note**: Data collection timing differs by resource type:
 >
-> | Resource Type | Collection Method | Timing |
-> |---------------|-------------------|--------|
-> | Locations, OCloudSites, ResourcePools | Watch-based | Nearly immediate |
-> | Resources (BareMetalHosts) | Polling-based | Up to 1 minute (default interval) |
->
-> The Resources endpoint data is polled every minute. If a newly labeled BMH
-> does not appear immediately, wait for the next polling cycle.
+> All inventory data (Locations, OCloudSites, ResourcePools, and Resources)
+> is collected via K8s watches and reflected in the API within seconds of
+> the underlying CR change.
 
 First, set up authentication (see
 [Testing API endpoints](environment-setup.md#testing-api-endpoints-on-a-cluster)

--- a/internal/hardwaremanager/controller/inventory.go
+++ b/internal/hardwaremanager/controller/inventory.go
@@ -374,6 +374,13 @@ func IncludeInInventory(bmh *metal3v1alpha1.BareMetalHost) bool {
 	return false
 }
 
+func parseUUIDOrNil(s string) uuid.UUID {
+	if s == "" {
+		return uuid.Nil
+	}
+	return uuid.MustParse(s)
+}
+
 func GetResourceInfo(bmh *metal3v1alpha1.BareMetalHost, node *hwmgmtv1alpha1.AllocatedNode, hwdata *metal3v1alpha1.HardwareData, poolNameToUID map[string]string) ResourceInfo {
 	nics := getResourceInfoNics(bmh, hwdata)
 	storage := getResourceInfoStorage(hwdata)
@@ -393,7 +400,7 @@ func GetResourceInfo(bmh *metal3v1alpha1.BareMetalHost, node *hwmgmtv1alpha1.All
 		PowerState:       getResourceInfoPowerState(bmh),
 		Processors:       getResourceInfoProcessors(hwdata),
 		ResourceId:       getResourceInfoResourceId(bmh),
-		ResourcePoolId:   uuid.MustParse(GetResourceInfoResourcePoolUID(bmh, poolNameToUID)),
+		ResourcePoolId:   parseUUIDOrNil(GetResourceInfoResourcePoolUID(bmh, poolNameToUID)),
 		Tags:             getResourceInfoTags(bmh),
 		UsageState:       getResourceInfoUsageState(bmh),
 		Vendor:           getResourceInfoVendor(hwdata),

--- a/internal/hardwaremanager/controller/inventory.go
+++ b/internal/hardwaremanager/controller/inventory.go
@@ -7,20 +7,15 @@ SPDX-License-Identifier: Apache-2.0
 package controller
 
 import (
-	"context"
 	"fmt"
-	"log/slog"
 	"regexp"
 	"slices"
 
 	"github.com/google/uuid"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
-	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
-	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
 )
 
 const (
@@ -193,7 +188,7 @@ func getResourceInfoResourceId(bmh *metal3v1alpha1.BareMetalHost) uuid.UUID {
 // getResourceInfoResourcePoolUID returns the Kubernetes UID of the ResourcePool CR.
 // It looks up the pool name from the BMH label and finds the corresponding UID from the map.
 // Returns empty string if the pool name is not found or doesn't exist in the map.
-func getResourceInfoResourcePoolUID(bmh *metal3v1alpha1.BareMetalHost, poolNameToUID map[string]string) string {
+func GetResourceInfoResourcePoolUID(bmh *metal3v1alpha1.BareMetalHost, poolNameToUID map[string]string) string {
 	poolName := bmh.Labels[constants.LabelResourcePoolName]
 	if poolName == "" {
 		return ""
@@ -361,7 +356,7 @@ func IsOCloudManaged(bmh *metal3v1alpha1.BareMetalHost) bool {
 	return hasRequiredLabel || hasResourceSelectorLabels
 }
 
-func includeInInventory(bmh *metal3v1alpha1.BareMetalHost) bool {
+func IncludeInInventory(bmh *metal3v1alpha1.BareMetalHost) bool {
 	if !IsOCloudManaged(bmh) {
 		// Ignore BMH CRs without the required labels
 		return false
@@ -379,7 +374,7 @@ func includeInInventory(bmh *metal3v1alpha1.BareMetalHost) bool {
 	return false
 }
 
-func getResourceInfo(bmh *metal3v1alpha1.BareMetalHost, node *hwmgmtv1alpha1.AllocatedNode, hwdata *metal3v1alpha1.HardwareData, poolNameToUID map[string]string) ResourceInfo {
+func GetResourceInfo(bmh *metal3v1alpha1.BareMetalHost, node *hwmgmtv1alpha1.AllocatedNode, hwdata *metal3v1alpha1.HardwareData, poolNameToUID map[string]string) ResourceInfo {
 	nics := getResourceInfoNics(bmh, hwdata)
 	storage := getResourceInfoStorage(hwdata)
 
@@ -398,7 +393,7 @@ func getResourceInfo(bmh *metal3v1alpha1.BareMetalHost, node *hwmgmtv1alpha1.All
 		PowerState:       getResourceInfoPowerState(bmh),
 		Processors:       getResourceInfoProcessors(hwdata),
 		ResourceId:       getResourceInfoResourceId(bmh),
-		ResourcePoolId:   uuid.MustParse(getResourceInfoResourcePoolUID(bmh, poolNameToUID)),
+		ResourcePoolId:   uuid.MustParse(GetResourceInfoResourcePoolUID(bmh, poolNameToUID)),
 		Tags:             getResourceInfoTags(bmh),
 		UsageState:       getResourceInfoUsageState(bmh),
 		Vendor:           getResourceInfoVendor(hwdata),
@@ -413,68 +408,4 @@ func getResourceInfo(bmh *metal3v1alpha1.BareMetalHost, node *hwmgmtv1alpha1.All
 	}
 
 	return result
-}
-
-func GetResources(ctx context.Context,
-	logger *slog.Logger,
-	c client.Client) ([]ResourceInfo, error) {
-	var resp []ResourceInfo
-
-	nodes, err := hwmgrutils.GetBMHToNodeMap(ctx, logger, c)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query current nodes: %w", err)
-	}
-
-	var bmhList metal3v1alpha1.BareMetalHostList
-	if err := c.List(ctx, &bmhList); err != nil {
-		return nil, fmt.Errorf("failed to list BareMetalHosts: %w", err)
-	}
-
-	var hwdataList metal3v1alpha1.HardwareDataList
-	if err := c.List(ctx, &hwdataList); err != nil {
-		return nil, fmt.Errorf("failed to list HardwareData: %w", err)
-	}
-
-	// Build map of ResourcePool name to UID for lookup
-	var poolList inventoryv1alpha1.ResourcePoolList
-	if err := c.List(ctx, &poolList); err != nil {
-		return nil, fmt.Errorf("failed to list ResourcePools: %w", err)
-	}
-	poolNameToUID := make(map[string]string, len(poolList.Items))
-	for _, pool := range poolList.Items {
-		if !inventoryv1alpha1.IsResourceReady(pool.Status.Conditions) {
-			logger.DebugContext(ctx, "skipping ResourcePool: not Ready",
-				slog.String("pool", pool.Name),
-				slog.String("reason", inventoryv1alpha1.GetReadyReason(pool.Status.Conditions)))
-			continue
-		}
-		poolNameToUID[pool.Name] = string(pool.UID)
-	}
-
-	bmhToHardwareData := make(map[string]metal3v1alpha1.HardwareData)
-	for _, hwdata := range hwdataList.Items {
-		bmhToHardwareData[hwdata.Namespace+"/"+hwdata.Name] = hwdata
-	}
-
-	for _, bmh := range bmhList.Items {
-		if !includeInInventory(&bmh) {
-			logger.DebugContext(ctx, "skipping BMH inventory resource: not included in inventory listing",
-				slog.String("bmh", bmh.Namespace+"/"+bmh.Name),
-				slog.Bool("oCloudManaged", IsOCloudManaged(&bmh)),
-				slog.String("provisioningState", string(bmh.Status.Provisioning.State)))
-			continue
-		}
-		poolUID := getResourceInfoResourcePoolUID(&bmh, poolNameToUID)
-		if poolUID == "" {
-			poolName := bmh.Labels[constants.LabelResourcePoolName]
-			logger.Debug("skipping BMH inventory resource: unresolved resourcePoolId",
-				slog.String("bmh", bmh.Namespace+"/"+bmh.Name),
-				slog.String("poolName", poolName))
-			continue
-		}
-		hwdata := bmhToHardwareData[bmh.Namespace+"/"+bmh.Name]
-		resp = append(resp, getResourceInfo(&bmh, hwmgrutils.GetNodeForBMH(nodes, &bmh), &hwdata, poolNameToUID))
-	}
-
-	return resp, nil
 }

--- a/internal/hardwaremanager/controller/inventory_test.go
+++ b/internal/hardwaremanager/controller/inventory_test.go
@@ -11,8 +11,6 @@ Generated-By: Cursor/claude-4-sonnet
 package controller
 
 import (
-	"context"
-	"log/slog"
 	"regexp"
 
 	"github.com/google/uuid"
@@ -20,12 +18,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
-	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 )
 
@@ -605,7 +600,7 @@ var _ = Describe("Inventory", func() {
 			poolNameToUID := map[string]string{
 				"pool123": poolUID,
 			}
-			result := getResourceInfoResourcePoolUID(bmh, poolNameToUID)
+			result := GetResourceInfoResourcePoolUID(bmh, poolNameToUID)
 			Expect(result).To(Equal(poolUID))
 		})
 
@@ -614,7 +609,7 @@ var _ = Describe("Inventory", func() {
 				constants.LabelResourcePoolName: "pool123",
 			})
 			poolNameToUID := map[string]string{} // Empty map
-			result := getResourceInfoResourcePoolUID(bmh, poolNameToUID)
+			result := GetResourceInfoResourcePoolUID(bmh, poolNameToUID)
 			Expect(result).To(Equal(""))
 		})
 
@@ -623,7 +618,7 @@ var _ = Describe("Inventory", func() {
 			poolNameToUID := map[string]string{
 				"pool123": "some-uid",
 			}
-			result := getResourceInfoResourcePoolUID(bmh, poolNameToUID)
+			result := GetResourceInfoResourcePoolUID(bmh, poolNameToUID)
 			Expect(result).To(Equal(""))
 		})
 	})
@@ -1040,7 +1035,7 @@ var _ = Describe("Inventory", func() {
 	Describe("includeInInventory", func() {
 		It("should return false when labels are nil", func() {
 			bmh := createBasicBMH("test-bmh", "test-ns")
-			result := includeInInventory(bmh)
+			result := IncludeInInventory(bmh)
 			Expect(result).To(BeFalse())
 		})
 
@@ -1048,7 +1043,7 @@ var _ = Describe("Inventory", func() {
 			bmh := createBMHWithLabels("test-bmh", "test-ns", map[string]string{
 				"some-other-label": "value",
 			})
-			result := includeInInventory(bmh)
+			result := IncludeInInventory(bmh)
 			Expect(result).To(BeFalse())
 		})
 
@@ -1063,43 +1058,43 @@ var _ = Describe("Inventory", func() {
 
 			It("should return true for StateAvailable", func() {
 				bmh.Status.Provisioning.State = metal3v1alpha1.StateAvailable
-				result := includeInInventory(bmh)
+				result := IncludeInInventory(bmh)
 				Expect(result).To(BeTrue())
 			})
 
 			It("should return true for StateProvisioning", func() {
 				bmh.Status.Provisioning.State = metal3v1alpha1.StateProvisioning
-				result := includeInInventory(bmh)
+				result := IncludeInInventory(bmh)
 				Expect(result).To(BeTrue())
 			})
 
 			It("should return true for StateProvisioned", func() {
 				bmh.Status.Provisioning.State = metal3v1alpha1.StateProvisioned
-				result := includeInInventory(bmh)
+				result := IncludeInInventory(bmh)
 				Expect(result).To(BeTrue())
 			})
 
 			It("should return true for StateExternallyProvisioned", func() {
 				bmh.Status.Provisioning.State = metal3v1alpha1.StateExternallyProvisioned
-				result := includeInInventory(bmh)
+				result := IncludeInInventory(bmh)
 				Expect(result).To(BeTrue())
 			})
 
 			It("should return true for StatePreparing", func() {
 				bmh.Status.Provisioning.State = metal3v1alpha1.StatePreparing
-				result := includeInInventory(bmh)
+				result := IncludeInInventory(bmh)
 				Expect(result).To(BeTrue())
 			})
 
 			It("should return true for StateDeprovisioning", func() {
 				bmh.Status.Provisioning.State = metal3v1alpha1.StateDeprovisioning
-				result := includeInInventory(bmh)
+				result := IncludeInInventory(bmh)
 				Expect(result).To(BeTrue())
 			})
 
 			It("should return false for other states", func() {
 				bmh.Status.Provisioning.State = metal3v1alpha1.StateInspecting
-				result := includeInInventory(bmh)
+				result := IncludeInInventory(bmh)
 				Expect(result).To(BeFalse())
 			})
 		})
@@ -1132,7 +1127,7 @@ var _ = Describe("Inventory", func() {
 				"pool123": testPoolUID,
 			}
 
-			result := getResourceInfo(bmh, node, hwdata, poolNameToUID)
+			result := GetResourceInfo(bmh, node, hwdata, poolNameToUID)
 
 			Expect(result.AdminState).To(Equal(ResourceInfoAdminStateUNLOCKED))
 			Expect(result.Description).To(Equal("Test description"))
@@ -1151,225 +1146,6 @@ var _ = Describe("Inventory", func() {
 			Expect(*result.GlobalAssetId).To(Equal("ABC123456"))
 			Expect(result.Allocated).ToNot(BeNil())
 			Expect(*result.Allocated).To(BeFalse())
-		})
-	})
-
-	Describe("GetResources", func() {
-		var (
-			ctx    context.Context
-			logger *slog.Logger
-			scheme *runtime.Scheme
-		)
-
-		BeforeEach(func() {
-			ctx = context.Background()
-			logger = slog.Default()
-			scheme = runtime.NewScheme()
-			Expect(metal3v1alpha1.AddToScheme(scheme)).To(Succeed())
-			Expect(hwmgmtv1alpha1.AddToScheme(scheme)).To(Succeed())
-			Expect(inventoryv1alpha1.AddToScheme(scheme)).To(Succeed())
-		})
-
-		It("should return resources from BMHs included in inventory", func() {
-			// Create BMH with required label and valid state
-			testUID := types.UID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
-			poolUID := types.UID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
-			bmh := createBasicBMH("test-bmh", "test-ns")
-			bmh.UID = testUID
-			bmh.Labels = map[string]string{
-				constants.LabelResourcePoolName: "pool123",
-			}
-			bmh.Status.Provisioning.State = metal3v1alpha1.StateAvailable
-
-			// Create HardwareData for the BMH
-			hwdata := createHardwareData("test-bmh", "test-ns")
-
-			// Create AllocatedNode that corresponds to this BMH
-			node := createAllocatedNode("test-node", "profile123")
-			node.Spec.HwMgrNodeId = "test-bmh"
-			node.Spec.HwMgrNodeNs = "test-ns"
-
-			// Create ResourcePool CR that the BMH references
-			pool := &inventoryv1alpha1.ResourcePool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pool123",
-					UID:  poolUID,
-				},
-				Status: inventoryv1alpha1.ResourcePoolStatus{
-					Conditions: []metav1.Condition{{
-						Type:   inventoryv1alpha1.ConditionTypeReady,
-						Status: metav1.ConditionTrue,
-					}},
-				},
-			}
-
-			client := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(bmh, hwdata, node, pool).
-				Build()
-
-			result, err := GetResources(ctx, logger, client)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(result).To(HaveLen(1))
-
-			resource := result[0]
-			Expect(resource.Name).To(Equal("test-bmh"))
-			Expect(resource.ResourceId).To(Equal(uuid.MustParse(string(testUID))))
-			Expect(resource.ResourcePoolId).To(Equal(uuid.MustParse(string(poolUID))))
-			Expect(resource.HwProfile).To(Equal("profile123"))
-		})
-
-		It("should handle BMH without corresponding AllocatedNode", func() {
-			// Create BMH with required label and valid state
-			poolUID := types.UID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
-			bmh := createBMHWithLabels("test-bmh", "test-ns", map[string]string{
-				constants.LabelResourcePoolName: "pool123",
-			})
-			bmh.UID = types.UID("b2c3d4e5-f6a7-8901-bcde-f12345678901")
-			bmh.Status.Provisioning.State = metal3v1alpha1.StateAvailable
-
-			// Create HardwareData for the BMH
-			hwdata := createHardwareData("test-bmh", "test-ns")
-
-			// Create ResourcePool CR that the BMH references
-			pool := &inventoryv1alpha1.ResourcePool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pool123",
-					UID:  poolUID,
-				},
-				Status: inventoryv1alpha1.ResourcePoolStatus{
-					Conditions: []metav1.Condition{{
-						Type:   inventoryv1alpha1.ConditionTypeReady,
-						Status: metav1.ConditionTrue,
-					}},
-				},
-			}
-
-			client := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(bmh, hwdata, pool).
-				Build()
-
-			result, err := GetResources(ctx, logger, client)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(result).To(HaveLen(1))
-
-			resource := result[0]
-			Expect(resource.Name).To(Equal("test-bmh"))
-			Expect(resource.HwProfile).To(Equal("")) // No corresponding node
-		})
-
-		It("should omit BMH when ResourcePool CR is missing for the pool label", func() {
-			bmh := createBMHWithLabels("test-bmh", "test-ns", map[string]string{
-				constants.LabelResourcePoolName: "pool123",
-			})
-			bmh.Status.Provisioning.State = metal3v1alpha1.StateAvailable
-			hwdata := createHardwareData("test-bmh", "test-ns")
-
-			client := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(bmh, hwdata).
-				Build()
-
-			result, err := GetResources(ctx, logger, client)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(result).To(BeEmpty())
-		})
-
-		It("should omit BMH when only resource-selector labels exist (no resolvable resourcePoolId)", func() {
-			bmh := createBasicBMH("test-bmh", "test-ns")
-			bmh.Labels = map[string]string{
-				LabelPrefixResourceSelector + "zone": "east",
-			}
-			bmh.Status.Provisioning.State = metal3v1alpha1.StateAvailable
-			hwdata := createHardwareData("test-bmh", "test-ns")
-
-			client := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(bmh, hwdata).
-				Build()
-
-			result, err := GetResources(ctx, logger, client)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(result).To(BeEmpty())
-		})
-
-		It("should include only BMHs whose pool label maps to a ResourcePool CR", func() {
-			poolUID := types.UID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
-			goodBMH := createBMHWithLabels("good-bmh", "test-ns", map[string]string{
-				constants.LabelResourcePoolName: "pool123",
-			})
-			goodBMH.UID = types.UID("c3d4e5f6-a7b8-9012-cdef-123456789012")
-			goodBMH.Status.Provisioning.State = metal3v1alpha1.StateAvailable
-			badBMH := createBMHWithLabels("bad-bmh", "test-ns", map[string]string{
-				constants.LabelResourcePoolName: "missing-pool",
-			})
-			badBMH.UID = types.UID("d4e5f6a7-b8c9-0123-defa-234567890123")
-			badBMH.Status.Provisioning.State = metal3v1alpha1.StateAvailable
-			hwGood := createHardwareData("good-bmh", "test-ns")
-			hwBad := createHardwareData("bad-bmh", "test-ns")
-			pool := &inventoryv1alpha1.ResourcePool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pool123",
-					UID:  poolUID,
-				},
-				Status: inventoryv1alpha1.ResourcePoolStatus{
-					Conditions: []metav1.Condition{{
-						Type:   inventoryv1alpha1.ConditionTypeReady,
-						Status: metav1.ConditionTrue,
-					}},
-				},
-			}
-
-			client := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(goodBMH, badBMH, hwGood, hwBad, pool).
-				Build()
-
-			result, err := GetResources(ctx, logger, client)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(result).To(HaveLen(1))
-			Expect(result[0].Name).To(Equal("good-bmh"))
-			Expect(result[0].ResourcePoolId).To(Equal(uuid.MustParse(string(poolUID))))
-		})
-
-		It("should skip BMHs whose ResourcePool exists but is not Ready", func() {
-			poolUID := types.UID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
-			bmh := createBMHWithLabels("test-bmh", "test-ns", map[string]string{
-				constants.LabelResourcePoolName: "pool123",
-			})
-			bmh.UID = types.UID("e5f6a7b8-c9d0-1234-efab-345678901234")
-			bmh.Status.Provisioning.State = metal3v1alpha1.StateAvailable
-			hwdata := createHardwareData("test-bmh", "test-ns")
-
-			pool := &inventoryv1alpha1.ResourcePool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pool123",
-					UID:  poolUID,
-				},
-				Status: inventoryv1alpha1.ResourcePoolStatus{
-					Conditions: []metav1.Condition{{
-						Type:   inventoryv1alpha1.ConditionTypeReady,
-						Status: metav1.ConditionFalse,
-						Reason: inventoryv1alpha1.ReasonParentNotFound,
-					}},
-				},
-			}
-
-			client := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(bmh, hwdata, pool).
-				Build()
-
-			result, err := GetResources(ctx, logger, client)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(result).To(BeEmpty())
 		})
 	})
 

--- a/internal/hardwaremanager/utils/allocated_node.go
+++ b/internal/hardwaremanager/utils/allocated_node.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
@@ -63,51 +62,6 @@ func GetNode(
 		return node, fmt.Errorf("failed to get AllocatedNode for update: %w", err)
 	}
 	return node, nil
-}
-
-// GetNodeList retrieves the node list
-func GetNodeList(ctx context.Context, c client.Client) (*hwmgmtv1alpha1.AllocatedNodeList, error) {
-
-	nodeList := &hwmgmtv1alpha1.AllocatedNodeList{}
-	if err := c.List(ctx, nodeList); err != nil {
-		return nodeList, fmt.Errorf("failed to list AllocatedNodes: %w", err)
-	}
-
-	return nodeList, nil
-}
-
-// GetBMHToNodeMap get a list of nodes, mapped to BMH namespace/name
-func GetBMHToNodeMap(ctx context.Context,
-	logger *slog.Logger,
-	c client.Client) (map[string]hwmgmtv1alpha1.AllocatedNode, error) {
-	nodes := make(map[string]hwmgmtv1alpha1.AllocatedNode)
-
-	nodelist, err := GetNodeList(ctx, c)
-	if err != nil {
-		logger.InfoContext(ctx, "Unable to query node list", slog.String("error", err.Error()))
-		return nodes, fmt.Errorf("failed to query node list: %w", err)
-	}
-
-	for _, node := range nodelist.Items {
-		bmhName := node.Spec.HwMgrNodeId
-		bmhNamespace := node.Spec.HwMgrNodeNs
-
-		if bmhName != "" && bmhNamespace != "" {
-			nodes[bmhNamespace+"/"+bmhName] = node
-		}
-	}
-
-	return nodes, nil
-}
-
-func GetNodeForBMH(nodes map[string]hwmgmtv1alpha1.AllocatedNode, bmh *metal3v1alpha1.BareMetalHost) *hwmgmtv1alpha1.AllocatedNode {
-	bmhName := bmh.Name
-	bmhNamespace := bmh.Namespace
-
-	if node, exists := nodes[bmhNamespace+"/"+bmhName]; exists {
-		return &node
-	}
-	return nil
 }
 
 // GenerateNodeName generates a deterministic AllocatedNode name based on the clusterID,

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -28,8 +27,6 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/repo"
 )
 
-const pollingDelay = 1 * time.Minute
-
 // asyncEventBufferSize defines the number of buffered entries in the async event channel
 const asyncEventBufferSize = 10
 
@@ -44,16 +41,22 @@ type DataSource interface {
 	IncrGenerationID() int
 }
 
-// ResourceDataSource defines an interface of a data source capable of getting handling Inventory resources.
-type ResourceDataSource interface {
-	DataSource
-	GetResources(ctx context.Context) ([]models.Resource, error)
-	MakeResourceType(resource *models.Resource) (*models.ResourceType, error)
-}
-
 // WatchableDataSource defines an interface of a data source capable of watching for async events.
 type WatchableDataSource interface {
 	Watch(ctx context.Context) error
+}
+
+// ResourceWithType pairs a Resource with its corresponding ResourceType for
+// batch persistence operations.
+type ResourceWithType struct {
+	Resource     models.Resource
+	ResourceType models.ResourceType
+}
+
+// PoolChangeNotifier is implemented by data sources that need to re-evaluate
+// their resources when a ResourcePool is created or updated.
+type PoolChangeNotifier interface {
+	BuildResourcesForPool(ctx context.Context, poolName string) ([]ResourceWithType, error)
 }
 
 // NotificationHandler defines an interface over which notifications are published.
@@ -81,29 +84,23 @@ func NewCollector(pool *pgxpool.Pool, repo *repo.ResourcesRepository, notificati
 	}
 }
 
-// Run executes the collector main loop to gather data from external sources and writing to the database
+// Run executes the collector main loop to process watch events from all data sources
 func (c *Collector) Run(ctx context.Context) error {
 	if err := c.init(ctx); err != nil {
 		return err
 	}
 
-	// Start listening for async events
+	// Start listening for async events from all data sources
 	if err := c.watchForChanges(ctx); err != nil {
 		return fmt.Errorf("failed to start listeners: %w", err)
 	}
 
-	// Run the initial data collection
-	c.execute(ctx)
-
 	for {
 		select {
-		// TODO: Add hook for new data sources from watch events
 		case event := <-c.AsyncChangeEvents:
 			if err := c.handleAsyncEvent(ctx, event); err != nil {
 				slog.Error("failed to handle async change", "event", event, "error", err)
 			}
-		case <-time.After(pollingDelay):
-			c.execute(ctx)
 		case <-ctx.Done():
 			slog.Info("Context terminated; collector exiting")
 			return nil
@@ -168,35 +165,89 @@ func (c *Collector) watchForChanges(ctx context.Context) error {
 	return nil
 }
 
-// execute runs a single iteration of the main loop.  It does not return an error because all errors should be handled
-// gracefully.  If a truly unrecoverable error happens then a panic should be used to restart the process.
-func (c *Collector) execute(ctx context.Context) {
-	slog.Debug("collector loop running", "sources", len(c.dataSources))
+// handleAsyncResourceTypeEvent handles an async event for a ResourceType object.
+func (c *Collector) handleAsyncResourceTypeEvent(ctx context.Context, resourceType models.ResourceType, deleted bool) error {
+	var dataChangeEvent *models2.DataChangeEvent
+	var err error
 
-	for _, d := range c.dataSources {
-		rd, ok := d.(ResourceDataSource)
-		if !ok {
-			continue
+	if deleted {
+		dataChangeEvent, err = svcutils.DeleteObjectWithChangeEvent(
+			ctx, c.pool, resourceType, resourceType.ResourceTypeID, nil, func(object interface{}) any {
+				record, _ := object.(models.ResourceType)
+				return models.ResourceTypeToModel(&record, nil)
+			})
+		if err != nil {
+			return fmt.Errorf("failed to delete resource type '%s': %w", resourceType.ResourceTypeID, err)
 		}
+	} else {
+		alarmDictIDMap, mapErr := c.buildAlarmDictionaryIDMap(ctx)
+		if mapErr != nil {
+			slog.Warn("failed to fetch alarm dictionaries for resource type", "error", mapErr)
+			alarmDictIDMap = make(map[string]*uuid.UUID)
+		}
+		alarmDictID := alarmDictIDMap[resourceType.ResourceTypeID.String()]
 
-		d.IncrGenerationID()
-		slog.Debug("collecting data from data source", "source", d.Name(), "generationID", d.GetGenerationID())
-		if err := c.executeOneDataSource(ctx, rd); err != nil {
-			slog.Warn("failed to collect data from data source", "source", d.Name(), "error", err)
-		} else {
-			slog.Debug("collected data from data source", "source", d.Name())
+		dataChangeEvent, err = svcutils.PersistObjectWithChangeEvent(
+			ctx, c.pool, resourceType, resourceType.ResourceTypeID, nil, func(object interface{}) any {
+				record, _ := object.(models.ResourceType)
+				return models.ResourceTypeToModel(&record, alarmDictID)
+			})
+		if err != nil {
+			return fmt.Errorf("failed to persist resource type '%s': %w", resourceType.ResourceTypeID, err)
 		}
 	}
-	slog.Debug("collector loop complete", "sources", len(c.dataSources))
+
+	if dataChangeEvent != nil {
+		c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
+	}
+
+	return nil
 }
 
-func (c *Collector) purgeStaleResources(ctx context.Context, dataSource DataSource) (int, error) {
-	resources, err := c.repository.FindStaleResources(ctx, dataSource.GetID(), dataSource.GetGenerationID())
-	if err != nil {
-		return 0, fmt.Errorf("failed to find stale resources: %w", err)
+// handleAsyncResourceEvent handles an async event for a Resource object.
+func (c *Collector) handleAsyncResourceEvent(ctx context.Context, resource models.Resource, deleted bool) error {
+	var dataChangeEvent *models2.DataChangeEvent
+	var err error
+
+	if deleted {
+		dataChangeEvent, err = svcutils.DeleteObjectWithChangeEvent(
+			ctx, c.pool, resource, resource.ResourceID, &resource.ResourcePoolID, func(object interface{}) any {
+				record, _ := object.(models.Resource)
+				return models.ResourceToModel(&record, nil)
+			})
+		if err != nil {
+			return fmt.Errorf("failed to delete resource '%s': %w", resource.ResourceID, err)
+		}
+	} else {
+		dataChangeEvent, err = svcutils.PersistObjectWithChangeEvent(
+			ctx, c.pool, resource, resource.ResourceID, &resource.ResourcePoolID, func(object interface{}) any {
+				record, _ := object.(models.Resource)
+				return models.ResourceToModel(&record, nil)
+			})
+		if err != nil {
+			return fmt.Errorf("failed to persist resource '%s': %w", resource.ResourceID, err)
+		}
 	}
 
-	count := 0
+	if dataChangeEvent != nil {
+		c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
+	}
+
+	return nil
+}
+
+// handleResourceSyncCompletion handles the sync completion for Resource objects
+// by purging resources and resource types not in the key set.
+func (c *Collector) handleResourceSyncCompletion(ctx context.Context, ids []any) error {
+	slog.Debug("Handling end of sync for Resource instances", "count", len(ids))
+
+	// Purge stale resources
+	resources, err := c.repository.GetResourcesNotIn(ctx, ids)
+	if err != nil {
+		return fmt.Errorf("failed to get stale resources: %w", err)
+	}
+
+	resourceCount := 0
 	for _, resource := range resources {
 		dataChangeEvent, err := svcutils.DeleteObjectWithChangeEvent(ctx, c.pool, resource, resource.ResourceID,
 			&resource.ResourcePoolID, func(object interface{}) any {
@@ -204,28 +255,26 @@ func (c *Collector) purgeStaleResources(ctx context.Context, dataSource DataSour
 				return models.ResourceToModel(&r, nil)
 			})
 		if err != nil {
-			return count, fmt.Errorf("failed to delete stale resource: %w", err)
+			return fmt.Errorf("failed to delete stale resource: %w", err)
 		}
 		if dataChangeEvent != nil {
-			count++
 			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
+			resourceCount++
 		}
 	}
 
-	if count > 0 {
-		slog.Info("Purged stale resources", "count", count)
+	// Purge stale resource types
+	resourceTypeIDs := make([]any, 0)
+	for _, id := range ids {
+		resourceTypeIDs = append(resourceTypeIDs, id)
 	}
 
-	return count, nil
-}
-
-func (c *Collector) purgeStaleResourceTypes(ctx context.Context, dataSource DataSource) (int, error) {
-	resourceTypes, err := c.repository.FindStaleResourceTypes(ctx, dataSource.GetID(), dataSource.GetGenerationID())
+	resourceTypes, err := c.repository.GetResourceTypesNotIn(ctx, resourceTypeIDs)
 	if err != nil {
-		return 0, fmt.Errorf("failed to find stale resource types: %w", err)
+		return fmt.Errorf("failed to get stale resource types: %w", err)
 	}
 
-	count := 0
+	resourceTypeCount := 0
 	for _, resourceType := range resourceTypes {
 		dataChangeEvent, err := svcutils.DeleteObjectWithChangeEvent(ctx, c.pool, resourceType, resourceType.ResourceTypeID,
 			nil, func(object interface{}) any {
@@ -233,142 +282,19 @@ func (c *Collector) purgeStaleResourceTypes(ctx context.Context, dataSource Data
 				return models.ResourceTypeToModel(&r, nil)
 			})
 		if err != nil {
-			return count, fmt.Errorf("failed to delete stale resource type: %w", err)
+			return fmt.Errorf("failed to delete stale resource type: %w", err)
 		}
 		if dataChangeEvent != nil {
-			count++
 			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
+			resourceTypeCount++
 		}
 	}
 
-	if count > 0 {
-		slog.Info("Purged stale resource types", "count", count)
-	}
-
-	return count, nil
-}
-
-// purgeStaleData removes any records that have a generation id older than the generation id of the data source which
-// created it.
-func (c *Collector) purgeStaleData(ctx context.Context, dataSource DataSource) error {
-	slog.Info("Purging stale data", "source", dataSource.Name())
-
-	total := 0
-	count := 0
-
-	count, err := c.purgeStaleResources(ctx, dataSource)
-	if err != nil {
-		return fmt.Errorf("failed to purge stale resources': %w", err)
-	}
-	total += count
-
-	count, err = c.purgeStaleResourceTypes(ctx, dataSource)
-	if err != nil {
-		return fmt.Errorf("failed to purge stale resource types: %w", err)
-	}
-	total += count
-
-	slog.Info("Purged stale data", "source", dataSource.Name(), "count", total)
-
-	return nil
-}
-
-// executeOneDataSource runs a single iteration of the main loop for a specific data source instance.
-// Note: ResourcePools are now collected via CRD-based ResourcePoolDataSource (watch-based).
-func (c *Collector) executeOneDataSource(ctx context.Context, dataSource ResourceDataSource) (err error) {
-	// TODO: Add code to retrieve alarm dictionaries
-
-	// Get the list of resources for this data source
-	_, err = c.collectResources(ctx, dataSource)
-	if err != nil {
-		return fmt.Errorf("failed to collect resources: %w", err)
-	}
-
-	// Persist data source info
-	id := dataSource.GetID()
-	_, err = c.repository.UpdateDataSource(ctx, &models2.DataSource{
-		DataSourceID: &id,
-		Name:         dataSource.Name(),
-		GenerationID: dataSource.GetGenerationID(),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to update data source %q: %w", dataSource.Name(), err)
-	}
-
-	err = c.purgeStaleData(ctx, dataSource)
-	if err != nil {
-		return fmt.Errorf("failed to purge stale data from '%s': %w", dataSource.Name(), err)
+	if resourceCount > 0 || resourceTypeCount > 0 {
+		slog.Info("Deleted stale records", "resources", resourceCount, "resourceTypes", resourceTypeCount)
 	}
 
 	return nil
-}
-
-// collectResources collects Resource objects from the data source, persists them to the database,
-// and signals any change events to the notification processor.
-func (c *Collector) collectResources(ctx context.Context, dataSource ResourceDataSource) ([]models.Resource, error) {
-	slog.Debug("collecting resource and types", "source", dataSource.Name())
-
-	resources, err := dataSource.GetResources(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get resources: %w", err)
-	}
-
-	// Fetch all alarm dictionaries and build a map of resource type ID -> alarm dictionary ID
-	alarmDictIDMap, err := c.buildAlarmDictionaryIDMap(ctx)
-	if err != nil {
-		slog.Warn("failed to fetch alarm dictionaries for notifications", "error", err)
-		// Continue without alarm dictionaries - notifications will have nil alarmDictionaryId
-		alarmDictIDMap = make(map[string]*uuid.UUID)
-	}
-
-	// Loop over the set of resources and create the associated resource types.
-	seen := make(map[uuid.UUID]bool)
-	for _, resource := range resources {
-		resourceType, err := dataSource.MakeResourceType(&resource)
-		if err != nil {
-			return nil, fmt.Errorf("failed to make resource type from '%v': %w", resource, err)
-		}
-
-		if seen[resourceType.ResourceTypeID] {
-			// We have already seen this one so skip
-			continue
-		}
-		seen[resourceType.ResourceTypeID] = true
-
-		// Capture alarm dictionary ID for this resource type (may be nil if not found)
-		alarmDictID := alarmDictIDMap[resourceType.ResourceTypeID.String()]
-
-		dataChangeEvent, err := svcutils.PersistObjectWithChangeEvent(
-			ctx, c.pool, *resourceType, resourceType.ResourceTypeID, nil, func(object interface{}) any {
-				record, _ := object.(models.ResourceType)
-				return models.ResourceTypeToModel(&record, alarmDictID)
-			})
-		if err != nil {
-			return nil, fmt.Errorf("failed to persist resource type': %w", err)
-		}
-
-		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
-		}
-	}
-
-	// Loop over the set of resources and insert (or update) as needed
-	for _, resource := range resources {
-		dataChangeEvent, err := svcutils.PersistObjectWithChangeEvent(
-			ctx, c.pool, resource, resource.ResourceID, &resource.ResourcePoolID, func(object interface{}) any {
-				record, _ := object.(models.Resource)
-				return models.ResourceToModel(&record, nil)
-			})
-		if err != nil {
-			return nil, fmt.Errorf("failed to persist resource: %w", err)
-		}
-
-		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
-		}
-	}
-
-	return resources, nil
 }
 
 // buildAlarmDictionaryIDMap fetches all alarm dictionaries and returns a map
@@ -443,6 +369,8 @@ func (c *Collector) handleSyncCompletion(ctx context.Context, objectType db.Mode
 		return c.handleOCloudSiteSyncCompletion(ctx, ids)
 	case models.ResourcePool:
 		return c.handleResourcePoolSyncCompletion(ctx, ids)
+	case models.Resource:
+		return c.handleResourceSyncCompletion(ctx, ids)
 	default:
 		return fmt.Errorf("unsupported sync completion type for '%T'", obj)
 	}
@@ -464,6 +392,10 @@ func (c *Collector) handleAsyncEvent(ctx context.Context, event *async.AsyncChan
 		return c.handleAsyncOCloudSiteEvent(ctx, value, event.EventType == async.Deleted)
 	case models.ResourcePool:
 		return c.handleAsyncResourcePoolEvent(ctx, value, event.EventType == async.Deleted)
+	case models.ResourceType:
+		return c.handleAsyncResourceTypeEvent(ctx, value, event.EventType == async.Deleted)
+	case models.Resource:
+		return c.handleAsyncResourceEvent(ctx, value, event.EventType == async.Deleted)
 	default:
 		return fmt.Errorf("unknown object type '%T'", event.Object)
 	}
@@ -693,6 +625,8 @@ func (c *Collector) handleAsyncResourcePoolEvent(ctx context.Context, pool model
 		if err != nil {
 			return fmt.Errorf("failed to persist ResourcePool '%s': %w", pool.ResourcePoolID, err)
 		}
+
+		c.rebuildResourcesForPool(ctx, pool.Name)
 	}
 
 	if dataChangeEvent != nil {
@@ -700,6 +634,39 @@ func (c *Collector) handleAsyncResourcePoolEvent(ctx context.Context, pool model
 	}
 
 	return nil
+}
+
+// rebuildResourcesForPool asks data sources to re-evaluate resources that
+// reference the given pool. This handles the case where BMH events arrive
+// before the ResourcePool CR exists.
+func (c *Collector) rebuildResourcesForPool(ctx context.Context, poolName string) {
+	for _, ds := range c.dataSources {
+		handler, ok := ds.(PoolChangeNotifier)
+		if !ok {
+			continue
+		}
+
+		results, err := handler.BuildResourcesForPool(ctx, poolName)
+		if err != nil {
+			slog.Error("failed to rebuild resources for pool", "pool", poolName, "error", err)
+			continue
+		}
+
+		for i := range results {
+			if err := c.handleAsyncResourceTypeEvent(ctx, results[i].ResourceType, false); err != nil {
+				slog.Error("failed to persist resource type during pool rebuild",
+					"pool", poolName, "error", err)
+			}
+			if err := c.handleAsyncResourceEvent(ctx, results[i].Resource, false); err != nil {
+				slog.Error("failed to persist resource during pool rebuild",
+					"pool", poolName, "error", err)
+			}
+		}
+
+		if len(results) > 0 {
+			slog.Info("Rebuilt resources for pool", "pool", poolName, "count", len(results))
+		}
+	}
 }
 
 // handleResourcePoolSyncCompletion handles the sync completion for ResourcePool objects.

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -71,6 +71,7 @@ type Collector struct {
 	repository          *repo.ResourcesRepository
 	dataSources         []DataSource
 	AsyncChangeEvents   chan *async.AsyncChangeEvent
+	alarmDictCache      map[string]*uuid.UUID
 }
 
 // NewCollector creates a new collector instance
@@ -180,12 +181,7 @@ func (c *Collector) handleAsyncResourceTypeEvent(ctx context.Context, resourceTy
 			return fmt.Errorf("failed to delete resource type '%s': %w", resourceType.ResourceTypeID, err)
 		}
 	} else {
-		alarmDictIDMap, mapErr := c.buildAlarmDictionaryIDMap(ctx)
-		if mapErr != nil {
-			slog.Warn("failed to fetch alarm dictionaries for resource type", "error", mapErr)
-			alarmDictIDMap = make(map[string]*uuid.UUID)
-		}
-		alarmDictID := alarmDictIDMap[resourceType.ResourceTypeID.String()]
+		alarmDictID := c.getAlarmDictionaryID(ctx, resourceType.ResourceTypeID)
 
 		dataChangeEvent, err = svcutils.PersistObjectWithChangeEvent(
 			ctx, c.pool, resourceType, resourceType.ResourceTypeID, nil, func(object interface{}) any {
@@ -240,6 +236,7 @@ func (c *Collector) handleAsyncResourceEvent(ctx context.Context, resource model
 // by purging resources and resource types not in the key set.
 func (c *Collector) handleResourceSyncCompletion(ctx context.Context, ids []any) error {
 	slog.Debug("Handling end of sync for Resource instances", "count", len(ids))
+	c.invalidateAlarmDictCache()
 
 	// Purge stale resources
 	resources, err := c.repository.GetResourcesNotIn(ctx, ids)
@@ -270,21 +267,28 @@ func (c *Collector) handleResourceSyncCompletion(ctx context.Context, ids []any)
 	return nil
 }
 
-// buildAlarmDictionaryIDMap fetches all alarm dictionaries and returns a map
-// of resource type ID -> alarm dictionary ID for efficient lookup.
-func (c *Collector) buildAlarmDictionaryIDMap(ctx context.Context) (map[string]*uuid.UUID, error) {
-	alarmDictionaries, err := c.repository.GetAlarmDictionaries(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get alarm dictionaries: %w", err)
+// getAlarmDictionaryID returns the alarm dictionary ID for a given resource
+// type, using a cached map to avoid repeated database queries.
+func (c *Collector) getAlarmDictionaryID(ctx context.Context, resourceTypeID uuid.UUID) *uuid.UUID {
+	if c.alarmDictCache == nil {
+		alarmDictionaries, err := c.repository.GetAlarmDictionaries(ctx)
+		if err != nil {
+			slog.Warn("failed to fetch alarm dictionaries", "error", err)
+			return nil
+		}
+		c.alarmDictCache = make(map[string]*uuid.UUID)
+		for _, dict := range alarmDictionaries {
+			dictID := dict.AlarmDictionaryID
+			c.alarmDictCache[dict.ResourceTypeID.String()] = &dictID
+		}
 	}
+	return c.alarmDictCache[resourceTypeID.String()]
+}
 
-	result := make(map[string]*uuid.UUID)
-	for _, dict := range alarmDictionaries {
-		dictID := dict.AlarmDictionaryID
-		result[dict.ResourceTypeID.String()] = &dictID
-	}
-
-	return result, nil
+// invalidateAlarmDictCache clears the cached alarm dictionary map so it will
+// be refreshed on the next lookup.
+func (c *Collector) invalidateAlarmDictCache() {
+	c.alarmDictCache = nil
 }
 
 // collectResourcePools collects ResourcePool objects from the data source, persists them to the database,

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -263,35 +263,8 @@ func (c *Collector) handleResourceSyncCompletion(ctx context.Context, ids []any)
 		}
 	}
 
-	// Purge stale resource types
-	resourceTypeIDs := make([]any, 0)
-	for _, id := range ids {
-		resourceTypeIDs = append(resourceTypeIDs, id)
-	}
-
-	resourceTypes, err := c.repository.GetResourceTypesNotIn(ctx, resourceTypeIDs)
-	if err != nil {
-		return fmt.Errorf("failed to get stale resource types: %w", err)
-	}
-
-	resourceTypeCount := 0
-	for _, resourceType := range resourceTypes {
-		dataChangeEvent, err := svcutils.DeleteObjectWithChangeEvent(ctx, c.pool, resourceType, resourceType.ResourceTypeID,
-			nil, func(object interface{}) any {
-				r, _ := object.(models.ResourceType)
-				return models.ResourceTypeToModel(&r, nil)
-			})
-		if err != nil {
-			return fmt.Errorf("failed to delete stale resource type: %w", err)
-		}
-		if dataChangeEvent != nil {
-			c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
-			resourceTypeCount++
-		}
-	}
-
-	if resourceCount > 0 || resourceTypeCount > 0 {
-		slog.Info("Deleted stale records", "resources", resourceCount, "resourceTypes", resourceTypeCount)
+	if resourceCount > 0 {
+		slog.Info("Deleted stale resources", "count", resourceCount)
 	}
 
 	return nil

--- a/internal/service/resources/collector/collector_hwmgr.go
+++ b/internal/service/resources/collector/collector_hwmgr.go
@@ -11,11 +11,21 @@ import (
 	"fmt"
 	"log/slog"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
-
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	hwmgrcontroller "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/controller"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/async"
@@ -23,16 +33,25 @@ import (
 )
 
 // Interface compile enforcement
-var _ ResourceDataSource = (*HardwareDataSource)(nil)
+var _ WatchableDataSource = (*HardwareDataSource)(nil)
+var _ async.AsyncEventHandler = (*HardwareDataSource)(nil)
+var _ PoolChangeNotifier = (*HardwareDataSource)(nil)
 
-// HardwareDataSource collects hardware inventory data (BMHs, AllocatedNodes)
-// directly via the K8s client.
+const (
+	bmhReflectorName           = "bmh-reflector"
+	hwdataReflectorName        = "hwdata-reflector"
+	allocatednodeReflectorName = "allocatednode-reflector"
+)
+
+// HardwareDataSource collects hardware inventory data (BMHs, HardwareData,
+// AllocatedNodes) via K8s watches using three separate Reflectors.
 type HardwareDataSource struct {
-	dataSourceID  uuid.UUID
-	generationID  atomic.Int32
-	cloudID       uuid.UUID
-	globalCloudID uuid.UUID
-	hubClient     rtclient.Client
+	dataSourceID      uuid.UUID
+	generationID      atomic.Int32
+	cloudID           uuid.UUID
+	globalCloudID     uuid.UUID
+	hubClient         client.WithWatch
+	AsyncChangeEvents chan<- *async.AsyncChangeEvent
 }
 
 // Defines the UUID namespace values used to generate name based UUID values for inventory objects.
@@ -58,14 +77,18 @@ const (
 	storageExtension          = "storage"
 )
 
-// NewHardwareDataSource creates a hardware inventory data source that collects
-// BMH resource data directly via the K8s client.
-func NewHardwareDataSource(hubClient rtclient.Client, cloudID, globalCloudID uuid.UUID) DataSource {
+// NewHardwareDataSource creates a hardware inventory data source that watches
+// BMH, HardwareData, and AllocatedNode CRs for changes.
+func NewHardwareDataSource(hubClient client.WithWatch, cloudID, globalCloudID uuid.UUID) (DataSource, error) {
+	if hubClient == nil {
+		return nil, fmt.Errorf("hubClient is required")
+	}
+
 	return &HardwareDataSource{
 		cloudID:       cloudID,
 		globalCloudID: globalCloudID,
 		hubClient:     hubClient,
-	}
+	}, nil
 }
 
 // Name returns the name of this data source
@@ -78,15 +101,15 @@ func (d *HardwareDataSource) GetID() uuid.UUID {
 	return d.dataSourceID
 }
 
-// Init initializes the data source with its configuration data; including the ID, the GenerationID, and its extension
-// values if provided.
+// Init initializes the data source with its configuration data; including the ID, the GenerationID, and the
+// async event channel for sending events to the collector.
 func (d *HardwareDataSource) Init(uuid uuid.UUID, generationID int, asyncEventChannel chan<- *async.AsyncChangeEvent) {
 	d.dataSourceID = uuid
 	d.generationID.Store(int32(generationID)) //nolint:gosec // generationID is a small counter, overflow impossible
+	d.AsyncChangeEvents = asyncEventChannel
 }
 
-// SetGenerationID sets the current generation id for this data source.  This value is expected to
-// be restored from persistent storage at initialization time.
+// SetGenerationID sets the current generation id for this data source.
 func (d *HardwareDataSource) SetGenerationID(value int) {
 	d.generationID.Store(int32(value)) //nolint:gosec // generationID is a small counter, overflow impossible
 }
@@ -101,6 +124,390 @@ func (d *HardwareDataSource) IncrGenerationID() int {
 	return int(d.generationID.Add(1))
 }
 
+// Watch starts watchers for BMH, HardwareData, and AllocatedNode CRs.
+func (d *HardwareDataSource) Watch(ctx context.Context) error {
+	stopCh := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		slog.Info("context canceled; stopping hardware data source reflectors")
+		close(stopCh)
+	}()
+
+	d.watchBMH(ctx, stopCh)
+	d.watchHardwareData(ctx, stopCh)
+	d.watchAllocatedNodes(ctx, stopCh)
+
+	return nil
+}
+
+func (d *HardwareDataSource) watchBMH(ctx context.Context, stopCh <-chan struct{}) {
+	lister := cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			var list metal3v1alpha1.BareMetalHostList
+			if err := d.hubClient.List(ctx, &list, &client.ListOptions{Raw: &options}); err != nil {
+				return nil, fmt.Errorf("error listing BareMetalHosts: %w", err)
+			}
+			return &list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			var list metal3v1alpha1.BareMetalHostList
+			w, err := d.hubClient.Watch(ctx, &list, &client.ListOptions{Raw: &options})
+			if err != nil {
+				return nil, fmt.Errorf("error watching BareMetalHosts: %w", err)
+			}
+			return w, nil
+		},
+		DisableChunking: false,
+	}
+
+	store := async.NewReflectorStore(&metal3v1alpha1.BareMetalHost{})
+	reflector := cache.NewNamedReflector(bmhReflectorName, &lister, &metal3v1alpha1.BareMetalHost{}, store, time.Duration(0))
+	slog.Info("starting BMH reflector")
+	go reflector.Run(stopCh)
+	go store.Receive(ctx, d)
+}
+
+func (d *HardwareDataSource) watchHardwareData(ctx context.Context, stopCh <-chan struct{}) {
+	lister := cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			var list metal3v1alpha1.HardwareDataList
+			if err := d.hubClient.List(ctx, &list, &client.ListOptions{Raw: &options}); err != nil {
+				return nil, fmt.Errorf("error listing HardwareData: %w", err)
+			}
+			return &list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			var list metal3v1alpha1.HardwareDataList
+			w, err := d.hubClient.Watch(ctx, &list, &client.ListOptions{Raw: &options})
+			if err != nil {
+				return nil, fmt.Errorf("error watching HardwareData: %w", err)
+			}
+			return w, nil
+		},
+		DisableChunking: false,
+	}
+
+	store := async.NewReflectorStore(&metal3v1alpha1.HardwareData{})
+	reflector := cache.NewNamedReflector(hwdataReflectorName, &lister, &metal3v1alpha1.HardwareData{}, store, time.Duration(0))
+	slog.Info("starting HardwareData reflector")
+	go reflector.Run(stopCh)
+	go store.Receive(ctx, d)
+}
+
+func (d *HardwareDataSource) watchAllocatedNodes(ctx context.Context, stopCh <-chan struct{}) {
+	lister := cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			var list hwmgmtv1alpha1.AllocatedNodeList
+			if err := d.hubClient.List(ctx, &list, &client.ListOptions{Raw: &options}); err != nil {
+				return nil, fmt.Errorf("error listing AllocatedNodes: %w", err)
+			}
+			return &list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			var list hwmgmtv1alpha1.AllocatedNodeList
+			w, err := d.hubClient.Watch(ctx, &list, &client.ListOptions{Raw: &options})
+			if err != nil {
+				return nil, fmt.Errorf("error watching AllocatedNodes: %w", err)
+			}
+			return w, nil
+		},
+		DisableChunking: false,
+	}
+
+	store := async.NewReflectorStore(&hwmgmtv1alpha1.AllocatedNode{})
+	reflector := cache.NewNamedReflector(allocatednodeReflectorName, &lister, &hwmgmtv1alpha1.AllocatedNode{}, store, time.Duration(0))
+	slog.Info("starting AllocatedNode reflector")
+	go reflector.Run(stopCh)
+	go store.Receive(ctx, d)
+}
+
+// HandleAsyncEvent handles an add/update/delete event from any of the three Reflectors.
+func (d *HardwareDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
+	switch value := obj.(type) {
+	case *metal3v1alpha1.BareMetalHost:
+		return d.handleBMHEvent(ctx, value, eventType)
+	case *metal3v1alpha1.HardwareData:
+		return d.handleHardwareDataEvent(ctx, value, eventType)
+	case *hwmgmtv1alpha1.AllocatedNode:
+		return d.handleAllocatedNodeEvent(ctx, value, eventType)
+	default:
+		slog.Warn("Unknown object type in HardwareDataSource", "type", fmt.Sprintf("%T", obj))
+		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
+	}
+}
+
+// HandleSyncComplete handles the end of a sync operation.
+// Only BMH SyncComplete triggers resource purging; HardwareData and
+// AllocatedNode SyncComplete are no-ops since BMH is the authoritative
+// source for resource existence.
+func (d *HardwareDataSource) HandleSyncComplete(ctx context.Context, objectType runtime.Object, keys []uuid.UUID) error {
+	switch objectType.(type) {
+	case *metal3v1alpha1.BareMetalHost:
+		slog.Info("BMH sync complete", "resourceCount", len(keys))
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled; aborting")
+		case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
+			DataSourceID: d.dataSourceID,
+			EventType:    async.SyncComplete,
+			Object:       models.Resource{},
+			Keys:         keys}:
+			return nil
+		}
+	case *metal3v1alpha1.HardwareData:
+		slog.Info("HardwareData sync complete")
+		return nil
+	case *hwmgmtv1alpha1.AllocatedNode:
+		slog.Info("AllocatedNode sync complete")
+		return nil
+	default:
+		slog.Warn("Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
+		return nil
+	}
+}
+
+// handleBMHEvent handles a BMH watch event by building the full resource
+// from BMH + HardwareData + AllocatedNode and sending events to the collector.
+func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1alpha1.BareMetalHost, eventType async.AsyncEventType) (uuid.UUID, error) {
+	slog.Debug("handleBMHEvent", "bmh", bmh.Namespace+"/"+bmh.Name, "type", eventType)
+
+	resourceID := uuid.MustParse(string(bmh.UID))
+
+	if eventType == async.Deleted {
+		return d.sendDeleteEvent(ctx, resourceID)
+	}
+
+	if !hwmgrcontroller.IncludeInInventory(bmh) {
+		slog.Debug("BMH not included in inventory, treating as deletion",
+			"bmh", bmh.Namespace+"/"+bmh.Name)
+		return d.sendDeleteEvent(ctx, resourceID)
+	}
+
+	return d.buildAndSendResource(ctx, bmh)
+}
+
+// handleHardwareDataEvent handles a HardwareData watch event by looking up
+// the corresponding BMH and rebuilding the resource.
+func (d *HardwareDataSource) handleHardwareDataEvent(ctx context.Context, hwdata *metal3v1alpha1.HardwareData, eventType async.AsyncEventType) (uuid.UUID, error) {
+	slog.Debug("handleHardwareDataEvent", "hwdata", hwdata.Namespace+"/"+hwdata.Name, "type", eventType)
+
+	var bmh metal3v1alpha1.BareMetalHost
+	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: hwdata.Name, Namespace: hwdata.Namespace}, &bmh); err != nil {
+		if errors.IsNotFound(err) {
+			slog.Debug("BMH not found for HardwareData, skipping", "hwdata", hwdata.Namespace+"/"+hwdata.Name)
+			return uuid.Nil, nil
+		}
+		return uuid.Nil, fmt.Errorf("failed to get BMH for HardwareData %s/%s: %w", hwdata.Namespace, hwdata.Name, err)
+	}
+
+	if !hwmgrcontroller.IncludeInInventory(&bmh) {
+		return uuid.Nil, nil
+	}
+
+	return d.buildAndSendResource(ctx, &bmh)
+}
+
+// handleAllocatedNodeEvent handles an AllocatedNode watch event by looking up
+// the corresponding BMH and rebuilding the resource.
+func (d *HardwareDataSource) handleAllocatedNodeEvent(ctx context.Context, node *hwmgmtv1alpha1.AllocatedNode, eventType async.AsyncEventType) (uuid.UUID, error) {
+	slog.Debug("handleAllocatedNodeEvent", "node", node.Namespace+"/"+node.Name, "type", eventType)
+
+	bmhName := node.Spec.HwMgrNodeId
+	bmhNamespace := node.Spec.HwMgrNodeNs
+	if bmhName == "" || bmhNamespace == "" {
+		slog.Debug("AllocatedNode missing BMH reference, skipping", "node", node.Namespace+"/"+node.Name)
+		return uuid.Nil, nil
+	}
+
+	var bmh metal3v1alpha1.BareMetalHost
+	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: bmhName, Namespace: bmhNamespace}, &bmh); err != nil {
+		if errors.IsNotFound(err) {
+			slog.Debug("BMH not found for AllocatedNode, skipping", "bmh", bmhNamespace+"/"+bmhName)
+			return uuid.Nil, nil
+		}
+		return uuid.Nil, fmt.Errorf("failed to get BMH for AllocatedNode %s/%s: %w", node.Namespace, node.Name, err)
+	}
+
+	if !hwmgrcontroller.IncludeInInventory(&bmh) {
+		return uuid.Nil, nil
+	}
+
+	return d.buildAndSendResource(ctx, &bmh)
+}
+
+// buildAndSendResource builds a complete Resource from a BMH by looking up
+// the related HardwareData and AllocatedNode, then sends both ResourceType
+// and Resource events to the collector.
+func (d *HardwareDataSource) buildAndSendResource(ctx context.Context, bmh *metal3v1alpha1.BareMetalHost) (uuid.UUID, error) {
+	// Look up HardwareData by same name/namespace
+	var hwdata metal3v1alpha1.HardwareData
+	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}, &hwdata); err != nil {
+		if !errors.IsNotFound(err) {
+			return uuid.Nil, fmt.Errorf("failed to get HardwareData for BMH %s/%s: %w", bmh.Namespace, bmh.Name, err)
+		}
+		// HardwareData not found — use empty (BMH may not have been inspected yet)
+		hwdata = metal3v1alpha1.HardwareData{}
+	}
+
+	// Look up AllocatedNode for this BMH
+	node := d.findAllocatedNodeForBMH(ctx, bmh)
+
+	// Build ResourcePool name→UID map
+	poolNameToUID, err := d.getPoolNameToUID(ctx)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to get ResourcePool UIDs: %w", err)
+	}
+
+	// Check that the BMH has a valid pool reference
+	poolUID := hwmgrcontroller.GetResourceInfoResourcePoolUID(bmh, poolNameToUID)
+	if poolUID == "" {
+		poolName := bmh.Labels[constants.LabelResourcePoolName]
+		slog.Warn("skipping BMH: unresolved resourcePoolId (will retry on pool creation)",
+			"bmh", bmh.Namespace+"/"+bmh.Name, "poolName", poolName)
+		return uuid.Nil, nil
+	}
+
+	// Build ResourceInfo using existing inventory logic
+	resourceInfo := hwmgrcontroller.GetResourceInfo(bmh, node, &hwdata, poolNameToUID)
+
+	// Convert to models
+	resource := d.convertResource(&resourceInfo)
+	resourceType, err := d.MakeResourceType(resource)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to make resource type: %w", err)
+	}
+
+	// Send ResourceType event first (FK ordering)
+	select {
+	case <-ctx.Done():
+		return uuid.Nil, fmt.Errorf("context cancelled; aborting")
+	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
+		DataSourceID: d.dataSourceID,
+		EventType:    async.Updated,
+		Object:       *resourceType}:
+	}
+
+	// Send Resource event
+	select {
+	case <-ctx.Done():
+		return uuid.Nil, fmt.Errorf("context cancelled; aborting")
+	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
+		DataSourceID: d.dataSourceID,
+		EventType:    async.Updated,
+		Object:       *resource}:
+	}
+
+	return resource.ResourceID, nil
+}
+
+// sendDeleteEvent sends a delete event for a resource with the given ID.
+func (d *HardwareDataSource) sendDeleteEvent(ctx context.Context, resourceID uuid.UUID) (uuid.UUID, error) {
+	select {
+	case <-ctx.Done():
+		return uuid.Nil, fmt.Errorf("context cancelled; aborting")
+	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
+		DataSourceID: d.dataSourceID,
+		EventType:    async.Deleted,
+		Object:       models.Resource{ResourceID: resourceID}}:
+		return resourceID, nil
+	}
+}
+
+// findAllocatedNodeForBMH looks up the AllocatedNode for a BMH using the
+// allocation label on the BMH.
+func (d *HardwareDataSource) findAllocatedNodeForBMH(ctx context.Context, bmh *metal3v1alpha1.BareMetalHost) *hwmgmtv1alpha1.AllocatedNode {
+	if bmh.Labels == nil {
+		return nil
+	}
+	nodeName, exists := bmh.Labels[ctlrutils.AllocatedNodeLabel]
+	if !exists || nodeName == "" {
+		return nil
+	}
+
+	var node hwmgmtv1alpha1.AllocatedNode
+	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: bmh.Namespace}, &node); err != nil {
+		if !errors.IsNotFound(err) {
+			slog.Warn("failed to get AllocatedNode for BMH",
+				"bmh", bmh.Namespace+"/"+bmh.Name, "node", nodeName, "error", err)
+		}
+		return nil
+	}
+	return &node
+}
+
+// getPoolNameToUID builds a map of ResourcePool name → UID.
+func (d *HardwareDataSource) getPoolNameToUID(ctx context.Context) (map[string]string, error) {
+	var poolList inventoryv1alpha1.ResourcePoolList
+	if err := d.hubClient.List(ctx, &poolList); err != nil {
+		return nil, fmt.Errorf("failed to list ResourcePools: %w", err)
+	}
+	result := make(map[string]string, len(poolList.Items))
+	for _, pool := range poolList.Items {
+		if !inventoryv1alpha1.IsResourceReady(pool.Status.Conditions) {
+			continue
+		}
+		result[pool.Name] = string(pool.UID)
+	}
+	return result, nil
+}
+
+// BuildResourcesForPool lists BMHs that reference the given pool and builds
+// Resource + ResourceType pairs for each. This is called by the collector when
+// a ResourcePool is created or updated, to handle the case where BMH events
+// arrived before the pool existed.
+func (d *HardwareDataSource) BuildResourcesForPool(ctx context.Context, poolName string) ([]ResourceWithType, error) {
+	var bmhList metal3v1alpha1.BareMetalHostList
+	if err := d.hubClient.List(ctx, &bmhList, client.MatchingLabels{
+		constants.LabelResourcePoolName: poolName,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list BMHs for pool %s: %w", poolName, err)
+	}
+
+	poolNameToUID, err := d.getPoolNameToUID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ResourcePool UIDs: %w", err)
+	}
+
+	var results []ResourceWithType
+	for i := range bmhList.Items {
+		bmh := &bmhList.Items[i]
+		if !hwmgrcontroller.IncludeInInventory(bmh) {
+			continue
+		}
+
+		poolUID := hwmgrcontroller.GetResourceInfoResourcePoolUID(bmh, poolNameToUID)
+		if poolUID == "" {
+			continue
+		}
+
+		var hwdata metal3v1alpha1.HardwareData
+		if err := d.hubClient.Get(ctx, types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}, &hwdata); err != nil {
+			if !errors.IsNotFound(err) {
+				slog.Warn("failed to get HardwareData during pool rebuild",
+					"bmh", bmh.Namespace+"/"+bmh.Name, "error", err)
+			}
+			hwdata = metal3v1alpha1.HardwareData{}
+		}
+
+		node := d.findAllocatedNodeForBMH(ctx, bmh)
+		resourceInfo := hwmgrcontroller.GetResourceInfo(bmh, node, &hwdata, poolNameToUID)
+		resource := d.convertResource(&resourceInfo)
+		resourceType, err := d.MakeResourceType(resource)
+		if err != nil {
+			slog.Warn("failed to make resource type during pool rebuild",
+				"bmh", bmh.Namespace+"/"+bmh.Name, "error", err)
+			continue
+		}
+
+		results = append(results, ResourceWithType{
+			Resource:     *resource,
+			ResourceType: *resourceType,
+		})
+	}
+
+	return results, nil
+}
+
 // MakeResourceType creates an instance of a ResourceType from a Resource object.
 func (d *HardwareDataSource) MakeResourceType(resource *models.Resource) (*models.ResourceType, error) {
 	vendor := resource.Extensions[vendorExtension].(string)
@@ -108,7 +515,6 @@ func (d *HardwareDataSource) MakeResourceType(resource *models.Resource) (*model
 	name := fmt.Sprintf("%s/%s", vendor, model)
 	resourceTypeID := ctlrutils.MakeUUIDFromNames(ResourceTypeUUIDNamespace, d.cloudID, name)
 
-	// TODO: finish filling this in with data
 	result := models.ResourceType{
 		ResourceTypeID: resourceTypeID,
 		Name:           name,
@@ -126,26 +532,8 @@ func (d *HardwareDataSource) MakeResourceType(resource *models.Resource) (*model
 	return &result, nil
 }
 
-// GetResources returns the list of resources available for this data source.
-func (d *HardwareDataSource) GetResources(ctx context.Context) ([]models.Resource, error) {
-	resourceInfos, err := hwmgrcontroller.GetResources(ctx, slog.Default(), d.hubClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get resources: %w", err)
-	}
-
-	resources := make([]models.Resource, 0, len(resourceInfos))
-	for i := range resourceInfos {
-		converted := d.convertResource(&resourceInfos[i])
-		resources = append(resources, *converted)
-	}
-
-	return resources, nil
-}
-
 func (d *HardwareDataSource) convertResource(resource *hwmgrcontroller.ResourceInfo) *models.Resource {
 	resourceID := resource.ResourceId
-
-	// ResourcePoolId is the Kubernetes UID of the ResourcePool CR
 	resourcePoolID := resource.ResourcePoolId
 
 	name := fmt.Sprintf("%s/%s", resource.Vendor, resource.Model)

--- a/internal/service/resources/collector/collector_hwmgr_test.go
+++ b/internal/service/resources/collector/collector_hwmgr_test.go
@@ -7,14 +7,91 @@ SPDX-License-Identifier: Apache-2.0
 package collector
 
 import (
+	"context"
+
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	hwmgrcontroller "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/controller"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/async"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/models"
 )
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = metal3v1alpha1.AddToScheme(scheme)
+	_ = hwmgmtv1alpha1.AddToScheme(scheme)
+	_ = inventoryv1alpha1.AddToScheme(scheme)
+	return scheme
+}
+
+const testNamespace = "test-ns"
+
+func newTestBMH(name, poolName string, state metal3v1alpha1.ProvisioningState) *metal3v1alpha1.BareMetalHost {
+	bmh := &metal3v1alpha1.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			UID:       types.UID(uuid.NewSHA1(uuid.Nil, []byte(testNamespace+"/"+name)).String()),
+			Labels: map[string]string{
+				constants.LabelResourcePoolName: poolName,
+			},
+		},
+		Spec: metal3v1alpha1.BareMetalHostSpec{
+			Online: true,
+		},
+	}
+	bmh.Status.Provisioning.State = state
+	return bmh
+}
+
+func newTestHardwareData(name string) *metal3v1alpha1.HardwareData {
+	return &metal3v1alpha1.HardwareData{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: metal3v1alpha1.HardwareDataSpec{
+			HardwareDetails: &metal3v1alpha1.HardwareDetails{
+				SystemVendor: metal3v1alpha1.HardwareSystemVendor{
+					Manufacturer: "Dell",
+					ProductName:  "R640",
+					SerialNumber: "SN123",
+				},
+				RAMMebibytes: 16384,
+				CPU: metal3v1alpha1.CPU{
+					Arch:  "x86_64",
+					Count: 32,
+				},
+			},
+		},
+	}
+}
+
+func newTestResourcePool(name string) *inventoryv1alpha1.ResourcePool {
+	return &inventoryv1alpha1.ResourcePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "oran-o2ims",
+			UID:       types.UID(uuid.NewSHA1(uuid.Nil, []byte("pool/"+name)).String()),
+		},
+		Status: inventoryv1alpha1.ResourcePoolStatus{
+			Conditions: []metav1.Condition{{
+				Type:   inventoryv1alpha1.ConditionTypeReady,
+				Status: metav1.ConditionTrue,
+			}},
+		},
+	}
+}
 
 var _ = Describe("HardwareDataSource", func() {
 	var (
@@ -30,13 +107,14 @@ var _ = Describe("HardwareDataSource", func() {
 	})
 
 	Describe("Init / generation / identity", func() {
-		It("records data source id and generation from Init", func() {
+		It("records data source id, generation, and channel from Init", func() {
 			id := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 			ch := make(chan *async.AsyncChangeEvent, 1)
 			ds.Init(id, 3, ch)
 			Expect(ds.GetID()).To(Equal(id))
 			Expect(ds.GetGenerationID()).To(Equal(3))
 			Expect(ds.Name()).To(Equal("HardwareDataSource"))
+			Expect(ds.AsyncChangeEvents).NotTo(BeNil())
 		})
 
 		It("updates generation via SetGenerationID and IncrGenerationID", func() {
@@ -135,6 +213,232 @@ var _ = Describe("HardwareDataSource", func() {
 			Expect(rt.ResourceKind).To(Equal(models.ResourceKindPhysical))
 			Expect(rt.ResourceClass).To(Equal(models.ResourceClassCompute))
 			Expect(rt.GenerationID).To(Equal(2))
+		})
+	})
+
+	Describe("HandleAsyncEvent", func() {
+		var (
+			ctx     context.Context
+			eventCh chan *async.AsyncChangeEvent
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			eventCh = make(chan *async.AsyncChangeEvent, 20)
+			scheme := newTestScheme()
+			pool := newTestResourcePool("test-pool")
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pool).Build()
+			ds.hubClient = fakeClient
+			ds.Init(uuid.MustParse("99999999-9999-9999-9999-999999999999"), 1, eventCh)
+		})
+
+		It("sends ResourceType and Resource events for a valid BMH", func() {
+			bmh := newTestBMH("bmh-1", "test-pool", metal3v1alpha1.StateAvailable)
+			hwdata := newTestHardwareData("bmh-1")
+
+			scheme := newTestScheme()
+			pool := newTestResourcePool("test-pool")
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh, hwdata, pool).Build()
+			ds.hubClient = fakeClient
+
+			key, err := ds.HandleAsyncEvent(ctx, bmh, async.Updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key).NotTo(Equal(uuid.Nil))
+
+			Expect(eventCh).To(HaveLen(2))
+			rtEvent := <-eventCh
+			Expect(rtEvent.EventType).To(Equal(async.Updated))
+			_, isRT := rtEvent.Object.(models.ResourceType)
+			Expect(isRT).To(BeTrue())
+
+			resEvent := <-eventCh
+			Expect(resEvent.EventType).To(Equal(async.Updated))
+			res, isRes := resEvent.Object.(models.Resource)
+			Expect(isRes).To(BeTrue())
+			Expect(res.Extensions[vendorExtension]).To(Equal("Dell"))
+		})
+
+		It("sends delete event for a BMH not included in inventory", func() {
+			bmh := newTestBMH("bmh-del", "test-pool", metal3v1alpha1.StateRegistering)
+
+			key, err := ds.HandleAsyncEvent(ctx, bmh, async.Updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key).NotTo(Equal(uuid.Nil))
+
+			Expect(eventCh).To(HaveLen(1))
+			event := <-eventCh
+			Expect(event.EventType).To(Equal(async.Deleted))
+		})
+
+		It("sends delete event for a deleted BMH", func() {
+			bmh := newTestBMH("bmh-gone", "test-pool", metal3v1alpha1.StateAvailable)
+
+			key, err := ds.HandleAsyncEvent(ctx, bmh, async.Deleted)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key).NotTo(Equal(uuid.Nil))
+
+			Expect(eventCh).To(HaveLen(1))
+			event := <-eventCh
+			Expect(event.EventType).To(Equal(async.Deleted))
+		})
+
+		It("rebuilds resource from HardwareData event", func() {
+			bmh := newTestBMH("hwdata-bmh", "test-pool", metal3v1alpha1.StateAvailable)
+			hwdata := newTestHardwareData("hwdata-bmh")
+			pool := newTestResourcePool("test-pool")
+
+			scheme := newTestScheme()
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh, hwdata, pool).Build()
+			ds.hubClient = fakeClient
+
+			key, err := ds.HandleAsyncEvent(ctx, hwdata, async.Updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key).NotTo(Equal(uuid.Nil))
+			Expect(eventCh).To(HaveLen(2))
+		})
+
+		It("skips HardwareData event when BMH not found", func() {
+			hwdata := newTestHardwareData("no-bmh")
+
+			key, err := ds.HandleAsyncEvent(ctx, hwdata, async.Updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key).To(Equal(uuid.Nil))
+			Expect(eventCh).To(BeEmpty())
+		})
+
+		It("rebuilds resource from AllocatedNode event", func() {
+			bmh := newTestBMH("an-bmh", "test-pool", metal3v1alpha1.StateAvailable)
+			hwdata := newTestHardwareData("an-bmh")
+			pool := newTestResourcePool("test-pool")
+			node := &hwmgmtv1alpha1.AllocatedNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-node",
+					Namespace: testNamespace,
+				},
+				Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
+					HwMgrNodeId: "an-bmh",
+					HwMgrNodeNs: testNamespace,
+				},
+			}
+
+			scheme := newTestScheme()
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh, hwdata, pool, node).Build()
+			ds.hubClient = fakeClient
+
+			key, err := ds.HandleAsyncEvent(ctx, node, async.Updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key).NotTo(Equal(uuid.Nil))
+			Expect(eventCh).To(HaveLen(2))
+		})
+
+		It("skips AllocatedNode event when BMH not found", func() {
+			node := &hwmgmtv1alpha1.AllocatedNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "orphan-node",
+					Namespace: testNamespace,
+				},
+				Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
+					HwMgrNodeId: "missing-bmh",
+					HwMgrNodeNs: testNamespace,
+				},
+			}
+
+			key, err := ds.HandleAsyncEvent(ctx, node, async.Updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key).To(Equal(uuid.Nil))
+			Expect(eventCh).To(BeEmpty())
+		})
+
+		It("returns error for unknown object type", func() {
+			_, err := ds.HandleAsyncEvent(ctx, "not-a-k8s-object", async.Updated)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("HandleSyncComplete", func() {
+		var (
+			ctx     context.Context
+			eventCh chan *async.AsyncChangeEvent
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			eventCh = make(chan *async.AsyncChangeEvent, 5)
+			ds.Init(uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), 1, eventCh)
+		})
+
+		It("sends SyncComplete event for BMH objectType", func() {
+			keys := []uuid.UUID{uuid.New(), uuid.New()}
+			err := ds.HandleSyncComplete(ctx, &metal3v1alpha1.BareMetalHost{}, keys)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(eventCh).To(HaveLen(1))
+			event := <-eventCh
+			Expect(event.EventType).To(Equal(async.SyncComplete))
+			_, isResource := event.Object.(models.Resource)
+			Expect(isResource).To(BeTrue())
+			Expect(event.Keys).To(Equal(keys))
+		})
+
+		It("does not send event for HardwareData objectType", func() {
+			err := ds.HandleSyncComplete(ctx, &metal3v1alpha1.HardwareData{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(eventCh).To(BeEmpty())
+		})
+
+		It("does not send event for AllocatedNode objectType", func() {
+			err := ds.HandleSyncComplete(ctx, &hwmgmtv1alpha1.AllocatedNode{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(eventCh).To(BeEmpty())
+		})
+	})
+
+	Describe("BuildResourcesForPool", func() {
+		var ctx context.Context
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			ds.Init(uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), 1, nil)
+		})
+
+		It("returns resources for BMHs in the given pool", func() {
+			bmh := newTestBMH("pool-bmh", "my-pool", metal3v1alpha1.StateAvailable)
+			hwdata := newTestHardwareData("pool-bmh")
+			pool := newTestResourcePool("my-pool")
+
+			scheme := newTestScheme()
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh, hwdata, pool).Build()
+			ds.hubClient = fakeClient
+
+			results, err := ds.BuildResourcesForPool(ctx, "my-pool")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Resource.Extensions[vendorExtension]).To(Equal("Dell"))
+			Expect(results[0].ResourceType.Vendor).To(Equal("Dell"))
+		})
+
+		It("returns empty when no BMHs reference the pool", func() {
+			pool := newTestResourcePool("empty-pool")
+			scheme := newTestScheme()
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pool).Build()
+			ds.hubClient = fakeClient
+
+			results, err := ds.BuildResourcesForPool(ctx, "empty-pool")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(BeEmpty())
+		})
+
+		It("skips BMHs not included in inventory", func() {
+			bmh := newTestBMH("bad-state", "my-pool", metal3v1alpha1.StateRegistering)
+			pool := newTestResourcePool("my-pool")
+
+			scheme := newTestScheme()
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh, pool).Build()
+			ds.hubClient = fakeClient
+
+			results, err := ds.BuildResourcesForPool(ctx, "my-pool")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(BeEmpty())
 		})
 	})
 })

--- a/internal/service/resources/db/repo/repository.go
+++ b/internal/service/resources/db/repo/repository.go
@@ -91,6 +91,26 @@ func (r *ResourcesRepository) GetResourcePoolsNotIn(ctx context.Context, keys []
 	return svcutils.Search[models.ResourcePool](ctx, r.Db, e)
 }
 
+// GetResourcesNotIn returns the list of Resource records not matching the list of keys provided, or
+// an empty list if none exist; otherwise an error
+func (r *ResourcesRepository) GetResourcesNotIn(ctx context.Context, keys []any) ([]models.Resource, error) {
+	var e bob.Expression
+	if len(keys) > 0 {
+		e = psql.Quote(models.Resource{}.PrimaryKey()).NotIn(psql.Arg(keys...))
+	}
+	return svcutils.Search[models.Resource](ctx, r.Db, e)
+}
+
+// GetResourceTypesNotIn returns the list of ResourceType records not matching the list of keys provided, or
+// an empty list if none exist; otherwise an error
+func (r *ResourcesRepository) GetResourceTypesNotIn(ctx context.Context, keys []any) ([]models.ResourceType, error) {
+	var e bob.Expression
+	if len(keys) > 0 {
+		e = psql.Quote(models.ResourceType{}.PrimaryKey()).NotIn(psql.Arg(keys...))
+	}
+	return svcutils.Search[models.ResourceType](ctx, r.Db, e)
+}
+
 // GetResourcePoolResources retrieves all Resource tuples for a specific ResourcePool returns an empty array if not found
 func (r *ResourcesRepository) GetResourcePoolResources(ctx context.Context, id uuid.UUID) ([]models.Resource, error) {
 	e := psql.Quote("resource_pool_id").EQ(psql.Arg(id))
@@ -110,24 +130,6 @@ func (r *ResourcesRepository) CreateResource(ctx context.Context, resource *mode
 // UpdateResource updates a specific Resource tuple
 func (r *ResourcesRepository) UpdateResource(ctx context.Context, resource *models.Resource) (*models.Resource, error) {
 	return svcutils.Update[models.Resource](ctx, r.Db, resource.ResourceID, *resource)
-}
-
-// FindStaleResources returns any Resource objects that have a generation less than the specific generation
-func (r *ResourcesRepository) FindStaleResources(ctx context.Context, dataSourceID uuid.UUID, generationID int) ([]models.Resource, error) {
-	e := psql.Quote("data_source_id").EQ(psql.Arg(dataSourceID)).And(psql.Quote("generation_id").LT(psql.Arg(generationID)))
-	return svcutils.Search[models.Resource](ctx, r.Db, e)
-}
-
-// FindStaleResourcePools returns any ResourcePool objects that have a generation less than the specific generation
-func (r *ResourcesRepository) FindStaleResourcePools(ctx context.Context, dataSourceID uuid.UUID, generationID int) ([]models.ResourcePool, error) {
-	e := psql.Quote("data_source_id").EQ(psql.Arg(dataSourceID)).And(psql.Quote("generation_id").LT(psql.Arg(generationID)))
-	return svcutils.Search[models.ResourcePool](ctx, r.Db, e)
-}
-
-// FindStaleResourceTypes returns any ResourceType objects that have a generation less than the specific generation
-func (r *ResourcesRepository) FindStaleResourceTypes(ctx context.Context, dataSourceID uuid.UUID, generationID int) ([]models.ResourceType, error) {
-	e := psql.Quote("data_source_id").EQ(psql.Arg(dataSourceID)).And(psql.Quote("generation_id").LT(psql.Arg(generationID)))
-	return svcutils.Search[models.ResourceType](ctx, r.Db, e)
 }
 
 // GetOCloudSitesNotIn returns the list of OCloudSite records not matching the list of keys provided, or

--- a/internal/service/resources/db/repo/repository.go
+++ b/internal/service/resources/db/repo/repository.go
@@ -101,16 +101,6 @@ func (r *ResourcesRepository) GetResourcesNotIn(ctx context.Context, keys []any)
 	return svcutils.Search[models.Resource](ctx, r.Db, e)
 }
 
-// GetResourceTypesNotIn returns the list of ResourceType records not matching the list of keys provided, or
-// an empty list if none exist; otherwise an error
-func (r *ResourcesRepository) GetResourceTypesNotIn(ctx context.Context, keys []any) ([]models.ResourceType, error) {
-	var e bob.Expression
-	if len(keys) > 0 {
-		e = psql.Quote(models.ResourceType{}.PrimaryKey()).NotIn(psql.Arg(keys...))
-	}
-	return svcutils.Search[models.ResourceType](ctx, r.Db, e)
-}
-
 // GetResourcePoolResources retrieves all Resource tuples for a specific ResourcePool returns an empty array if not found
 func (r *ResourcesRepository) GetResourcePoolResources(ctx context.Context, id uuid.UUID) ([]models.Resource, error) {
 	e := psql.Quote("resource_pool_id").EQ(psql.Arg(id))

--- a/internal/service/resources/db/repo/repository_test.go
+++ b/internal/service/resources/db/repo/repository_test.go
@@ -1129,71 +1129,101 @@ var _ = Describe("Extended ResourcesRepository coverage", func() {
 		})
 	})
 
-	Describe("FindStaleResources", func() {
-		It("should return resources below generation for data source", func() {
-			dsID := uuid.New()
+	Describe("GetResourcesNotIn", func() {
+		It("should return resources not in the given list", func() {
+			resID1 := uuid.New()
+			resID2 := uuid.New()
+			excludedResID := uuid.New()
+
+			rows := pgxmock.NewRows([]string{
+				"resource_id", "description", "resource_type_id", "global_asset_id", "resource_pool_id",
+				"extensions", "groups", "tags", "data_source_id", "generation_id", "external_id", "created_at",
+			}).AddRow(
+				resID1, "r1", uuid.New(), nil, uuid.New(),
+				nil, nil, nil, uuid.New(), 1, "ext-1", nil,
+			).AddRow(
+				resID2, "r2", uuid.New(), nil, uuid.New(),
+				nil, nil, nil, uuid.New(), 1, "ext-2", nil,
+			)
+
+			mock.ExpectQuery(`SELECT .* FROM resource WHERE .* NOT IN`).
+				WithArgs(excludedResID).
+				WillReturnRows(rows)
+
+			result, err := repository.GetResourcesNotIn(ctx, []any{excludedResID})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].ResourceID).To(Equal(resID1))
+			Expect(result[1].ResourceID).To(Equal(resID2))
+			Expect(mock.ExpectationsWereMet()).To(Succeed())
+		})
+
+		It("should return all resources when keys list is empty", func() {
 			resID := uuid.New()
+
 			rows := pgxmock.NewRows([]string{
 				"resource_id", "description", "resource_type_id", "global_asset_id", "resource_pool_id",
 				"extensions", "groups", "tags", "data_source_id", "generation_id", "external_id", "created_at",
 			}).AddRow(
 				resID, "r1", uuid.New(), nil, uuid.New(),
-				nil, nil, nil, dsID, 0, "ext", nil,
+				nil, nil, nil, uuid.New(), 1, "ext-1", nil,
 			)
 
-			mock.ExpectQuery(`SELECT .* FROM resource WHERE`).
-				WithArgs(dsID, 5).
-				WillReturnRows(rows)
+			mock.ExpectQuery(`SELECT .* FROM resource`).WillReturnRows(rows)
 
-			result, err := repository.FindStaleResources(ctx, dsID, 5)
+			result, err := repository.GetResourcesNotIn(ctx, []any{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(HaveLen(1))
 			Expect(mock.ExpectationsWereMet()).To(Succeed())
 		})
 	})
 
-	Describe("FindStaleResourcePools", func() {
-		It("should return resource pools below generation for data source", func() {
-			dsID := uuid.New()
-			poolID := uuid.New()
-			siteID := uuid.New()
+	Describe("GetResourceTypesNotIn", func() {
+		It("should return resource types not in the given list", func() {
+			rtID1 := uuid.New()
+			rtID2 := uuid.New()
+			excludedRtID := uuid.New()
+
 			rows := pgxmock.NewRows([]string{
-				"resource_pool_id", "name", "description", "o_cloud_site_id",
-				"extensions", "data_source_id", "generation_id", "external_id", "created_at",
+				"resource_type_id", "name", "description", "vendor", "model", "version",
+				"resource_kind", "resource_class", "extensions", "data_source_id", "generation_id", "created_at",
 			}).AddRow(
-				poolID, "p1", "d", siteID,
-				nil, dsID, 0, "ext", nil,
+				rtID1, "rt1", "d1", "v1", "m1", "1",
+				string(models.ResourceKindPhysical), string(models.ResourceClassCompute),
+				nil, uuid.New(), 1, nil,
+			).AddRow(
+				rtID2, "rt2", "d2", "v2", "m2", "1",
+				string(models.ResourceKindPhysical), string(models.ResourceClassCompute),
+				nil, uuid.New(), 1, nil,
 			)
 
-			mock.ExpectQuery(`SELECT .* FROM resource_pool WHERE`).
-				WithArgs(dsID, 3).
+			mock.ExpectQuery(`SELECT .* FROM resource_type WHERE .* NOT IN`).
+				WithArgs(excludedRtID).
 				WillReturnRows(rows)
 
-			result, err := repository.FindStaleResourcePools(ctx, dsID, 3)
+			result, err := repository.GetResourceTypesNotIn(ctx, []any{excludedRtID})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(HaveLen(1))
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].ResourceTypeID).To(Equal(rtID1))
+			Expect(result[1].ResourceTypeID).To(Equal(rtID2))
 			Expect(mock.ExpectationsWereMet()).To(Succeed())
 		})
-	})
 
-	Describe("FindStaleResourceTypes", func() {
-		It("should return resource types below generation for data source", func() {
-			dsID := uuid.New()
+		It("should return all resource types when keys list is empty", func() {
 			rtID := uuid.New()
+
 			rows := pgxmock.NewRows([]string{
 				"resource_type_id", "name", "description", "vendor", "model", "version",
 				"resource_kind", "resource_class", "extensions", "data_source_id", "generation_id", "created_at",
 			}).AddRow(
 				rtID, "rt1", "d", "v", "m", "1",
 				string(models.ResourceKindPhysical), string(models.ResourceClassCompute),
-				nil, dsID, 0, nil,
+				nil, uuid.New(), 1, nil,
 			)
 
-			mock.ExpectQuery(`SELECT .* FROM resource_type WHERE`).
-				WithArgs(dsID, 2).
-				WillReturnRows(rows)
+			mock.ExpectQuery(`SELECT .* FROM resource_type`).WillReturnRows(rows)
 
-			result, err := repository.FindStaleResourceTypes(ctx, dsID, 2)
+			result, err := repository.GetResourceTypesNotIn(ctx, []any{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(HaveLen(1))
 			Expect(mock.ExpectationsWereMet()).To(Succeed())

--- a/internal/service/resources/db/repo/repository_test.go
+++ b/internal/service/resources/db/repo/repository_test.go
@@ -1178,58 +1178,6 @@ var _ = Describe("Extended ResourcesRepository coverage", func() {
 		})
 	})
 
-	Describe("GetResourceTypesNotIn", func() {
-		It("should return resource types not in the given list", func() {
-			rtID1 := uuid.New()
-			rtID2 := uuid.New()
-			excludedRtID := uuid.New()
-
-			rows := pgxmock.NewRows([]string{
-				"resource_type_id", "name", "description", "vendor", "model", "version",
-				"resource_kind", "resource_class", "extensions", "data_source_id", "generation_id", "created_at",
-			}).AddRow(
-				rtID1, "rt1", "d1", "v1", "m1", "1",
-				string(models.ResourceKindPhysical), string(models.ResourceClassCompute),
-				nil, uuid.New(), 1, nil,
-			).AddRow(
-				rtID2, "rt2", "d2", "v2", "m2", "1",
-				string(models.ResourceKindPhysical), string(models.ResourceClassCompute),
-				nil, uuid.New(), 1, nil,
-			)
-
-			mock.ExpectQuery(`SELECT .* FROM resource_type WHERE .* NOT IN`).
-				WithArgs(excludedRtID).
-				WillReturnRows(rows)
-
-			result, err := repository.GetResourceTypesNotIn(ctx, []any{excludedRtID})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(HaveLen(2))
-			Expect(result[0].ResourceTypeID).To(Equal(rtID1))
-			Expect(result[1].ResourceTypeID).To(Equal(rtID2))
-			Expect(mock.ExpectationsWereMet()).To(Succeed())
-		})
-
-		It("should return all resource types when keys list is empty", func() {
-			rtID := uuid.New()
-
-			rows := pgxmock.NewRows([]string{
-				"resource_type_id", "name", "description", "vendor", "model", "version",
-				"resource_kind", "resource_class", "extensions", "data_source_id", "generation_id", "created_at",
-			}).AddRow(
-				rtID, "rt1", "d", "v", "m", "1",
-				string(models.ResourceKindPhysical), string(models.ResourceClassCompute),
-				nil, uuid.New(), 1, nil,
-			)
-
-			mock.ExpectQuery(`SELECT .* FROM resource_type`).WillReturnRows(rows)
-
-			result, err := repository.GetResourceTypesNotIn(ctx, []any{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(HaveLen(1))
-			Expect(mock.ExpectationsWereMet()).To(Succeed())
-		})
-	})
-
 	Describe("GetAlarmDictionaries", func() {
 		It("should return all alarm dictionaries", func() {
 			adID := uuid.New()

--- a/internal/service/resources/db/repo/repository_test.go
+++ b/internal/service/resources/db/repo/repository_test.go
@@ -1146,7 +1146,7 @@ var _ = Describe("Extended ResourcesRepository coverage", func() {
 				nil, nil, nil, uuid.New(), 1, "ext-2", nil,
 			)
 
-			mock.ExpectQuery(`SELECT .* FROM resource WHERE .* NOT IN`).
+			mock.ExpectQuery(`SELECT .* FROM resource WHERE .*resource_id.* NOT IN`).
 				WithArgs(excludedResID).
 				WillReturnRows(rows)
 

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -142,7 +142,10 @@ func Serve(config *api.ResourceServerConfig) error {
 	}
 
 	// Create data sources
-	hardwareDS := collector.NewHardwareDataSource(hubClient, cloudID, globalCloudID)
+	hardwareDS, err := collector.NewHardwareDataSource(hubClient, cloudID, globalCloudID)
+	if err != nil {
+		return fmt.Errorf("failed to create hardware data source: %w", err)
+	}
 
 	locationDS, err := collector.NewLocationDataSource(cloudID, hubClient)
 	if err != nil {


### PR DESCRIPTION
Convert HardwareDataSource from 60-second polling to event-driven K8s watches using three separate Reflectors (BareMetalHost, HardwareData, AllocatedNode). On any watch event, cross-reference the related K8s objects and rebuild the full Resource for persistence.

Changes:
- HardwareDataSource implements WatchableDataSource with three Reflectors instead of ResourceDataSource with GetResources()
- Add Resource and ResourceType async event handlers to collector
- Add PoolChangeNotifier interface so ResourcePool creation triggers re-evaluation of BMHs (handles startup race where BMH events arrive before ResourcePool CRs exist)
- Remove polling loop (execute, pollingDelay, ResourceDataSource interface, generation-based stale data purging)
- Export IncludeInInventory, GetResourceInfo, and GetResourceInfoResourcePoolUID from inventory package
- Remove dead code: GetResources, GetBMHToNodeMap, GetNodeForBMH, GetNodeList, FindStaleResources, FindStaleResourceTypes, FindStaleResourcePools and their tests