### PR TITLE
test: cleanup naming and misleading comments

### DIFF
--- a/docs/user-guide/cluster-api.md
+++ b/docs/user-guide/cluster-api.md
@@ -43,7 +43,7 @@ Example response:
   {
     "nodeClusterId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "nodeClusterTypeId": "d1eabf91-f0e6-5170-97dc-797d35146dad",
-    "name": "cnfdg16",
+    "name": "my-sno-cluster",
     "description": "SNO RAN DU cluster",
     "extensions": {
       "clusterID": "c5e3f8a2-1b4d-4e6f-8a9b-0c1d2e3f4a5b",
@@ -67,7 +67,7 @@ curl -ks -H "Authorization: Bearer ${MY_TOKEN}" \
 ```bash
 # Find clusters by name
 curl -ks -H "Authorization: Bearer ${MY_TOKEN}" \
-  "https://${API_URI}/o2ims-infrastructureCluster/v1/nodeClusters?filter=(eq,name,cnfdg16)" | jq
+  "https://${API_URI}/o2ims-infrastructureCluster/v1/nodeClusters?filter=(eq,name,my-sno-cluster)" | jq
 
 # Exclude the local hub cluster
 curl -ks -H "Authorization: Bearer ${MY_TOKEN}" \

--- a/test/e2e/bmh_test.go
+++ b/test/e2e/bmh_test.go
@@ -22,7 +22,6 @@ import (
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
 )
 
-// TODO: These tests do not test any actual functionality, leave them here for now for revisiting.
 // Test empty bootMACAddress workflow where bootMAC is populated from interface labels
 var _ = Describe("BareMetalHost with empty bootMACAddress", Ordered, func() {
 	const timeout = time.Second * 90

--- a/test/e2e/mno_hw_configuration_test.go
+++ b/test/e2e/mno_hw_configuration_test.go
@@ -868,7 +868,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			}
 		})
 
-		It("Should PR reach HardwareConfigured=True after callback", func() {
+		It("Should PR reach HardwareConfigured=True", func() {
 			Eventually(func() bool {
 				Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
 				cond := meta.FindStatusCondition(pr.Status.Conditions,
@@ -883,9 +883,10 @@ func intPtr(v int) *int { return &v }
 
 // testNonCachingListAllocatedNodesForNAR is a test-only helper that lists AllocatedNodes
 // for a NAR using the non-caching K8SClient with in-memory filtering. This is
-// intentionally different from the production testNonCachingListAllocatedNodesForNAR which
-// uses MatchingFields on a cached client — the non-caching client is needed
-// here so test assertions see the latest API server state without cache delay.
+// intentionally different from the production listAllocatedNodesForNAR in
+// internal/controllers/helpers.go which uses MatchingFields on a cached client
+// — the non-caching client is needed here so test assertions see the latest
+// API server state without cache delay.
 func testNonCachingListAllocatedNodesForNAR(ctx context.Context, narName string) *hwmgmtv1alpha1.AllocatedNodeList {
 	all := &hwmgmtv1alpha1.AllocatedNodeList{}
 	Expect(K8SClient.List(ctx, all, client.InNamespace(constants.DefaultNamespace))).To(Succeed())

--- a/test/utils/vars.go
+++ b/test/utils/vars.go
@@ -467,7 +467,7 @@ var (
 		var bmhs []BMHData
 		for i := 1; i <= masterCount; i++ {
 			bmhs = append(bmhs, BMHData{
-				Name:           fmt.Sprintf("cnfdf%d", i),
+				Name:           fmt.Sprintf("test-master%d", i),
 				Namespace:      "dell-r740-pool",
 				MacAddress:     fmt.Sprintf("aa:bb:cc:11:00:%02x", i),
 				BmcAddress:     fmt.Sprintf("redfish://192.168.1.%d/redfish/v1/Systems/1", 100+i),
@@ -478,7 +478,7 @@ var (
 		}
 		for i := 1; i <= workerCount; i++ {
 			bmhs = append(bmhs, BMHData{
-				Name:           fmt.Sprintf("cnfdg%d", i),
+				Name:           fmt.Sprintf("test-worker%d", i),
 				Namespace:      "dell-xr8620t-pool",
 				MacAddress:     fmt.Sprintf("aa:bb:cc:22:00:%02x", i),
 				BmcAddress:     fmt.Sprintf("redfish://192.168.2.%d/redfish/v1/Systems/1", 100+i),


### PR DESCRIPTION
Phase 1 of test code improvements:

- Rename test fixture prefix "cnfdg"/"cnfdf" to "test-worker"/"test-master" in test/utils/vars.go to avoid confusion with internal lab naming conventions (these names caused confusion during OCPBUGS-85549 investigation)
- Update "cnfdg16" in docs/user-guide/cluster-api.md to generic "my-sno-cluster" example name
- Fix stale test name "Should PR reach HardwareConfigured=True after callback" — remove "after callback" which referenced the removed webhook callback architecture
- Fix self-referential comment in testNonCachingListAllocatedNodesForNAR to correctly reference the production function listAllocatedNodesForNAR in internal/controllers/helpers.go
- Remove misleading TODO comment from test/e2e/bmh_test.go that claimed tests "do not test any actual functionality" — the tests do validate bootMACAddress workflow and BMH state for allocation