### PR TITLE
chore: ignore hive/apis in dependabot to unblock dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,11 @@ updates:
       versions: [">= 0.13.0"]
     - dependency-name: "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
       versions: [">= 0.90.0"]
+    # hive/apis is a Go submodule using pseudo-versions, managed via
+    # .dep-branches.yaml (as a siteconfig alignWith subdep). Dependabot
+    # cannot resolve it and fails the entire dependency graph, blocking
+    # all other updates.
+    - dependency-name: "github.com/openshift/hive/apis"
    groups:
     k8s:
      patterns: ["k8s.io/*", "sigs.k8s.io/*"]


### PR DESCRIPTION
Dependabot cannot resolve github.com/openshift/hive/apis (a Go submodule using pseudo-versions) and fails with "does not contain package github.com/openshift/hive/apis". This blocks the entire dependency graph resolution, preventing all other updates.

This module is managed via .dep-branches.yaml as a siteconfig alignWith subdependency, so dependabot should not be updating it.