### PR TITLE
chore: ignore k8s.io >= 0.36.0 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
    schedule:
     interval: "daily"
    open-pull-requests-limit: 5
+   ignore:
+    # k8s.io v0.36+ requires Go 1.26; stay on v0.35.x until Go is upgraded
+    - dependency-name: "k8s.io/*"
+      versions: [">= 0.36.0"]
    groups:
     k8s:
      patterns: ["k8s.io/*", "sigs.k8s.io/*"]


### PR DESCRIPTION
k8s.io v0.36+ requires Go 1.26 which we don't have yet. Prevent dependabot from proposing updates that would break the build.