### PR TITLE
fix: clear stale alarm events before refresh in crd-watcher

### DIFF
--- a/dev-tools/crd-watcher/tui.go
+++ b/dev-tools/crd-watcher/tui.go
@@ -427,6 +427,22 @@ func (t *TUIFormatter) cleanupDeletedResources() {
 	}
 }
 
+// clearEventsForType removes all events of a specific CRD type from the display.
+// Used to ensure stale data is removed before adding a fresh batch (e.g., alarms
+// that may have been filtered out on refresh).
+func (t *TUIFormatter) clearEventsForType(crdType string) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	filtered := t.events[:0]
+	for _, event := range t.events {
+		if event.CRDType != crdType {
+			filtered = append(filtered, event)
+		}
+	}
+	t.events = filtered
+}
+
 // cleanupStaleInventoryObjects performs immediate cleanup of stale inventory objects only
 func (t *TUIFormatter) cleanupStaleInventoryObjects() {
 	if t.verifyFunc == nil {

--- a/dev-tools/crd-watcher/watcher.go
+++ b/dev-tools/crd-watcher/watcher.go
@@ -1090,6 +1090,10 @@ func (w *CRDWatcher) refreshAlarms(ctx context.Context) error {
 		return fmt.Errorf("failed to get alarms: %w", err)
 	}
 
+	if tuiFormatter, ok := w.formatter.(*TUIFormatter); ok {
+		tuiFormatter.clearEventsForType(CRDTypeInventoryAlarms)
+	}
+
 	filtered := w.filterAlarms(alarms)
 	for _, alarm := range filtered {
 		event := WatchEvent{


### PR DESCRIPTION
## Summary
- Fix stale alarm events remaining in the crd-watcher display after they are
  filtered out on refresh (e.g., an alarm transitions from firing to cleared
  and is excluded by `--alarm-max-severity`)
- Add `clearEventsForType` method to TUI formatter that removes all events
  of a specific CRD type before adding a fresh batch
- Call it in `refreshAlarms` before re-adding the current alarm set

## Test plan
- [x] `make crd-watcher` builds
- [x] `go test ./dev-tools/crd-watcher/...` passes
- [x] `make golangci-lint` passes
- [x] Run with `--alarms --alarm-max-severity 4`, verify cleared alarms
  disappear from display on next refresh cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)