### PR TITLE
test: standardize on .ToNot() for negated Gomega assertions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,11 @@ issues during code review.
   `NamespacedName`. `ProvisioningRequest` is cluster-scoped (`scope: Cluster`
   in the CRD) and has no namespace.
 
+## Test Conventions
+
+- Use `.ToNot()` for negated Gomega assertions, not `.NotTo()` or
+  `.ShouldNot()`. The codebase is standardized on `.ToNot()`.
+
 ## Contributing Requirements
 
 - All commits must be signed off with DCO: `git commit -s`

--- a/api/provisioning/v1alpha1/provisioningrequest_webhook_test.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_webhook_test.go
@@ -104,13 +104,13 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 			It("should allow the change when the ProvisioningRequest is fulfilled", func() {
 				newPr.Status.ProvisioningStatus.ProvisioningPhase = StateFulfilled
 				_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("should allow the change when the ProvisioningRequest is failed", func() {
 				newPr.Status.ProvisioningStatus.ProvisioningPhase = StateFailed
 				_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -437,7 +437,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 			}`)
 
 					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("should allow extraLabels changes after completion", func() {
@@ -468,7 +468,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 			}`)
 
 					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("should allow node scaling (adding nodes) after completion", func() {
@@ -502,7 +502,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 			}`)
 
 					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("should allow node scaling (removing nodes) after completion", func() {
@@ -552,7 +552,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 			}`)
 
 					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("should reject immutable field changes after completion", func() {
@@ -621,7 +621,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 			}`)
 
 					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 
@@ -652,7 +652,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 			}`)
 
 					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("should allow all changes when condition is Failed", func() {
@@ -681,7 +681,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 			}`)
 
 					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 		})
@@ -790,7 +790,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 				newPr.Annotations = map[string]string{"new-annotation": "new-value"}
 
 				_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("should reject spec changes when hardware provisioning has failed", func() {
@@ -863,7 +863,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 				}
 
 				_, err := validator.ValidateCreate(ctx, pr)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -963,7 +963,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 				}
 
 				_, err := validator.ValidateCreate(ctx, pr)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("should skip hwProfile validation when PR has no hwMgmtParameters at all", func() {
@@ -985,7 +985,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 				}
 
 				_, err := validator.ValidateCreate(ctx, pr)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("should skip validation when hwMgmtParameters has no nodeGroupData", func() {
@@ -1010,7 +1010,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 				}
 
 				_, err := validator.ValidateCreate(ctx, pr)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("should reject when hwMgmtParameters is not an object", func() {
@@ -1059,7 +1059,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 				}
 
 				_, err := validator.ValidateCreate(ctx, pr)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("should skip validation when nodeGroupData entry has no hwProfile", func() {
@@ -1086,7 +1086,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 				}
 
 				_, err := validator.ValidateCreate(ctx, pr)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("should skip validation when PR has no hwMgmtParameters", func() {
@@ -1108,7 +1108,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 				}
 
 				_, err := validator.ValidateCreate(ctx, pr)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -1210,7 +1210,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 
 			// Should not fail — hwMgmtParameters properties are stripped before schema validation
 			err := pr.ValidateTemplateInputMatchesSchema(ct)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -1227,7 +1227,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 			Expect(fakeClient.Create(ctx, pr)).To(Succeed())
 
 			warnings, err := validator.ValidateDelete(ctx, pr)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(warnings).To(HaveLen(1))
 			Expect(warnings[0]).To(ContainSubstring("several minutes"))
 		})

--- a/internal/controllers/clustertemplate_controller_test.go
+++ b/internal/controllers/clustertemplate_controller_test.go
@@ -1161,7 +1161,7 @@ var _ = Describe("Validate Cluster Instance TemplateID", func() {
 		ct1 := &provisioningv1alpha1.ClusterTemplate{}
 		err = c.Get(ctx, client.ObjectKeyFromObject(ct), ct1)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ct1.Spec.TemplateID).NotTo(Equal(""))
+		Expect(ct1.Spec.TemplateID).ToNot(Equal(""))
 	})
 	It("should validate templateID if is not empty, bad UUID", func() {
 		// Create a valid cluster template
@@ -1961,11 +1961,11 @@ var _ = Describe("validateClusterImageSetMatchesRelease", func() {
 		// Initialize scheme with required types
 		scheme = runtime.NewScheme()
 		err := corev1.AddToScheme(scheme)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		err = provisioningv1alpha1.AddToScheme(scheme)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		err = hivev1.AddToScheme(scheme)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		c = fake.NewClientBuilder().WithScheme(scheme).Build()
 

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Inventory Controller", func() {
 
 			// Set up necessary env variables
 			err := os.Setenv(constants.PostgresImageName, "postgres:test")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Update the testcase objects to include the Namespace.
 			objs = append(objs, ns, ingress, search, cv)

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -2011,7 +2011,7 @@ plan:
 
 				existingCI, canSkip := task.canSkipClusterInstanceRendering(ctx)
 				Expect(canSkip).To(BeTrue())
-				Expect(existingCI).NotTo(BeNil())
+				Expect(existingCI).ToNot(BeNil())
 				Expect(existingCI.Name).To(Equal(clusterName))
 			})
 		})
@@ -2176,8 +2176,8 @@ plan:
 				Expect(c.Create(ctx, ci)).To(Succeed())
 
 				retrievedCI, err := task.getExistingClusterInstance(ctx)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(retrievedCI).NotTo(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(retrievedCI).ToNot(BeNil())
 				Expect(retrievedCI.Name).To(Equal(clusterInstanceName))
 				Expect(retrievedCI.Spec.ClusterName).To(Equal(clusterInstanceName))
 			})
@@ -2287,8 +2287,8 @@ plan:
 			ci, err := task.handleRenderClusterInstance(ctx)
 
 			// Verify
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ci).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ci).ToNot(BeNil())
 			Expect(ci.Name).To(Equal(clusterName))
 			Expect(ci.Spec.ClusterName).To(Equal(clusterName))
 		})

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -1688,7 +1688,7 @@ var _ = Describe("Server predicate functions", func() {
 
 var _ = Describe("TLS cipher suite configuration", func() {
 	It("should derive PFS cipher suites from tls.CipherSuites()", func() {
-		Expect(pfsCipherSuites).NotTo(BeEmpty())
+		Expect(pfsCipherSuites).ToNot(BeEmpty())
 		for _, suite := range pfsCipherSuites {
 			name := tls.CipherSuiteName(suite)
 			Expect(strings.HasPrefix(name, "TLS_ECDHE_")).To(BeTrue(),
@@ -1711,7 +1711,7 @@ var _ = Describe("TLS cipher suite configuration", func() {
 		defer cancel()
 
 		cfg, err := GetClientTLSConfig(ctx, "", "", "")
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg.CipherSuites).To(Equal(pfsCipherSuites))
 	})
 
@@ -1739,15 +1739,15 @@ var _ = Describe("TLS cipher suite configuration", func() {
 		keyFile := filepath.Join(dir, "tls.key")
 
 		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		template := &x509.Certificate{SerialNumber: big.NewInt(1)}
 		certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 		keyDER, err := x509.MarshalECPrivateKey(key)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
 
 		Expect(os.WriteFile(certFile, certPEM, 0o600)).To(Succeed())
@@ -1757,7 +1757,7 @@ var _ = Describe("TLS cipher suite configuration", func() {
 		defer cancel()
 
 		cfg, err := GetServerTLSConfig(ctx, certFile, keyFile)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg.CipherSuites).To(Equal(pfsCipherSuites))
 	})
 

--- a/internal/hardwaremanager/controller/allocatednode_controller_test.go
+++ b/internal/hardwaremanager/controller/allocatednode_controller_test.go
@@ -271,7 +271,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 
 				result, err := reconciler.Reconcile(ctx, req)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(hwmgrutils.DoNotRequeue()))
 			})
 		})
@@ -280,7 +280,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 			It("should add finalizer if not present and not requeue", func() {
 				result, err := reconciler.Reconcile(ctx, req)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(hwmgrutils.DoNotRequeue()))
 
 				// Verify finalizer was added
@@ -296,7 +296,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 
 				result, err := reconciler.Reconcile(ctx, req)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(hwmgrutils.DoNotRequeue()))
 
 				// Verify finalizer is still present
@@ -341,7 +341,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 
 				result, err := reconciler.Reconcile(ctx, req)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(hwmgrutils.DoNotRequeue()))
 			})
 
@@ -352,7 +352,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 				result, err := reconciler.Reconcile(ctx, req)
 
 				// Should complete successfully even if BMH is not found
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(hwmgrutils.DoNotRequeue()))
 			})
 		})
@@ -378,7 +378,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 
 				result, err := reconciler.Reconcile(ctx, req)
 
-				Expect(err).NotTo(HaveOccurred()) // Controller should handle the error gracefully
+				Expect(err).ToNot(HaveOccurred()) // Controller should handle the error gracefully
 				Expect(result).To(Equal(hwmgrutils.RequeueWithShortInterval()))
 			})
 
@@ -398,7 +398,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 
 				result, err := reconciler.Reconcile(ctx, req)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(hwmgrutils.RequeueWithShortInterval()))
 			})
 
@@ -534,7 +534,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 
 				result, err := reconciler.Reconcile(ctx, req)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(hwmgrutils.DoNotRequeue()))
 			})
 		})
@@ -586,13 +586,13 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 				// First call should initiate deallocation and return completed=false
 				completed, err := reconciler.handleAllocatedNodeDeletion(ctx, allocatedNode)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(completed).To(BeFalse()) // First call is not complete, deallocation in progress
 
 				// Second call should detect deallocation is done and return completed=true
 				completed, err = reconciler.handleAllocatedNodeDeletion(ctx, allocatedNode)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(completed).To(BeTrue()) // Second call completes the process
 
 				// Verify BMH was deallocated (check that allocated label is removed)
@@ -614,7 +614,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 				completed, err := reconciler.handleAllocatedNodeDeletion(ctx, allocatedNode)
 
 				// Should complete successfully without error when BMH is not found
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(completed).To(BeTrue()) // Returns true to indicate we should proceed with finalizer removal
 			})
 		})
@@ -628,7 +628,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 				completed, err := reconciler.handleAllocatedNodeDeletion(ctx, allocatedNode)
 
 				// Should complete successfully without error when BMH is not found
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(completed).To(BeTrue())
 			})
 		})
@@ -717,7 +717,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 			It("should return BMH successfully", func() {
 				retrievedBMH, err := getBMHForNode(ctx, fakeClient, allocatedNode)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(retrievedBMH.Name).To(Equal(bmh.Name))
 				Expect(retrievedBMH.Namespace).To(Equal(bmh.Namespace))
 			})
@@ -776,7 +776,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 			It("should deallocate BMH completely", func() {
 				err := deallocateBMH(ctx, fakeClient, logger, bmh, false)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify BMH was deallocated
 				var updatedBMH metal3v1alpha1.BareMetalHost
@@ -842,7 +842,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 			// to capture and verify log output
 			result, err := reconciler.Reconcile(ctx, req)
 
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(hwmgrutils.DoNotRequeue()))
 			// Note: Log verification would require a custom logger implementation
 		})
@@ -856,7 +856,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 
 			// The controller should handle context cancellation appropriately
 			// The exact behavior depends on how the underlying utilities handle context
-			Expect(result).NotTo(BeNil())
+			Expect(result).ToNot(BeNil())
 			Expect(err).To(BeNil()) // Assuming the controller handles cancellation gracefully
 			// Note: Error expectations would depend on implementation specifics
 		})
@@ -876,7 +876,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 		It("should handle resource version conflicts during updates", func() {
 			// First reconciliation should add finalizer
 			result, err := reconciler.Reconcile(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(hwmgrutils.DoNotRequeue()))
 
 			// Get the updated resource version
@@ -885,7 +885,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 
 			// Simulate a second reconciliation with the same request (same resource version)
 			result, err = reconciler.Reconcile(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(hwmgrutils.DoNotRequeue()))
 		})
 	})

--- a/internal/hardwaremanager/controller/baremetalhost_manager_test.go
+++ b/internal/hardwaremanager/controller/baremetalhost_manager_test.go
@@ -216,13 +216,13 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := setBootMACAddressFromLabel(ctx, fakeClient, logger, bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify bootMACAddress was set
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.BootMACAddress).To(Equal(testBootMAC))
 		})
 
@@ -235,13 +235,13 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := setBootMACAddressFromLabel(ctx, fakeClient, logger, bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify bootMACAddress was set to eth1's MAC
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.BootMACAddress).To(Equal("00:11:22:33:44:56"))
 		})
 
@@ -261,13 +261,13 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := setBootMACAddressFromLabel(ctx, fakeClient, logger, bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify bootMACAddress was set using case-insensitive matching
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.BootMACAddress).To(Equal("00:11:22:33:44:aa"))
 		})
 
@@ -281,13 +281,13 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := setBootMACAddressFromLabel(ctx, fakeClient, logger, bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify bootMACAddress was not changed
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.BootMACAddress).To(Equal(testBootMAC))
 		})
 
@@ -300,13 +300,13 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := setBootMACAddressFromLabel(ctx, fakeClient, logger, bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify bootMACAddress was not changed
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.BootMACAddress).To(Equal(testBootMAC))
 		})
 
@@ -375,7 +375,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 			bmh.Spec.BootMACAddress = testBootMAC
 
 			interfaces, err := buildInterfacesFromBMH(bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(interfaces)).To(Equal(2))
 
 			// Find boot interface
@@ -386,7 +386,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 					break
 				}
 			}
-			Expect(bootInterface).NotTo(BeNil())
+			Expect(bootInterface).ToNot(BeNil())
 			Expect(bootInterface.Label).To(Equal(constants.BootInterfaceLabel))
 			Expect(bootInterface.Name).To(Equal("eth0"))
 		})
@@ -397,7 +397,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 			}, nil, metal3v1alpha1.StateAvailable)
 
 			interfaces, err := buildInterfacesFromBMH(bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(interfaces)).To(Equal(2))
 
 			// Find labeled interface
@@ -408,7 +408,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 					break
 				}
 			}
-			Expect(labeledInterface).NotTo(BeNil())
+			Expect(labeledInterface).ToNot(BeNil())
 			Expect(labeledInterface.Label).To(Equal("mgmt"))
 		})
 
@@ -452,24 +452,24 @@ var _ = Describe("BareMetalHost Manager", func() {
 		It("should add label successfully", func() {
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err := updateBMHMetaWithRetry(ctx, fakeClient, logger, name, MetaTypeLabel, "test-key", "test-value", OpAdd)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify label was added
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Labels["test-key"]).To(Equal("test-value"))
 		})
 
 		It("should add annotation successfully", func() {
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err := updateBMHMetaWithRetry(ctx, fakeClient, logger, name, MetaTypeAnnotation, "test-key", "test-value", OpAdd)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify annotation was added
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Annotations["test-key"]).To(Equal("test-value"))
 		})
 
@@ -480,12 +480,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err := updateBMHMetaWithRetry(ctx, fakeClient, logger, name, MetaTypeLabel, "test-key", "", OpRemove)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify label was removed
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			_, exists := updatedBMH.Labels["test-key"]
 			Expect(exists).To(BeFalse())
 		})
@@ -507,7 +507,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 		It("should skip remove operation when map is nil", func() {
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err := updateBMHMetaWithRetry(ctx, fakeClient, logger, name, MetaTypeLabel, "test-key", "", OpRemove)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should skip remove operation when key doesn't exist", func() {
@@ -516,7 +516,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err := updateBMHMetaWithRetry(ctx, fakeClient, logger, name, MetaTypeLabel, "test-key", "", OpRemove)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -533,13 +533,13 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 		It("should mark BMH as allocated", func() {
 			err := markBMHAllocated(ctx, fakeClient, logger, bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify BMH was marked as allocated
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Labels[BmhAllocatedLabel]).To(Equal(ValueTrue))
 		})
 
@@ -548,7 +548,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := markBMHAllocated(ctx, fakeClient, logger, bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -565,13 +565,13 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 		It("should add host management annotation", func() {
 			err := allowHostManagement(ctx, fakeClient, logger, bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify annotation was added
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			_, exists := updatedBMH.Annotations[BmhHostMgmtAnnotation]
 			Expect(exists).To(BeTrue())
 		})
@@ -581,7 +581,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := allowHostManagement(ctx, fakeClient, logger, bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -600,7 +600,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 		It("should return BMH for node successfully", func() {
 			retrievedBMH, err := getBMHForNode(ctx, fakeClient, node)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(retrievedBMH.Name).To(Equal("test-bmh"))
 			Expect(retrievedBMH.Namespace).To(Equal("test-ns"))
 		})
@@ -664,7 +664,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 		It("should fetch only unallocated BMHs", func() {
 			bmhList, err := fetchBMHList(ctx, fakeClient, logger, nodeGroup)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(bmhList.Items)).To(Equal(1))
 			Expect(bmhList.Items[0].Name).To(Equal("bmh2"))
 		})
@@ -710,7 +710,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh1, bmh2, bmh3, hwData1, hwData2, hwData3).Build()
 
 			bmhList, err := fetchBMHList(ctx, fakeClient, logger, nodeGroup)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(bmhList.Items)).To(Equal(1)) // Only bmh2 should match (bmh1 is allocated, bmh3 is pool2)
 		})
 	})
@@ -746,13 +746,13 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 		It("should deallocate BMH successfully", func() {
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify BMH was deallocated correctly
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Check that allocation labels were removed
 			_, hasOwnedBy := updatedBMH.Labels[SiteConfigOwnedByLabel]
@@ -781,12 +781,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(Equal("original-network-data"))
 			_, hasAnnotation := updatedBMH.Annotations[OrigNetworkDataAnnotation]
 			Expect(hasAnnotation).To(BeFalse())
@@ -799,12 +799,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(BeEmpty())
 		})
 
@@ -813,12 +813,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(Equal("some-network-data"))
 		})
 
@@ -836,12 +836,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh, secret).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(Equal(expectedSecretName))
 		})
 
@@ -851,12 +851,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(BeEmpty())
 		})
 
@@ -865,12 +865,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.AutomatedCleaningMode).To(Equal(metal3v1alpha1.CleaningModeMetadata))
 		})
 
@@ -880,12 +880,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.AutomatedCleaningMode).To(Equal(metal3v1alpha1.CleaningModeMetadata))
 			Expect(updatedBMH.Spec.Online).To(BeFalse())
 			Expect(updatedBMH.Annotations[IBIWarningAnnotation]).To(Equal(IBIWarningMessage))
@@ -896,12 +896,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, false)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			_, hasIBIWarning := updatedBMH.Annotations[IBIWarningAnnotation]
 			Expect(hasIBIWarning).To(BeFalse())
 		})
@@ -912,17 +912,17 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, true)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedBMH.Spec.AutomatedCleaningMode).To(BeEmpty())
 			Expect(updatedBMH.Spec.Online).To(BeTrue())
 			// Ensure deploy/image/networkdata were NOT cleared/reset when skipCleanup is true
-			Expect(updatedBMH.Spec.CustomDeploy).NotTo(BeNil())
-			Expect(updatedBMH.Spec.Image).NotTo(BeNil())
+			Expect(updatedBMH.Spec.CustomDeploy).ToNot(BeNil())
+			Expect(updatedBMH.Spec.Image).ToNot(BeNil())
 			Expect(updatedBMH.Spec.PreprovisioningNetworkDataName).To(Equal("old-network-data"))
 		})
 
@@ -933,12 +933,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
 
 			err := finalizeBMHDeallocation(ctx, fakeClient, logger, bmh, true)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			// skipCleanup=true should skip cleaning, power-off, and IBI warning
 			Expect(updatedBMH.Spec.AutomatedCleaningMode).To(BeEmpty())
 			Expect(updatedBMH.Spec.Online).To(BeTrue())
@@ -972,12 +972,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 		It("should remove InfraEnv label from PreprovisioningImage", func() {
 			name := types.NamespacedName{Name: image.Name, Namespace: image.Namespace}
 			err := removeInfraEnvLabelFromPreprovisioningImage(ctx, fakeClient, logger, name)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify label was removed
 			var updatedImage metal3v1alpha1.PreprovisioningImage
 			err = fakeClient.Get(ctx, name, &updatedImage)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			_, exists := updatedImage.Labels[BmhInfraEnvLabel]
 			Expect(exists).To(BeFalse())
 			// Other labels should remain
@@ -993,13 +993,13 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 			name := types.NamespacedName{Name: image.Name, Namespace: image.Namespace}
 			err := removeInfraEnvLabelFromPreprovisioningImage(ctx, fakeClient, logger, name)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify finalizer was removed
 			var updatedImage metal3v1alpha1.PreprovisioningImage
 			err = fakeClient.Get(ctx, name, &updatedImage)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedImage.Finalizers).NotTo(ContainElement(PreprovisioningImageDeprovisionFinalizer))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedImage.Finalizers).ToNot(ContainElement(PreprovisioningImageDeprovisionFinalizer))
 			// Other finalizers should remain
 			Expect(updatedImage.Finalizers).To(ContainElement("other-finalizer"))
 		})
@@ -1010,12 +1010,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 			name := types.NamespacedName{Name: image.Name, Namespace: image.Namespace}
 			err := removeInfraEnvLabelFromPreprovisioningImage(ctx, fakeClient, logger, name)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify other finalizers are untouched
 			var updatedImage metal3v1alpha1.PreprovisioningImage
 			err = fakeClient.Get(ctx, name, &updatedImage)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedImage.Finalizers).To(ContainElement("other-finalizer"))
 		})
 	})
@@ -1033,12 +1033,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 		It("should annotate node with config in progress", func() {
 			err := annotateNodeConfigInProgress(ctx, fakeClient, logger, "test-ns", "test-node", UpdateReasonBIOSSettings)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify annotation was added
 			var updatedNode hwmgmtv1alpha1.AllocatedNode
 			err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-node", Namespace: "test-ns"}, &updatedNode)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedNode.Annotations[ConfigAnnotation]).To(Equal(UpdateReasonBIOSSettings))
 		})
 
@@ -1047,12 +1047,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
 
 			err := annotateNodeConfigInProgress(ctx, fakeClient, logger, "test-ns", "test-node", UpdateReasonFirmware)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify both annotations exist
 			var updatedNode hwmgmtv1alpha1.AllocatedNode
 			err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-node", Namespace: "test-ns"}, &updatedNode)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedNode.Annotations[ConfigAnnotation]).To(Equal(UpdateReasonFirmware))
 			Expect(updatedNode.Annotations["existing"]).To(Equal("value"))
 		})
@@ -1071,13 +1071,13 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 		It("should add reboot annotation to BMH", func() {
 			err := addRebootAnnotation(ctx, fakeClient, logger, bmh)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify annotation was added
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			_, exists := updatedBMH.Annotations[BmhRebootAnnotation]
 			Expect(exists).To(BeTrue())
 		})
@@ -1111,19 +1111,19 @@ var _ = Describe("BareMetalHost Manager", func() {
 		It("should remove InfraEnv label from both BMH and PreprovisioningImage", func() {
 			name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 			err := removeInfraEnvLabel(ctx, fakeClient, logger, name)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify label was removed from BMH
 			var updatedBMH metal3v1alpha1.BareMetalHost
 			err = fakeClient.Get(ctx, name, &updatedBMH)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			_, exists := updatedBMH.Labels[BmhInfraEnvLabel]
 			Expect(exists).To(BeFalse())
 
 			// Verify label was removed from PreprovisioningImage
 			var updatedImage metal3v1alpha1.PreprovisioningImage
 			err = fakeClient.Get(ctx, name, &updatedImage)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			_, exists = updatedImage.Labels[BmhInfraEnvLabel]
 			Expect(exists).To(BeFalse())
 		})
@@ -1207,7 +1207,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 				node.Annotations = nil
 				setConfigAnnotation(node, "test-reason")
 
-				Expect(node.Annotations).NotTo(BeNil())
+				Expect(node.Annotations).ToNot(BeNil())
 				Expect(node.Annotations[ConfigAnnotation]).To(Equal("test-reason"))
 			})
 
@@ -1253,7 +1253,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 		Describe("removeConfigAnnotation", func() {
 			It("should handle nil annotations map gracefully", func() {
 				node.Annotations = nil
-				Expect(func() { removeConfigAnnotation(node) }).NotTo(Panic())
+				Expect(func() { removeConfigAnnotation(node) }).ToNot(Panic())
 			})
 
 			It("should remove config annotation when it exists", func() {
@@ -1270,7 +1270,7 @@ var _ = Describe("BareMetalHost Manager", func() {
 
 			It("should handle non-existent config annotation gracefully", func() {
 				node.Annotations = map[string]string{"other": "value"}
-				Expect(func() { removeConfigAnnotation(node) }).NotTo(Panic())
+				Expect(func() { removeConfigAnnotation(node) }).ToNot(Panic())
 				Expect(node.Annotations["other"]).To(Equal("value"))
 			})
 		})

--- a/internal/hardwaremanager/controller/helpers_test.go
+++ b/internal/hardwaremanager/controller/helpers_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Helpers", func() {
 				setConfigAnnotation(testNode, "test-reason")
 
 				annotations := testNode.GetAnnotations()
-				Expect(annotations).NotTo(BeNil())
+				Expect(annotations).ToNot(BeNil())
 				Expect(annotations[ConfigAnnotation]).To(Equal("test-reason"))
 			})
 
@@ -212,7 +212,7 @@ var _ = Describe("Helpers", func() {
 				removeConfigAnnotation(testNode)
 
 				annotations := testNode.GetAnnotations()
-				Expect(annotations).NotTo(HaveKey(ConfigAnnotation))
+				Expect(annotations).ToNot(HaveKey(ConfigAnnotation))
 				Expect(annotations["other"]).To(Equal("value"))
 			})
 		})
@@ -250,14 +250,14 @@ var _ = Describe("Helpers", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify annotation was removed from in-memory object
-				Expect(allocNode.Annotations).NotTo(HaveKey(ConfigAnnotation))
+				Expect(allocNode.Annotations).ToNot(HaveKey(ConfigAnnotation))
 				Expect(allocNode.Annotations["other"]).To(Equal("value"))
 
 				// Verify the change was persisted
 				updatedNode := &hwmgmtv1alpha1.AllocatedNode{}
 				err = testClient.Get(ctx, types.NamespacedName{Name: "test-node", Namespace: "test-namespace"}, updatedNode)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(updatedNode.Annotations).NotTo(HaveKey(ConfigAnnotation))
+				Expect(updatedNode.Annotations).ToNot(HaveKey(ConfigAnnotation))
 				Expect(updatedNode.Annotations["other"]).To(Equal("value"))
 			})
 
@@ -345,7 +345,7 @@ var _ = Describe("Helpers", func() {
 		It("should create a new AllocatedNode successfully", func() {
 			_, err := createNode(ctx, fakeClient, logger, testNamespace, nodeAllocationRequest,
 				"test-node", "test-node-id", "test-node-ns", "test-group", "test-profile")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify node was created
 			createdNode := &hwmgmtv1alpha1.AllocatedNode{}
@@ -353,7 +353,7 @@ var _ = Describe("Helpers", func() {
 				Name:      "test-node",
 				Namespace: testNamespace,
 			}, createdNode)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createdNode.Spec.GroupName).To(Equal("test-group"))
 			Expect(createdNode.Spec.HwProfile).To(Equal("test-profile"))
 			Expect(createdNode.Spec.HwMgrNodeId).To(Equal("test-node-id"))
@@ -372,7 +372,7 @@ var _ = Describe("Helpers", func() {
 
 			_, err := createNode(ctx, fakeClient, logger, testNamespace, nodeAllocationRequest,
 				"existing-node", "test-node-id", "test-node-ns", "test-group", "test-profile")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify original node wasn't modified
 			retrievedNode := &hwmgmtv1alpha1.AllocatedNode{}
@@ -380,7 +380,7 @@ var _ = Describe("Helpers", func() {
 				Name:      "existing-node",
 				Namespace: testNamespace,
 			}, retrievedNode)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			// Original spec should be empty since we didn't set it
 			Expect(retrievedNode.Spec.GroupName).To(Equal(""))
 		})
@@ -642,13 +642,13 @@ var _ = Describe("Helpers", func() {
 
 		It("should succeed when enough resources are available", func() {
 			err := processNewNodeAllocationRequest(ctx, fakeClient, logger, nodeAllocationRequest)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should skip groups with size 0", func() {
 			nodeAllocationRequest.Spec.NodeGroup[0].Size = 0
 			err := processNewNodeAllocationRequest(ctx, fakeClient, logger, nodeAllocationRequest)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return error when not enough resources are available", func() {
@@ -771,21 +771,21 @@ var _ = Describe("Helpers", func() {
 
 		It("should return true when all groups are fully allocated", func() {
 			result, err := isNodeAllocationRequestFullyAllocated(ctx, fakeNoncached, logger, testNamespace, nodeAllocationRequest)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
 
 		It("should return false when a group is not fully allocated", func() {
 			nodeAllocationRequest.Spec.NodeGroup[0].Size = 3
 			result, err := isNodeAllocationRequestFullyAllocated(ctx, fakeNoncached, logger, testNamespace, nodeAllocationRequest)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
 
 		It("should return true even when NodeNames in status is empty (counts CRs, not status)", func() {
 			nodeAllocationRequest.Status.Properties.NodeNames = nil
 			result, err := isNodeAllocationRequestFullyAllocated(ctx, fakeNoncached, logger, testNamespace, nodeAllocationRequest)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
 
@@ -807,7 +807,7 @@ var _ = Describe("Helpers", func() {
 			fakeNoncached = fakeClient
 
 			result, err := isNodeAllocationRequestFullyAllocated(ctx, fakeNoncached, logger, testNamespace, nodeAllocationRequest)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
 	})
@@ -924,7 +924,7 @@ var _ = Describe("Helpers", func() {
 		Describe("validateFirmwareVersions", func() {
 			It("should return true when firmware versions match", func() {
 				valid, err := validateFirmwareVersions(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeTrue())
 			})
 
@@ -935,7 +935,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHwProfile)).To(Succeed())
 
 				valid, err := validateFirmwareVersions(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeTrue())
 			})
 
@@ -945,7 +945,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHFC)).To(Succeed())
 
 				valid, err := validateFirmwareVersions(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
 			})
 
@@ -954,7 +954,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Delete(ctx, testHFC)).To(Succeed())
 
 				valid, err := validateFirmwareVersions(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
 			})
 
@@ -968,7 +968,7 @@ var _ = Describe("Helpers", func() {
 		Describe("validateAppliedBiosSettings", func() {
 			It("should return true when BIOS settings match", func() {
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeTrue())
 			})
 
@@ -978,7 +978,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHwProfile)).To(Succeed())
 
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeTrue())
 			})
 
@@ -988,7 +988,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHFS)).To(Succeed())
 
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
 			})
 
@@ -998,7 +998,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHFS)).To(Succeed())
 
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
 			})
 
@@ -1007,13 +1007,13 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Delete(ctx, testHFS)).To(Succeed())
 
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
 			})
 
 			It("should return true when NIC firmware versions match", func() {
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeTrue())
 			})
 
@@ -1023,7 +1023,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHwProfile)).To(Succeed())
 
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeTrue())
 			})
 
@@ -1033,7 +1033,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHFC)).To(Succeed())
 
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
 			})
 
@@ -1043,7 +1043,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHFC)).To(Succeed())
 
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
 			})
 
@@ -1052,7 +1052,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Delete(ctx, testHFC)).To(Succeed())
 
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
 			})
 
@@ -1067,7 +1067,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHwProfile)).To(Succeed())
 
 				valid, err := validateAppliedBiosSettings(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeTrue())
 			})
 		})
@@ -1075,7 +1075,7 @@ var _ = Describe("Helpers", func() {
 		Describe("validateNodeConfiguration", func() {
 			It("should return true when both firmware and BIOS validation pass", func() {
 				valid, err := validateNodeConfiguration(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeTrue())
 			})
 
@@ -1085,7 +1085,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHFC)).To(Succeed())
 
 				valid, err := validateNodeConfiguration(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
 			})
 
@@ -1095,7 +1095,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHFS)).To(Succeed())
 
 				valid, err := validateNodeConfiguration(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
 			})
 
@@ -1107,7 +1107,7 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Update(ctx, testHwProfile)).To(Succeed())
 
 				valid, err := validateNodeConfiguration(ctx, testClient, testClient, logger, testBMH, testNamespace, "test-profile")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeTrue())
 			})
 
@@ -1462,14 +1462,14 @@ var _ = Describe("Helpers", func() {
 				Expect(testClient.Get(ctx, nodeKey, updatedNode)).To(Succeed())
 
 				// The annotation should be removed
-				Expect(updatedNode.Annotations).NotTo(HaveKey(ConfigAnnotation))
+				Expect(updatedNode.Annotations).ToNot(HaveKey(ConfigAnnotation))
 
 				// Verify requeue result (should not requeue on terminal error)
 				Expect(result.Requeue).To(BeFalse())
 
 				// Verify node condition was updated to Failed
 				cond := meta.FindStatusCondition(updatedNode.Status.Conditions, string(hwmgmtv1alpha1.Configured))
-				Expect(cond).NotTo(BeNil())
+				Expect(cond).ToNot(BeNil())
 				Expect(cond.Reason).To(Equal(string(hwmgmtv1alpha1.Failed)))
 				Expect(cond.Message).To(Equal(BmhServicingErr))
 			})
@@ -1501,7 +1501,7 @@ var _ = Describe("Helpers", func() {
 
 				// Verify node condition message was updated to NodeWaitingBMHComplete
 				cond := meta.FindStatusCondition(updatedNode.Status.Conditions, string(hwmgmtv1alpha1.Configured))
-				Expect(cond).NotTo(BeNil())
+				Expect(cond).ToNot(BeNil())
 				Expect(cond.Reason).To(Equal(string(hwmgmtv1alpha1.ConfigUpdate)))
 				Expect(cond.Message).To(Equal(string(hwmgmtv1alpha1.NodeWaitingBMHComplete)))
 			})
@@ -1525,12 +1525,12 @@ var _ = Describe("Helpers", func() {
 				updatedNode := &hwmgmtv1alpha1.AllocatedNode{}
 				nodeKey := types.NamespacedName{Name: testNode.Name, Namespace: testNode.Namespace}
 				Expect(testClient.Get(ctx, nodeKey, updatedNode)).To(Succeed())
-				Expect(updatedNode.Annotations).NotTo(HaveKey(ConfigAnnotation))
+				Expect(updatedNode.Annotations).ToNot(HaveKey(ConfigAnnotation))
 
 				Expect(updatedNode.Status.HwProfile).To(Equal("test-hw-profile"))
 				// Verify node condition was updated to ConfigApplied
 				cond := meta.FindStatusCondition(updatedNode.Status.Conditions, string(hwmgmtv1alpha1.Configured))
-				Expect(cond).NotTo(BeNil())
+				Expect(cond).ToNot(BeNil())
 				Expect(cond.Reason).To(Equal(string(hwmgmtv1alpha1.ConfigApplied)))
 				Expect(cond.Message).To(Equal(string(hwmgmtv1alpha1.ConfigSuccess)))
 			})
@@ -1561,7 +1561,7 @@ var _ = Describe("Helpers", func() {
 
 				// Verify node condition message was updated to NodeWaitingReady
 				cond := meta.FindStatusCondition(updatedNode.Status.Conditions, string(hwmgmtv1alpha1.Configured))
-				Expect(cond).NotTo(BeNil())
+				Expect(cond).ToNot(BeNil())
 				Expect(cond.Reason).To(Equal(string(hwmgmtv1alpha1.ConfigUpdate)))
 				Expect(cond.Message).To(Equal(string(hwmgmtv1alpha1.NodeWaitingReady)))
 			})

--- a/internal/hardwaremanager/controller/hostfirmwarecomponents_manager_test.go
+++ b/internal/hardwaremanager/controller/hostfirmwarecomponents_manager_test.go
@@ -686,11 +686,11 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 				}
 			}
 
-			Expect(biosUpdate).NotTo(BeNil())
+			Expect(biosUpdate).ToNot(BeNil())
 			Expect(biosUpdate.Component).To(Equal("bios"))
 			Expect(biosUpdate.URL).To(Equal("https://example.com/bios.bin"))
 
-			Expect(bmcUpdate).NotTo(BeNil())
+			Expect(bmcUpdate).ToNot(BeNil())
 			Expect(bmcUpdate.Component).To(Equal("bmc"))
 			Expect(bmcUpdate.URL).To(Equal("https://example.com/bmc.bin"))
 		})
@@ -841,7 +841,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 
 			hfc, err := createHostFirmwareComponents(ctx, fakeClient, bmh, spec)
 			Expect(err).To(BeNil())
-			Expect(hfc).NotTo(BeNil())
+			Expect(hfc).ToNot(BeNil())
 			Expect(hfc.Name).To(Equal("test-bmh"))
 			Expect(hfc.Namespace).To(Equal("test-namespace"))
 			Expect(hfc.Spec.Updates).To(HaveLen(1))
@@ -861,7 +861,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 
 			hfc, err := createHostFirmwareComponents(ctx, fakeClient, bmh, spec)
 			Expect(err).To(BeNil())
-			Expect(hfc).NotTo(BeNil())
+			Expect(hfc).ToNot(BeNil())
 			Expect(hfc.Spec.Updates).To(BeEmpty())
 		})
 	})
@@ -926,7 +926,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 
 			retrievedHFC, err := getHostFirmwareComponents(ctx, fakeClient, "test-bmh", "test-namespace")
 			Expect(err).To(BeNil())
-			Expect(retrievedHFC).NotTo(BeNil())
+			Expect(retrievedHFC).ToNot(BeNil())
 			Expect(retrievedHFC.Name).To(Equal("test-bmh"))
 			Expect(retrievedHFC.Namespace).To(Equal("test-namespace"))
 		})
@@ -1157,7 +1157,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).NotTo(BeNil())
+			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("BIOS firmware update requested but BIOS component not found"))
 		})
 
@@ -1176,7 +1176,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).NotTo(BeNil())
+			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("BMC firmware update requested but BMC component not found"))
 		})
 
@@ -1194,7 +1194,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).NotTo(BeNil())
+			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("NIC firmware update requested but no NIC components found"))
 		})
 
@@ -1215,7 +1215,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).NotTo(BeNil())
+			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("NIC firmware update requested for 3 NICs but only 1 NIC components found"))
 		})
 
@@ -1287,7 +1287,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).NotTo(BeNil())
+			Expect(err).ToNot(BeNil())
 			// Should fail on first missing component (BIOS)
 			Expect(err.Error()).To(ContainSubstring("BIOS firmware update requested but BIOS component not found"))
 		})

--- a/internal/hardwaremanager/controller/hostupdatepolicy_manager_test.go
+++ b/internal/hardwaremanager/controller/hostupdatepolicy_manager_test.go
@@ -87,13 +87,13 @@ var _ = Describe("HostUpdatePolicy Manager", func() {
 		Context("when HostUpdatePolicy does not exist", func() {
 			It("should create a new HostUpdatePolicy with firmware updates only", func() {
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, bmh, true, false)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify the policy was created
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(policy.Name).To(Equal(bmh.Name))
 				Expect(policy.Namespace).To(Equal(bmh.Namespace))
 				Expect(policy.Spec.FirmwareUpdates).To(Equal(metal3v1alpha1.HostUpdatePolicyOnReboot))
@@ -102,13 +102,13 @@ var _ = Describe("HostUpdatePolicy Manager", func() {
 
 			It("should create a new HostUpdatePolicy with BIOS updates only", func() {
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, bmh, false, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify the policy was created
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(policy.Name).To(Equal(bmh.Name))
 				Expect(policy.Namespace).To(Equal(bmh.Namespace))
 				Expect(policy.Spec.FirmwareUpdates).To(BeEmpty())
@@ -117,13 +117,13 @@ var _ = Describe("HostUpdatePolicy Manager", func() {
 
 			It("should create a new HostUpdatePolicy with both firmware and BIOS updates", func() {
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, bmh, true, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify the policy was created
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(policy.Name).To(Equal(bmh.Name))
 				Expect(policy.Namespace).To(Equal(bmh.Namespace))
 				Expect(policy.Spec.FirmwareUpdates).To(Equal(metal3v1alpha1.HostUpdatePolicyOnReboot))
@@ -132,13 +132,13 @@ var _ = Describe("HostUpdatePolicy Manager", func() {
 
 			It("should create a new HostUpdatePolicy with empty spec when no updates required", func() {
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, bmh, false, false)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify the policy was created
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(policy.Name).To(Equal(bmh.Name))
 				Expect(policy.Namespace).To(Equal(bmh.Namespace))
 				Expect(policy.Spec.FirmwareUpdates).To(BeEmpty())
@@ -165,26 +165,26 @@ var _ = Describe("HostUpdatePolicy Manager", func() {
 
 			It("should update the policy when firmware updates requirement changes", func() {
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, bmh, false, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify the policy was updated
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(policy.Spec.FirmwareUpdates).To(BeEmpty())
 				Expect(policy.Spec.FirmwareSettings).To(Equal(metal3v1alpha1.HostUpdatePolicyOnReboot))
 			})
 
 			It("should update the policy when BIOS updates requirement is added", func() {
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, bmh, true, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify the policy was updated
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(policy.Spec.FirmwareUpdates).To(Equal(metal3v1alpha1.HostUpdatePolicyOnReboot))
 				Expect(policy.Spec.FirmwareSettings).To(Equal(metal3v1alpha1.HostUpdatePolicyOnReboot))
 			})
@@ -192,26 +192,26 @@ var _ = Describe("HostUpdatePolicy Manager", func() {
 			It("should not update the policy when spec is already correct", func() {
 				// Policy already has firmware updates = "onReboot", call with same requirements
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, bmh, true, false)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify the policy was not changed
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(policy.Spec.FirmwareUpdates).To(Equal(metal3v1alpha1.HostUpdatePolicyOnReboot))
 				Expect(policy.Spec.FirmwareSettings).To(BeEmpty())
 			})
 
 			It("should clear both settings when no updates are required", func() {
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, bmh, false, false)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify the policy was updated to have empty spec
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(policy.Spec.FirmwareUpdates).To(BeEmpty())
 				Expect(policy.Spec.FirmwareSettings).To(BeEmpty())
 			})
@@ -239,13 +239,13 @@ var _ = Describe("HostUpdatePolicy Manager", func() {
 				}
 
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, differentBmh, true, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify the policy was created with correct name and namespace
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: differentBmh.Name, Namespace: differentBmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(policy.Name).To(Equal(differentBmh.Name))
 				Expect(policy.Namespace).To(Equal(differentBmh.Namespace))
 				Expect(policy.Spec.FirmwareUpdates).To(Equal(metal3v1alpha1.HostUpdatePolicyOnReboot))
@@ -261,13 +261,13 @@ var _ = Describe("HostUpdatePolicy Manager", func() {
 				}
 
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, specialBmh, false, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify the policy was created with the special name
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: specialBmh.Name, Namespace: specialBmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(policy.Name).To(Equal(specialBmh.Name))
 				Expect(policy.Spec.FirmwareSettings).To(Equal(metal3v1alpha1.HostUpdatePolicyOnReboot))
 			})
@@ -276,34 +276,34 @@ var _ = Describe("HostUpdatePolicy Manager", func() {
 		Context("spec validation", func() {
 			It("should set correct values for firmware updates", func() {
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, bmh, true, false)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify that the firmware updates field is set to exactly HostUpdatePolicyOnReboot
 				Expect(policy.Spec.FirmwareUpdates).To(Equal(metal3v1alpha1.HostUpdatePolicyOnReboot))
 				Expect(string(policy.Spec.FirmwareUpdates)).To(Equal("onReboot"))
-				Expect(string(policy.Spec.FirmwareUpdates)).NotTo(Equal("OnReboot"))
-				Expect(string(policy.Spec.FirmwareUpdates)).NotTo(Equal("onreboot"))
+				Expect(string(policy.Spec.FirmwareUpdates)).ToNot(Equal("OnReboot"))
+				Expect(string(policy.Spec.FirmwareUpdates)).ToNot(Equal("onreboot"))
 			})
 
 			It("should set correct values for BIOS updates", func() {
 				err := createOrUpdateHostUpdatePolicy(ctx, fakeClient, logger, bmh, false, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				policy := &metal3v1alpha1.HostUpdatePolicy{}
 				key := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 				err = fakeClient.Get(ctx, key, policy)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Verify that the firmware settings field is set to exactly HostUpdatePolicyOnReboot
 				Expect(policy.Spec.FirmwareSettings).To(Equal(metal3v1alpha1.HostUpdatePolicyOnReboot))
 				Expect(string(policy.Spec.FirmwareSettings)).To(Equal("onReboot"))
-				Expect(string(policy.Spec.FirmwareSettings)).NotTo(Equal("OnReboot"))
-				Expect(string(policy.Spec.FirmwareSettings)).NotTo(Equal("onreboot"))
+				Expect(string(policy.Spec.FirmwareSettings)).ToNot(Equal("OnReboot"))
+				Expect(string(policy.Spec.FirmwareSettings)).ToNot(Equal("onreboot"))
 			})
 		})
 	})

--- a/internal/hardwaremanager/controller/resource_selection_test.go
+++ b/internal/hardwaremanager/controller/resource_selection_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Resource Selection", func() {
 			}
 
 			opts, err := ResourceSelectionPrimaryFilter(ctx, nil, logger, nodeGroupData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			matchingLabels, ok := opts[1].(client.MatchingLabels)
 			Expect(ok).To(BeTrue())
@@ -95,7 +95,7 @@ var _ = Describe("Resource Selection", func() {
 			}
 
 			opts, err := ResourceSelectionPrimaryFilter(ctx, nil, logger, nodeGroupData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			matchingLabels, ok := opts[1].(client.MatchingLabels)
 			Expect(ok).To(BeTrue())
@@ -111,7 +111,7 @@ var _ = Describe("Resource Selection", func() {
 			}
 
 			opts, err := ResourceSelectionPrimaryFilter(ctx, nil, logger, nodeGroupData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Check that the label selector excludes allocated BMHs
 			labelSelector, ok := opts[0].(client.MatchingLabelsSelector)
@@ -153,7 +153,7 @@ var _ = Describe("Resource Selection", func() {
 			}
 
 			result, err := ResourceSelectionSecondaryFilter(ctx, fakeClient, logger, nodeGroupData, bmhList)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(result.Items)).To(Equal(0)) // No hardware data available, so no BMHs pass
 		})
 
@@ -192,7 +192,7 @@ var _ = Describe("Resource Selection", func() {
 			}
 
 			result, err := ResourceSelectionSecondaryFilter(ctx, fakeClient, logger, nodeGroupData, bmhList)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(result.Items)).To(Equal(1))
 			Expect(result.Items[0].Name).To(Equal("bmh1"))
 		})
@@ -212,7 +212,7 @@ var _ = Describe("Resource Selection", func() {
 			}
 
 			result, err := ResourceSelectionSecondaryFilter(ctx, fakeClient, logger, nodeGroupData, bmhList)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(result.Items)).To(Equal(0))
 		})
 	})
@@ -222,7 +222,7 @@ var _ = Describe("Resource Selection", func() {
 			hwData := createHardwareData("test", "test-ns", &metal3v1alpha1.HardwareDetails{})
 
 			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, "zone", "east", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
 
@@ -232,11 +232,11 @@ var _ = Describe("Resource Selection", func() {
 			})
 
 			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldCPUArch, "x86_64", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 
 			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldCPUArch, "arm64", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
 
@@ -246,11 +246,11 @@ var _ = Describe("Resource Selection", func() {
 			})
 
 			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldCPUModel, "Intel Xeon", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 
 			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldCPUModel, "AMD EPYC", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
 
@@ -260,15 +260,15 @@ var _ = Describe("Resource Selection", func() {
 			})
 
 			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldNumThreads, "8", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 
 			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldNumThreads+";gt", "4", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 
 			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldNumThreads+";lt", "4", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
 
@@ -278,11 +278,11 @@ var _ = Describe("Resource Selection", func() {
 			})
 
 			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldRAM, "16384", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 
 			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldRAM+";gte", "8192", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
 
@@ -294,11 +294,11 @@ var _ = Describe("Resource Selection", func() {
 			})
 
 			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldManufacturer, "Dell Inc.", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 
 			result, err = ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldManufacturer, "HP", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
 
@@ -310,7 +310,7 @@ var _ = Describe("Resource Selection", func() {
 			})
 
 			result, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldProductName, "PowerEdge R640", hwData)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
 
@@ -435,11 +435,11 @@ var _ = Describe("Resource Selection", func() {
 				defer func() {
 					if r := recover(); r != nil {
 						// This is expected behavior when hardware details is nil
-						Expect(r).NotTo(BeNil())
+						Expect(r).ToNot(BeNil())
 					}
 				}()
 				_, err := ResourceSelectionSecondaryFilterHardwareData(ctx, nil, logger, HardwareDataPrefix+FieldCPUArch, "x86_64", hwData)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			}()
 		})
 	})
@@ -484,89 +484,89 @@ var _ = Describe("Resource Selection", func() {
 		Describe("checkIntWithQualifiers", func() {
 			It("should match exact values by default", func() {
 				result, err := checkIntWithQualifiers([]string{}, "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{}, "8", 4)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should handle greater than comparisons", func() {
 				result, err := checkIntWithQualifiers([]string{"gt"}, "4", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{">"}, "4", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{"gt"}, "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should handle greater than or equal comparisons", func() {
 				result, err := checkIntWithQualifiers([]string{"gte"}, "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{">="}, "8", 16)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{"gte"}, "16", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should handle less than comparisons", func() {
 				result, err := checkIntWithQualifiers([]string{"lt"}, "16", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{"<"}, "16", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{"lt"}, "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should handle less than or equal comparisons", func() {
 				result, err := checkIntWithQualifiers([]string{"lte"}, "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{"<="}, "16", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{"lte"}, "4", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should handle equality and inequality", func() {
 				result, err := checkIntWithQualifiers([]string{"eq"}, "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{"=="}, "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{"neq"}, "8", 4)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{"!="}, "8", 4)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithQualifiers([]string{"neq"}, "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
@@ -604,55 +604,55 @@ var _ = Describe("Resource Selection", func() {
 
 			It("should filter by model", func() {
 				result, err := checkNicsWithQualifiers([]string{"model=Intel E1000"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkNicsWithQualifiers([]string{"model!=Intel E1000"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue()) // Should match other NICs
 
 				result, err = checkNicsWithQualifiers([]string{"model=NonExistent"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should filter by speed", func() {
 				result, err := checkNicsWithQualifiers([]string{"speedGbps==10"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkNicsWithQualifiers([]string{"speedGbps>5"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkNicsWithQualifiers([]string{"speedGbps>20"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should filter by count", func() {
 				result, err := checkNicsWithQualifiers([]string{"count==3"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkNicsWithQualifiers([]string{"count>=2"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkNicsWithQualifiers([]string{"count>5"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should combine multiple criteria", func() {
 				// Should match Intel NICs with speed >= 10
 				result, err := checkNicsWithQualifiers([]string{"model~Intel", "speedGbps>=10"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				// Should count NICs with speed >= 10 and check if count >= 2
 				result, err = checkNicsWithQualifiers([]string{"speedGbps>=10", "count>=2"}, "present", nics, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 			})
 
@@ -725,49 +725,49 @@ var _ = Describe("Resource Selection", func() {
 
 			It("should filter by storage type", func() {
 				result, err := checkStorageWithQualifiers([]string{"type=HDD"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStorageWithQualifiers([]string{"type=SSD"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStorageWithQualifiers([]string{"type=NVME"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should filter by size", func() {
 				result, err := checkStorageWithQualifiers([]string{"sizeBytes>600000000000"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStorageWithQualifiers([]string{"sizeBytes<400000000000"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should filter by vendor", func() {
 				result, err := checkStorageWithQualifiers([]string{"vendor=Seagate"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStorageWithQualifiers([]string{"vendor~Sam"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStorageWithQualifiers([]string{"vendor=Intel"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should filter by model", func() {
 				result, err := checkStorageWithQualifiers([]string{"model=ST1000"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStorageWithQualifiers([]string{"model~EVO"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 			})
 
@@ -775,41 +775,41 @@ var _ = Describe("Resource Selection", func() {
 				storage[0].AlternateNames = []string{"disk1", "primary-disk"}
 
 				result, err := checkStorageWithQualifiers([]string{"name=sda"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStorageWithQualifiers([]string{"name=disk1"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStorageWithQualifiers([]string{"name=nonexistent"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should filter by count", func() {
 				result, err := checkStorageWithQualifiers([]string{"count==2"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStorageWithQualifiers([]string{"count>=1"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStorageWithQualifiers([]string{"count>5"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should combine multiple criteria", func() {
 				// Should count SSD devices and verify count >= 1
 				result, err := checkStorageWithQualifiers([]string{"type=SSD", "count>=1"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				// Should match devices with size > 600GB and vendor Seagate
 				result, err = checkStorageWithQualifiers([]string{"sizeBytes>600000000000", "vendor=Seagate"}, "present", storage, true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 			})
 
@@ -881,7 +881,7 @@ var _ = Describe("Resource Selection", func() {
 				qualifiers := []string{"model=Intel", "speedGbps>10"}
 
 				result, err := qualifierSetFromQualifiers(qualifiers)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(len(result)).To(Equal(2))
 				Expect(result["model"].Op).To(Equal("="))
 				Expect(result["model"].Value).To(Equal("Intel"))
@@ -893,7 +893,7 @@ var _ = Describe("Resource Selection", func() {
 				qualifiers := []string{"size>=1000", "name!=sda", "vendor~Samsung"}
 
 				result, err := qualifierSetFromQualifiers(qualifiers)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result["size"].Op).To(Equal(">="))
 				Expect(result["size"].Value).To(Equal("1000"))
 				Expect(result["name"].Op).To(Equal("!="))
@@ -916,29 +916,29 @@ var _ = Describe("Resource Selection", func() {
 		Describe("checkStringWithOpQualifier", func() {
 			It("should handle equality operators", func() {
 				result, err := checkStringWithOpQualifier("=", "test", "test", true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStringWithOpQualifier("!=", "test", "other", true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStringWithOpQualifier("!=", "test", "test", true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
 			It("should handle substring operators", func() {
 				result, err := checkStringWithOpQualifier("~", "tel", "Intel", true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStringWithOpQualifier("!~", "AMD", "Intel", true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkStringWithOpQualifier("!~", "tel", "Intel", true)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
 
@@ -954,27 +954,27 @@ var _ = Describe("Resource Selection", func() {
 		Describe("checkIntWithOpQualifier", func() {
 			It("should handle all comparison operators", func() {
 				result, err := checkIntWithOpQualifier("==", "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithOpQualifier("!=", "8", 4)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithOpQualifier(">", "4", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithOpQualifier(">=", "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithOpQualifier("<", "16", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 
 				result, err = checkIntWithOpQualifier("<=", "8", 8)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
 			})
 

--- a/internal/hardwaremanager/utils/allocated_node_test.go
+++ b/internal/hardwaremanager/utils/allocated_node_test.go
@@ -172,19 +172,19 @@ var _ = Describe("AllocatedNode Utilities", func() {
 			It("should generate different names for different BMH names", func() {
 				result1 := GenerateNodeName(clusterID, bmhNamespace, "master-0")
 				result2 := GenerateNodeName(clusterID, bmhNamespace, "master-1")
-				Expect(result1).NotTo(Equal(result2))
+				Expect(result1).ToNot(Equal(result2))
 			})
 
 			It("should generate different names for different namespaces", func() {
 				result1 := GenerateNodeName(clusterID, "namespace1", bmhName)
 				result2 := GenerateNodeName(clusterID, "namespace2", bmhName)
-				Expect(result1).NotTo(Equal(result2))
+				Expect(result1).ToNot(Equal(result2))
 			})
 
 			It("should generate different names for different cluster IDs", func() {
 				result1 := GenerateNodeName("cluster1", bmhNamespace, bmhName)
 				result2 := GenerateNodeName("cluster2", bmhNamespace, bmhName)
-				Expect(result1).NotTo(Equal(result2))
+				Expect(result1).ToNot(Equal(result2))
 			})
 		})
 
@@ -227,14 +227,14 @@ var _ = Describe("AllocatedNode Utilities", func() {
 				longName2 := strings.Repeat("b", 300)
 				result1 := GenerateNodeName(longName1, "namespace", "bmh")
 				result2 := GenerateNodeName(longName2, "namespace", "bmh")
-				Expect(result1).NotTo(Equal(result2))
+				Expect(result1).ToNot(Equal(result2))
 			})
 		})
 
 		Context("when inputs result in empty sanitized name", func() {
 			It("should use hash-based fallback for empty sanitized names", func() {
 				result := GenerateNodeName("###", "!!!", "%%%")
-				Expect(result).NotTo(BeEmpty())
+				Expect(result).ToNot(BeEmpty())
 				Expect(len(result)).To(BeNumerically("<=", 253))
 				Expect(result).To(MatchRegexp("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"))
 			})
@@ -249,7 +249,7 @@ var _ = Describe("AllocatedNode Utilities", func() {
 		Context("when testing edge cases", func() {
 			It("should handle empty strings", func() {
 				result := GenerateNodeName("", "", "")
-				Expect(result).NotTo(BeEmpty())
+				Expect(result).ToNot(BeEmpty())
 				Expect(result).To(MatchRegexp("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"))
 			})
 
@@ -260,7 +260,7 @@ var _ = Describe("AllocatedNode Utilities", func() {
 
 			It("should handle names with only hyphens", func() {
 				result := GenerateNodeName("---", "---", "---")
-				Expect(result).NotTo(BeEmpty())
+				Expect(result).ToNot(BeEmpty())
 				Expect(result).To(MatchRegexp("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"))
 			})
 		})

--- a/internal/service/alarms/api/server_test.go
+++ b/internal/service/alarms/api/server_test.go
@@ -74,7 +74,7 @@ var _ = Describe("AlarmsServer", func() {
 					AlarmEventRecordId: testUUID,
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(alarmapi.GetAlarm404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -90,7 +90,7 @@ var _ = Describe("AlarmsServer", func() {
 					AlarmEventRecordId: testUUID,
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(alarmapi.GetAlarm200JSONResponse{}))
 			})
 		})
@@ -121,7 +121,7 @@ var _ = Describe("AlarmsServer", func() {
 					},
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(alarmapi.CreateSubscription409ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -138,11 +138,11 @@ var _ = Describe("AlarmsServer", func() {
 					},
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(alarmapi.CreateSubscription400ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusBadRequest))
 				Expect(problemResp.AdditionalAttributes).To(BeNil())
-				Expect(problemResp.Detail).NotTo(ContainSubstring(callbackURL))
+				Expect(problemResp.Detail).ToNot(ContainSubstring(callbackURL))
 			})
 		})
 
@@ -162,12 +162,12 @@ var _ = Describe("AlarmsServer", func() {
 					},
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(alarmapi.CreateSubscription400ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusBadRequest))
-				Expect(problemResp.Detail).NotTo(ContainSubstring(callbackURL))
-				Expect(problemResp.Detail).NotTo(ContainSubstring("192.0.2.1"))
-				Expect(problemResp.Detail).NotTo(ContainSubstring("secret=token123"))
+				Expect(problemResp.Detail).ToNot(ContainSubstring(callbackURL))
+				Expect(problemResp.Detail).ToNot(ContainSubstring("192.0.2.1"))
+				Expect(problemResp.Detail).ToNot(ContainSubstring("secret=token123"))
 			})
 		})
 
@@ -193,7 +193,7 @@ var _ = Describe("AlarmsServer", func() {
 					},
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(alarmapi.CreateSubscription400ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusBadRequest))
 				Expect(problemResp.Detail).To(Equal("callback value must be unique"))

--- a/internal/service/alarms/internal/alertmanager/api_test.go
+++ b/internal/service/alarms/internal/alertmanager/api_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Alertmanager API Client", func() {
 		tempDir := GinkgoT().TempDir()
 		tempTokenFile = tempDir + "/token"
 		err := os.WriteFile(tempTokenFile, []byte("fake-token"), 0o600)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		// Extract server certificate for use in our fake CA file
 		certPEM := pem.EncodeToMemory(&pem.Block{
@@ -81,7 +81,7 @@ var _ = Describe("Alertmanager API Client", func() {
 		// Create temporary CA file with the test server's certificate
 		tempCAFile := tempDir + "/ca.crt"
 		err = os.WriteFile(tempCAFile, certPEM, 0o600)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		// Extract server hostname from test server URL without the scheme
 		serverHost := mockAMServer.URL[8:] // Skip "https://"
@@ -160,7 +160,7 @@ var _ = Describe("Alertmanager API Client", func() {
 			err := amClient.SyncAlerts(ctx)
 
 			// Then
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should handle empty alerts gracefully", func() {
@@ -168,7 +168,7 @@ var _ = Describe("Alertmanager API Client", func() {
 			err := amClient.SyncAlerts(ctx)
 
 			// Assert
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should handle API errors appropriately", func() {
@@ -245,7 +245,7 @@ var _ = Describe("Alertmanager API Client", func() {
 				err = fmt.Errorf("timed out waiting for scheduler to return")
 			}
 
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/internal/service/alarms/internal/alertmanager/config_test.go
+++ b/internal/service/alarms/internal/alertmanager/config_test.go
@@ -72,7 +72,7 @@ route:
 			},
 		}
 		err := c.Create(ctx, secret)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -83,11 +83,11 @@ route:
 	Describe("Setup", func() {
 		It("verifies that the alertmanager.yaml key is populated", func() {
 			err := alertmanager.Setup(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			secret := &corev1.Secret{}
 			err = c.Get(ctx, client.ObjectKey{Namespace: alertmanager.ACMObsAMNamespace, Name: alertmanager.ACMObsAMSecretName}, secret)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Expected configuration for comparison.
 			mergedconfig := `
@@ -127,10 +127,10 @@ route:
       receiver: "null"
 `
 			var config map[string]interface{}
-			Expect(yaml.Unmarshal(secret.Data[alertmanager.ACMObsAMSecretKey], &config)).NotTo(HaveOccurred())
+			Expect(yaml.Unmarshal(secret.Data[alertmanager.ACMObsAMSecretKey], &config)).ToNot(HaveOccurred())
 
 			var expectedConf map[string]interface{}
-			Expect(yaml.Unmarshal([]byte(mergedconfig), &expectedConf)).NotTo(HaveOccurred())
+			Expect(yaml.Unmarshal([]byte(mergedconfig), &expectedConf)).ToNot(HaveOccurred())
 
 			Expect(config).To(Equal(expectedConf))
 		})
@@ -139,11 +139,11 @@ route:
 			// Retrieve the secret and remove the alertmanager.yaml key.
 			secret := &corev1.Secret{}
 			err := c.Get(ctx, client.ObjectKey{Namespace: alertmanager.ACMObsAMNamespace, Name: alertmanager.ACMObsAMSecretName}, secret)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			secret.Data = map[string][]byte{} // remove the key
 			err = c.Update(ctx, secret)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			err = alertmanager.Setup(ctx)
 			Expect(err).To(HaveOccurred())
@@ -152,17 +152,17 @@ route:
 		It("does not duplicate oran configuration when run multiple times", func() {
 			// Run Setup twice.
 			err := alertmanager.Setup(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			err = alertmanager.Setup(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			secret := &corev1.Secret{}
 			err = c.Get(ctx, client.ObjectKey{Namespace: alertmanager.ACMObsAMNamespace, Name: alertmanager.ACMObsAMSecretName}, secret)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var config map[string]interface{}
-			Expect(yaml.Unmarshal(secret.Data[alertmanager.ACMObsAMSecretKey], &config)).NotTo(HaveOccurred())
+			Expect(yaml.Unmarshal(secret.Data[alertmanager.ACMObsAMSecretKey], &config)).ToNot(HaveOccurred())
 
 			receivers, ok := config["receivers"].([]interface{})
 			Expect(ok).To(BeTrue())
@@ -181,7 +181,7 @@ route:
 			// Update the secret with an extra receiver and route.
 			secret := &corev1.Secret{}
 			err := c.Get(ctx, client.ObjectKey{Namespace: alertmanager.ACMObsAMNamespace, Name: alertmanager.ACMObsAMSecretName}, secret)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			extraConfig := `
 global:
@@ -202,17 +202,17 @@ route:
 `
 			secret.Data[alertmanager.ACMObsAMSecretKey] = []byte(extraConfig)
 			err = c.Update(ctx, secret)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			err = alertmanager.Setup(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			updatedSecret := &corev1.Secret{}
 			err = c.Get(ctx, client.ObjectKey{Namespace: alertmanager.ACMObsAMNamespace, Name: alertmanager.ACMObsAMSecretName}, updatedSecret)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var config map[string]interface{}
-			Expect(yaml.Unmarshal(updatedSecret.Data[alertmanager.ACMObsAMSecretKey], &config)).NotTo(HaveOccurred())
+			Expect(yaml.Unmarshal(updatedSecret.Data[alertmanager.ACMObsAMSecretKey], &config)).ToNot(HaveOccurred())
 
 			// Ensure the extra_receiver remains present.
 			receivers, ok := config["receivers"].([]interface{})
@@ -275,7 +275,7 @@ route:
 				},
 			}
 			err := conflictClient.Create(ctx, secret)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Override GetHubClient to return our conflict-simulating client
 			alertmanager.GetHubClient = func() (client.WithWatch, error) {
@@ -284,7 +284,7 @@ route:
 
 			// Run Setup - should succeed despite the initial conflict
 			err = alertmanager.Setup(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify that update was attempted more than once (retry occurred)
 			Expect(updateAttempts).To(BeNumerically(">", 1), "Setup should have retried after conflict")
@@ -292,10 +292,10 @@ route:
 			// Verify the final configuration is correct
 			finalSecret := &corev1.Secret{}
 			err = conflictClient.Get(ctx, client.ObjectKey{Namespace: alertmanager.ACMObsAMNamespace, Name: alertmanager.ACMObsAMSecretName}, finalSecret)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			var config map[string]interface{}
-			Expect(yaml.Unmarshal(finalSecret.Data[alertmanager.ACMObsAMSecretKey], &config)).NotTo(HaveOccurred())
+			Expect(yaml.Unmarshal(finalSecret.Data[alertmanager.ACMObsAMSecretKey], &config)).ToNot(HaveOccurred())
 
 			// Verify oran receiver was added
 			receivers, ok := config["receivers"].([]interface{})

--- a/internal/service/alarms/internal/alertmanager/converter_test.go
+++ b/internal/service/alarms/internal/alertmanager/converter_test.go
@@ -87,9 +87,9 @@ var _ = Describe("Alertmanager Functions", func() {
 			Expect(record.AlarmRaisedTime).To(Equal(now))
 
 			// Check cluster ID and alarm definition ID
-			Expect(record.ObjectID).NotTo(BeNil())
+			Expect(record.ObjectID).ToNot(BeNil())
 			Expect(*record.ObjectID).To(Equal(clusterUUID))
-			Expect(record.AlarmDefinitionID).NotTo(BeNil())
+			Expect(record.AlarmDefinitionID).ToNot(BeNil())
 			Expect(*record.AlarmDefinitionID).To(Equal(alarmDefUUID))
 		})
 
@@ -139,7 +139,7 @@ var _ = Describe("Alertmanager Functions", func() {
 
 			Expect(record.AlarmStatus).To(Equal("resolved"))
 			Expect(record.PerceivedSeverity).To(Equal(api.CLEARED))
-			Expect(record.AlarmClearedTime).NotTo(BeNil())
+			Expect(record.AlarmClearedTime).ToNot(BeNil())
 			Expect(*record.AlarmClearedTime).To(Equal(endTime))
 		})
 
@@ -275,9 +275,9 @@ var _ = Describe("Alertmanager Functions", func() {
 			Expect(records).To(HaveLen(1))
 			record := records[0]
 
-			Expect(record.ObjectID).NotTo(BeNil())
+			Expect(record.ObjectID).ToNot(BeNil())
 			Expect(*record.ObjectID).To(Equal(clusterUUID))
-			Expect(record.AlarmDefinitionID).NotTo(BeNil())
+			Expect(record.AlarmDefinitionID).ToNot(BeNil())
 			Expect(*record.AlarmDefinitionID).To(Equal(alarmDefUUID))
 			Expect(record.PerceivedSeverity).To(Equal(api.MAJOR)) // important maps to MAJOR
 		})

--- a/internal/service/alarms/internal/db/repo/alarms_repository_test.go
+++ b/internal/service/alarms/internal/db/repo/alarms_repository_test.go
@@ -33,7 +33,7 @@ var _ = Describe("AlarmsRepository", func() {
 	BeforeEach(func() {
 		var err error
 		mock, err = pgxmock.NewPool()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		repo = &alarmsrepo.AlarmsRepository{
 			Db: mock,
@@ -61,11 +61,11 @@ var _ = Describe("AlarmsRepository", func() {
 					)
 
 				config, err := repo.CreateServiceConfiguration(ctx, 30)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(config.RetentionPeriod).To(Equal(30))
 
 				// Verify all expectations were met
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 		When("one configuration exists", func() {
@@ -78,9 +78,9 @@ var _ = Describe("AlarmsRepository", func() {
 					)
 
 				config, err := repo.CreateServiceConfiguration(ctx, 30)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(config.RetentionPeriod).To(Equal(45)) // should return existing value, not input value
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 
@@ -103,9 +103,9 @@ var _ = Describe("AlarmsRepository", func() {
 					WillReturnResult(pgxmock.NewResult("DELETE", 2))
 
 				config, err := repo.CreateServiceConfiguration(ctx, 30)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(config.RetentionPeriod).To(Equal(45)) // should keep first config's value
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 
@@ -130,7 +130,7 @@ var _ = Describe("AlarmsRepository", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to delete additional service configurations"))
 				Expect(config).To(BeNil())
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 
@@ -142,7 +142,7 @@ var _ = Describe("AlarmsRepository", func() {
 				config, err := repo.CreateServiceConfiguration(ctx, 30)
 				Expect(err).To(HaveOccurred())
 				Expect(config).To(BeNil())
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -163,11 +163,11 @@ var _ = Describe("AlarmsRepository", func() {
 					)
 
 				records, err := repo.GetAlarmEventRecords(ctx)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(records).To(HaveLen(2))
 				Expect(records[0].AlarmEventRecordID).To(Equal(id1))
 				Expect(records[1].AlarmEventRecordID).To(Equal(id2))
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -193,10 +193,10 @@ var _ = Describe("AlarmsRepository", func() {
 					)
 
 				result, err := repo.PatchAlarmEventRecordACK(ctx, id, record)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(result.AlarmAcknowledged).To(BeTrue())
 				Expect(result.AlarmAcknowledgedTime).To(Equal(&now))
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -216,9 +216,9 @@ var _ = Describe("AlarmsRepository", func() {
 					)
 
 				records, err := repo.GetAlarmEventRecord(ctx, id1)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(records.AlarmEventRecordID).To(Equal(id1))
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -239,11 +239,11 @@ var _ = Describe("AlarmsRepository", func() {
 					)
 
 				subscription, err := repo.GetAlarmSubscription(ctx, id)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(subscription.SubscriptionID).To(Equal(id))
 				Expect(subscription.ConsumerSubscriptionID).To(Equal(&conId))
 				Expect(subscription.Callback).To(Equal(callback))
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 
@@ -257,7 +257,7 @@ var _ = Describe("AlarmsRepository", func() {
 				subscription, err := repo.GetAlarmSubscription(ctx, id)
 				Expect(err).To(HaveOccurred())
 				Expect(subscription).To(BeNil())
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -298,8 +298,8 @@ var _ = Describe("AlarmsRepository", func() {
 				err := repo.WithTransaction(ctx, func(tx pgx.Tx) error {
 					return repo.UpsertAlarmEventCaaSRecord(ctx, tx, records, int64(0))
 				})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 
@@ -353,8 +353,8 @@ var _ = Describe("AlarmsRepository", func() {
 				err := repo.WithTransaction(ctx, func(tx pgx.Tx) error {
 					return repo.UpsertAlarmEventCaaSRecord(ctx, tx, records, int64(0))
 				})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 
@@ -374,8 +374,8 @@ var _ = Describe("AlarmsRepository", func() {
 				err := repo.WithTransaction(ctx, func(tx pgx.Tx) error {
 					return repo.UpsertAlarmEventCaaSRecord(ctx, tx, []models.AlarmEventRecord{}, int64(0))
 				})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 
 			})
 		})
@@ -394,8 +394,8 @@ var _ = Describe("AlarmsRepository", func() {
 					WillReturnRows(pgxmock.NewRows([]string{"subscription_id"}).AddRow(subscription.SubscriptionID))
 
 				err := repo.UpdateSubscriptionEventCursor(ctx, subscription)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 
@@ -412,7 +412,7 @@ var _ = Describe("AlarmsRepository", func() {
 
 				err := repo.UpdateSubscriptionEventCursor(ctx, subscription)
 				Expect(err).To(HaveOccurred())
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -441,8 +441,8 @@ var _ = Describe("AlarmsRepository", func() {
 				err := repo.WithTransaction(ctx, func(tx pgx.Tx) error {
 					return repo.ResolveStaleAlarmEventCaaSRecord(ctx, tx, int64(2))
 				})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -463,11 +463,11 @@ var _ = Describe("AlarmsRepository", func() {
 					)
 
 				records, err := repo.GetServiceConfigurations(ctx)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(records).To(HaveLen(1))
 				Expect(records[0].ID).To(Equal(id1))
 				Expect(records[0].RetentionPeriod).To(Equal(s.RetentionPeriod))
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -488,10 +488,10 @@ var _ = Describe("AlarmsRepository", func() {
 					)
 
 				record, err := repo.UpdateServiceConfiguration(ctx, s.ID, &s)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(record.ID).To(Equal(s.ID))
 				Expect(record.RetentionPeriod).To(Equal(s.RetentionPeriod))
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -512,11 +512,11 @@ var _ = Describe("AlarmsRepository", func() {
 					)
 
 				records, err := repo.GetAlarmSubscriptions(ctx)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(records).To(HaveLen(2))
 				Expect(records[0].SubscriptionID).To(Equal(id1))
 				Expect(records[1].SubscriptionID).To(Equal(id2))
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -531,9 +531,9 @@ var _ = Describe("AlarmsRepository", func() {
 					WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
 				count, err := repo.DeleteAlarmSubscription(ctx, id)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(count).To(Equal(int64(1)))
-				Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+				Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -557,9 +557,9 @@ var _ = Describe("AlarmsRepository", func() {
 					AddRow(time.Now(), uuid.New(), &id, &f, "http://test.com/callback", int64(10), time.Now()))
 
 			result, err := repo.CreateAlarmSubscription(ctx, subscription)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result.ConsumerSubscriptionID).To(Equal(subscription.ConsumerSubscriptionID))
-			Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+			Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/internal/service/cluster/api/server_test.go
+++ b/internal/service/cluster/api/server_test.go
@@ -332,14 +332,14 @@ var _ = Describe("Cluster Server", func() {
 					},
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apigenerated.CreateSubscription400ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusBadRequest))
-				Expect(problemResp.AdditionalAttributes).NotTo(BeNil())
+				Expect(problemResp.AdditionalAttributes).ToNot(BeNil())
 				attrs := *problemResp.AdditionalAttributes
-				Expect(attrs).NotTo(HaveKey("callback"))
-				Expect(attrs).NotTo(HaveKey("filter"))
-				Expect(problemResp.Detail).NotTo(ContainSubstring(callbackURL))
+				Expect(attrs).ToNot(HaveKey("callback"))
+				Expect(attrs).ToNot(HaveKey("filter"))
+				Expect(problemResp.Detail).ToNot(ContainSubstring(callbackURL))
 			})
 		})
 
@@ -358,12 +358,12 @@ var _ = Describe("Cluster Server", func() {
 					},
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apigenerated.CreateSubscription400ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusBadRequest))
-				Expect(problemResp.Detail).NotTo(ContainSubstring(callbackURL))
-				Expect(problemResp.Detail).NotTo(ContainSubstring("192.0.2.1"))
-				Expect(problemResp.Detail).NotTo(ContainSubstring("secret=token123"))
+				Expect(problemResp.Detail).ToNot(ContainSubstring(callbackURL))
+				Expect(problemResp.Detail).ToNot(ContainSubstring("192.0.2.1"))
+				Expect(problemResp.Detail).ToNot(ContainSubstring("secret=token123"))
 			})
 		})
 
@@ -388,13 +388,13 @@ var _ = Describe("Cluster Server", func() {
 					},
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apigenerated.CreateSubscription400ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusBadRequest))
 				Expect(problemResp.Detail).To(Equal("callback value must be unique"))
-				Expect(problemResp.AdditionalAttributes).NotTo(BeNil())
+				Expect(problemResp.AdditionalAttributes).ToNot(BeNil())
 				attrs := *problemResp.AdditionalAttributes
-				Expect(attrs).NotTo(HaveKey("callback"))
+				Expect(attrs).ToNot(HaveKey("callback"))
 			})
 		})
 	})

--- a/internal/service/cluster/collector/collector_alarms_test.go
+++ b/internal/service/cluster/collector/collector_alarms_test.go
@@ -82,13 +82,13 @@ var _ = Describe("Alarms Collector", func() {
 
 			for _, cluster := range managedClusters {
 				err := r.hubClient.Create(ctx, cluster)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			}
 		})
 
 		It("returns a cluster with the correct version", func() {
 			cluster, err := r.getManagedCluster(ctx, version4167)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(cluster.Labels[ctlrutils.OpenshiftVersionLabelName]).To(Equal(version4167))
 			Expect(cluster.Labels).ToNot(HaveKey(ctlrutils.LocalClusterLabelName))
@@ -129,7 +129,7 @@ var _ = Describe("Alarms Collector", func() {
 			}
 
 			err := r.hubClient.Create(ctx, managedCluster)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			temp = getClientForCluster
 			getClientForCluster = func(ctx context.Context, hubClient client.Client, clusterName string) (client.Client, error) {
@@ -210,7 +210,7 @@ var _ = Describe("Alarms Collector", func() {
 
 				for _, rule := range rules {
 					err := withWatch.Create(ctx, rule)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 				}
 
 				return withWatch, nil
@@ -223,7 +223,7 @@ var _ = Describe("Alarms Collector", func() {
 
 		It("returns prometheus rules associated with a cluster", func() {
 			rules, err := r.processManagedCluster(ctx, version4167)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(rules).To(HaveLen(2))
 		})
@@ -307,12 +307,12 @@ var _ = Describe("Alarms Collector", func() {
 
 			for _, rule := range rules {
 				err := r.hubClient.Create(ctx, rule)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			}
 
 			// Call getRules and verify only non-hardware alerts are returned
 			result, err := r.getRules(ctx, r.hubClient)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].Alert).To(Equal("ClusterMemoryHigh"))
 		})
@@ -356,11 +356,11 @@ var _ = Describe("Alarms Collector", func() {
 
 			for _, rule := range rules {
 				err := r.hubClient.Create(ctx, rule)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			}
 
 			result, err := r.getRules(ctx, r.hubClient)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(HaveLen(2))
 		})
 
@@ -411,12 +411,12 @@ var _ = Describe("Alarms Collector", func() {
 
 			for _, rule := range rules {
 				err := r.hubClient.Create(ctx, rule)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			}
 
 			// Both alerts should be included since neither group has BOTH labels
 			result, err := r.getRules(ctx, r.hubClient)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(HaveLen(2))
 		})
 	})
@@ -473,7 +473,7 @@ var _ = Describe("Alarms Collector", func() {
 			for _, rule := range result {
 				Expect(rule.Alert).To(Equal("ViolatedPolicyReport"))
 				severity := rule.Labels["severity"]
-				Expect(severity).NotTo(ContainSubstring("{{"))
+				Expect(severity).ToNot(ContainSubstring("{{"))
 				severities[severity] = true
 			}
 

--- a/internal/service/cluster/collector/collector_k8s_test.go
+++ b/internal/service/cluster/collector/collector_k8s_test.go
@@ -62,8 +62,8 @@ var _ = Describe("K8S Collector", func() {
 
 		It("extracts kubernetes version to extensions", func() {
 			result, err := dataSource.convertManagedClusterToNodeCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Extensions).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Extensions).ToNot(BeNil())
 
 			extensions := *result.Extensions
 			Expect(extensions).To(HaveKey("kubernetesVersion"))
@@ -72,8 +72,8 @@ var _ = Describe("K8S Collector", func() {
 
 		It("extracts capacity resources to extensions", func() {
 			result, err := dataSource.convertManagedClusterToNodeCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Extensions).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Extensions).ToNot(BeNil())
 
 			extensions := *result.Extensions
 			Expect(extensions).To(HaveKey("capacity"))
@@ -90,8 +90,8 @@ var _ = Describe("K8S Collector", func() {
 
 		It("extracts allocatable resources to extensions", func() {
 			result, err := dataSource.convertManagedClusterToNodeCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Extensions).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Extensions).ToNot(BeNil())
 
 			extensions := *result.Extensions
 			Expect(extensions).To(HaveKey("allocatable"))
@@ -109,39 +109,39 @@ var _ = Describe("K8S Collector", func() {
 			cluster.Status.Version.Kubernetes = ""
 
 			result, err := dataSource.convertManagedClusterToNodeCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Extensions).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Extensions).ToNot(BeNil())
 
 			extensions := *result.Extensions
-			Expect(extensions).NotTo(HaveKey("kubernetesVersion"))
+			Expect(extensions).ToNot(HaveKey("kubernetesVersion"))
 		})
 
 		It("handles missing capacity gracefully", func() {
 			cluster.Status.Capacity = nil
 
 			result, err := dataSource.convertManagedClusterToNodeCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Extensions).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Extensions).ToNot(BeNil())
 
 			extensions := *result.Extensions
-			Expect(extensions).NotTo(HaveKey("capacity"))
+			Expect(extensions).ToNot(HaveKey("capacity"))
 		})
 
 		It("handles missing allocatable gracefully", func() {
 			cluster.Status.Allocatable = nil
 
 			result, err := dataSource.convertManagedClusterToNodeCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Extensions).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Extensions).ToNot(BeNil())
 
 			extensions := *result.Extensions
-			Expect(extensions).NotTo(HaveKey("allocatable"))
+			Expect(extensions).ToNot(HaveKey("allocatable"))
 		})
 
 		It("preserves existing extensions from labels", func() {
 			result, err := dataSource.convertManagedClusterToNodeCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Extensions).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Extensions).ToNot(BeNil())
 
 			extensions := *result.Extensions
 			// Check that label-based extensions are still present

--- a/internal/service/common/api/middleware/filtering_test.go
+++ b/internal/service/common/api/middleware/filtering_test.go
@@ -41,11 +41,11 @@ var _ = Describe("ResponseFilter", func() {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 		var err error
 		adapter, err = NewFilterAdapterWithSchemas(logger, nil)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		list := []object{{Name: "hello", Value: 1}, {Name: "world", Value: 10}}
 		body, err := json.Marshal(list)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		next = func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -61,7 +61,7 @@ var _ = Describe("ResponseFilter", func() {
 		Expect(recorder.Code).To(Equal(http.StatusOK))
 		var list []object
 		err := json.Unmarshal(recorder.Body.Bytes(), &list)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(list).To(HaveLen(1))
 		Expect(list[0].Name).To(Equal("hello"))
 		Expect(list[0].Value).To(Equal(1))
@@ -70,7 +70,7 @@ var _ = Describe("ResponseFilter", func() {
 	It("should not process the filter if an error is returned", func() {
 		list := []object{{Name: "hello", Value: 1}, {Name: "world", Value: 10}}
 		body, err := json.Marshal(list)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		next = func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write(body)
@@ -82,14 +82,14 @@ var _ = Describe("ResponseFilter", func() {
 
 		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
 		err = json.Unmarshal(recorder.Body.Bytes(), &list)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(list).To(HaveLen(2))
 	})
 
 	It("should not process the filter on a get request", func() {
 		record := object{Name: "hello", Value: 1}
 		body, err := json.Marshal(record)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		next = func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(body)
@@ -101,7 +101,7 @@ var _ = Describe("ResponseFilter", func() {
 
 		Expect(recorder.Code).To(Equal(http.StatusOK))
 		err = json.Unmarshal(recorder.Body.Bytes(), &record)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(record.Name).To(Equal("hello"))
 	})
 
@@ -111,7 +111,7 @@ var _ = Describe("ResponseFilter", func() {
 		Expect(recorder.Code).To(Equal(http.StatusOK))
 		var list []object
 		err := json.Unmarshal(recorder.Body.Bytes(), &list)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(list).To(HaveLen(2))
 	})
 
@@ -122,7 +122,7 @@ var _ = Describe("ResponseFilter", func() {
 		Expect(recorder.Code).To(Equal(http.StatusOK))
 		var list []object
 		err := json.Unmarshal(recorder.Body.Bytes(), &list)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(list).To(HaveLen(0))
 	})
 
@@ -150,7 +150,7 @@ var _ = Describe("ResponseFilter", func() {
 		Expect(recorder.Code).To(Equal(http.StatusOK))
 		var result []object
 		err := json.Unmarshal(recorder.Body.Bytes(), &result)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(HaveLen(0))
 	})
 
@@ -182,7 +182,7 @@ var _ = Describe("ResponseFilter", func() {
 			{Name: "world", Value: 10, OptionalField: nil},
 		}
 		body, err := json.Marshal(list)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		next = func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -197,10 +197,10 @@ var _ = Describe("ResponseFilter", func() {
 		Expect(recorder.Code).To(Equal(http.StatusOK))
 		var result []object
 		err = json.Unmarshal(recorder.Body.Bytes(), &result)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(HaveLen(1))
 		Expect(result[0].Name).To(Equal("hello"))
-		Expect(result[0].OptionalField).NotTo(BeNil())
+		Expect(result[0].OptionalField).ToNot(BeNil())
 		Expect(*result[0].OptionalField).To(Equal("optional_value"))
 	})
 
@@ -211,7 +211,7 @@ var _ = Describe("ResponseFilter", func() {
 			{Name: "world", Value: 10, OptionalField: nil},
 		}
 		body, err := json.Marshal(list)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		next = func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -226,7 +226,7 @@ var _ = Describe("ResponseFilter", func() {
 		Expect(recorder.Code).To(Equal(http.StatusOK))
 		var result []object
 		err = json.Unmarshal(recorder.Body.Bytes(), &result)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(HaveLen(0)) // No objects should match since the field is nil
 	})
 
@@ -255,13 +255,13 @@ var _ = Describe("ResponseFilter", func() {
 			logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 			var err error
 			schemaAdapter, err = NewFilterAdapterWithSchemas(logger, schemas)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return bad request for truly invalid field names with schema validation", func() {
 			list := []object{{Name: "hello", Value: 1}, {Name: "world", Value: 10}}
 			body, err := json.Marshal(list)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			next := func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -277,7 +277,7 @@ var _ = Describe("ResponseFilter", func() {
 			// Verify the error message is user-friendly
 			var errorResponse map[string]interface{}
 			err = json.Unmarshal(recorder.Body.Bytes(), &errorResponse)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(errorResponse["detail"]).To(ContainSubstring("invalid field name 'invalidField'"))
 			Expect(errorResponse["detail"]).To(ContainSubstring("does not exist in the API schema"))
 		})
@@ -285,7 +285,7 @@ var _ = Describe("ResponseFilter", func() {
 		It("should return descriptive error for typos in field names", func() {
 			list := []object{{Name: "hello", Value: 1}, {Name: "world", Value: 10}}
 			body, err := json.Marshal(list)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			next := func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -302,7 +302,7 @@ var _ = Describe("ResponseFilter", func() {
 			// Verify the error message specifically mentions the typo
 			var errorResponse map[string]interface{}
 			err = json.Unmarshal(recorder.Body.Bytes(), &errorResponse)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(errorResponse["detail"]).To(ContainSubstring("invalid field name 'filte2r'"))
 			Expect(errorResponse["detail"]).To(ContainSubstring("does not exist in the API schema"))
 		})
@@ -314,7 +314,7 @@ var _ = Describe("ResponseFilter", func() {
 				{Name: "world", Value: 10, OptionalField: nil},
 			}
 			body, err := json.Marshal(list)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			next := func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -328,7 +328,7 @@ var _ = Describe("ResponseFilter", func() {
 			Expect(recorder.Code).To(Equal(http.StatusOK))
 			var result []object
 			err = json.Unmarshal(recorder.Body.Bytes(), &result)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].Name).To(Equal("hello"))
 		})
@@ -341,9 +341,9 @@ var _ = Describe("ResponseFilter", func() {
 
 		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
 		body := recorder.Body.String()
-		Expect(body).NotTo(ContainSubstring(maliciousQuery))
-		Expect(body).NotTo(ContainSubstring("sensitive-data"))
-		Expect(body).NotTo(ContainSubstring("%zz"))
+		Expect(body).ToNot(ContainSubstring(maliciousQuery))
+		Expect(body).ToNot(ContainSubstring("sensitive-data"))
+		Expect(body).ToNot(ContainSubstring("%zz"))
 		Expect(body).To(ContainSubstring("failed to parse query parameters"))
 	})
 
@@ -354,8 +354,8 @@ var _ = Describe("ResponseFilter", func() {
 
 		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
 		body := recorder.Body.String()
-		Expect(body).NotTo(ContainSubstring("<script>"))
-		Expect(body).NotTo(ContainSubstring("alert(1)"))
+		Expect(body).ToNot(ContainSubstring("<script>"))
+		Expect(body).ToNot(ContainSubstring("alert(1)"))
 		Expect(body).To(ContainSubstring("invalid filter syntax"))
 	})
 })

--- a/internal/service/common/api/middleware/middleware_test.go
+++ b/internal/service/common/api/middleware/middleware_test.go
@@ -92,9 +92,9 @@ var _ = Describe("Validation error logging", func() {
 
 			Expect(recorder.Code).To(Equal(http.StatusBadRequest))
 			body := recorder.Body.String()
-			Expect(body).NotTo(ContainSubstring(maliciousInput))
+			Expect(body).ToNot(ContainSubstring(maliciousInput))
 			Expect(body).To(ContainSubstring("Invalid format for parameter subscriptionId"))
-			Expect(body).NotTo(ContainSubstring("error unmarshaling"))
+			Expect(body).ToNot(ContainSubstring("error unmarshaling"))
 
 			var logEntry map[string]any
 			Expect(json.Unmarshal(buf.Bytes(), &logEntry)).To(Succeed())

--- a/internal/service/common/api/middleware/schema_utils_test.go
+++ b/internal/service/common/api/middleware/schema_utils_test.go
@@ -96,8 +96,8 @@ var _ = Describe("SchemaUtils", func() {
 
 			Expect(schemas).To(HaveLen(1))
 			Expect(schemas).To(HaveKey("ValidSchema"))
-			Expect(schemas).NotTo(HaveKey("NilRef"))
-			Expect(schemas).NotTo(HaveKey("EmptyRef"))
+			Expect(schemas).ToNot(HaveKey("NilRef"))
+			Expect(schemas).ToNot(HaveKey("EmptyRef"))
 		})
 	})
 
@@ -122,16 +122,16 @@ var _ = Describe("SchemaUtils", func() {
 
 			adapter, err := NewFilterAdapterFromSwagger(logger, swagger)
 
-			Expect(err).NotTo(HaveOccurred())
-			Expect(adapter).NotTo(BeNil())
-			Expect(adapter.schemaValidator).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(adapter).ToNot(BeNil())
+			Expect(adapter.schemaValidator).ToNot(BeNil())
 		})
 
 		It("should work with nil swagger (no schema validation)", func() {
 			adapter, err := NewFilterAdapterFromSwagger(logger, nil)
 
-			Expect(err).NotTo(HaveOccurred())
-			Expect(adapter).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(adapter).ToNot(BeNil())
 			Expect(adapter.schemaValidator).To(BeNil())
 		})
 	})

--- a/internal/service/common/api/utils_test.go
+++ b/internal/service/common/api/utils_test.go
@@ -45,7 +45,7 @@ var _ = Describe("ValidateCallbackURL", func() {
 		It("should not return an error", func() {
 			stub := &stubClientProvider{client: client}
 			err := api.ValidateCallbackURL(ctx, stub, callback)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -104,7 +104,7 @@ var _ = Describe("CheckCallbackReachabilityGET", func() {
 
 	It("should succeed when the server returns 204", func() {
 		err := api.CheckCallbackReachabilityGET(ctx, client, callback)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should fail when the server returns a status other than 204", func() {

--- a/internal/service/common/async/store_test.go
+++ b/internal/service/common/async/store_test.go
@@ -58,11 +58,11 @@ var _ = Describe("ReflectorStore", func() {
 	Describe("NewReflectorStore", func() {
 		It("should create a new ReflectorStore with correct initial state", func() {
 			newStore := NewReflectorStore(objectType)
-			Expect(newStore).NotTo(BeNil())
+			Expect(newStore).ToNot(BeNil())
 			Expect(newStore.ObjectType).To(Equal(objectType))
 			Expect(newStore.HasSynced()).To(BeFalse())
 			Expect(newStore.queue).To(HaveLen(0))
-			Expect(newStore.ready).NotTo(BeNil())
+			Expect(newStore.ready).ToNot(BeNil())
 		})
 	})
 
@@ -73,7 +73,7 @@ var _ = Describe("ReflectorStore", func() {
 
 		It("should return true after Replace is called", func() {
 			err := store.Replace([]interface{}{}, "version1")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(store.HasSynced()).To(BeTrue())
 		})
 	})
@@ -82,13 +82,13 @@ var _ = Describe("ReflectorStore", func() {
 		It("should successfully add an object", func() {
 			obj := &testObject{Name: "test1"}
 			err := store.Add(obj)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should enqueue an Updated operation", func() {
 			obj := &testObject{Name: "test1"}
 			err := store.Add(obj)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			store.mutex.Lock()
 			Expect(store.queue).To(HaveLen(1))
@@ -103,13 +103,13 @@ var _ = Describe("ReflectorStore", func() {
 		It("should successfully update an object", func() {
 			obj := &testObject{Name: "test1"}
 			err := store.Update(obj)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should enqueue an Updated operation", func() {
 			obj := &testObject{Name: "test1"}
 			err := store.Update(obj)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			store.mutex.Lock()
 			Expect(store.queue).To(HaveLen(1))
@@ -124,13 +124,13 @@ var _ = Describe("ReflectorStore", func() {
 		It("should successfully delete an object", func() {
 			obj := &testObject{Name: "test1"}
 			err := store.Delete(obj)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should enqueue a Deleted operation", func() {
 			obj := &testObject{Name: "test1"}
 			err := store.Delete(obj)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			store.mutex.Lock()
 			Expect(store.queue).To(HaveLen(1))
@@ -144,7 +144,7 @@ var _ = Describe("ReflectorStore", func() {
 	Describe("Replace", func() {
 		It("should successfully replace with empty list", func() {
 			err := store.Replace([]interface{}{}, "version1")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should successfully replace with objects", func() {
@@ -153,7 +153,7 @@ var _ = Describe("ReflectorStore", func() {
 				&testObject{Name: "obj2"},
 			}
 			err := store.Replace(objects, "version1")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should enqueue a SyncComplete operation and set hasSynced", func() {
@@ -162,7 +162,7 @@ var _ = Describe("ReflectorStore", func() {
 				&testObject{Name: "obj2"},
 			}
 			err := store.Replace(objects, "version1")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			store.mutex.Lock()
 			Expect(store.queue).To(HaveLen(1))
@@ -176,7 +176,7 @@ var _ = Describe("ReflectorStore", func() {
 	Describe("Resync", func() {
 		It("should return nil without error", func() {
 			err := store.Resync()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -196,7 +196,7 @@ var _ = Describe("ReflectorStore", func() {
 
 				// Add an object
 				err := store.Add(obj)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Give some time for processing
 				time.Sleep(100 * time.Millisecond)
@@ -217,7 +217,7 @@ var _ = Describe("ReflectorStore", func() {
 
 				// Update an object
 				err := store.Update(obj)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Give some time for processing
 				time.Sleep(100 * time.Millisecond)
@@ -237,7 +237,7 @@ var _ = Describe("ReflectorStore", func() {
 
 				// Add an object
 				err := store.Add(obj)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Give some time for processing
 				time.Sleep(100 * time.Millisecond)
@@ -260,7 +260,7 @@ var _ = Describe("ReflectorStore", func() {
 
 				// Delete an object
 				err := store.Delete(obj)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Give some time for processing
 				time.Sleep(100 * time.Millisecond)
@@ -300,7 +300,7 @@ var _ = Describe("ReflectorStore", func() {
 
 				// Replace objects
 				err := store.Replace(objects, "version1")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Give some time for processing
 				time.Sleep(100 * time.Millisecond)
@@ -337,7 +337,7 @@ var _ = Describe("ReflectorStore", func() {
 
 				// Replace objects
 				err := store.Replace(objects, "version1")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Give some time for processing
 				time.Sleep(100 * time.Millisecond)
@@ -374,7 +374,7 @@ var _ = Describe("ReflectorStore", func() {
 
 				// Replace objects
 				err := store.Replace(objects, "version1")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Give some time for processing
 				time.Sleep(100 * time.Millisecond)
@@ -400,7 +400,7 @@ var _ = Describe("ReflectorStore", func() {
 
 				// Replace objects
 				err := store.Replace(objects, "version1")
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Give some time for processing
 				time.Sleep(100 * time.Millisecond)
@@ -452,13 +452,13 @@ var _ = Describe("ReflectorStore", func() {
 
 				// Add multiple operations
 				err := store.Add(obj1)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				err = store.Delete(obj2)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				err = store.Update(obj3)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Give some time for processing
 				time.Sleep(100 * time.Millisecond)

--- a/internal/service/common/cache/cache_test.go
+++ b/internal/service/common/cache/cache_test.go
@@ -36,7 +36,7 @@ var _ = ginkgo.Describe("Entry", func() {
 		})
 
 		result, err := entry.Get(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(Equal("hello"))
 		Expect(callCount).To(Equal(1))
 	})
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("Entry", func() {
 		_, _ = entry.Get(ctx)
 		result, err := entry.Get(ctx)
 
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(Equal("hello"))
 		Expect(callCount).To(Equal(1))
 	})
@@ -126,7 +126,7 @@ var _ = ginkgo.Describe("Entry", func() {
 		Expect(err).To(HaveOccurred())
 
 		result, err := entry.Get(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(Equal("recovered"))
 	})
 
@@ -140,7 +140,7 @@ var _ = ginkgo.Describe("Entry", func() {
 		})
 
 		result, err := entry.Get(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(result.Count).To(Equal(2))
 		Expect(result.Items).To(Equal([]string{"a", "b"}))
 	})

--- a/internal/service/common/utils/utils_test.go
+++ b/internal/service/common/utils/utils_test.go
@@ -52,13 +52,13 @@ var _ = Describe("Utils", func() {
 			result1 := GetTrackingUUID(testLocationKey)
 			result2 := GetTrackingUUID(testLocationKey)
 			Expect(result1).To(Equal(result2)) // deterministic
-			Expect(result1).NotTo(Equal(uuid.Nil))
+			Expect(result1).ToNot(Equal(uuid.Nil))
 		})
 
 		It("returns different UUIDs for different string keys", func() {
 			result1 := GetTrackingUUID(testLocationKey)
 			result2 := GetTrackingUUID("LOC-002")
-			Expect(result1).NotTo(Equal(result2))
+			Expect(result1).ToNot(Equal(result2))
 		})
 
 		It("returns UUID using SHA1 namespace for string keys", func() {
@@ -70,7 +70,7 @@ var _ = Describe("Utils", func() {
 
 		It("handles empty string key", func() {
 			result := GetTrackingUUID("")
-			Expect(result).NotTo(Equal(uuid.Nil))
+			Expect(result).ToNot(Equal(uuid.Nil))
 			// Empty string should still produce a deterministic UUID
 			Expect(result).To(Equal(GetTrackingUUID("")))
 		})
@@ -80,10 +80,10 @@ var _ = Describe("Utils", func() {
 			result1 := GetTrackingUUID(42)
 			result2 := GetTrackingUUID(42)
 			Expect(result1).To(Equal(result2))
-			Expect(result1).NotTo(Equal(uuid.Nil))
+			Expect(result1).ToNot(Equal(uuid.Nil))
 
 			// Different integers produce different UUIDs
-			Expect(GetTrackingUUID(42)).NotTo(Equal(GetTrackingUUID(43)))
+			Expect(GetTrackingUUID(42)).ToNot(Equal(GetTrackingUUID(43)))
 		})
 	})
 

--- a/internal/service/provisioning/api/envtest/server_test.go
+++ b/internal/service/provisioning/api/envtest/server_test.go
@@ -35,7 +35,7 @@ var _ = Describe("ProvisioningServer", Label("envtest"), func() {
 	// with the given name and template parameters
 	buildPR := func(name string) *provisioningv1alpha1.ProvisioningRequest {
 		templateParamsBytes, err := json.Marshal(map[string]interface{}{"key": "value"})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		return &provisioningv1alpha1.ProvisioningRequest{
 			ObjectMeta: metav1.ObjectMeta{
@@ -96,15 +96,15 @@ var _ = Describe("ProvisioningServer", Label("envtest"), func() {
 			bodyReader = strings.NewReader(jsonBody)
 		}
 		req, err := http.NewRequestWithContext(ctx, method, baseURL+path, bodyReader)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		if jsonBody != "" {
 			req.Header.Set("Content-Type", "application/json")
 		}
 		resp, err := httpClient.Do(req)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		return resp, body
 	}
 
@@ -115,10 +115,10 @@ var _ = Describe("ProvisioningServer", Label("envtest"), func() {
 
 			var versions commonapi.APIVersions
 			Expect(json.Unmarshal(body, &versions)).To(Succeed())
-			Expect(versions.ApiVersions).NotTo(BeNil())
+			Expect(versions.ApiVersions).ToNot(BeNil())
 			Expect(*versions.ApiVersions).To(HaveLen(1))
 			Expect(*(*versions.ApiVersions)[0].Version).To(Equal("1.2.0"))
-			Expect(versions.UriPrefix).NotTo(BeNil())
+			Expect(versions.UriPrefix).ToNot(BeNil())
 		})
 	})
 
@@ -129,10 +129,10 @@ var _ = Describe("ProvisioningServer", Label("envtest"), func() {
 
 			var versions commonapi.APIVersions
 			Expect(json.Unmarshal(body, &versions)).To(Succeed())
-			Expect(versions.ApiVersions).NotTo(BeNil())
+			Expect(versions.ApiVersions).ToNot(BeNil())
 			Expect(*versions.ApiVersions).To(HaveLen(1))
 			Expect(*(*versions.ApiVersions)[0].Version).To(Equal("1.2.0"))
-			Expect(versions.UriPrefix).NotTo(BeNil())
+			Expect(versions.UriPrefix).ToNot(BeNil())
 		})
 	})
 
@@ -192,7 +192,7 @@ var _ = Describe("ProvisioningServer", Label("envtest"), func() {
 					TemplateParameters:    map[string]interface{}{"key": "value"},
 				}
 				b, err := json.Marshal(createBody)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				resp, _ := httpDo(http.MethodPost, provisioningBase+"/provisioningRequests", string(b))
 				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
@@ -440,7 +440,7 @@ var _ = Describe("ProvisioningServer", Label("envtest"), func() {
 				TemplateParameters:    templateParams,
 			}
 			b, err := json.Marshal(body)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			return string(b)
 		}
 
@@ -515,7 +515,7 @@ var _ = Describe("ProvisioningServer", Label("envtest"), func() {
 				TemplateParameters:    map[string]interface{}{"key": "value"},
 			}
 			b, err := json.Marshal(body)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			resp, _ := httpDo(http.MethodPost,
 				provisioningBase+"/provisioningRequests", string(b))

--- a/internal/service/provisioning/api/server_test.go
+++ b/internal/service/provisioning/api/server_test.go
@@ -72,7 +72,7 @@ var _ = Describe("ProvisioningServer", func() {
 			provisioningDetails string,
 		) *provisioningv1alpha1.ProvisioningRequest {
 			templateParamsBytes, err := json.Marshal(map[string]interface{}{"key": "value"})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			pr := &provisioningv1alpha1.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -97,12 +97,12 @@ var _ = Describe("ProvisioningServer", func() {
 
 		getNodeClusterStatus := func(prName string) provisioningapi.ResourceProvisioningStatus {
 			reqUUID, err := uuid.Parse(prName)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			resp, err := server.GetProvisioningRequest(ctx, provisioningapi.GetProvisioningRequestRequestObject{
 				ProvisioningRequestId: reqUUID,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			result := resp.(provisioningapi.GetProvisioningRequest200JSONResponse)
 			return result.Status.NodeClusterProvisioningStatus
 		}
@@ -222,7 +222,7 @@ var _ = Describe("ProvisioningServer", func() {
 				server = &api.ProvisioningServer{HubClient: fakeClient}
 
 				status := getNodeClusterStatus(prName)
-				Expect(status).NotTo(BeZero())
+				Expect(status).ToNot(BeZero())
 				Expect(status.ResourceName).To(Equal("cluster-001"))
 				Expect(status.ResourceProvisioningPhase).To(Equal(provisioningapi.ResourceProvisioningPhasePROCESSING))
 				Expect(status.ResourceId).To(BeEmpty())
@@ -257,7 +257,7 @@ var _ = Describe("ProvisioningServer", func() {
 				server = &api.ProvisioningServer{HubClient: fakeClient}
 
 				status := getNodeClusterStatus(prName)
-				Expect(status).NotTo(BeZero())
+				Expect(status).ToNot(BeZero())
 				Expect(status.ResourceName).To(Equal("cluster-002"))
 				Expect(status.ResourceProvisioningPhase).To(Equal(provisioningapi.ResourceProvisioningPhasePROCESSING))
 				Expect(status.ResourceId).To(BeEmpty())
@@ -293,7 +293,7 @@ var _ = Describe("ProvisioningServer", func() {
 				server = &api.ProvisioningServer{HubClient: fakeClient}
 
 				status := getNodeClusterStatus(prName)
-				Expect(status).NotTo(BeZero())
+				Expect(status).ToNot(BeZero())
 				Expect(status.ResourceName).To(Equal("cluster-003"))
 				Expect(status.ResourceProvisioningPhase).To(Equal(provisioningapi.ResourceProvisioningPhasePROVISIONED))
 				Expect(status.ResourceId).To(Equal(clusterId))
@@ -328,7 +328,7 @@ var _ = Describe("ProvisioningServer", func() {
 				server = &api.ProvisioningServer{HubClient: fakeClient}
 
 				status := getNodeClusterStatus(prName)
-				Expect(status).NotTo(BeZero())
+				Expect(status).ToNot(BeZero())
 				Expect(status.ResourceName).To(Equal("cluster-004"))
 				Expect(status.ResourceProvisioningPhase).To(Equal(provisioningapi.ResourceProvisioningPhasePROVISIONED))
 				Expect(status.ResourceId).To(BeEmpty())
@@ -363,7 +363,7 @@ var _ = Describe("ProvisioningServer", func() {
 				server = &api.ProvisioningServer{HubClient: fakeClient}
 
 				status := getNodeClusterStatus(prName)
-				Expect(status).NotTo(BeZero())
+				Expect(status).ToNot(BeZero())
 				Expect(status.ResourceName).To(Equal("cluster-005"))
 				Expect(status.ResourceProvisioningPhase).To(Equal(provisioningapi.ResourceProvisioningPhaseFAILED))
 				Expect(status.ResourceId).To(BeEmpty())
@@ -398,7 +398,7 @@ var _ = Describe("ProvisioningServer", func() {
 				server = &api.ProvisioningServer{HubClient: fakeClient}
 
 				status := getNodeClusterStatus(prName)
-				Expect(status).NotTo(BeZero())
+				Expect(status).ToNot(BeZero())
 				Expect(status.ResourceName).To(Equal("cluster-006"))
 				Expect(status.ResourceProvisioningPhase).To(Equal(provisioningapi.ResourceProvisioningPhaseFAILED))
 				Expect(status.ResourceId).To(BeEmpty())
@@ -444,7 +444,7 @@ var _ = Describe("ProvisioningServer", func() {
 				server = &api.ProvisioningServer{HubClient: fakeClient}
 
 				status := getNodeClusterStatus(prName)
-				Expect(status).NotTo(BeZero())
+				Expect(status).ToNot(BeZero())
 				Expect(status.ResourceName).To(Equal("cluster-007"))
 				Expect(status.ResourceProvisioningPhase).To(Equal(provisioningapi.ResourceProvisioningPhasePROVISIONED))
 				Expect(status.ResourceId).To(Equal(clusterId))
@@ -470,7 +470,7 @@ var _ = Describe("ProvisioningServer", func() {
 			statuses []provisioningv1alpha1.InfrastructureResourceStatus,
 		) *provisioningv1alpha1.ProvisioningRequest {
 			templateParamsBytes, err := json.Marshal(map[string]interface{}{"key": "value"})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			pr := &provisioningv1alpha1.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -491,12 +491,12 @@ var _ = Describe("ProvisioningServer", func() {
 
 		getInfraStatuses := func(prName string) []provisioningapi.ResourceProvisioningStatus {
 			reqUUID, err := uuid.Parse(prName)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			resp, err := server.GetProvisioningRequest(ctx, provisioningapi.GetProvisioningRequestRequestObject{
 				ProvisioningRequestId: reqUUID,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			result := resp.(provisioningapi.GetProvisioningRequest200JSONResponse)
 			return result.Status.InfrastructureResourceProvisioningStatus
 		}
@@ -605,7 +605,7 @@ var _ = Describe("ProvisioningServer", func() {
 					"baseDomain":  "example.com",
 				}
 				templateParamsBytes, err := json.Marshal(initialTemplateParams)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				prUID := uuid.New().String()
 				initialPR := &provisioningv1alpha1.ProvisioningRequest{
@@ -655,13 +655,13 @@ var _ = Describe("ProvisioningServer", func() {
 
 				// First update should succeed
 				resp, err := server.UpdateProvisioningRequest(ctx, updateRequest1)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(provisioningapi.UpdateProvisioningRequest200JSONResponse{}))
 
 				// Verify the update was applied
 				updatedPR := &provisioningv1alpha1.ProvisioningRequest{}
 				err = fakeClient.Get(ctx, types.NamespacedName{Name: testUUID.String()}, updatedPR)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedPR.Spec.Name).To(Equal("test-updated-1"))
 				Expect(updatedPR.Spec.Description).To(Equal("updated description 1"))
 			})
@@ -673,7 +673,7 @@ var _ = Describe("ProvisioningServer", func() {
 					"baseDomain":  "example.com",
 				}
 				templateParamsBytes, err := json.Marshal(initialTemplateParams)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				prUID := uuid.New().String()
 				initialPR := &provisioningv1alpha1.ProvisioningRequest{
@@ -721,7 +721,7 @@ var _ = Describe("ProvisioningServer", func() {
 				}
 
 				resp1, err := server.UpdateProvisioningRequest(ctx, updateRequest1)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp1).To(BeAssignableToTypeOf(provisioningapi.UpdateProvisioningRequest200JSONResponse{}))
 
 				updatedTemplateParams2 := map[string]interface{}{
@@ -742,13 +742,13 @@ var _ = Describe("ProvisioningServer", func() {
 				}
 
 				resp2, err := server.UpdateProvisioningRequest(ctx, updateRequest2)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp2).To(BeAssignableToTypeOf(provisioningapi.UpdateProvisioningRequest200JSONResponse{}))
 
 				// Verify final state
 				finalPR := &provisioningv1alpha1.ProvisioningRequest{}
 				err = fakeClient.Get(ctx, types.NamespacedName{Name: testUUID.String()}, finalPR)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(finalPR.Spec.Name).To(Equal("test-seq-2"))
 				Expect(finalPR.Spec.Description).To(Equal("sequential update 2"))
 			})
@@ -780,7 +780,7 @@ var _ = Describe("ProvisioningServer", func() {
 				}
 
 				resp, err := server.UpdateProvisioningRequest(ctx, updateRequest)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(provisioningapi.UpdateProvisioningRequest422ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(422))
 			})
@@ -811,7 +811,7 @@ var _ = Describe("ProvisioningServer", func() {
 				}
 
 				resp, err := server.UpdateProvisioningRequest(ctx, updateRequest)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(provisioningapi.UpdateProvisioningRequest404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(404))
 			})
@@ -861,7 +861,7 @@ var _ = Describe("ProvisioningServer", func() {
 			}
 
 			resp, err := server.CreateProvisioningRequest(ctx, createRequest)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			created, ok := resp.(provisioningapi.CreateProvisioningRequest201JSONResponse)
 			Expect(ok).To(BeTrue())
@@ -885,7 +885,7 @@ var _ = Describe("ProvisioningServer", func() {
 		It("should populate the Location header with the resource URI", func() {
 			templateParams := map[string]interface{}{"key": "value"}
 			templateParamsBytes, err := json.Marshal(templateParams)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			prUID := uuid.New().String()
 			initialPR := &provisioningv1alpha1.ProvisioningRequest{
@@ -916,7 +916,7 @@ var _ = Describe("ProvisioningServer", func() {
 			}
 
 			resp, err := server.DeleteProvisioningRequest(ctx, deleteRequest)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			deleted, ok := resp.(provisioningapi.DeleteProvisioningRequest202Response)
 			Expect(ok).To(BeTrue())

--- a/internal/service/resources/api/server_test.go
+++ b/internal/service/resources/api/server_test.go
@@ -97,7 +97,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetAllVersions(ctx, apiGenerated.GetAllVersionsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetAllVersions200JSONResponse{}))
 			})
 		})
@@ -110,7 +110,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetMinorVersions(ctx, apiGenerated.GetMinorVersionsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetMinorVersions200JSONResponse{}))
 			})
 		})
@@ -123,7 +123,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetCloudInfo(ctx, apiGenerated.GetCloudInfoRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetCloudInfo200JSONResponse{}))
 			})
 		})
@@ -138,7 +138,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetCloudInfo400ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -159,7 +159,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetDeploymentManager200JSONResponse{}))
 			})
 		})
@@ -175,7 +175,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetDeploymentManager404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -192,7 +192,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetDeploymentManager500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -212,7 +212,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetDeploymentManagers(ctx, apiGenerated.GetDeploymentManagersRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetDeploymentManagers200JSONResponse{}))
 				deploymentManagers := resp.(apiGenerated.GetDeploymentManagers200JSONResponse)
 				Expect(deploymentManagers).To(HaveLen(2))
@@ -230,7 +230,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetDeploymentManagers(ctx, apiGenerated.GetDeploymentManagersRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetDeploymentManagers200JSONResponse{}))
 				Expect(resp.(apiGenerated.GetDeploymentManagers200JSONResponse)).To(HaveLen(0))
 			})
@@ -245,7 +245,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetDeploymentManagers(ctx, apiGenerated.GetDeploymentManagersRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetDeploymentManagers500ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -261,7 +261,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetDeploymentManagers400ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -282,14 +282,14 @@ var _ = Describe("ResourceServer", func() {
 					},
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.CreateSubscription400ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusBadRequest))
-				Expect(problemResp.AdditionalAttributes).NotTo(BeNil())
+				Expect(problemResp.AdditionalAttributes).ToNot(BeNil())
 				attrs := *problemResp.AdditionalAttributes
-				Expect(attrs).NotTo(HaveKey("callback"))
-				Expect(attrs).NotTo(HaveKey("filter"))
-				Expect(problemResp.Detail).NotTo(ContainSubstring(callbackURL))
+				Expect(attrs).ToNot(HaveKey("callback"))
+				Expect(attrs).ToNot(HaveKey("filter"))
+				Expect(problemResp.Detail).ToNot(ContainSubstring(callbackURL))
 			})
 		})
 
@@ -311,12 +311,12 @@ var _ = Describe("ResourceServer", func() {
 					},
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.CreateSubscription400ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusBadRequest))
-				Expect(problemResp.Detail).NotTo(ContainSubstring(callbackURL))
-				Expect(problemResp.Detail).NotTo(ContainSubstring("192.0.2.1"))
-				Expect(problemResp.Detail).NotTo(ContainSubstring("secret=token123"))
+				Expect(problemResp.Detail).ToNot(ContainSubstring(callbackURL))
+				Expect(problemResp.Detail).ToNot(ContainSubstring("192.0.2.1"))
+				Expect(problemResp.Detail).ToNot(ContainSubstring("secret=token123"))
 			})
 		})
 
@@ -344,13 +344,13 @@ var _ = Describe("ResourceServer", func() {
 					},
 				})
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.CreateSubscription400ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusBadRequest))
 				Expect(problemResp.Detail).To(Equal("callback value must be unique"))
-				Expect(problemResp.AdditionalAttributes).NotTo(BeNil())
+				Expect(problemResp.AdditionalAttributes).ToNot(BeNil())
 				attrs := *problemResp.AdditionalAttributes
-				Expect(attrs).NotTo(HaveKey("callback"))
+				Expect(attrs).ToNot(HaveKey("callback"))
 			})
 		})
 	})
@@ -367,7 +367,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetSubscription200JSONResponse{}))
 			})
 		})
@@ -383,7 +383,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetSubscription404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -400,7 +400,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetSubscription500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -422,7 +422,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetSubscriptions(ctx, apiGenerated.GetSubscriptionsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetSubscriptions200JSONResponse{}))
 				subscriptions := resp.(apiGenerated.GetSubscriptions200JSONResponse)
 				Expect(subscriptions).To(HaveLen(2))
@@ -440,7 +440,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetSubscriptions(ctx, apiGenerated.GetSubscriptionsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetSubscriptions200JSONResponse{}))
 				Expect(resp.(apiGenerated.GetSubscriptions200JSONResponse)).To(HaveLen(0))
 			})
@@ -455,7 +455,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetSubscriptions(ctx, apiGenerated.GetSubscriptionsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetSubscriptions500ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -471,7 +471,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetSubscriptions400ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -489,7 +489,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.DeleteSubscription200Response{}))
 			})
 		})
@@ -505,7 +505,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.DeleteSubscription404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -522,7 +522,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.DeleteSubscription500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -544,7 +544,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourcePool200JSONResponse{}))
 			})
 		})
@@ -560,7 +560,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResourcePool404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -577,7 +577,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResourcePool500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -597,7 +597,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetResourcePools(ctx, apiGenerated.GetResourcePoolsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourcePools200JSONResponse{}))
 				resourcePools := resp.(apiGenerated.GetResourcePools200JSONResponse)
 				Expect(resourcePools).To(HaveLen(2))
@@ -615,7 +615,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetResourcePools(ctx, apiGenerated.GetResourcePoolsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourcePools200JSONResponse{}))
 				Expect(resp.(apiGenerated.GetResourcePools200JSONResponse)).To(HaveLen(0))
 			})
@@ -630,7 +630,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetResourcePools(ctx, apiGenerated.GetResourcePoolsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourcePools500ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -646,7 +646,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourcePools400ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -678,7 +678,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResource200JSONResponse{}))
 			})
 		})
@@ -695,7 +695,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResource404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 				Expect(*problemResp.AdditionalAttributes).To(HaveKeyWithValue("resourcePoolId", poolID.String()))
@@ -717,7 +717,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResource404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -735,7 +735,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResource500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -756,7 +756,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResource500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -789,7 +789,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResources200JSONResponse{}))
 				resources := resp.(apiGenerated.GetResources200JSONResponse)
 				Expect(resources).To(HaveLen(2))
@@ -809,7 +809,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResources404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -829,7 +829,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResources500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -847,7 +847,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResources400ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -865,7 +865,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetInternalResourceById200JSONResponse{}))
 			})
 		})
@@ -881,7 +881,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetInternalResourceById404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -898,7 +898,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetInternalResourceById500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -923,7 +923,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourceType200JSONResponse{}))
 			})
 		})
@@ -943,7 +943,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourceType200JSONResponse{}))
 				resourceType := resp.(apiGenerated.GetResourceType200JSONResponse)
 				Expect(resourceType.AlarmDictionaryId).To(Equal(&dictID))
@@ -961,7 +961,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResourceType404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -978,7 +978,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResourceType500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1001,7 +1001,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetResourceTypes(ctx, apiGenerated.GetResourceTypesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourceTypes200JSONResponse{}))
 				resourceTypes := resp.(apiGenerated.GetResourceTypes200JSONResponse)
 				Expect(resourceTypes).To(HaveLen(2))
@@ -1028,7 +1028,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetResourceTypes(ctx, apiGenerated.GetResourceTypesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourceTypes200JSONResponse{}))
 				resourceTypes := resp.(apiGenerated.GetResourceTypes200JSONResponse)
 				Expect(resourceTypes).To(HaveLen(1))
@@ -1050,7 +1050,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetResourceTypes(ctx, apiGenerated.GetResourceTypesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourceTypes200JSONResponse{}))
 				Expect(resp.(apiGenerated.GetResourceTypes200JSONResponse)).To(HaveLen(0))
 			})
@@ -1065,7 +1065,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetResourceTypes(ctx, apiGenerated.GetResourceTypesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourceTypes500ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -1084,7 +1084,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetResourceTypes(ctx, apiGenerated.GetResourceTypesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResourceTypes500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1101,7 +1101,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourceTypes400ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -1125,7 +1125,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetAlarmDictionary200JSONResponse{}))
 			})
 		})
@@ -1141,7 +1141,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetAlarmDictionary404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -1158,7 +1158,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetAlarmDictionary500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1186,7 +1186,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetAlarmDictionaries200JSONResponse{}))
 				alarmDictionaries := resp.(apiGenerated.GetAlarmDictionaries200JSONResponse)
 				Expect(alarmDictionaries).To(HaveLen(2))
@@ -1204,7 +1204,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetAlarmDictionaries200JSONResponse{}))
 				Expect(resp.(apiGenerated.GetAlarmDictionaries200JSONResponse)).To(HaveLen(0))
 			})
@@ -1219,7 +1219,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetAlarmDictionaries500ApplicationProblemPlusJSONResponse{}))
 			})
 		})
@@ -1239,11 +1239,11 @@ var _ = Describe("ResourceServer", func() {
 				Times(1)
 
 			resp1, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(resp1.(apiGenerated.GetAlarmDictionaries200JSONResponse)).To(HaveLen(1))
 
 			resp2, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(resp2.(apiGenerated.GetAlarmDictionaries200JSONResponse)).To(HaveLen(1))
 		})
 
@@ -1275,13 +1275,13 @@ var _ = Describe("ResourceServer", func() {
 			)
 
 			resp1, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(resp1.(apiGenerated.GetAlarmDictionaries200JSONResponse)).To(HaveLen(1))
 
 			server.InvalidateAlarmDictCache()
 
 			resp2, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(resp2.(apiGenerated.GetAlarmDictionaries200JSONResponse)).To(HaveLen(2))
 		})
 
@@ -1298,13 +1298,13 @@ var _ = Describe("ResourceServer", func() {
 			byID, err := server.GetAlarmDictionary(ctx, apiGenerated.GetAlarmDictionaryRequestObject{
 				AlarmDictionaryId: dictID,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(byID).To(BeAssignableToTypeOf(apiGenerated.GetAlarmDictionary200JSONResponse{}))
 
 			byRT, err := server.GetResourceTypeAlarmDictionary(ctx, apiGenerated.GetResourceTypeAlarmDictionaryRequestObject{
 				ResourceTypeId: rtID,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(byRT).To(BeAssignableToTypeOf(apiGenerated.GetResourceTypeAlarmDictionary200JSONResponse{}))
 		})
 	})
@@ -1320,7 +1320,7 @@ var _ = Describe("ResourceServer", func() {
 				Return(nil, fmt.Errorf("definitions query failed"))
 
 			resp, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetAlarmDictionaries500ApplicationProblemPlusJSONResponse{}))
 		})
 	})
@@ -1341,7 +1341,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetResourceTypeAlarmDictionary200JSONResponse{}))
 			})
 		})
@@ -1357,7 +1357,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResourceTypeAlarmDictionary404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -1374,7 +1374,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetResourceTypeAlarmDictionary500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1405,7 +1405,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetLocation200JSONResponse{}))
 			})
 		})
@@ -1421,7 +1421,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetLocation404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -1438,7 +1438,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetLocation500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1458,7 +1458,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetLocation500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1487,7 +1487,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetLocations(ctx, apiGenerated.GetLocationsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetLocations200JSONResponse{}))
 				locations := resp.(apiGenerated.GetLocations200JSONResponse)
 				Expect(locations).To(HaveLen(2))
@@ -1508,7 +1508,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetLocations(ctx, apiGenerated.GetLocationsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetLocations200JSONResponse{}))
 				Expect(resp.(apiGenerated.GetLocations200JSONResponse)).To(HaveLen(0))
 			})
@@ -1523,7 +1523,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetLocations(ctx, apiGenerated.GetLocationsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetLocations500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1543,10 +1543,10 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetLocations(ctx, apiGenerated.GetLocationsRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetLocations500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
-				Expect(problemResp.Detail).NotTo(BeEmpty())
+				Expect(problemResp.Detail).ToNot(BeEmpty())
 			})
 		})
 	})
@@ -1569,7 +1569,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetOCloudSite200JSONResponse{}))
 			})
 		})
@@ -1585,7 +1585,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetOCloudSite404ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusNotFound))
 			})
@@ -1602,7 +1602,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetOCloudSite500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1622,7 +1622,7 @@ var _ = Describe("ResourceServer", func() {
 				})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetOCloudSite500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1651,7 +1651,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetOCloudSites(ctx, apiGenerated.GetOCloudSitesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetOCloudSites200JSONResponse{}))
 				sites := resp.(apiGenerated.GetOCloudSites200JSONResponse)
 				Expect(sites).To(HaveLen(2))
@@ -1672,7 +1672,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetOCloudSites(ctx, apiGenerated.GetOCloudSitesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apiGenerated.GetOCloudSites200JSONResponse{}))
 				Expect(resp.(apiGenerated.GetOCloudSites200JSONResponse)).To(HaveLen(0))
 			})
@@ -1687,7 +1687,7 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetOCloudSites(ctx, apiGenerated.GetOCloudSitesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetOCloudSites500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1708,10 +1708,10 @@ var _ = Describe("ResourceServer", func() {
 				resp, err := server.GetOCloudSites(ctx, apiGenerated.GetOCloudSitesRequestObject{})
 
 				// verify
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				problemResp := resp.(apiGenerated.GetOCloudSites500ApplicationProblemPlusJSONResponse)
 				Expect(problemResp.Status).To(Equal(http.StatusInternalServerError))
-				Expect(problemResp.Detail).NotTo(BeEmpty())
+				Expect(problemResp.Detail).ToNot(BeEmpty())
 			})
 		})
 	})

--- a/internal/service/resources/collector/collector_hwmgr_test.go
+++ b/internal/service/resources/collector/collector_hwmgr_test.go
@@ -114,7 +114,7 @@ var _ = Describe("HardwareDataSource", func() {
 			Expect(ds.GetID()).To(Equal(id))
 			Expect(ds.GetGenerationID()).To(Equal(3))
 			Expect(ds.Name()).To(Equal("HardwareDataSource"))
-			Expect(ds.AsyncChangeEvents).NotTo(BeNil())
+			Expect(ds.AsyncChangeEvents).ToNot(BeNil())
 		})
 
 		It("updates generation via SetGenerationID and IncrGenerationID", func() {
@@ -206,7 +206,7 @@ var _ = Describe("HardwareDataSource", func() {
 				},
 			}
 			rt, err := ds.MakeResourceType(res)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(rt.Name).To(Equal("Acme/Box"))
 			Expect(rt.Vendor).To(Equal("Acme"))
 			Expect(rt.Model).To(Equal("Box"))
@@ -242,8 +242,8 @@ var _ = Describe("HardwareDataSource", func() {
 			ds.hubClient = fakeClient
 
 			key, err := ds.HandleAsyncEvent(ctx, bmh, async.Updated)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(key).NotTo(Equal(uuid.Nil))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(key).ToNot(Equal(uuid.Nil))
 
 			Expect(eventCh).To(HaveLen(2))
 			rtEvent := <-eventCh
@@ -262,8 +262,8 @@ var _ = Describe("HardwareDataSource", func() {
 			bmh := newTestBMH("bmh-del", "test-pool", metal3v1alpha1.StateRegistering)
 
 			key, err := ds.HandleAsyncEvent(ctx, bmh, async.Updated)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(key).NotTo(Equal(uuid.Nil))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(key).ToNot(Equal(uuid.Nil))
 
 			Expect(eventCh).To(HaveLen(1))
 			event := <-eventCh
@@ -274,8 +274,8 @@ var _ = Describe("HardwareDataSource", func() {
 			bmh := newTestBMH("bmh-gone", "test-pool", metal3v1alpha1.StateAvailable)
 
 			key, err := ds.HandleAsyncEvent(ctx, bmh, async.Deleted)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(key).NotTo(Equal(uuid.Nil))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(key).ToNot(Equal(uuid.Nil))
 
 			Expect(eventCh).To(HaveLen(1))
 			event := <-eventCh
@@ -292,8 +292,8 @@ var _ = Describe("HardwareDataSource", func() {
 			ds.hubClient = fakeClient
 
 			key, err := ds.HandleAsyncEvent(ctx, hwdata, async.Updated)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(key).NotTo(Equal(uuid.Nil))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(key).ToNot(Equal(uuid.Nil))
 			Expect(eventCh).To(HaveLen(2))
 		})
 
@@ -301,7 +301,7 @@ var _ = Describe("HardwareDataSource", func() {
 			hwdata := newTestHardwareData("no-bmh")
 
 			key, err := ds.HandleAsyncEvent(ctx, hwdata, async.Updated)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(key).To(Equal(uuid.Nil))
 			Expect(eventCh).To(BeEmpty())
 		})
@@ -326,8 +326,8 @@ var _ = Describe("HardwareDataSource", func() {
 			ds.hubClient = fakeClient
 
 			key, err := ds.HandleAsyncEvent(ctx, node, async.Updated)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(key).NotTo(Equal(uuid.Nil))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(key).ToNot(Equal(uuid.Nil))
 			Expect(eventCh).To(HaveLen(2))
 		})
 
@@ -344,7 +344,7 @@ var _ = Describe("HardwareDataSource", func() {
 			}
 
 			key, err := ds.HandleAsyncEvent(ctx, node, async.Updated)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(key).To(Equal(uuid.Nil))
 			Expect(eventCh).To(BeEmpty())
 		})
@@ -370,7 +370,7 @@ var _ = Describe("HardwareDataSource", func() {
 		It("sends SyncComplete event for BMH objectType", func() {
 			keys := []uuid.UUID{uuid.New(), uuid.New()}
 			err := ds.HandleSyncComplete(ctx, &metal3v1alpha1.BareMetalHost{}, keys)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(eventCh).To(HaveLen(1))
 			event := <-eventCh
@@ -382,13 +382,13 @@ var _ = Describe("HardwareDataSource", func() {
 
 		It("does not send event for HardwareData objectType", func() {
 			err := ds.HandleSyncComplete(ctx, &metal3v1alpha1.HardwareData{}, nil)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(eventCh).To(BeEmpty())
 		})
 
 		It("does not send event for AllocatedNode objectType", func() {
 			err := ds.HandleSyncComplete(ctx, &hwmgmtv1alpha1.AllocatedNode{}, nil)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(eventCh).To(BeEmpty())
 		})
 	})
@@ -411,7 +411,7 @@ var _ = Describe("HardwareDataSource", func() {
 			ds.hubClient = fakeClient
 
 			results, err := ds.BuildResourcesForPool(ctx, "my-pool")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Resource.Extensions[vendorExtension]).To(Equal("Dell"))
 			Expect(results[0].ResourceType.Vendor).To(Equal("Dell"))
@@ -424,7 +424,7 @@ var _ = Describe("HardwareDataSource", func() {
 			ds.hubClient = fakeClient
 
 			results, err := ds.BuildResourcesForPool(ctx, "empty-pool")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(BeEmpty())
 		})
 
@@ -437,7 +437,7 @@ var _ = Describe("HardwareDataSource", func() {
 			ds.hubClient = fakeClient
 
 			results, err := ds.BuildResourcesForPool(ctx, "my-pool")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(BeEmpty())
 		})
 	})

--- a/internal/service/resources/collector/envtest/suite_test.go
+++ b/internal/service/resources/collector/envtest/suite_test.go
@@ -150,7 +150,7 @@ func ptrTo(s string) *string {
 func deleteAndWait(obj client.Object) {
 	err := k8sClient.Delete(ctx, obj)
 	if err != nil && !apierrors.IsNotFound(err) {
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 	}
 	// Wait until the CR is actually gone from the API server
 	Eventually(func() bool {

--- a/internal/service/resources/collector/hierarchy_test.go
+++ b/internal/service/resources/collector/hierarchy_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Hierarchy Helpers", func() {
 	Describe("convertCoordinateToGeoJSON", func() {
 		It("returns nil for nil coordinate", func() {
 			m, err := convertCoordinateToGeoJSON(nil)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(m).To(BeNil())
 		})
 
@@ -112,7 +112,7 @@ var _ = Describe("Hierarchy Helpers", func() {
 				Latitude:  "38.8951",
 				Longitude: "-77.0364",
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(m["type"]).To(Equal("Point"))
 			Expect(m["coordinates"]).To(Equal([]float64{-77.0364, 38.8951}))
 		})
@@ -124,7 +124,7 @@ var _ = Describe("Hierarchy Helpers", func() {
 				Longitude: "0",
 				Altitude:  &alt,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(m["coordinates"]).To(Equal([]float64{0, 0, 100.5}))
 		})
 

--- a/internal/service/resources/collector/transformer_test.go
+++ b/internal/service/resources/collector/transformer_test.go
@@ -26,7 +26,7 @@ var _ = Describe("NotificationTransformer", func() {
 		sub := &notifier.SubscriptionInfo{ConsumerSubscriptionID: nil}
 		n := &notifier.Notification{Payload: generated.InventoryChangeNotification{}}
 		out, err := t.Transform(sub, n)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(BeIdenticalTo(n))
 	})
 
@@ -50,11 +50,11 @@ var _ = Describe("NotificationTransformer", func() {
 		n := &notifier.Notification{Payload: payload}
 
 		out, err := t.Transform(sub, n)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(out).NotTo(BeIdenticalTo(n))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).ToNot(BeIdenticalTo(n))
 		typed, ok := out.Payload.(generated.InventoryChangeNotification)
 		Expect(ok).To(BeTrue())
-		Expect(typed.ConsumerSubscriptionId).NotTo(BeNil())
+		Expect(typed.ConsumerSubscriptionId).ToNot(BeNil())
 		Expect(*typed.ConsumerSubscriptionId).To(Equal(consID))
 		Expect(typed.NotificationId).To(Equal(nid))
 	})

--- a/internal/service/resources/listener/alarms_sync_test.go
+++ b/internal/service/resources/listener/alarms_sync_test.go
@@ -98,12 +98,12 @@ var _ = Describe("Alarms Sync", func() {
 
 			for _, rule := range rules {
 				err := hubClient.Create(ctx, rule)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			}
 
 			// Call getIronicPrometheusRules and verify only hardware alerts are returned
 			result, err := getIronicPrometheusRules(ctx, hubClient)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].Alert).To(Equal("IronicHardwareTemperatureHigh"))
 		})
@@ -144,11 +144,11 @@ var _ = Describe("Alarms Sync", func() {
 
 			for _, rule := range rules {
 				err := hubClient.Create(ctx, rule)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			}
 
 			result, err := getIronicPrometheusRules(ctx, hubClient)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(HaveLen(0))
 		})
 
@@ -209,12 +209,12 @@ var _ = Describe("Alarms Sync", func() {
 
 			for _, rule := range rules {
 				err := hubClient.Create(ctx, rule)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			}
 
 			// Only the alert from group with BOTH labels should be included
 			result, err := getIronicPrometheusRules(ctx, hubClient)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].Alert).To(Equal("ValidHardwareAlert"))
 		})
@@ -337,8 +337,8 @@ var _ = Describe("Alarms Sync", func() {
 
 			additionalFields := *result[0].AlarmAdditionalFields
 			Expect(additionalFields["Expr"]).To(Equal("up == 0"))
-			Expect(additionalFields).NotTo(HaveKey("For"))
-			Expect(additionalFields).NotTo(HaveKey("KeepFiringFor"))
+			Expect(additionalFields).ToNot(HaveKey("For"))
+			Expect(additionalFields).ToNot(HaveKey("KeepFiringFor"))
 		})
 	})
 })

--- a/internal/service/resources/listener/pg_listener_test.go
+++ b/internal/service/resources/listener/pg_listener_test.go
@@ -29,12 +29,12 @@ var _ = Describe("processResourceTypeChangeNotification", func() {
 			ChangeType:     "deleted",
 		}
 		payload, err := json.Marshal(notification)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		err = processResourceTypeChangeNotification(ctx, nil, &pgconn.Notification{
 			Payload: string(payload),
 		})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("returns error for invalid JSON payload", func() {
@@ -51,11 +51,11 @@ var _ = Describe("processResourceTypeChangeNotification", func() {
 			ChangeType:     "unknown-type",
 		}
 		payload, err := json.Marshal(notification)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		err = processResourceTypeChangeNotification(ctx, nil, &pgconn.Notification{
 			Payload: string(payload),
 		})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -86,31 +86,31 @@ var _ = BeforeSuite(func() {
 	// Set the scheme.
 	testScheme := runtime.NewScheme()
 	err := provisioningv1alpha1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = hwmgmtv1alpha1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = corev1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = siteconfig.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = policiesv1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = clusterv1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = assistedservicev1beta1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = apiextensionsv1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = admissionregistrationv1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = ibgu.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = hivev1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = metal3v1alpha1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	err = observabilityv1beta1.AddToScheme(testScheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	// Get the needed external CRDs. Their details are under test/utils/vars.go - ExternalCrdsData.
 	// Update that with any other CRDs that the provisioning controller depends on.
@@ -137,7 +137,7 @@ var _ = BeforeSuite(func() {
 		Scheme: testScheme,
 	})
 	Expect(err).ToNot(HaveOccurred())
-	Expect(ProvisioningManager).NotTo(BeNil())
+	Expect(ProvisioningManager).ToNot(BeNil())
 
 	// Get a separate manager for hardware manager controllers (simulates separate pod deployment).
 	HwMgrManager, err = ctrl.NewManager(cfg, ctrl.Options{
@@ -147,12 +147,12 @@ var _ = BeforeSuite(func() {
 		},
 	})
 	Expect(err).ToNot(HaveOccurred())
-	Expect(HwMgrManager).NotTo(BeNil())
+	Expect(HwMgrManager).ToNot(BeNil())
 
 	// Get the client.
 	K8SClient, err = client.New(cfg, client.Options{Scheme: testScheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(K8SClient).NotTo(BeNil())
+	Expect(err).ToNot(HaveOccurred())
+	Expect(K8SClient).ToNot(BeNil())
 
 	// Setup the ClusterTemplate Reconciler.
 	ClusterTemplateTestReconciler = &provisioningcontrollers.ClusterTemplateReconciler{
@@ -220,5 +220,5 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 })


### PR DESCRIPTION
Replace all 675 instances of .NotTo() with .ToNot() across 37 test files. Both are functionally identical Gomega aliases, but mixed usage is inconsistent. .ToNot() was already the 68% majority (1,157 vs 675 instances).

Add AGENTS.md test convention rule to prevent drift.