### PR TITLE
feat: add alarm display and filtering to crd-watcher

### DIFF
--- a/dev-tools/crd-watcher/formatter.go
+++ b/dev-tools/crd-watcher/formatter.go
@@ -42,6 +42,7 @@ const (
 	CRDTypeInventoryResources     = "inventory-resources"
 	CRDTypeInventoryResourcePools = "inventory-resource-pools"
 	CRDTypeInventoryNodeClusters  = "inventory-node-clusters"
+	CRDTypeInventoryAlarms        = "inventory-alarms"
 )
 
 // Common string constants

--- a/dev-tools/crd-watcher/inventory.go
+++ b/dev-tools/crd-watcher/inventory.go
@@ -114,6 +114,22 @@ type NodeCluster struct {
 	Extensions        map[string]interface{} `json:"extensions"`
 }
 
+// AlarmRecord represents an alarm event record from the monitoring API
+type AlarmRecord struct {
+	AlarmEventRecordID string            `json:"alarmEventRecordId"`
+	AlarmRaisedTime    time.Time         `json:"alarmRaisedTime"`
+	AlarmChangedTime   *time.Time        `json:"alarmChangedTime,omitempty"`
+	AlarmClearedTime   *time.Time        `json:"alarmClearedTime,omitempty"`
+	AlarmAcknowledged  bool              `json:"alarmAcknowledged"`
+	PerceivedSeverity  int               `json:"perceivedSeverity"`
+	Extensions         map[string]string `json:"extensions"`
+}
+
+// ToRuntimeObject converts an AlarmRecord to a runtime.Object for use with formatters
+func (a *AlarmRecord) ToRuntimeObject() runtime.Object {
+	return &AlarmObject{Alarm: *a}
+}
+
 // GetSite extracts site information from the resource pool
 func (rp *ResourcePool) GetSite() string {
 	// Try to get site from extensions
@@ -552,6 +568,41 @@ func (c *InventoryClient) GetNodeClusters(ctx context.Context) ([]NodeCluster, e
 	return clusters, nil
 }
 
+// GetAlarms fetches all alarms from the monitoring API
+func (c *InventoryClient) GetAlarms(ctx context.Context) ([]AlarmRecord, error) {
+	klog.V(2).Info("Fetching alarms from monitoring API")
+
+	monitoringBaseURL := strings.Replace(c.baseURL, constants.O2IMSInventoryBaseURL, constants.O2IMSMonitoringBaseURL, 1)
+	url := monitoringBaseURL + "/alarms"
+
+	resp, err := c.retryHTTPRequest(ctx, func() (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		return c.httpClient.Do(req)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			klog.V(2).Infof("Failed to close response body: %v", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("monitoring API returned status %d", resp.StatusCode)
+	}
+
+	var alarms []AlarmRecord
+	if err := json.NewDecoder(resp.Body).Decode(&alarms); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return alarms, nil
+}
+
 // GetResources fetches all resources from a specific resource pool
 func (c *InventoryClient) GetResources(ctx context.Context, resourcePoolID string) ([]InventoryResource, error) {
 	klog.V(2).Infof("Fetching resources from resource pool: %s", resourcePoolID)
@@ -752,5 +803,35 @@ func (k *NodeClusterObjectKind) GroupVersionKind() schema.GroupVersionKind {
 		Group:   "inventory.o2ims.io",
 		Version: "v1",
 		Kind:    "NodeCluster",
+	}
+}
+
+// AlarmObject is a runtime.Object wrapper for AlarmRecord
+type AlarmObject struct {
+	Alarm AlarmRecord
+}
+
+// DeepCopyObject implements runtime.Object
+func (o *AlarmObject) DeepCopyObject() runtime.Object {
+	return &AlarmObject{Alarm: o.Alarm}
+}
+
+// GetObjectKind implements runtime.Object
+func (o *AlarmObject) GetObjectKind() schema.ObjectKind {
+	return &AlarmObjectKind{}
+}
+
+// AlarmObjectKind implements schema.ObjectKind for alarm records
+type AlarmObjectKind struct{}
+
+// SetGroupVersionKind implements schema.ObjectKind
+func (k *AlarmObjectKind) SetGroupVersionKind(gvk schema.GroupVersionKind) {}
+
+// GroupVersionKind implements schema.ObjectKind
+func (k *AlarmObjectKind) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "monitoring.o2ims.io",
+		Version: "v1",
+		Kind:    "AlarmEventRecord",
 	}
 }

--- a/dev-tools/crd-watcher/main.go
+++ b/dev-tools/crd-watcher/main.go
@@ -67,7 +67,11 @@ type Config struct {
 	// Output formatting configuration
 	UseASCII bool // Use ASCII characters instead of Unicode for table formatting
 	// Alarms display
-	EnableAlarms bool // Enable fetching and displaying O-RAN alarms (requires --enable-inventory)
+	EnableAlarms         bool     // Enable fetching and displaying O-RAN alarms (requires --enable-inventory)
+	AlarmExcludeNames    []string // Alert names to exclude from display
+	AlarmMaxSeverity     int      // Only show alarms at or below this severity (0=CRITICAL..5=CLEARED)
+	AlarmCluster         string   // Only show alarms for this cluster
+	AlarmExcludeClusters []string // Clusters to exclude from alarm display
 }
 
 var (
@@ -142,6 +146,10 @@ func addFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&config.InventoryRefreshInterval, "inventory-refresh-interval", 120, "Inventory data refresh interval in seconds (0 to disable periodic refresh)")
 	flags.BoolVar(&config.UseASCII, "ascii", false, "Use ASCII characters instead of Unicode for table formatting")
 	flags.BoolVar(&config.EnableAlarms, "alarms", false, "Enable alarm display (requires --enable-inventory)")
+	flags.StringSliceVar(&config.AlarmExcludeNames, "alarm-exclude-name", nil, "Exclude alarms with this alert name (can be specified multiple times)")
+	flags.IntVar(&config.AlarmMaxSeverity, "alarm-max-severity", 5, "Only show alarms at or below this severity (0=CRITICAL, 1=MAJOR, 2=MINOR, 3=WARNING, 4=INDETERMINATE, 5=CLEARED)")
+	flags.StringVar(&config.AlarmCluster, "alarm-cluster", "", "Only show alarms for this managed cluster")
+	flags.StringSliceVar(&config.AlarmExcludeClusters, "alarm-exclude-cluster", nil, "Exclude alarms from this managed cluster (can be specified multiple times)")
 
 	// Inventory module flags
 	flags.BoolVar(&config.EnableInventory, "enable-inventory", false, "Enable inventory module to fetch resources from O2IMS API")

--- a/dev-tools/crd-watcher/main.go
+++ b/dev-tools/crd-watcher/main.go
@@ -66,6 +66,8 @@ type Config struct {
 	InventoryRefreshInterval int // Interval in seconds for refreshing inventory data from O2IMS API
 	// Output formatting configuration
 	UseASCII bool // Use ASCII characters instead of Unicode for table formatting
+	// Alarms display
+	EnableAlarms bool // Enable fetching and displaying O-RAN alarms (requires --enable-inventory)
 }
 
 var (
@@ -139,6 +141,7 @@ func addFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&config.RefreshInterval, "refresh-interval", 2, "Screen refresh interval in seconds during inactivity (watch mode only)")
 	flags.IntVar(&config.InventoryRefreshInterval, "inventory-refresh-interval", 120, "Inventory data refresh interval in seconds (0 to disable periodic refresh)")
 	flags.BoolVar(&config.UseASCII, "ascii", false, "Use ASCII characters instead of Unicode for table formatting")
+	flags.BoolVar(&config.EnableAlarms, "alarms", false, "Enable alarm display (requires --enable-inventory)")
 
 	// Inventory module flags
 	flags.BoolVar(&config.EnableInventory, "enable-inventory", false, "Enable inventory module to fetch resources from O2IMS API")
@@ -196,6 +199,10 @@ func runCommand() error {
 		if _, exists := availableCRDs[crdType]; !exists {
 			return fmt.Errorf("unknown CRD type: %s. Available types: %s", crdType, strings.Join(getAvailableCRDNames(), ", "))
 		}
+	}
+
+	if config.EnableAlarms && !config.EnableInventory {
+		return fmt.Errorf("--alarms requires --enable-inventory")
 	}
 
 	// Process OAuth scopes - handle space-separated scopes in a single string

--- a/dev-tools/crd-watcher/tui.go
+++ b/dev-tools/crd-watcher/tui.go
@@ -354,6 +354,10 @@ func (t *TUIFormatter) getResourceKey(event WatchEvent) string {
 		if nco, ok := event.Object.(*NodeClusterObject); ok && nco != nil {
 			return fmt.Sprintf("%s/%s", event.CRDType, nco.NodeCluster.Name)
 		}
+	case CRDTypeInventoryAlarms:
+		if ao, ok := event.Object.(*AlarmObject); ok && ao != nil {
+			return fmt.Sprintf("%s/%s", event.CRDType, ao.Alarm.AlarmEventRecordID)
+		}
 	}
 
 	// For standard Kubernetes resources, use name and namespace
@@ -441,7 +445,8 @@ func (t *TUIFormatter) cleanupStaleInventoryObjects() {
 		// Only verify inventory objects during inventory refresh
 		if event.CRDType == "inventory-resources" ||
 			event.CRDType == "inventory-resource-pools" ||
-			event.CRDType == "inventory-node-clusters" {
+			event.CRDType == "inventory-node-clusters" ||
+			event.CRDType == CRDTypeInventoryAlarms {
 
 			resourceKey := t.getResourceKey(event)
 			klog.V(3).Infof("Verifying inventory object existence: %s", resourceKey)
@@ -703,6 +708,7 @@ func (t *TUIFormatter) formatCRDHeader(crdType string) string {
 		CRDTypeInventoryResourcePools: "O-RAN Resource Pools",
 		CRDTypeInventoryResources:     "O-RAN Resources",
 		CRDTypeInventoryNodeClusters:  "O-RAN Nodes",
+		CRDTypeInventoryAlarms:        "O-RAN Alarms",
 	}
 
 	// Use the mapped header or fall back to the original crdType
@@ -801,6 +807,17 @@ func (t *TUIFormatter) compareEvents(crdType string, a, b WatchEvent) bool {
 		nameA := t.getInventoryNodeClusterName(a.Object)
 		nameB := t.getInventoryNodeClusterName(b.Object)
 		return nameA < nameB
+	case CRDTypeInventoryAlarms:
+		// Sort by severity (most severe first), then raised time (most recent first)
+		aoA, okA := a.Object.(*AlarmObject)
+		aoB, okB := b.Object.(*AlarmObject)
+		if okA && okB {
+			if aoA.Alarm.PerceivedSeverity != aoB.Alarm.PerceivedSeverity {
+				return aoA.Alarm.PerceivedSeverity < aoB.Alarm.PerceivedSeverity
+			}
+			return aoA.Alarm.AlarmRaisedTime.After(aoB.Alarm.AlarmRaisedTime)
+		}
+		return false
 	default:
 		// Default to sorting by name with nil safety
 		accessor1, _ := meta.Accessor(a.Object)
@@ -903,6 +920,7 @@ func (t *TUIFormatter) getOrderedCRDTypes(grouped map[string][]WatchEvent) []str
 		CRDTypeInventoryResourcePools,
 		CRDTypeInventoryResources,
 		CRDTypeInventoryNodeClusters,
+		CRDTypeInventoryAlarms,
 	}
 
 	var result []string
@@ -1036,6 +1054,13 @@ func (t *TUIFormatter) initializeHeaderWidths(crdType string) FieldWidths {
 		widths.Field1 = safeMax(widths.Field1, len("NODE-NAME"))
 		widths.Field2 = safeMax(widths.Field2, len("NODE-CLUSTER-ID"))
 		widths.Field3 = safeMax(widths.Field3, len("NODE-CLUSTER-TYPE-ID"))
+	case CRDTypeInventoryAlarms:
+		widths.Field1 = safeMax(widths.Field1, len("SEVERITY"))
+		widths.Field2 = safeMax(widths.Field2, len("ALERT"))
+		widths.Field3 = safeMax(widths.Field3, len("CLUSTER"))
+		widths.Field4 = safeMax(widths.Field4, len("STATUS"))
+		widths.Field5 = safeMax(widths.Field5, len("ACK"))
+		widths.Field6 = safeMax(widths.Field6, len("RAISED"))
 	}
 
 	return widths
@@ -1494,6 +1519,8 @@ func (t *TUIFormatter) calculateFieldWidths(crdType string, events []WatchEvent)
 		widths = t.calculateInventoryResourcePoolWidths(events, widths)
 	case CRDTypeInventoryNodeClusters:
 		widths = t.calculateInventoryNodeClusterWidths(events, widths)
+	case CRDTypeInventoryAlarms:
+		widths = t.calculateAlarmWidths(events, widths)
 	}
 
 	// Apply reasonable maximum widths to prevent overly wide columns
@@ -1541,6 +1568,10 @@ func (t *TUIFormatter) buildCRDTableHeader(crdType string, widths FieldWidths, s
 	case CRDTypeInventoryNodeClusters:
 		sb.WriteString(fmt.Sprintf("%s %-*s   %-*s   %-*s\n",
 			sidebarChar, widths.Field1, "NODE-NAME", widths.Field2, "NODE-CLUSTER-ID", widths.Field3, "NODE-CLUSTER-TYPE-ID"))
+	case CRDTypeInventoryAlarms:
+		sb.WriteString(fmt.Sprintf("%s %-*s   %-*s   %-*s   %-*s   %-*s   %-*s\n",
+			sidebarChar, widths.Field1, "SEVERITY", widths.Field2, "ALERT", widths.Field3, "CLUSTER",
+			widths.Field4, "STATUS", widths.Field5, "ACK", widths.Field6, "RAISED"))
 	}
 }
 
@@ -1573,6 +1604,8 @@ func (t *TUIFormatter) buildEventLine(event WatchEvent, widths FieldWidths, sb *
 		t.buildInventoryResourcePoolLine(age, event.Object, widths, sb)
 	case CRDTypeInventoryNodeClusters:
 		t.buildInventoryNodeClusterLine(age, event.Object, widths, sb)
+	case CRDTypeInventoryAlarms:
+		t.buildAlarmLine(event.Object, widths, sb)
 	}
 }
 
@@ -2068,4 +2101,96 @@ func (t *TUIFormatter) resetRefreshTimer() {
 		t.refreshTimer.Stop()
 	}
 	t.startRefreshTimer()
+}
+
+func severityToString(severity int) string {
+	switch severity {
+	case 0:
+		return "CRITICAL"
+	case 1:
+		return "MAJOR"
+	case 2:
+		return "MINOR"
+	case 3:
+		return "WARNING"
+	case 4:
+		return "INDETERM"
+	case 5:
+		return "CLEARED"
+	default:
+		return StringUnknown
+	}
+}
+
+func severityColor(severity int) string {
+	switch severity {
+	case 0:
+		return ansiRed
+	case 1:
+		return ansiYellow
+	case 5:
+		return ansiGreen
+	default:
+		return ""
+	}
+}
+
+func (t *TUIFormatter) calculateAlarmWidths(events []WatchEvent, widths FieldWidths) FieldWidths {
+	for _, event := range events {
+		ao, ok := event.Object.(*AlarmObject)
+		if !ok {
+			continue
+		}
+
+		widths.Field1 = safeMax(widths.Field1, len(severityToString(ao.Alarm.PerceivedSeverity)))
+		widths.Field2 = safeMax(widths.Field2, len(ao.Alarm.Extensions["alertname"]))
+		widths.Field3 = safeMax(widths.Field3, len(ao.Alarm.Extensions["managed_cluster"]))
+
+		status := "Firing"
+		if ao.Alarm.AlarmClearedTime != nil {
+			status = "Cleared"
+		}
+		widths.Field4 = safeMax(widths.Field4, len(status))
+		widths.Field5 = safeMax(widths.Field5, 3) // Y/N
+		widths.Field6 = safeMax(widths.Field6, len(ao.Alarm.AlarmRaisedTime.Format("2006-01-02 15:04:05")))
+	}
+	return widths
+}
+
+func (t *TUIFormatter) buildAlarmLine(obj runtime.Object, widths FieldWidths, sb *strings.Builder) {
+	ao, ok := obj.(*AlarmObject)
+	if !ok {
+		return
+	}
+
+	sidebarChar := t.getSidebarChar()
+	alarm := ao.Alarm
+
+	severity := severityToString(alarm.PerceivedSeverity)
+	color := severityColor(alarm.PerceivedSeverity)
+	resetColor := ""
+	if color != "" {
+		resetColor = ansiReset
+	}
+
+	alertName := alarm.Extensions["alertname"]
+	cluster := alarm.Extensions["managed_cluster"]
+	status := "Firing"
+	if alarm.AlarmClearedTime != nil {
+		status = "Cleared"
+	}
+	ack := StringNo
+	if alarm.AlarmAcknowledged {
+		ack = StringYes
+	}
+	raised := alarm.AlarmRaisedTime.Format("2006-01-02 15:04:05")
+
+	sb.WriteString(fmt.Sprintf("%s %s%-*s%s   %-*s   %-*s   %-*s   %-*s   %-*s\n",
+		sidebarChar,
+		color, widths.Field1, severity, resetColor,
+		widths.Field2, alertName,
+		widths.Field3, cluster,
+		widths.Field4, status,
+		widths.Field5, ack,
+		widths.Field6, raised))
 }

