### PR TITLE
test: consolidate getFakeClientFromObjects into shared test/fakeclient package

### DIFF
--- a/internal/controllers/clustertemplate_controller_test.go
+++ b/internal/controllers/clustertemplate_controller_test.go
@@ -151,7 +151,7 @@ var _ = Describe("ClusterTemplateReconciler", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{ct, clusterInstanceCRD}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{ct, clusterInstanceCRD}...)
 		reconciler = &ClusterTemplateReconciler{
 			Client: c,
 			Logger: logger,
@@ -324,7 +324,7 @@ var _ = Describe("enqueueClusterTemplatesForConfigmap", func() {
 		for _, ct := range cts {
 			objs = append(objs, ct)
 		}
-		c = fakeclient.GetFakeClientFromObjects(scheme, objs...)
+		c = fakeclient.GetFakeClientFromObjects(objs...)
 
 		r = &ClusterTemplateReconciler{
 			Client: c,
@@ -580,7 +580,7 @@ clustertemplate-a-policy-v1-defaultHugepagesSize: "1G"`,
 		clusterInstanceCRD, err := ctlrutils.BuildTestClusterInstanceCRD(ctlrutils.TestClusterInstanceSpecOk)
 		Expect(err).ToNot(HaveOccurred())
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{ct, clusterInstanceCRD}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{ct, clusterInstanceCRD}...)
 
 		t = &clusterTemplateReconcilerTask{
 			client: c,
@@ -752,7 +752,7 @@ var _ = Describe("validateConfigmapReference", func() {
 		ctx = context.Background()
 		clusterInstanceCRD, err := ctlrutils.BuildTestClusterInstanceCRD(ctlrutils.TestClusterInstanceSpecOk)
 		Expect(err).ToNot(HaveOccurred())
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{clusterInstanceCRD}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{clusterInstanceCRD}...)
 	})
 
 	It("should validate a valid configmap", func() {
@@ -1005,7 +1005,7 @@ var _ = Describe("Validate Cluster Instance Name", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		c = fakeclient.GetFakeClientFromObjects(scheme)
+		c = fakeclient.GetFakeClientFromObjects()
 	})
 
 	It("should validate a cluster template name", func() {
@@ -1131,7 +1131,7 @@ var _ = Describe("Validate Cluster Instance TemplateID", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		c = fakeclient.GetFakeClientFromObjects(scheme)
+		c = fakeclient.GetFakeClientFromObjects()
 	})
 
 	It("Generate templateID", func() {
@@ -1699,7 +1699,7 @@ var _ = Describe("validateUpgradeDefaultsConfigmap", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{ct}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{ct}...)
 
 		t = &clusterTemplateReconcilerTask{
 			client: c,

--- a/internal/controllers/clustertemplate_controller_test.go
+++ b/internal/controllers/clustertemplate_controller_test.go
@@ -97,6 +97,7 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"gopkg.in/yaml.v3"
@@ -150,7 +151,7 @@ var _ = Describe("ClusterTemplateReconciler", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{ct, clusterInstanceCRD}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{ct, clusterInstanceCRD}...)
 		reconciler = &ClusterTemplateReconciler{
 			Client: c,
 			Logger: logger,
@@ -323,7 +324,7 @@ var _ = Describe("enqueueClusterTemplatesForConfigmap", func() {
 		for _, ct := range cts {
 			objs = append(objs, ct)
 		}
-		c = getFakeClientFromObjects(objs...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, objs...)
 
 		r = &ClusterTemplateReconciler{
 			Client: c,
@@ -579,7 +580,7 @@ clustertemplate-a-policy-v1-defaultHugepagesSize: "1G"`,
 		clusterInstanceCRD, err := ctlrutils.BuildTestClusterInstanceCRD(ctlrutils.TestClusterInstanceSpecOk)
 		Expect(err).ToNot(HaveOccurred())
 
-		c = getFakeClientFromObjects([]client.Object{ct, clusterInstanceCRD}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{ct, clusterInstanceCRD}...)
 
 		t = &clusterTemplateReconcilerTask{
 			client: c,
@@ -751,7 +752,7 @@ var _ = Describe("validateConfigmapReference", func() {
 		ctx = context.Background()
 		clusterInstanceCRD, err := ctlrutils.BuildTestClusterInstanceCRD(ctlrutils.TestClusterInstanceSpecOk)
 		Expect(err).ToNot(HaveOccurred())
-		c = getFakeClientFromObjects([]client.Object{clusterInstanceCRD}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{clusterInstanceCRD}...)
 	})
 
 	It("should validate a valid configmap", func() {
@@ -1004,7 +1005,7 @@ var _ = Describe("Validate Cluster Instance Name", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		c = getFakeClientFromObjects()
+		c = fakeclient.GetFakeClientFromObjects(scheme)
 	})
 
 	It("should validate a cluster template name", func() {
@@ -1130,7 +1131,7 @@ var _ = Describe("Validate Cluster Instance TemplateID", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		c = getFakeClientFromObjects()
+		c = fakeclient.GetFakeClientFromObjects(scheme)
 	})
 
 	It("Generate templateID", func() {
@@ -1698,7 +1699,7 @@ var _ = Describe("validateUpgradeDefaultsConfigmap", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{ct}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{ct}...)
 
 		t = &clusterTemplateReconcilerTask{
 			client: c,

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -51,6 +51,7 @@ import (
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -138,7 +139,7 @@ var _ = Describe("Inventory Controller", func() {
 			objs = append(objs, pods...)
 
 			// Get the fake client.
-			fakeClient := getFakeClientFromObjects(objs...)
+			fakeClient := fakeclient.GetFakeClientFromObjects(scheme, objs...)
 
 			// Initialize the O-Cloud Manager reconciler.
 			r := &Reconciler{

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Inventory Controller", func() {
 			objs = append(objs, pods...)
 
 			// Get the fake client.
-			fakeClient := fakeclient.GetFakeClientFromObjects(scheme, objs...)
+			fakeClient := fakeclient.GetFakeClientFromObjects(objs...)
 
 			// Initialize the O-Cloud Manager reconciler.
 			r := &Reconciler{

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -312,7 +312,7 @@ defaultHugepagesSize: "1G"`,
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, crs...)
+		c = fakeclient.GetFakeClientFromObjects(crs...)
 
 		// Reconcile the ClusterTemplate.
 		CTReconciler = &ClusterTemplateReconciler{
@@ -1635,7 +1635,7 @@ var _ = Describe("hasPolicyConfigurationTimedOut", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, crs...)
+		c = fakeclient.GetFakeClientFromObjects(crs...)
 		// Reconcile the ClusterTemplate.
 		CTReconciler = &ClusterTemplateReconciler{
 			Client: c,
@@ -1876,7 +1876,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, crs...)
+		c = fakeclient.GetFakeClientFromObjects(crs...)
 
 		// Populate the NodeAllocationRequest without creating it.
 		nodeAllocationRequest = &hwmgmtv1alpha1.NodeAllocationRequest{

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -81,6 +81,7 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -311,7 +312,7 @@ defaultHugepagesSize: "1G"`,
 			},
 		}
 
-		c = getFakeClientFromObjects(crs...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, crs...)
 
 		// Reconcile the ClusterTemplate.
 		CTReconciler = &ClusterTemplateReconciler{
@@ -1634,7 +1635,7 @@ var _ = Describe("hasPolicyConfigurationTimedOut", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects(crs...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, crs...)
 		// Reconcile the ClusterTemplate.
 		CTReconciler = &ClusterTemplateReconciler{
 			Client: c,
@@ -1875,7 +1876,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects(crs...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, crs...)
 
 		// Populate the NodeAllocationRequest without creating it.
 		nodeAllocationRequest = &hwmgmtv1alpha1.NodeAllocationRequest{

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -148,7 +148,7 @@ var _ = Describe("handleRenderClusterInstance", func() {
 		// Use helper function to get ConfigMap with ClusterInstance defaults
 		cm := getClusterInstanceDefaultsConfigMap(ciDefaultsCm, ctNamespace)
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, ct, cm}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr, ct, cm}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -320,7 +320,7 @@ var _ = Describe("handleClusterInstallation", func() {
 		// Use helper function to get ConfigMap with ClusterInstance defaults
 		cm := getClusterInstanceDefaultsConfigMap(ciDefaultsCm, ctNamespace)
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, ct, cm}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr, ct, cm}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -64,6 +64,7 @@ import (
 
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
 )
 
@@ -147,7 +148,7 @@ var _ = Describe("handleRenderClusterInstance", func() {
 		// Use helper function to get ConfigMap with ClusterInstance defaults
 		cm := getClusterInstanceDefaultsConfigMap(ciDefaultsCm, ctNamespace)
 
-		c = getFakeClientFromObjects([]client.Object{cr, ct, cm}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, ct, cm}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -319,7 +320,7 @@ var _ = Describe("handleClusterInstallation", func() {
 		// Use helper function to get ConfigMap with ClusterInstance defaults
 		cm := getClusterInstanceDefaultsConfigMap(ciDefaultsCm, ctNamespace)
 
-		c = getFakeClientFromObjects([]client.Object{cr, ct, cm}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, ct, cm}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -179,6 +179,7 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -5801,7 +5802,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 	}
 
 	It("should use defaults only when no hwMgmtParameters in PR", func() {
-		c = getFakeClientFromObjects(createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
 		task = buildTask(c, `{"nodeClusterName": "test"}`)
 
 		err := task.validateAndMergeHwMgmtInput(ctx, ct)
@@ -5816,7 +5817,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 	})
 
 	It("should merge hwMgmtParameters over defaults", func() {
-		c = getFakeClientFromObjects(createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {
@@ -5846,7 +5847,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				{Name: "controller", Role: "master", HwProfile: "profile-64G"},
 			},
 		}
-		c = getFakeClientFromObjects(createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {
@@ -5873,7 +5874,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				{Name: "controller", Role: "master", ResourcePoolId: "pool-1"},
 			},
 		}
-		c = getFakeClientFromObjects()
+		c = fakeclient.GetFakeClientFromObjects(scheme)
 		task = buildTask(c, `{"nodeClusterName": "test"}`)
 
 		err := task.validateAndMergeHwMgmtInput(ctx, ct)
@@ -5882,7 +5883,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 	})
 
 	It("should override timeout from defaults with PR parameter", func() {
-		c = getFakeClientFromObjects(createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {
@@ -5901,7 +5902,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				{Name: "controller", Role: "master", ResourcePoolId: "pool-1"},
 			},
 		}
-		c = getFakeClientFromObjects(createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
 		task = buildTask(c, `{"nodeClusterName": "test"}`)
 
 		err := task.validateAndMergeHwMgmtInput(ctx, ct)
@@ -5916,7 +5917,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				{Name: "controller", Role: "master", ResourcePoolId: "pool-1"},
 			},
 		}
-		c = getFakeClientFromObjects()
+		c = fakeclient.GetFakeClientFromObjects(scheme)
 		task = buildTask(c, `{"nodeClusterName": "test"}`)
 
 		err := task.validateAndMergeHwMgmtInput(ctx, ct)
@@ -5925,7 +5926,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 	})
 
 	It("should return error for negative timeout in PR override", func() {
-		c = getFakeClientFromObjects(createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {
@@ -5944,7 +5945,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "profile-spr-single-processor-64G", Namespace: utils.InventoryNamespace},
 			},
 		)
-		c = getFakeClientFromObjects(hwProfiles...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, hwProfiles...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {
@@ -5972,7 +5973,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "profile-spr-single-processor-64G", Namespace: utils.InventoryNamespace},
 			},
 		)
-		c = getFakeClientFromObjects(hwProfiles...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, hwProfiles...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -5802,7 +5802,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 	}
 
 	It("should use defaults only when no hwMgmtParameters in PR", func() {
-		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(createHwProfiles()...)
 		task = buildTask(c, `{"nodeClusterName": "test"}`)
 
 		err := task.validateAndMergeHwMgmtInput(ctx, ct)
@@ -5817,7 +5817,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 	})
 
 	It("should merge hwMgmtParameters over defaults", func() {
-		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(createHwProfiles()...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {
@@ -5847,7 +5847,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				{Name: "controller", Role: "master", HwProfile: "profile-64G"},
 			},
 		}
-		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(createHwProfiles()...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {
@@ -5874,7 +5874,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				{Name: "controller", Role: "master", ResourcePoolId: "pool-1"},
 			},
 		}
-		c = fakeclient.GetFakeClientFromObjects(scheme)
+		c = fakeclient.GetFakeClientFromObjects()
 		task = buildTask(c, `{"nodeClusterName": "test"}`)
 
 		err := task.validateAndMergeHwMgmtInput(ctx, ct)
@@ -5883,7 +5883,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 	})
 
 	It("should override timeout from defaults with PR parameter", func() {
-		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(createHwProfiles()...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {
@@ -5902,7 +5902,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				{Name: "controller", Role: "master", ResourcePoolId: "pool-1"},
 			},
 		}
-		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(createHwProfiles()...)
 		task = buildTask(c, `{"nodeClusterName": "test"}`)
 
 		err := task.validateAndMergeHwMgmtInput(ctx, ct)
@@ -5917,7 +5917,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				{Name: "controller", Role: "master", ResourcePoolId: "pool-1"},
 			},
 		}
-		c = fakeclient.GetFakeClientFromObjects(scheme)
+		c = fakeclient.GetFakeClientFromObjects()
 		task = buildTask(c, `{"nodeClusterName": "test"}`)
 
 		err := task.validateAndMergeHwMgmtInput(ctx, ct)
@@ -5926,7 +5926,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 	})
 
 	It("should return error for negative timeout in PR override", func() {
-		c = fakeclient.GetFakeClientFromObjects(scheme, createHwProfiles()...)
+		c = fakeclient.GetFakeClientFromObjects(createHwProfiles()...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {
@@ -5945,7 +5945,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "profile-spr-single-processor-64G", Namespace: utils.InventoryNamespace},
 			},
 		)
-		c = fakeclient.GetFakeClientFromObjects(scheme, hwProfiles...)
+		c = fakeclient.GetFakeClientFromObjects(hwProfiles...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {
@@ -5973,7 +5973,7 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "profile-spr-single-processor-64G", Namespace: utils.InventoryNamespace},
 			},
 		)
-		c = fakeclient.GetFakeClientFromObjects(scheme, hwProfiles...)
+		c = fakeclient.GetFakeClientFromObjects(hwProfiles...)
 		task = buildTask(c, `{
 			"nodeClusterName": "test",
 			"hwMgmtParameters": {

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -168,7 +168,7 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -359,7 +359,7 @@ var _ = Describe("waitForNodeAllocationRequestProvision", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -622,7 +622,7 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -803,7 +803,7 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -1087,7 +1087,7 @@ var _ = Describe("updateAllocatedNodeHostMap", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -1219,7 +1219,7 @@ var _ = Describe("waitForHardwareData", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, ct}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr, ct}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -1322,7 +1322,7 @@ var _ = Describe("checkExistingNodeAllocationRequest", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -1553,7 +1553,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, ct}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr, ct}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -1905,7 +1905,7 @@ var _ = Describe("ProvisioningRequest Status Update After Hardware Failure", fun
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, template}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr, template}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -2114,7 +2114,7 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{pr}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{pr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -2762,7 +2762,7 @@ var _ = Describe("updateInfrastructureResourceStatuses", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr}...)
 		task = &provisioningRequestReconcilerTask{
 			logger: logger,
 			client: c,

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -86,6 +86,7 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
 	"github.com/openshift/assisted-service/api/v1beta1"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
@@ -167,7 +168,7 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -358,7 +359,7 @@ var _ = Describe("waitForNodeAllocationRequestProvision", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -621,7 +622,7 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -802,7 +803,7 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -1086,7 +1087,7 @@ var _ = Describe("updateAllocatedNodeHostMap", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -1218,7 +1219,7 @@ var _ = Describe("waitForHardwareData", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr, ct}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, ct}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -1321,7 +1322,7 @@ var _ = Describe("checkExistingNodeAllocationRequest", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -1552,7 +1553,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr, ct}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, ct}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -1904,7 +1905,7 @@ var _ = Describe("ProvisioningRequest Status Update After Hardware Failure", fun
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr, template}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, template}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -2113,7 +2114,7 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{pr}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{pr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -2761,7 +2762,7 @@ var _ = Describe("updateInfrastructureResourceStatuses", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
 		task = &provisioningRequestReconcilerTask{
 			logger: logger,
 			client: c,

--- a/internal/controllers/provisioningrequest_resourcecreation_test.go
+++ b/internal/controllers/provisioningrequest_resourcecreation_test.go
@@ -80,7 +80,7 @@ var _ = Describe("createPolicyTemplateConfigMap", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -209,7 +209,7 @@ var _ = Describe("createClusterInstanceBMCSecrets", func() {
 			},
 		}
 
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -353,7 +353,7 @@ var _ = Describe("createOrUpdateClusterResources", func() {
 			},
 			Data: map[string][]byte{},
 		}
-		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, pull_secret}...)
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{cr, pull_secret}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,

--- a/internal/controllers/provisioningrequest_resourcecreation_test.go
+++ b/internal/controllers/provisioningrequest_resourcecreation_test.go
@@ -51,6 +51,7 @@ import (
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 )
 
@@ -79,7 +80,7 @@ var _ = Describe("createPolicyTemplateConfigMap", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -208,7 +209,7 @@ var _ = Describe("createClusterInstanceBMCSecrets", func() {
 			},
 		}
 
-		c = getFakeClientFromObjects([]client.Object{cr}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,
@@ -352,7 +353,7 @@ var _ = Describe("createOrUpdateClusterResources", func() {
 			},
 			Data: map[string][]byte{},
 		}
-		c = getFakeClientFromObjects([]client.Object{cr, pull_secret}...)
+		c = fakeclient.GetFakeClientFromObjects(scheme, []client.Object{cr, pull_secret}...)
 		reconciler = &ProvisioningRequestReconciler{
 			Client: c,
 			Logger: logger,

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -84,8 +84,6 @@ cluster template validation through complete cluster deployment and configuratio
 package controllers
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -100,16 +98,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	ibguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
@@ -117,7 +110,6 @@ import (
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -126,99 +118,6 @@ import (
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controllers")
-}
-
-// SSACompatibleClient wraps a fake client and converts Server-Side Apply operations
-// to traditional create/update operations, providing compatibility for testing.
-type SSACompatibleClient struct {
-	client.WithWatch
-}
-
-// Patch intercepts Server-Side Apply operations and converts them to create/update
-func (c *SSACompatibleClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-	// Check if this is a Server-Side Apply operation
-	if patch.Type() == types.ApplyPatchType {
-		return c.handleServerSideApply(ctx, obj, opts...)
-	}
-
-	// For non-SSA patches, delegate to the underlying client
-	if err := c.WithWatch.Patch(ctx, obj, patch, opts...); err != nil {
-		return fmt.Errorf("failed to apply patch: %w", err)
-	}
-	return nil
-}
-
-// handleServerSideApply converts SSA operations to create/update operations
-func (c *SSACompatibleClient) handleServerSideApply(ctx context.Context, obj client.Object, opts ...client.PatchOption) error {
-	// Check for dry-run option by inspecting patch options
-	isDryRun := false
-	for _, opt := range opts {
-		// Check if this is a dry-run option by examining the string representation
-		optStr := fmt.Sprintf("%T", opt)
-		if optStr == "client.dryRunAll" {
-			isDryRun = true
-			break
-		}
-	}
-
-	// For dry-run, just validate without actually creating/updating
-	if isDryRun {
-		return nil
-	}
-
-	// Check if the object already exists
-	existing := obj.DeepCopyObject().(client.Object)
-	err := c.WithWatch.Get(ctx, client.ObjectKeyFromObject(obj), existing)
-
-	switch {
-	case errors.IsNotFound(err):
-		// Create the object
-		if createErr := c.WithWatch.Create(ctx, obj); createErr != nil {
-			return fmt.Errorf("failed to create object: %w", createErr)
-		}
-		return nil
-	case err != nil:
-		return fmt.Errorf("failed to check existing object: %w", err)
-	default:
-		// Update the existing object
-		obj.SetResourceVersion(existing.GetResourceVersion())
-		if updateErr := c.WithWatch.Update(ctx, obj); updateErr != nil {
-			return fmt.Errorf("failed to update object: %w", updateErr)
-		}
-		return nil
-	}
-}
-
-func getFakeClientFromObjects(objs ...client.Object) client.WithWatch {
-	// Create the Inventory CRD object for CRD ownership of cluster-scoped resources
-	inventoryCRD := &apiextensionsv1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ctlrutils.InventoryCRDName,
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(objs...).
-		WithObjects(inventoryCRD).
-		WithStatusSubresource(&inventoryv1alpha1.Inventory{}).
-		WithStatusSubresource(&provisioningv1alpha1.ClusterTemplate{}).
-		WithStatusSubresource(&provisioningv1alpha1.ProvisioningRequest{}).
-		WithStatusSubresource(&siteconfig.ClusterInstance{}).
-		WithStatusSubresource(&clusterv1.ManagedCluster{}).
-		WithStatusSubresource(&hwmgmtv1alpha1.NodeAllocationRequest{}).
-		WithStatusSubresource(&hwmgmtv1alpha1.AllocatedNode{}).
-		WithStatusSubresource(&openshiftv1.ClusterVersion{}).
-		WithStatusSubresource(&openshiftoperatorv1.IngressController{}).
-		WithStatusSubresource(&policiesv1.Policy{}).
-		WithStatusSubresource(&clusterv1.ManagedCluster{}).
-		WithIndex(&hwmgmtv1alpha1.AllocatedNode{}, "spec.nodeAllocationRequest", func(obj client.Object) []string {
-			return []string{obj.(*hwmgmtv1alpha1.AllocatedNode).Spec.NodeAllocationRequest}
-		}).
-		Build()
-
-	// Wrap the fake client with SSA compatibility for testing
-	return &SSACompatibleClient{WithWatch: fakeClient}
 }
 
 // Logger used for tests:

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -91,28 +91,11 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
-	openshiftv1 "github.com/openshift/api/config/v1"
-	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
-	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
-	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	ibguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
-	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
-	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
-	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
-	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
-	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 )
 
 func TestControllers(t *testing.T) {
@@ -123,8 +106,8 @@ func TestControllers(t *testing.T) {
 // Logger used for tests:
 var logger *slog.Logger
 
-// Scheme used for the tests:
-var scheme = clientgoscheme.Scheme
+// Scheme alias for tests that build their own fake clients directly.
+var scheme = fakeclient.Scheme
 
 var _ = BeforeSuite(func() {
 	// Create a logger that writes to the Ginkgo writer, so that the log messages will be
@@ -141,39 +124,4 @@ var _ = BeforeSuite(func() {
 	klog.SetLogger(adapter)
 
 	os.Setenv(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
-
-	// Add all the required types to the scheme used by the tests:
-	scheme.AddKnownTypes(inventoryv1alpha1.GroupVersion, &inventoryv1alpha1.Inventory{})
-	scheme.AddKnownTypes(inventoryv1alpha1.GroupVersion, &inventoryv1alpha1.InventoryList{})
-	scheme.AddKnownTypes(provisioningv1alpha1.GroupVersion, &provisioningv1alpha1.ClusterTemplate{})
-	scheme.AddKnownTypes(provisioningv1alpha1.GroupVersion, &provisioningv1alpha1.ClusterTemplateList{})
-	scheme.AddKnownTypes(provisioningv1alpha1.GroupVersion, &provisioningv1alpha1.ProvisioningRequest{})
-	scheme.AddKnownTypes(provisioningv1alpha1.GroupVersion, &provisioningv1alpha1.ProvisioningRequestList{})
-	scheme.AddKnownTypes(networkingv1.SchemeGroupVersion, &networkingv1.Ingress{})
-	scheme.AddKnownTypes(networkingv1.SchemeGroupVersion, &networkingv1.IngressList{})
-	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceAccount{})
-	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceAccountList{})
-	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Service{})
-	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceList{})
-	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.Deployment{})
-	scheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DeploymentList{})
-	scheme.AddKnownTypes(siteconfig.GroupVersion, &siteconfig.ClusterInstance{})
-	scheme.AddKnownTypes(siteconfig.GroupVersion, &siteconfig.ClusterInstanceList{})
-	scheme.AddKnownTypes(hwmgmtv1alpha1.GroupVersion, &hwmgmtv1alpha1.HardwareProfile{})
-	scheme.AddKnownTypes(hwmgmtv1alpha1.GroupVersion, &hwmgmtv1alpha1.HardwareProfileList{})
-	scheme.AddKnownTypes(hwmgmtv1alpha1.GroupVersion, &hwmgmtv1alpha1.NodeAllocationRequest{})
-	scheme.AddKnownTypes(hwmgmtv1alpha1.GroupVersion, &hwmgmtv1alpha1.AllocatedNode{})
-	scheme.AddKnownTypes(hwmgmtv1alpha1.GroupVersion, &hwmgmtv1alpha1.AllocatedNodeList{})
-	scheme.AddKnownTypes(policiesv1.SchemeGroupVersion, &policiesv1.Policy{})
-	scheme.AddKnownTypes(policiesv1.SchemeGroupVersion, &policiesv1.PolicyList{})
-	scheme.AddKnownTypes(clusterv1.SchemeGroupVersion, &clusterv1.ManagedCluster{})
-	scheme.AddKnownTypes(clusterv1.SchemeGroupVersion, &clusterv1.ManagedClusterList{})
-	scheme.AddKnownTypes(openshiftv1.SchemeGroupVersion, &openshiftv1.ClusterVersion{})
-	scheme.AddKnownTypes(openshiftoperatorv1.SchemeGroupVersion, &openshiftoperatorv1.IngressController{})
-	scheme.AddKnownTypes(ibguv1alpha1.SchemeGroupVersion, &ibguv1alpha1.ImageBasedGroupUpgrade{})
-	scheme.AddKnownTypes(assistedservicev1beta1.GroupVersion, &assistedservicev1beta1.Agent{})
-	scheme.AddKnownTypes(assistedservicev1beta1.GroupVersion, &assistedservicev1beta1.AgentList{})
-	scheme.AddKnownTypes(apiextensionsv1.SchemeGroupVersion, &apiextensionsv1.CustomResourceDefinition{})
-	utilruntime.Must(bmhv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(hivev1.AddToScheme(scheme))
 })

--- a/internal/controllers/utils/provision_test.go
+++ b/internal/controllers/utils/provision_test.go
@@ -23,6 +23,7 @@ import (
 
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
@@ -331,7 +332,7 @@ var _ = Describe("ClusterIsReadyForPolicyConfig", func() {
 			},
 		}
 
-		fakeClient = getFakeClientFromObjects(crs...)
+		fakeClient = fakeclient.GetFakeClientFromObjects(suitescheme, crs...)
 	})
 
 	It("returns false and no error if the cluster doesn't exist", func() {
@@ -365,8 +366,7 @@ var _ = Describe("ClusterIsReadyForPolicyConfig", func() {
 			metav1.ConditionTrue,
 			"Managed cluster joined",
 		)
-		err = CreateK8sCR(context.TODO(), fakeClient, managedCluster1, nil, UPDATE)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(fakeClient.Status().Update(ctx, managedCluster1)).To(Succeed())
 
 		isReadyForConfig, err := ClusterIsReadyForPolicyConfig(ctx, fakeClient, clusterName)
 		Expect(err).ToNot(HaveOccurred())
@@ -374,7 +374,6 @@ var _ = Describe("ClusterIsReadyForPolicyConfig", func() {
 	})
 
 	It("returns true if cluster is available, hubAccepted and has joined", func() {
-		// Update the managedCluster cluster-1 to be available, joined and accepted.
 		managedCluster1 := &clusterv1.ManagedCluster{}
 		managedClusterExists, err := DoesK8SResourceExist(
 			ctx, fakeClient, clusterName, "", managedCluster1)
@@ -398,8 +397,7 @@ var _ = Describe("ClusterIsReadyForPolicyConfig", func() {
 			metav1.ConditionTrue,
 			"Managed cluster joined",
 		)
-		err = CreateK8sCR(context.TODO(), fakeClient, managedCluster1, nil, UPDATE)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(fakeClient.Status().Update(ctx, managedCluster1)).To(Succeed())
 
 		isReadyForConfig, err := ClusterIsReadyForPolicyConfig(ctx, fakeClient, clusterName)
 		Expect(err).ToNot(HaveOccurred())
@@ -492,7 +490,7 @@ var _ = Describe("ValidateDefaultConfigmapSchema", func() {
 	)
 
 	BeforeEach(func() {
-		fakeClient = getFakeClientFromObjects()
+		fakeClient = fakeclient.GetFakeClientFromObjects(suitescheme)
 	})
 
 	It("returns an error when the ClusterInstance CRD does not exist", func() {

--- a/internal/controllers/utils/provision_test.go
+++ b/internal/controllers/utils/provision_test.go
@@ -314,9 +314,6 @@ var _ = Describe("ClusterIsReadyForPolicyConfig", func() {
 		clusterName = "cluster-1"
 	)
 
-	suitescheme.AddKnownTypes(clusterv1.SchemeGroupVersion, &clusterv1.ManagedCluster{})
-	suitescheme.AddKnownTypes(clusterv1.SchemeGroupVersion, &clusterv1.ManagedClusterList{})
-
 	BeforeEach(func() {
 		// Define the needed resources.
 		crs := []client.Object{
@@ -332,7 +329,7 @@ var _ = Describe("ClusterIsReadyForPolicyConfig", func() {
 			},
 		}
 
-		fakeClient = fakeclient.GetFakeClientFromObjects(suitescheme, crs...)
+		fakeClient = fakeclient.GetFakeClientFromObjects(crs...)
 	})
 
 	It("returns false and no error if the cluster doesn't exist", func() {
@@ -490,7 +487,7 @@ var _ = Describe("ValidateDefaultConfigmapSchema", func() {
 	)
 
 	BeforeEach(func() {
-		fakeClient = fakeclient.GetFakeClientFromObjects(suitescheme)
+		fakeClient = fakeclient.GetFakeClientFromObjects()
 	})
 
 	It("returns an error when the ClusterInstance CRD does not exist", func() {

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -36,18 +36,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 )
-
-// Scheme used for the tests:
-var suitescheme = clientgoscheme.Scheme
-
-func init() {
-	suitescheme.AddKnownTypes(openshiftv1.SchemeGroupVersion, &openshiftv1.IngressController{})
-}
 
 func TestInventoryControllerUtils(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -100,12 +92,6 @@ var _ = Describe("ExtensionUtils", func() {
 })
 
 var _ = Describe("DoesK8SResourceExist", func() {
-
-	suitescheme.AddKnownTypes(inventoryv1alpha1.GroupVersion, &inventoryv1alpha1.Inventory{})
-	suitescheme.AddKnownTypes(inventoryv1alpha1.GroupVersion, &inventoryv1alpha1.InventoryList{})
-	suitescheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.Deployment{})
-	suitescheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DeploymentList{})
-
 	objs := []client.Object{
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -121,7 +107,7 @@ var _ = Describe("DoesK8SResourceExist", func() {
 	}
 
 	// Get a fake client.
-	fakeClient := fakeclient.GetFakeClientFromObjects(suitescheme, objs...)
+	fakeClient := fakeclient.GetFakeClientFromObjects(objs...)
 
 	It("If deployment does not exist, it will be created", func() {
 		Inventory := &inventoryv1alpha1.Inventory{
@@ -247,7 +233,7 @@ var _ = Describe("GetIngressDomain", func() {
 
 	It("If ingress controller does not exist, return error", func() {
 		objs := []client.Object{}
-		fakeClient := fakeclient.GetFakeClientFromObjects(suitescheme, objs...)
+		fakeClient := fakeclient.GetFakeClientFromObjects(objs...)
 		domain, err := GetIngressDomain(context.TODO(), fakeClient)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("ingress controller object not found"))
@@ -263,7 +249,7 @@ var _ = Describe("GetIngressDomain", func() {
 				Domain: "apps.example.com"}}
 
 		objs := []client.Object{ingress}
-		fakeClient := fakeclient.GetFakeClientFromObjects(suitescheme, objs...)
+		fakeClient := fakeclient.GetFakeClientFromObjects(objs...)
 		domain, err := GetIngressDomain(context.TODO(), fakeClient)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(domain).To(Equal("apps.example.com"))
@@ -845,7 +831,7 @@ var _ = Describe("GetDefaultsFromConfigMap", func() {
 			},
 		}
 		// Get a fake client.
-		c = fakeclient.GetFakeClientFromObjects(suitescheme, objs...)
+		c = fakeclient.GetFakeClientFromObjects(objs...)
 		clusterInstanceConfigMap = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configMapName,
@@ -1462,7 +1448,7 @@ var _ = Describe("SetCRDOwnerRef", func() {
 		crd.SetUID(types.UID(crdUID))
 
 		fakeClient = fake.NewClientBuilder().
-			WithScheme(suitescheme).
+			WithScheme(fakeclient.Scheme).
 			WithObjects(crd).
 			Build()
 	})
@@ -1530,7 +1516,7 @@ var _ = Describe("CreateK8sCR with cluster-scoped resources", func() {
 		crd.SetUID(types.UID(crdUID))
 
 		fakeClient = fake.NewClientBuilder().
-			WithScheme(suitescheme).
+			WithScheme(fakeclient.Scheme).
 			WithObjects(crd).
 			Build()
 	})

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -27,6 +27,7 @@ import (
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 	openshiftv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -44,21 +45,13 @@ import (
 // Scheme used for the tests:
 var suitescheme = clientgoscheme.Scheme
 
+func init() {
+	suitescheme.AddKnownTypes(openshiftv1.SchemeGroupVersion, &openshiftv1.IngressController{})
+}
+
 func TestInventoryControllerUtils(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Utils Suite")
-}
-
-//nolint:unparam
-func getFakeClientFromObjects(objs ...client.Object) client.WithWatch {
-	suitescheme.AddKnownTypes(openshiftv1.SchemeGroupVersion, &openshiftv1.IngressController{})
-
-	return fake.NewClientBuilder().
-		WithScheme(suitescheme).
-		WithObjects(objs...).
-		WithStatusSubresource(&inventoryv1alpha1.Inventory{}).
-		WithStatusSubresource(&openshiftv1.IngressController{}).
-		Build()
 }
 
 var _ = Describe("ExtensionUtils", func() {
@@ -128,7 +121,7 @@ var _ = Describe("DoesK8SResourceExist", func() {
 	}
 
 	// Get a fake client.
-	fakeClient := getFakeClientFromObjects(objs...)
+	fakeClient := fakeclient.GetFakeClientFromObjects(suitescheme, objs...)
 
 	It("If deployment does not exist, it will be created", func() {
 		Inventory := &inventoryv1alpha1.Inventory{
@@ -254,7 +247,7 @@ var _ = Describe("GetIngressDomain", func() {
 
 	It("If ingress controller does not exist, return error", func() {
 		objs := []client.Object{}
-		fakeClient := getFakeClientFromObjects(objs...)
+		fakeClient := fakeclient.GetFakeClientFromObjects(suitescheme, objs...)
 		domain, err := GetIngressDomain(context.TODO(), fakeClient)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("ingress controller object not found"))
@@ -270,7 +263,7 @@ var _ = Describe("GetIngressDomain", func() {
 				Domain: "apps.example.com"}}
 
 		objs := []client.Object{ingress}
-		fakeClient := getFakeClientFromObjects(objs...)
+		fakeClient := fakeclient.GetFakeClientFromObjects(suitescheme, objs...)
 		domain, err := GetIngressDomain(context.TODO(), fakeClient)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(domain).To(Equal("apps.example.com"))
@@ -852,7 +845,7 @@ var _ = Describe("GetDefaultsFromConfigMap", func() {
 			},
 		}
 		// Get a fake client.
-		c = getFakeClientFromObjects(objs...)
+		c = fakeclient.GetFakeClientFromObjects(suitescheme, objs...)
 		clusterInstanceConfigMap = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configMapName,

--- a/test/fakeclient/fakeclient.go
+++ b/test/fakeclient/fakeclient.go
@@ -100,17 +100,12 @@ func (c *SSACompatibleClient) Patch(ctx context.Context, obj client.Object, patc
 }
 
 func (c *SSACompatibleClient) handleServerSideApply(ctx context.Context, obj client.Object, opts ...client.PatchOption) error {
-	isDryRun := false
-	for _, opt := range opts {
-		optStr := fmt.Sprintf("%T", opt)
-		if optStr == "client.dryRunAll" {
-			isDryRun = true
-			break
+	patchOpts := &client.PatchOptions{}
+	patchOpts.ApplyOptions(opts)
+	for _, v := range patchOpts.DryRun {
+		if v == metav1.DryRunAll {
+			return nil
 		}
-	}
-
-	if isDryRun {
-		return nil
 	}
 
 	existing := obj.DeepCopyObject().(client.Object)

--- a/test/fakeclient/fakeclient.go
+++ b/test/fakeclient/fakeclient.go
@@ -13,6 +13,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -37,10 +38,12 @@ const inventoryCRDName = "inventories.ocloud.openshift.io"
 
 // Scheme is the shared scheme for all unit tests that use GetFakeClientFromObjects.
 // All custom resource types are registered here so callers don't need to manage
-// scheme setup individually.
-var Scheme = clientgoscheme.Scheme
+// scheme setup individually. Uses a dedicated scheme rather than the global
+// clientgoscheme.Scheme to avoid leaking type registrations across test suites.
+var Scheme = runtime.NewScheme()
 
 func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
 	Scheme.AddKnownTypes(inventoryv1alpha1.GroupVersion,
 		&inventoryv1alpha1.Inventory{}, &inventoryv1alpha1.InventoryList{})
 	Scheme.AddKnownTypes(provisioningv1alpha1.GroupVersion,

--- a/test/fakeclient/fakeclient.go
+++ b/test/fakeclient/fakeclient.go
@@ -13,72 +13,92 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	ibguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	openshiftv1 "github.com/openshift/api/config/v1"
 	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
+	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 const inventoryCRDName = "inventories.ocloud.openshift.io"
 
-// GetFakeClientFromObjects creates a fake Kubernetes client with comprehensive
-// test infrastructure: status subresources for all custom resource types known
-// to the scheme, the Inventory CRD for owner reference testing, a field indexer
-// for AllocatedNode lookups (if the type is in the scheme), and an
-// SSA-compatible wrapper.
-func GetFakeClientFromObjects(scheme *runtime.Scheme, objs ...client.Object) client.WithWatch {
-	builder := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(objs...)
+// Scheme is the shared scheme for all unit tests that use GetFakeClientFromObjects.
+// All custom resource types are registered here so callers don't need to manage
+// scheme setup individually.
+var Scheme = clientgoscheme.Scheme
 
+func init() {
+	Scheme.AddKnownTypes(inventoryv1alpha1.GroupVersion,
+		&inventoryv1alpha1.Inventory{}, &inventoryv1alpha1.InventoryList{})
+	Scheme.AddKnownTypes(provisioningv1alpha1.GroupVersion,
+		&provisioningv1alpha1.ClusterTemplate{}, &provisioningv1alpha1.ClusterTemplateList{},
+		&provisioningv1alpha1.ProvisioningRequest{}, &provisioningv1alpha1.ProvisioningRequestList{})
+	Scheme.AddKnownTypes(siteconfig.GroupVersion,
+		&siteconfig.ClusterInstance{}, &siteconfig.ClusterInstanceList{})
+	Scheme.AddKnownTypes(hwmgmtv1alpha1.GroupVersion,
+		&hwmgmtv1alpha1.HardwareProfile{}, &hwmgmtv1alpha1.HardwareProfileList{},
+		&hwmgmtv1alpha1.NodeAllocationRequest{},
+		&hwmgmtv1alpha1.AllocatedNode{}, &hwmgmtv1alpha1.AllocatedNodeList{})
+	Scheme.AddKnownTypes(policiesv1.SchemeGroupVersion,
+		&policiesv1.Policy{}, &policiesv1.PolicyList{})
+	Scheme.AddKnownTypes(clusterv1.SchemeGroupVersion,
+		&clusterv1.ManagedCluster{}, &clusterv1.ManagedClusterList{})
+	Scheme.AddKnownTypes(openshiftv1.SchemeGroupVersion, &openshiftv1.ClusterVersion{})
+	Scheme.AddKnownTypes(openshiftoperatorv1.SchemeGroupVersion, &openshiftoperatorv1.IngressController{})
+	Scheme.AddKnownTypes(apiextensionsv1.SchemeGroupVersion, &apiextensionsv1.CustomResourceDefinition{})
+	Scheme.AddKnownTypes(assistedservicev1beta1.GroupVersion,
+		&assistedservicev1beta1.Agent{}, &assistedservicev1beta1.AgentList{})
+	Scheme.AddKnownTypes(ibguv1alpha1.SchemeGroupVersion, &ibguv1alpha1.ImageBasedGroupUpgrade{})
+	utilruntime.Must(metal3v1alpha1.AddToScheme(Scheme))
+	utilruntime.Must(hivev1.AddToScheme(Scheme))
+}
+
+// GetFakeClientFromObjects creates a fake Kubernetes client with comprehensive
+// test infrastructure: status subresources for all custom resource types, the
+// Inventory CRD for owner reference testing, a field indexer for AllocatedNode
+// lookups, and an SSA-compatible wrapper.
+func GetFakeClientFromObjects(objs ...client.Object) client.WithWatch {
 	inventoryCRD := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: inventoryCRDName,
 		},
 	}
-	if isTypeRegistered(scheme, inventoryCRD) {
-		builder.WithObjects(inventoryCRD)
-	}
 
-	statusSubresources := []client.Object{
-		&inventoryv1alpha1.Inventory{},
-		&provisioningv1alpha1.ClusterTemplate{},
-		&provisioningv1alpha1.ProvisioningRequest{},
-		&siteconfig.ClusterInstance{},
-		&clusterv1.ManagedCluster{},
-		&hwmgmtv1alpha1.NodeAllocationRequest{},
-		&hwmgmtv1alpha1.AllocatedNode{},
-		&openshiftv1.ClusterVersion{},
-		&openshiftoperatorv1.IngressController{},
-		&policiesv1.Policy{},
-	}
-	for _, obj := range statusSubresources {
-		if isTypeRegistered(scheme, obj) {
-			builder.WithStatusSubresource(obj)
-		}
-	}
-
-	if isTypeRegistered(scheme, &hwmgmtv1alpha1.AllocatedNode{}) {
-		builder.WithIndex(&hwmgmtv1alpha1.AllocatedNode{}, "spec.nodeAllocationRequest", func(obj client.Object) []string {
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(objs...).
+		WithObjects(inventoryCRD).
+		WithStatusSubresource(
+			&inventoryv1alpha1.Inventory{},
+			&provisioningv1alpha1.ClusterTemplate{},
+			&provisioningv1alpha1.ProvisioningRequest{},
+			&siteconfig.ClusterInstance{},
+			&clusterv1.ManagedCluster{},
+			&hwmgmtv1alpha1.NodeAllocationRequest{},
+			&hwmgmtv1alpha1.AllocatedNode{},
+			&openshiftv1.ClusterVersion{},
+			&openshiftoperatorv1.IngressController{},
+			&policiesv1.Policy{},
+		).
+		WithIndex(&hwmgmtv1alpha1.AllocatedNode{}, "spec.nodeAllocationRequest", func(obj client.Object) []string {
 			return []string{obj.(*hwmgmtv1alpha1.AllocatedNode).Spec.NodeAllocationRequest}
-		})
-	}
+		}).
+		Build()
 
-	return &SSACompatibleClient{WithWatch: builder.Build()}
-}
-
-func isTypeRegistered(scheme *runtime.Scheme, obj runtime.Object) bool {
-	_, _, err := scheme.ObjectKinds(obj)
-	return err == nil
+	return &SSACompatibleClient{WithWatch: fakeClient}
 }
 
 // SSACompatibleClient wraps a fake client and converts Server-Side Apply operations

--- a/test/fakeclient/fakeclient.go
+++ b/test/fakeclient/fakeclient.go
@@ -1,0 +1,134 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fakeclient
+
+import (
+	"context"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	openshiftv1 "github.com/openshift/api/config/v1"
+	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
+	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
+)
+
+const inventoryCRDName = "inventories.ocloud.openshift.io"
+
+// GetFakeClientFromObjects creates a fake Kubernetes client with comprehensive
+// test infrastructure: status subresources for all custom resource types known
+// to the scheme, the Inventory CRD for owner reference testing, a field indexer
+// for AllocatedNode lookups (if the type is in the scheme), and an
+// SSA-compatible wrapper.
+func GetFakeClientFromObjects(scheme *runtime.Scheme, objs ...client.Object) client.WithWatch {
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...)
+
+	inventoryCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: inventoryCRDName,
+		},
+	}
+	if isTypeRegistered(scheme, inventoryCRD) {
+		builder.WithObjects(inventoryCRD)
+	}
+
+	statusSubresources := []client.Object{
+		&inventoryv1alpha1.Inventory{},
+		&provisioningv1alpha1.ClusterTemplate{},
+		&provisioningv1alpha1.ProvisioningRequest{},
+		&siteconfig.ClusterInstance{},
+		&clusterv1.ManagedCluster{},
+		&hwmgmtv1alpha1.NodeAllocationRequest{},
+		&hwmgmtv1alpha1.AllocatedNode{},
+		&openshiftv1.ClusterVersion{},
+		&openshiftoperatorv1.IngressController{},
+		&policiesv1.Policy{},
+	}
+	for _, obj := range statusSubresources {
+		if isTypeRegistered(scheme, obj) {
+			builder.WithStatusSubresource(obj)
+		}
+	}
+
+	if isTypeRegistered(scheme, &hwmgmtv1alpha1.AllocatedNode{}) {
+		builder.WithIndex(&hwmgmtv1alpha1.AllocatedNode{}, "spec.nodeAllocationRequest", func(obj client.Object) []string {
+			return []string{obj.(*hwmgmtv1alpha1.AllocatedNode).Spec.NodeAllocationRequest}
+		})
+	}
+
+	return &SSACompatibleClient{WithWatch: builder.Build()}
+}
+
+func isTypeRegistered(scheme *runtime.Scheme, obj runtime.Object) bool {
+	_, _, err := scheme.ObjectKinds(obj)
+	return err == nil
+}
+
+// SSACompatibleClient wraps a fake client and converts Server-Side Apply operations
+// to traditional create/update operations, providing compatibility for testing.
+type SSACompatibleClient struct {
+	client.WithWatch
+}
+
+// Patch intercepts Server-Side Apply operations and converts them to create/update
+func (c *SSACompatibleClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if patch.Type() == types.ApplyPatchType {
+		return c.handleServerSideApply(ctx, obj, opts...)
+	}
+
+	if err := c.WithWatch.Patch(ctx, obj, patch, opts...); err != nil {
+		return fmt.Errorf("failed to apply patch: %w", err)
+	}
+	return nil
+}
+
+func (c *SSACompatibleClient) handleServerSideApply(ctx context.Context, obj client.Object, opts ...client.PatchOption) error {
+	isDryRun := false
+	for _, opt := range opts {
+		optStr := fmt.Sprintf("%T", opt)
+		if optStr == "client.dryRunAll" {
+			isDryRun = true
+			break
+		}
+	}
+
+	if isDryRun {
+		return nil
+	}
+
+	existing := obj.DeepCopyObject().(client.Object)
+	err := c.WithWatch.Get(ctx, client.ObjectKeyFromObject(obj), existing)
+
+	switch {
+	case errors.IsNotFound(err):
+		if createErr := c.WithWatch.Create(ctx, obj); createErr != nil {
+			return fmt.Errorf("failed to create object: %w", createErr)
+		}
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to check existing object: %w", err)
+	default:
+		obj.SetResourceVersion(existing.GetResourceVersion())
+		if updateErr := c.WithWatch.Update(ctx, obj); updateErr != nil {
+			return fmt.Errorf("failed to update object: %w", updateErr)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
Move the duplicated getFakeClientFromObjects helper and SSACompatibleClient wrapper from internal/controllers/suite_test.go into a new test/fakeclient package. This eliminates the duplication between the comprehensive version (suite_test.go, 9 status subresources + field indexer + SSA wrapper) and the minimal version (utils_test.go, 2 status subresources).

A new package is needed because test/utils/ already imports internal/controllers/utils, which would create a circular import. The new test/fakeclient/ package has no internal/controllers dependency. It conditionally registers status subresources and the AllocatedNode field indexer based on which types are present in the caller's scheme.

Fix provision_test.go to use Status().Update() for ManagedCluster status changes — previously relied on the minimal fake client not having ManagedCluster as a status subresource, which allowed c.Update() to write status fields directly.