### PR TITLE
CNF-23714: Log all token validation failures explicitly

### DIFF
--- a/internal/service/common/auth/auth.go
+++ b/internal/service/common/auth/auth.go
@@ -36,11 +36,13 @@ func Authenticator(oauthHandler, kubernetesHandler authenticator.Request) middle
 
 			response, ok, err := handler.AuthenticateRequest(req)
 			if err != nil {
+				slog.Warn("authentication failed", "error", err, "method", req.Method, "path", req.URL.Path)
 				middleware.ProblemDetails(w, fmt.Sprintf("failed to authenticate request: %v", err), http.StatusUnauthorized)
 				return
 			}
 
 			if !ok {
+				slog.Warn("authentication rejected", "method", req.Method, "path", req.URL.Path)
 				middleware.ProblemDetails(w, "unable to authenticate request", http.StatusUnauthorized)
 				return
 			}

--- a/internal/service/common/auth/auth_test.go
+++ b/internal/service/common/auth/auth_test.go
@@ -7,8 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package auth
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -63,6 +65,8 @@ var _ = Describe("Authenticator", func() {
 	var oauthAuthenticator, k8sAuthenticator NoopAuthenticator
 	var recorder *httptest.ResponseRecorder
 	var handler http.Handler
+	var logBuffer bytes.Buffer
+	var origLogger *slog.Logger
 
 	BeforeEach(func() {
 		oauthAuthenticator = NoopAuthenticator{
@@ -87,10 +91,22 @@ var _ = Describe("Authenticator", func() {
 			Ok:    true,
 			Error: nil,
 		}
-		req = http.Request{Header: http.Header{}}
+		req = http.Request{
+			Header: http.Header{},
+			Method: http.MethodGet,
+			URL:    &url.URL{Path: "/api/test"},
+		}
 		next = &NoopHandler{}
 		recorder = httptest.NewRecorder()
 		handler = Authenticator(&oauthAuthenticator, &k8sAuthenticator)(next)
+
+		logBuffer.Reset()
+		origLogger = slog.Default()
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	})
+
+	AfterEach(func() {
+		slog.SetDefault(origLogger)
 	})
 
 	It("Authorizes the request using OAuth behind proxy", func() {
@@ -138,6 +154,13 @@ var _ = Describe("Authenticator", func() {
 		Expect(recorder.Code).To(Equal(http.StatusUnauthorized))
 		Expect(recorder.Body.String()).To(ContainSubstring("some error"))
 		Expect(recorder.Body.String()).To(ContainSubstring("failed to authenticate request"))
+
+		logOutput := logBuffer.String()
+		Expect(logOutput).To(ContainSubstring("authentication failed"))
+		Expect(logOutput).To(ContainSubstring(`"level":"WARN"`))
+		Expect(logOutput).To(ContainSubstring(`"method":"GET"`))
+		Expect(logOutput).To(ContainSubstring(`"/api/test"`))
+		Expect(logOutput).To(ContainSubstring("some error"))
 	})
 
 	It("Rejects the request when the handler returns false", func() {
@@ -148,6 +171,12 @@ var _ = Describe("Authenticator", func() {
 		Expect(next.(*NoopHandler).called).To(BeFalse())
 		Expect(recorder.Code).To(Equal(http.StatusUnauthorized))
 		Expect(recorder.Body.String()).To(ContainSubstring("unable to authenticate request"))
+
+		logOutput := logBuffer.String()
+		Expect(logOutput).To(ContainSubstring("authentication rejected"))
+		Expect(logOutput).To(ContainSubstring(`"level":"WARN"`))
+		Expect(logOutput).To(ContainSubstring(`"method":"GET"`))
+		Expect(logOutput).To(ContainSubstring(`"/api/test"`))
 	})
 })
 


### PR DESCRIPTION
## Summary

Add explicit structured logging (`slog.Warn`) for authentication failures in the `Authenticator` middleware so that expired, malformed, and invalid-signature token rejections are captured in application logs for forensic analysis.

**Jira**: [CNF-23714](https://redhat.atlassian.net/browse/CNF-23714) — REQ-027: Log all token validation failures explicitly
**Jira URL**: https://redhat.atlassian.net/browse/CNF-23714

## Changes

- **`internal/service/common/auth/auth.go`**: Add `slog.Warn("authentication failed", ...)` before the `ProblemDetails` call in the error path (line ~39), and `slog.Warn("authentication rejected", ...)` in the not-ok path (line ~44). Both include structured fields: `error` (when available), `method`, and `path`.
- **`internal/service/common/auth/auth_test.go`**: Add log capture infrastructure (`bytes.Buffer` + `slog.NewJSONHandler`) and verify that both failure paths produce WARN-level log entries with the expected structured fields.

## Acceptance Criteria

- [x] The `Authenticator` function logs all authentication failures (both error and not-ok paths) via `slog.Warn` with structured fields
- [x] Log entries include at minimum: error message (if present), HTTP method, and request path
- [x] Unit tests verify that authentication failures produce structured log entries

## Test Plan

- Unit tests verify the error path produces a log entry with message "authentication failed", level WARN, method, path, and error string
- Unit tests verify the rejection path produces a log entry with message "authentication rejected", level WARN, method, and path
- All 19 existing tests in the auth package pass (no regressions)
- `golangci-lint` passes cleanly

Generated with [Claude Code](https://claude.com/claude-code)