--- a/dev-tools/crd-watcher/tui.go
+++ b/dev-tools/crd-watcher/tui.go
@@ -2144,7 +2144,11 @@ func (t *TUIFormatter) calculateAlarmWidths(events []WatchEvent, widths FieldWid
 
 		widths.Field1 = safeMax(widths.Field1, len(severityToString(ao.Alarm.PerceivedSeverity)))
 		widths.Field2 = safeMax(widths.Field2, len(ao.Alarm.Extensions["alertname"]))
-		widths.Field3 = safeMax(widths.Field3, len(ao.Alarm.Extensions["managed_cluster"]))
+		cluster := ao.Alarm.Extensions["managed_cluster"]
+		if cluster == "" {
+			cluster = ao.Alarm.Extensions["clusterID"]
+		}
+		widths.Field3 = safeMax(widths.Field3, len(cluster))
 
 		status := "Firing"
 		if ao.Alarm.AlarmClearedTime != nil {
@@ -2175,6 +2179,9 @@ func (t *TUIFormatter) buildAlarmLine(obj runtime.Object, widths FieldWidths, sb
 
 	alertName := alarm.Extensions["alertname"]
 	cluster := alarm.Extensions["managed_cluster"]
+	if cluster == "" {
+		cluster = alarm.Extensions["clusterID"]
+	}
 	status := "Firing"
 	if alarm.AlarmClearedTime != nil {
 		status = "Cleared"

--- a/dev-tools/crd-watcher/watcher.go
+++ b/dev-tools/crd-watcher/watcher.go
@@ -158,6 +158,8 @@ func (w *CRDWatcher) verifyResourceExists(event WatchEvent) bool {
 		return w.verifyInventoryResourcePoolExists(ctx, event)
 	case "inventory-node-clusters":
 		return w.verifyInventoryNodeClusterExists(ctx, event)
+	case CRDTypeInventoryAlarms:
+		return true // Alarms are fully replaced on each refresh
 	default:
 		// For Kubernetes CRDs, use the dynamic client
 		return w.verifyKubernetesResourceExists(ctx, event)

--- a/dev-tools/crd-watcher/watcher.go
+++ b/dev-tools/crd-watcher/watcher.go
@@ -81,6 +81,9 @@ func NewCRDWatcher(clientset kubernetes.Interface, restConfig *rest.Config, sche
 			"inventory-resources",
 			"inventory-node-clusters",
 		}
+		if config.EnableAlarms {
+			inventoryTypes = append(inventoryTypes, CRDTypeInventoryAlarms)
+		}
 		crdTypes = append(crdTypes, inventoryTypes...)
 	}
 
@@ -310,6 +313,13 @@ func (w *CRDWatcher) Start(ctx context.Context) error {
 			klog.Errorf("Failed to fetch initial inventory node clusters: %v", err)
 		}
 
+		// Fetch and display initial alarms if enabled
+		if w.config.EnableAlarms {
+			if err := w.fetchAndDisplayAlarms(ctx); err != nil {
+				klog.Errorf("Failed to fetch initial alarms: %v", err)
+			}
+		}
+
 		// Start the inventory refresh timer for periodic updates
 		w.startInventoryRefreshTimer(ctx)
 	}
@@ -370,6 +380,16 @@ func (w *CRDWatcher) ListAndDisplay(ctx context.Context) error {
 			klog.Errorf("Failed to list inventory node clusters: %v", err)
 		} else {
 			allEvents = append(allEvents, nodeClusterEvents...)
+		}
+
+		// Fetch alarms if enabled
+		if w.config.EnableAlarms {
+			alarmEvents, err := w.listInventoryAlarms(ctx)
+			if err != nil {
+				klog.Errorf("Failed to list alarms: %v", err)
+			} else {
+				allEvents = append(allEvents, alarmEvents...)
+			}
 		}
 	}
 
@@ -533,6 +553,29 @@ func (w *CRDWatcher) listInventoryNodeClusters(ctx context.Context) ([]WatchEven
 	return events, nil
 }
 
+func (w *CRDWatcher) listInventoryAlarms(ctx context.Context) ([]WatchEvent, error) {
+	klog.V(1).Info("Fetching alarms from monitoring API")
+
+	alarms, err := w.inventoryClient.GetAlarms(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get alarms: %w", err)
+	}
+
+	var events []WatchEvent
+	for _, alarm := range alarms {
+		event := WatchEvent{
+			Type:      watch.Added,
+			Object:    alarm.ToRuntimeObject(),
+			Timestamp: time.Now(),
+			CRDType:   CRDTypeInventoryAlarms,
+		}
+		events = append(events, event)
+	}
+
+	klog.V(1).Infof("Collected %d alarm events", len(events))
+	return events, nil
+}
+
 func (w *CRDWatcher) fetchAndDisplayInventoryResourcePools(ctx context.Context) error {
 	resourcePools, err := w.inventoryClient.GetAllResourcePools(ctx)
 	if err != nil {
@@ -604,6 +647,28 @@ func (w *CRDWatcher) fetchAndDisplayInventoryNodeClusters(ctx context.Context) e
 	}
 
 	klog.V(1).Infof("Displayed %d inventory node clusters (filtered from %d total)", filteredCount, len(nodeClusters))
+	return nil
+}
+
+func (w *CRDWatcher) fetchAndDisplayAlarms(ctx context.Context) error {
+	alarms, err := w.inventoryClient.GetAlarms(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get alarms: %w", err)
+	}
+
+	for _, alarm := range alarms {
+		event := WatchEvent{
+			Type:      watch.Added,
+			Object:    alarm.ToRuntimeObject(),
+			Timestamp: time.Now(),
+			CRDType:   CRDTypeInventoryAlarms,
+		}
+		if err := w.formatter.FormatEvent(event); err != nil {
+			klog.Errorf("Error formatting alarm event: %v", err)
+		}
+	}
+
+	klog.V(1).Infof("Displayed %d alarms", len(alarms))
 	return nil
 }
 
@@ -854,6 +919,14 @@ func (w *CRDWatcher) performInventoryRefreshWithReason(ctx context.Context, reas
 		w.logInventoryRefreshError("node clusters", err)
 	}
 
+	// Refresh alarms if enabled
+	if w.config.EnableAlarms {
+		if err := w.refreshAlarms(refreshCtx); err != nil {
+			hadError = true
+			w.logInventoryRefreshError("alarms", err)
+		}
+	}
+
 	if hadError {
 		w.inventoryConsecutiveFailures++
 	} else {
@@ -964,6 +1037,28 @@ func (w *CRDWatcher) refreshInventoryNodeClusters(ctx context.Context) error {
 	}
 
 	klog.V(2).Infof("Refreshed %d inventory node clusters (filtered from %d total)", filteredCount, len(nodeClusters))
+	return nil
+}
+
+func (w *CRDWatcher) refreshAlarms(ctx context.Context) error {
+	alarms, err := w.inventoryClient.GetAlarms(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get alarms: %w", err)
+	}
+
+	for _, alarm := range alarms {
+		event := WatchEvent{
+			Type:      watch.Added,
+			Object:    alarm.ToRuntimeObject(),
+			Timestamp: time.Now(),
+			CRDType:   CRDTypeInventoryAlarms,
+		}
+		if err := w.formatter.FormatEvent(event); err != nil {
+			klog.Errorf("Error formatting refreshed alarm event: %v", err)
+		}
+	}
+
+	klog.V(2).Infof("Refreshed %d alarms", len(alarms))
 	return nil
 }
 

--- a/dev-tools/crd-watcher/watcher.go
+++ b/dev-tools/crd-watcher/watcher.go
@@ -561,8 +561,10 @@ func (w *CRDWatcher) listInventoryAlarms(ctx context.Context) ([]WatchEvent, err
 		return nil, fmt.Errorf("failed to get alarms: %w", err)
 	}
 
+	filtered := w.filterAlarms(alarms)
+
 	var events []WatchEvent
-	for _, alarm := range alarms {
+	for _, alarm := range filtered {
 		event := WatchEvent{
 			Type:      watch.Added,
 			Object:    alarm.ToRuntimeObject(),
@@ -572,8 +574,47 @@ func (w *CRDWatcher) listInventoryAlarms(ctx context.Context) ([]WatchEvent, err
 		events = append(events, event)
 	}
 
-	klog.V(1).Infof("Collected %d alarm events", len(events))
+	klog.V(1).Infof("Collected %d alarm events (filtered from %d total)", len(events), len(alarms))
 	return events, nil
+}
+
+func (w *CRDWatcher) filterAlarms(alarms []AlarmRecord) []AlarmRecord {
+	if len(w.config.AlarmExcludeNames) == 0 && w.config.AlarmMaxSeverity >= 5 &&
+		w.config.AlarmCluster == "" && len(w.config.AlarmExcludeClusters) == 0 {
+		return alarms
+	}
+
+	excludeNames := make(map[string]bool, len(w.config.AlarmExcludeNames))
+	for _, name := range w.config.AlarmExcludeNames {
+		excludeNames[name] = true
+	}
+
+	excludeClusters := make(map[string]bool, len(w.config.AlarmExcludeClusters))
+	for _, cluster := range w.config.AlarmExcludeClusters {
+		excludeClusters[cluster] = true
+	}
+
+	var result []AlarmRecord
+	for _, alarm := range alarms {
+		if excludeNames[alarm.Extensions["alertname"]] {
+			continue
+		}
+		if alarm.PerceivedSeverity > w.config.AlarmMaxSeverity {
+			continue
+		}
+		cluster := alarm.Extensions["managed_cluster"]
+		if cluster == "" {
+			cluster = alarm.Extensions["clusterID"]
+		}
+		if w.config.AlarmCluster != "" && cluster != w.config.AlarmCluster {
+			continue
+		}
+		if excludeClusters[cluster] {
+			continue
+		}
+		result = append(result, alarm)
+	}
+	return result
 }
 
 func (w *CRDWatcher) fetchAndDisplayInventoryResourcePools(ctx context.Context) error {
@@ -656,7 +697,8 @@ func (w *CRDWatcher) fetchAndDisplayAlarms(ctx context.Context) error {
 		return fmt.Errorf("failed to get alarms: %w", err)
 	}
 
-	for _, alarm := range alarms {
+	filtered := w.filterAlarms(alarms)
+	for _, alarm := range filtered {
 		event := WatchEvent{
 			Type:      watch.Added,
 			Object:    alarm.ToRuntimeObject(),
@@ -668,7 +710,7 @@ func (w *CRDWatcher) fetchAndDisplayAlarms(ctx context.Context) error {
 		}
 	}
 
-	klog.V(1).Infof("Displayed %d alarms", len(alarms))
+	klog.V(1).Infof("Displayed %d alarms (filtered from %d total)", len(filtered), len(alarms))
 	return nil
 }
 
@@ -1046,7 +1088,8 @@ func (w *CRDWatcher) refreshAlarms(ctx context.Context) error {
 		return fmt.Errorf("failed to get alarms: %w", err)
 	}
 
-	for _, alarm := range alarms {
+	filtered := w.filterAlarms(alarms)
+	for _, alarm := range filtered {
 		event := WatchEvent{
 			Type:      watch.Added,
 			Object:    alarm.ToRuntimeObject(),
@@ -1058,7 +1101,7 @@ func (w *CRDWatcher) refreshAlarms(ctx context.Context) error {
 		}
 	}
 
-	klog.V(2).Infof("Refreshed %d alarms", len(alarms))
+	klog.V(2).Infof("Refreshed %d alarms (filtered from %d total)", len(filtered), len(alarms))
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Add `--alarms` flag to crd-watcher (requires `--enable-inventory`) that fetches alarms from the O2IMS monitoring API and displays them in an "O-RAN Alarms" section
- Display fields: severity (color-coded), alert name, cluster, status (firing/cleared), acknowledged, raised time
- Alarms sorted by severity (most severe first), then raised time (most recent first)
- Add filtering options:
  - `--alarm-exclude-name`: exclude alerts by name (repeatable)
  - `--alarm-exclude-cluster`: exclude alerts from specific clusters (repeatable)
  - `--alarm-max-severity`: only show alarms at or below this severity (0=CRITICAL..5=CLEARED)
  - `--alarm-cluster`: only show alarms for a specific cluster
- Handle both `managed_cluster` and `clusterID` extension fields for cluster display and filtering (different alert sources use different label names)

## Test plan
- [x] `make crd-watcher` builds
- [x] `go test ./dev-tools/crd-watcher/...` passes (70/70)
- [x] `make golangci-lint` passes
- [x] Run with `--enable-inventory --alarms` and verify alarms display
- [x] Run with `--alarm-exclude-name UpdateAvailable --alarm-max-severity 4` and verify filtering
- [x] Run without `--alarms` and verify no alarm section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)