### PR TITLE
test: replace hardcoded timeouts with constants in e2e tests

### DIFF
--- a/test/e2e/mno_hw_configuration_test.go
+++ b/test/e2e/mno_hw_configuration_test.go
@@ -39,10 +39,16 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	mnoTimeout     = time.Minute * 2
+	mnoLongTimeout = time.Minute * 3
+	mnoInterval    = time.Second * 3
+)
+
 var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day2-hw-updates"), func() {
 	const (
-		timeout     = time.Minute * 2
-		interval    = time.Second * 3
+		timeout     = mnoTimeout
+		interval    = mnoInterval
 		master      = "master"
 		worker      = "worker"
 		masterCount = 3
@@ -830,7 +836,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 					}
 				}
 				return count
-			}, 3*time.Minute, interval).Should(Equal(7),
+			}, mnoLongTimeout, interval).Should(Equal(7),
 				"7 workers should converge to v2 ConfigApplied while Servicing worker defers")
 
 			By("Verifying the Servicing worker is still in ConfigUpdate with v1 profile (deferred abandon)")
@@ -977,7 +983,7 @@ func failBMHDay2(ctx context.Context, node *hwmgmtv1alpha1.AllocatedNode, bmh *m
 		n := &hwmgmtv1alpha1.AllocatedNode{}
 		Expect(K8SClient.Get(ctx, nodeKey, n)).To(Succeed())
 		return n.Annotations[hwmgrcontrollers.ConfigAnnotation] != ""
-	}, time.Minute*3, time.Second*2).Should(BeTrue(),
+	}, mnoLongTimeout, mnoInterval).Should(BeTrue(),
 		"AllocatedNode %s should have config annotation", node.Name)
 
 	// Step 5: Transition BMH to Error with an expired transient error timestamp.
@@ -1099,7 +1105,7 @@ func waitForBMHRebootAnnotation(ctx context.Context, bmhKey types.NamespacedName
 		Expect(K8SClient.Get(ctx, bmhKey, bmh)).To(Succeed())
 		_, exists := bmh.Annotations[hwmgrcontrollers.BmhRebootAnnotation]
 		return exists
-	}, time.Minute*3, time.Second*3).Should(BeTrue(),
+	}, mnoLongTimeout, mnoInterval).Should(BeTrue(),
 		"BMH %s should have reboot annotation", bmhKey.Name)
 }
 

--- a/test/e2e/sno_provisioning_test.go
+++ b/test/e2e/sno_provisioning_test.go
@@ -35,7 +35,7 @@ import (
 var _ = Describe("SNO End-to-end ProvisioningRequestReconcile with hardware manager", Ordered, Label("sno-provisioning"), func() {
 	// This test suite runs with both O2IMS and hardware manager controllers active
 	// Hardware manager runs alongside Provisioning manager for all tests
-	const timeout = time.Second * 60
+	const timeout = time.Minute * 3
 	const interval = time.Second * 3
 
 	var (
@@ -503,7 +503,7 @@ defaultHugepagesSize: "1G"`,
 			err := K8SClient.Get(testCtx, client.ObjectKeyFromObject(ProvRequestCR), reconciledPR)
 			Expect(err).ToNot(HaveOccurred())
 			return len(reconciledPR.Status.Conditions) == 2
-		}, time.Minute*3, time.Second*3).Should(BeTrue())
+		}, timeout, interval).Should(BeTrue())
 
 		conditions := reconciledPR.Status.Conditions
 		// Verify the ProvisioningRequest's status conditions.
@@ -561,7 +561,7 @@ defaultHugepagesSize: "1G"`,
 				}
 			}
 			return false
-		}, time.Minute*3, time.Second*3).Should(BeTrue())
+		}, timeout, interval).Should(BeTrue())
 
 		// Verify initial state - hardware provisioning in progress.
 		conditions := reconciledPR.Status.Conditions
