### PR TITLE
CNF-23712: Add structured logging for OpenAPI validation failures

### DIFF
--- a/internal/service/common/api/middleware/middleware.go
+++ b/internal/service/common/api/middleware/middleware.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package middleware
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -85,7 +86,7 @@ func OpenAPIValidation(swagger *openapi3.T) Middleware {
 		Options: openapi3filter.Options{
 			AuthenticationFunc: openapi3filter.NoopAuthenticationFunc, // No auth needed even when we have something in spec
 		},
-		ErrorHandler: getOranErrHandler(),
+		ErrorHandlerWithOpts: getOranErrHandler(),
 	})
 }
 
@@ -116,15 +117,27 @@ func ProblemDetails(w http.ResponseWriter, body string, code int) {
 }
 
 // getOranErrHandler override default validation error to allow for O-RAN specific error
-func getOranErrHandler() func(w http.ResponseWriter, message string, statusCode int) {
-	return func(w http.ResponseWriter, message string, statusCode int) {
-		ProblemDetails(w, message, statusCode)
+func getOranErrHandler() oapimiddleware.ErrorHandlerWithOpts {
+	return func(_ context.Context, err error, w http.ResponseWriter, r *http.Request, opts oapimiddleware.ErrorHandlerOpts) {
+		slog.Warn("OpenAPI validation failed",
+			"error", err.Error(),
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", opts.StatusCode,
+		)
+		ProblemDetails(w, err.Error(), opts.StatusCode)
 	}
 }
 
 // GetOranReqErrFunc override default validation errors to allow for O-RAN specific struct
 func GetOranReqErrFunc() func(w http.ResponseWriter, r *http.Request, err error) {
 	return func(w http.ResponseWriter, r *http.Request, err error) {
+		slog.Warn("OpenAPI request validation failed",
+			"error", err.Error(),
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", http.StatusBadRequest,
+		)
 		ProblemDetails(w, err.Error(), http.StatusBadRequest)
 	}
 }

--- a/internal/service/common/api/middleware/middleware_test.go
+++ b/internal/service/common/api/middleware/middleware_test.go
@@ -1,0 +1,82 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+
+	oapimiddleware "github.com/oapi-codegen/nethttp-middleware"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validation error logging", func() {
+	var (
+		buf      bytes.Buffer
+		original *slog.Logger
+	)
+
+	BeforeEach(func() {
+		buf.Reset()
+		original = slog.Default()
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	})
+
+	AfterEach(func() {
+		slog.SetDefault(original)
+	})
+
+	Describe("getOranErrHandler", func() {
+		It("should log a warning with structured fields on validation failure", func() {
+			handler := getOranErrHandler()
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/o2ims-infrastructureInventory/v1/resourcePools", nil)
+
+			handler(context.Background(), errors.New("request body has an error"), recorder, req, oapimiddleware.ErrorHandlerOpts{
+				StatusCode: http.StatusBadRequest,
+			})
+
+			Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+
+			var logEntry map[string]any
+			Expect(json.Unmarshal(buf.Bytes(), &logEntry)).To(Succeed())
+			Expect(logEntry).To(HaveKeyWithValue("level", "WARN"))
+			Expect(logEntry).To(HaveKeyWithValue("msg", "OpenAPI validation failed"))
+			Expect(logEntry).To(HaveKeyWithValue("error", "request body has an error"))
+			Expect(logEntry).To(HaveKeyWithValue("method", "POST"))
+			Expect(logEntry).To(HaveKeyWithValue("path", "/o2ims-infrastructureInventory/v1/resourcePools"))
+			Expect(logEntry).To(HaveKeyWithValue("status", BeNumerically("==", http.StatusBadRequest)))
+		})
+	})
+
+	Describe("GetOranReqErrFunc", func() {
+		It("should log a warning with structured fields on request validation failure", func() {
+			handler := GetOranReqErrFunc()
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/o2ims-infrastructureInventory/v1/deploymentManagers", nil)
+
+			handler(recorder, req, errors.New("parameter 'filter' has invalid value"))
+
+			Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+
+			var logEntry map[string]any
+			Expect(json.Unmarshal(buf.Bytes(), &logEntry)).To(Succeed())
+			Expect(logEntry).To(HaveKeyWithValue("level", "WARN"))
+			Expect(logEntry).To(HaveKeyWithValue("msg", "OpenAPI request validation failed"))
+			Expect(logEntry).To(HaveKeyWithValue("error", "parameter 'filter' has invalid value"))
+			Expect(logEntry).To(HaveKeyWithValue("method", "GET"))
+			Expect(logEntry).To(HaveKeyWithValue("path", "/o2ims-infrastructureInventory/v1/deploymentManagers"))
+			Expect(logEntry).To(HaveKeyWithValue("status", BeNumerically("==", http.StatusBadRequest)))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Add structured error logging (`slog.Warn`) to the OpenAPI validation error handlers so that request validation failures are captured in application logs, not just returned to the client. This improves security monitoring visibility for the O-Cloud Security Hardening initiative.

**Jira**: [CNF-23712](https://redhat.atlassian.net/browse/CNF-23712) — REQ-018: Add structured logging for OpenAPI validation failures  
**Jira URL**: https://redhat.atlassian.net/browse/CNF-23712

## Changes

* **`internal/service/common/api/middleware/middleware.go`**:  
   * Migrated `getOranErrHandler` from deprecated `ErrorHandler` to `ErrorHandlerWithOpts` to access the HTTP request  
   * Added `slog.Warn` to `getOranErrHandler` with structured fields: error, method, path, status  
   * Added `slog.Warn` to `GetOranReqErrFunc` with structured fields: error, method, path, status  
   * No request body/payload is logged (per REQ-034 coordination)
* **`internal/service/common/api/middleware/middleware_test.go`** (new):  
   * Test for `getOranErrHandler`: verifies structured WARN log entry with correct fields  
   * Test for `GetOranReqErrFunc`: verifies structured WARN log entry with correct fields

## Acceptance Criteria

* Validation failures produce a structured log entry at WARN level
* Log entries include: error message, HTTP method, URL path, status code
* Request body/payload is NOT logged
* Uses `slog.Warn` (not `slog.Error`) for client validation errors
* Unit tests verify log output on validation failure

## Test Plan

2 new Ginkgo tests added:

* `getOranErrHandler` log output verification (captures JSON log, asserts all structured fields)
* `GetOranReqErrFunc` log output verification (captures JSON log, asserts all structured fields)

All 28 middleware tests pass. golangci-lint reports 0 issues.

## Notes

* Migrated from `ErrorHandler` to `ErrorHandlerWithOpts` (the library's recommended approach) to access `*http.Request` for method/path logging. The old `ErrorHandler` type doesn't include the request in its signature.

Generated with Claude Code