@@ -605,7 +605,7 @@ defaultHugepagesSize: "1G"`,
 			}, nar)
 			Expect(err).ToNot(HaveOccurred())
 			return true
-		}, time.Minute*3, time.Second*3).Should(BeTrue())
+		}, timeout, interval).Should(BeTrue())
 
 		// Verify NodeAllocationRequest contains expected node groups (only 1 single-node group).
 		Expect(len(nar.Spec.NodeGroup)).To(Equal(1))
@@ -622,7 +622,7 @@ defaultHugepagesSize: "1G"`,
 			err := K8SClient.List(testCtx, allocatedNodes, client.InNamespace(constants.DefaultNamespace))
 			Expect(err).ToNot(HaveOccurred())
 			return len(allocatedNodes.Items) == 1 && allocatedNodes.Items[0].Spec.NodeAllocationRequest == crName
-		}, time.Minute*3, time.Second*3).Should(BeTrue())
+		}, timeout, interval).Should(BeTrue())
 
 		// Save the single allocated node for later use
 		allocatedNode = &allocatedNodes.Items[0]
@@ -683,7 +683,7 @@ defaultHugepagesSize: "1G"`,
 			err := K8SClient.Get(testCtx, types.NamespacedName{Name: allocatedNode.Name, Namespace: constants.DefaultNamespace}, allocatedNode)
 			Expect(err).ToNot(HaveOccurred())
 			return allocatedNode.Annotations[hwmgrcontrollers.ConfigAnnotation] != ""
-		}, time.Minute*3, time.Second*3).Should(BeTrue())
+		}, timeout, interval).Should(BeTrue())
 
 		// Check if the HostFirmwareComponents already exists.
 		hfc := &metal3v1alpha1.HostFirmwareComponents{}
@@ -755,7 +755,7 @@ defaultHugepagesSize: "1G"`,
 			Expect(err).ToNot(HaveOccurred())
 
 			return nar.Status.Conditions[0].Status == metav1.ConditionTrue && allocatedNode.Status.Conditions[0].Status == metav1.ConditionTrue
-		}, time.Minute*3, time.Second*5).Should(BeTrue())
+		}, timeout, interval).Should(BeTrue())
 		conditions := nar.Status.Conditions
 		testutils.VerifyStatusCondition(conditions[0], metav1.Condition{
 			Type:   string(hwmgmtv1alpha1.Provisioned),
@@ -777,7 +777,7 @@ defaultHugepagesSize: "1G"`,
 				}
 			}
 			return false
-		}, time.Minute*3, time.Second*5).Should(BeTrue())
+		}, timeout, interval).Should(BeTrue())
 
 		conditions := reconciledPR.Status.Conditions
 		// Find and verify HardwareProvisioned condition is now completed.
@@ -805,7 +805,7 @@ defaultHugepagesSize: "1G"`,
 			Expect(err).ToNot(HaveOccurred())
 			// Check if ProvisioningDetails moved from hardware provisioning message.
 			return !strings.Contains(reconciledPR.Status.ProvisioningStatus.ProvisioningDetails, "Hardware provisioning")
-		}, time.Minute*3, time.Second*5).Should(BeTrue())
+		}, timeout, interval).Should(BeTrue())
 
 		// Update the ProvisioningRequest to use a ClusterTemplate pointing to a ConfigMap that would attempt to
 		// trigger re-rendering the ClusterInstance.
@@ -848,6 +848,6 @@ defaultHugepagesSize: "1G"`,
 				provisioningv1alpha1.StateProgressing, fmt.Sprintf("Waiting for ClusterInstance (%s) to be processed", crName), nil)
 
 			return true
-		}, time.Minute, 5*time.Second).Should(BeTrue())
+		}, timeout, interval).Should(BeTrue())
 	})
 })


### PR DESCRIPTION
Replace 12 hardcoded duration values in Eventually() calls with defined constants:

- sno_provisioning_test.go: fix timeout constant from 60s to 3m to match actual usage (every Eventually was overriding it to 3m), replace 9 hardcoded instances with timeout/interval constants
- mno_hw_configuration_test.go: add package-level mnoTimeout, mnoLongTimeout, mnoInterval constants so helper functions outside the Describe block can reference them, replace 3 hardcoded instances