### PR TITLE
test: replace Expect(err).To(BeNil()) with HaveOccurred()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,9 @@ issues during code review.
 
 - Use `.ToNot()` for negated Gomega assertions, not `.NotTo()` or
   `.ShouldNot()`. The codebase is standardized on `.ToNot()`.
+- Use `Expect(err).ToNot(HaveOccurred())` for asserting no error, not
+  `Expect(err).To(BeNil())`. `HaveOccurred()` produces better failure
+  messages (prints the error vs just "expected nil").
 
 ## Contributing Requirements
 

--- a/internal/controllers/utils/provision_test.go
+++ b/internal/controllers/utils/provision_test.go
@@ -167,7 +167,7 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 			newClusterInstance.Object["spec"].(map[string]any),
 			IgnoredClusterInstanceFields,
 			provisioningv1alpha1.AllowedClusterInstanceFields)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedFields).To(BeEmpty())
 		Expect(scalingNodes).To(BeEmpty())
 	})
@@ -182,7 +182,7 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 			newClusterInstance.Object["spec"].(map[string]any),
 			IgnoredClusterInstanceFields,
 			provisioningv1alpha1.AllowedClusterInstanceFields)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedFields).To(ContainElement("baseDomain"))
 		Expect(scalingNodes).To(BeEmpty())
 	})
@@ -202,7 +202,7 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 			newClusterInstance.Object["spec"].(map[string]any),
 			IgnoredClusterInstanceFields,
 			provisioningv1alpha1.AllowedClusterInstanceFields)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedFields).To(ContainElement("clusterName"))
 		Expect(len(updatedFields)).To(Equal(1))
 		Expect(scalingNodes).To(BeEmpty())
@@ -220,7 +220,7 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 			newClusterInstance.Object["spec"].(map[string]any),
 			IgnoredClusterInstanceFields,
 			provisioningv1alpha1.AllowedClusterInstanceFields)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedFields).To(ContainElement(
 			"nodes.0.nodeNetwork.config.dns-resolver.config.server.0"))
 		Expect(scalingNodes).To(BeEmpty())
@@ -246,7 +246,7 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 			newClusterInstance.Object["spec"].(map[string]any),
 			IgnoredClusterInstanceFields,
 			provisioningv1alpha1.AllowedClusterInstanceFields)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedFields).To(ContainElement(
 			"nodes.0.nodeNetwork.config.dns-resolver.config.server.0"))
 		Expect(len(updatedFields)).To(Equal(1))
@@ -268,7 +268,7 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 			newClusterInstance.Object["spec"].(map[string]any),
 			IgnoredClusterInstanceFields,
 			provisioningv1alpha1.AllowedClusterInstanceFields)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedFields).To(BeEmpty())
 		Expect(scalingNodes).To(BeEmpty())
 	})
@@ -285,7 +285,7 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 			newClusterInstance.Object["spec"].(map[string]any),
 			IgnoredClusterInstanceFields,
 			provisioningv1alpha1.AllowedClusterInstanceFields)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedFields).To(BeEmpty())
 		Expect(scalingNodes).To(ContainElement("nodes.1"))
 	})
@@ -300,7 +300,7 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 			newClusterInstance.Object["spec"].(map[string]any),
 			IgnoredClusterInstanceFields,
 			provisioningv1alpha1.AllowedClusterInstanceFields)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedFields).To(BeEmpty())
 		Expect(scalingNodes).To(ContainElement("nodes.0"))
 	})

--- a/internal/hardwaremanager/controller/allocatednode_controller_test.go
+++ b/internal/hardwaremanager/controller/allocatednode_controller_test.go
@@ -857,7 +857,7 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 			// The controller should handle context cancellation appropriately
 			// The exact behavior depends on how the underlying utilities handle context
 			Expect(result).ToNot(BeNil())
-			Expect(err).To(BeNil()) // Assuming the controller handles cancellation gracefully
+			Expect(err).ToNot(HaveOccurred()) // Assuming the controller handles cancellation gracefully
 			// Note: Error expectations would depend on implementation specifics
 		})
 	})

--- a/internal/hardwaremanager/controller/hostfirmwarecomponents_manager_test.go
+++ b/internal/hardwaremanager/controller/hostfirmwarecomponents_manager_test.go
@@ -152,7 +152,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 		It("should return nil for empty firmware specs", func() {
 			spec := hwmgmtv1alpha1.HardwareProfileSpec{}
 			err := validateFirmwareUpdateSpec(spec)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return error when BIOS version is set but URL is empty", func() {
@@ -215,7 +215,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 				},
 			}
 			err := validateFirmwareUpdateSpec(spec)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return error when NIC version is set but URL is empty", func() {
@@ -260,7 +260,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 				},
 			}
 			err := validateFirmwareUpdateSpec(spec)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should skip NIC validation when version is empty", func() {
@@ -273,7 +273,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 				},
 			}
 			err := validateFirmwareUpdateSpec(spec)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should validate mixed firmware specs with BIOS, BMC, and NIC", func() {
@@ -294,7 +294,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 				},
 			}
 			err := validateFirmwareUpdateSpec(spec)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -499,7 +499,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			Expect(fakeClient.Create(ctx, hfc)).To(Succeed())
 
 			changeDetected, err := isHostFirmwareComponentsChangeDetectedAndValid(ctx, fakeClient, bmh)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(changeDetected).To(BeFalse())
 		})
 
@@ -521,7 +521,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			Expect(fakeClient.Create(ctx, hfc)).To(Succeed())
 
 			changeDetected, err := isHostFirmwareComponentsChangeDetectedAndValid(ctx, fakeClient, bmh)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(changeDetected).To(BeFalse())
 		})
 
@@ -543,7 +543,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			Expect(fakeClient.Create(ctx, hfc)).To(Succeed())
 
 			changeDetected, err := isHostFirmwareComponentsChangeDetectedAndValid(ctx, fakeClient, bmh)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(changeDetected).To(BeFalse())
 		})
 
@@ -565,7 +565,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			Expect(fakeClient.Create(ctx, hfc)).To(Succeed())
 
 			changeDetected, err := isHostFirmwareComponentsChangeDetectedAndValid(ctx, fakeClient, bmh)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(changeDetected).To(BeTrue())
 		})
 	})
@@ -840,7 +840,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			hfc, err := createHostFirmwareComponents(ctx, fakeClient, bmh, spec)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(hfc).ToNot(BeNil())
 			Expect(hfc.Name).To(Equal("test-bmh"))
 			Expect(hfc.Namespace).To(Equal("test-namespace"))
@@ -851,7 +851,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			// Verify it was created in the cluster
 			createdHFC := &metal3v1alpha1.HostFirmwareComponents{}
 			err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: "test-namespace"}, createdHFC)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createdHFC.Spec.Updates).To(HaveLen(1))
 		})
 
@@ -860,7 +860,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			spec := hwmgmtv1alpha1.HardwareProfileSpec{}
 
 			hfc, err := createHostFirmwareComponents(ctx, fakeClient, bmh, spec)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(hfc).ToNot(BeNil())
 			Expect(hfc.Spec.Updates).To(BeEmpty())
 		})
@@ -890,12 +890,12 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 				Name:      "test-bmh",
 				Namespace: "test-namespace",
 			}, newUpdates)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify the update
 			updatedHFC := &metal3v1alpha1.HostFirmwareComponents{}
 			err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: "test-namespace"}, updatedHFC)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedHFC.Spec.Updates).To(HaveLen(2))
 		})
 
@@ -925,7 +925,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			Expect(fakeClient.Create(ctx, hfc)).To(Succeed())
 
 			retrievedHFC, err := getHostFirmwareComponents(ctx, fakeClient, "test-bmh", "test-namespace")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(retrievedHFC).ToNot(BeNil())
 			Expect(retrievedHFC.Name).To(Equal("test-bmh"))
 			Expect(retrievedHFC.Namespace).To(Equal("test-namespace"))
@@ -981,7 +981,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			// validateOnly=true: reports update required but does not create HFC
 			validateOnly := true
 			required, err := IsFirmwareUpdateRequired(ctx, fakeClient, logger, bmh, spec, validateOnly)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(required).To(BeTrue())
 			hfc := &metal3v1alpha1.HostFirmwareComponents{}
 			err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: "test-namespace"}, hfc)
@@ -991,10 +991,10 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			// validateOnly=false: creates HFC
 			validateOnly = false
 			required, err = IsFirmwareUpdateRequired(ctx, fakeClient, logger, bmh, spec, validateOnly)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(required).To(BeTrue())
 			err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: "test-namespace"}, hfc)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return false when no update is needed", func() {
@@ -1019,13 +1019,13 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			// validateOnly=true: reports no update required
 			validateOnly := true
 			required, err := IsFirmwareUpdateRequired(ctx, fakeClient, logger, bmh, spec, validateOnly)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(required).To(BeFalse())
 
 			// validateOnly=false: reports no update required
 			validateOnly = false
 			required, err = IsFirmwareUpdateRequired(ctx, fakeClient, logger, bmh, spec, validateOnly)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(required).To(BeFalse())
 		})
 
@@ -1051,7 +1051,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			// validateOnly=true: reports update required but does not modify HFC
 			validateOnly := true
 			required, err := IsFirmwareUpdateRequired(ctx, fakeClient, logger, bmh, spec, validateOnly)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(required).To(BeTrue())
 			unchangedHFC := &metal3v1alpha1.HostFirmwareComponents{}
 			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: "test-namespace"}, unchangedHFC)).To(Succeed())
@@ -1060,7 +1060,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			// validateOnly=false: updates HFC with new firmware URL
 			validateOnly = false
 			required, err = IsFirmwareUpdateRequired(ctx, fakeClient, logger, bmh, spec, validateOnly)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(required).To(BeTrue())
 			updatedHFC := &metal3v1alpha1.HostFirmwareComponents{}
 			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: "test-namespace"}, updatedHFC)).To(Succeed())
@@ -1099,7 +1099,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			// validateOnly=true: reports update required but does not modify HFC
 			validateOnly := true
 			required, err := IsFirmwareUpdateRequired(ctx, fakeClient, logger, bmh, spec, validateOnly)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(required).To(BeTrue())
 			unchangedHFC := &metal3v1alpha1.HostFirmwareComponents{}
 			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: "test-namespace"}, unchangedHFC)).To(Succeed())
@@ -1108,13 +1108,13 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			// validateOnly=false: updates HFC with updates
 			validateOnly = false
 			required, err = IsFirmwareUpdateRequired(ctx, fakeClient, logger, bmh, spec, validateOnly)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(required).To(BeTrue())
 
 			// Verify HFC was updated with both firmware URLs
 			updatedHFC := &metal3v1alpha1.HostFirmwareComponents{}
 			err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-bmh", Namespace: "test-namespace"}, updatedHFC)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedHFC.Spec.Updates).To(HaveLen(2))
 
 			// Check that both components are included
@@ -1139,7 +1139,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			spec := hwmgmtv1alpha1.HardwareProfileSpec{}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return error when BIOS firmware required but not available", func() {
@@ -1157,7 +1157,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("BIOS firmware update requested but BIOS component not found"))
 		})
 
@@ -1176,7 +1176,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("BMC firmware update requested but BMC component not found"))
 		})
 
@@ -1194,7 +1194,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("NIC firmware update requested but no NIC components found"))
 		})
 
@@ -1215,7 +1215,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("NIC firmware update requested for 3 NICs but only 1 NIC components found"))
 		})
 
@@ -1244,7 +1244,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should skip empty NIC firmware specs when counting required NICs", func() {
@@ -1265,7 +1265,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return error when multiple components are missing", func() {
@@ -1287,7 +1287,7 @@ var _ = Describe("HostFirmwareComponents Manager", func() {
 			}
 
 			err := validateHFCHasRequiredComponents(status, spec)
-			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveOccurred())
 			// Should fail on first missing component (BIOS)
 			Expect(err.Error()).To(ContainSubstring("BIOS firmware update requested but BIOS component not found"))
 		})

--- a/internal/service/alarms/internal/alertmanager/api_test.go
+++ b/internal/service/alarms/internal/alertmanager/api_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Alertmanager API Client", func() {
 
 			w.Header().Set("Content-Type", "application/json")
 			err := json.NewEncoder(w).Encode(testAPIAlerts)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		}))
 
 		// Create temporary token file for testing

--- a/internal/service/alarms/internal/infrastructure/clusterserver_test.go
+++ b/internal/service/alarms/internal/infrastructure/clusterserver_test.go
@@ -96,7 +96,7 @@ var _ = Describe("ClusterServer", func() {
 				},
 			}
 			body, err := json.Marshal(nodeClusters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetNodeClusters(gomock.Any(), nil).Return(
 				&http.Response{
@@ -120,7 +120,7 @@ var _ = Describe("ClusterServer", func() {
 				},
 			}
 			body, err = json.Marshal(nodeClusterTypes)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetNodeClusterTypes(gomock.Any(), nil).Return(
 				&http.Response{
@@ -170,7 +170,7 @@ var _ = Describe("ClusterServer", func() {
 				},
 			}
 			body, err = json.Marshal(alarmDictionaries)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetAlarmDictionaries(gomock.Any(), nil).Return(
 				&http.Response{
@@ -180,7 +180,7 @@ var _ = Describe("ClusterServer", func() {
 				}, nil)
 
 			err = clusterServer.FetchAll(ctx)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(clusterServer.nodeClusterIDToNodeClusterTypeID).To(HaveLen(2))
 			Expect(clusterServer.nodeClusterTypeIDToAlarmDictionaryID).To(HaveLen(2))
@@ -206,7 +206,7 @@ var _ = Describe("ClusterServer", func() {
 			clusterServer.nodeClusterIDToNodeClusterTypeID[nodeClusterID] = nodeClusterTypeID
 
 			id, err := clusterServer.GetObjectTypeID(context.Background(), nodeClusterID)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id).To(Equal(nodeClusterTypeID))
 		})
 
@@ -221,7 +221,7 @@ var _ = Describe("ClusterServer", func() {
 				NodeClusterTypeId: nodeClusterTypeID,
 			}
 			body, err := json.Marshal(nodeClusters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetNodeCluster(gomock.Any(), nodeClusterID).Return(
 				&http.Response{
@@ -231,7 +231,7 @@ var _ = Describe("ClusterServer", func() {
 				}, nil)
 
 			id, err := clusterServer.GetObjectTypeID(context.Background(), nodeClusterID)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id).To(Equal(nodeClusterTypeID))
 			Expect(clusterServer.nodeClusterIDToNodeClusterTypeID[nodeClusterID]).To(Equal(nodeClusterTypeID))
 		})
@@ -270,7 +270,7 @@ var _ = Describe("ClusterServer", func() {
 			clusterServer.alarmDictionaryIDToAlarmDefinitions[alarmDictionaryID][alarmDefinitionIdentifier] = alarmDefinitionID
 
 			id, err := clusterServer.GetAlarmDefinitionID(context.Background(), nodeClusterTypeID, alarmDefinitionIdentifier.Name, alarmDefinitionIdentifier.Severity)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id).To(Equal(alarmDefinitionID))
 		})
 
@@ -296,7 +296,7 @@ var _ = Describe("ClusterServer", func() {
 				},
 			}
 			body, err := json.Marshal(nodeClusterType)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetNodeClusterType(gomock.Any(), nodeClusterTypeID).Return(
 				&http.Response{
@@ -306,7 +306,7 @@ var _ = Describe("ClusterServer", func() {
 				}, nil)
 
 			id, err := clusterServer.GetAlarmDefinitionID(context.Background(), nodeClusterTypeID, alarmDefinitionIdentifier.Name, alarmDefinitionIdentifier.Severity)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id).To(Equal(alarmDefinitionID))
 		})
 
@@ -356,7 +356,7 @@ var _ = Describe("ClusterServer", func() {
 				},
 			}
 			body, err := json.Marshal(alarmDictionary)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetAlarmDictionary(gomock.Any(), alarmDictionaryID).Return(
 				&http.Response{
@@ -366,7 +366,7 @@ var _ = Describe("ClusterServer", func() {
 				}, nil)
 
 			id, err := clusterServer.GetAlarmDefinitionID(context.Background(), nodeClusterTypeID, alarmDefinitionIdentifier.Name, alarmDefinitionIdentifier.Severity)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id).To(Equal(alarmDefinitionID))
 		})
 
@@ -420,7 +420,7 @@ var _ = Describe("ClusterServer", func() {
 				},
 			}
 			body, err := json.Marshal(alarmDictionary)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetAlarmDictionary(gomock.Any(), alarmDictionaryID).Return(
 				&http.Response{
@@ -430,7 +430,7 @@ var _ = Describe("ClusterServer", func() {
 				}, nil)
 
 			id, err := clusterServer.GetAlarmDefinitionID(context.Background(), nodeClusterTypeID, alarmDefinitionIdentifier.Name, alarmDefinitionIdentifier.Severity)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id).To(Equal(alarmDefinitionID))
 		})
 
@@ -460,7 +460,7 @@ var _ = Describe("ClusterServer", func() {
 				},
 			}
 			body, err := json.Marshal(alarmDictionary)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetAlarmDictionary(gomock.Any(), alarmDictionaryID).Return(
 				&http.Response{

--- a/internal/service/alarms/internal/infrastructure/resourceserver_test.go
+++ b/internal/service/alarms/internal/infrastructure/resourceserver_test.go
@@ -94,7 +94,7 @@ var _ = Describe("ResourceServer", func() {
 				},
 			}
 			body, err := json.Marshal(resourceTypes)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetResourceTypes(gomock.Any(), &generated.GetResourceTypesParams{}).Return(
 				&http.Response{
@@ -124,7 +124,7 @@ var _ = Describe("ResourceServer", func() {
 				},
 			}
 			body1, err := json.Marshal(firstDictionary)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetResourceTypeAlarmDictionary(gomock.Any(), firstAssociation.resourceTypeID).Return(
 				&http.Response{
@@ -153,7 +153,7 @@ var _ = Describe("ResourceServer", func() {
 				},
 			}
 			body2, err := json.Marshal(secondDictionary)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetResourceTypeAlarmDictionary(gomock.Any(), secondAssociation.resourceTypeID).Return(
 				&http.Response{
@@ -163,7 +163,7 @@ var _ = Describe("ResourceServer", func() {
 				}, nil)
 
 			err = resourceServer.FetchAll(ctx)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Verify the maps are populated correctly
 			Expect(resourceServer.resourceTypeIDToAlarmDefinitions).To(HaveLen(2))
@@ -186,7 +186,7 @@ var _ = Describe("ResourceServer", func() {
 				},
 			}
 			body, err := json.Marshal(resourceTypes)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetResourceTypes(gomock.Any(), &generated.GetResourceTypesParams{}).Return(
 				&http.Response{
@@ -204,7 +204,7 @@ var _ = Describe("ResourceServer", func() {
 				}, nil)
 
 			err = resourceServer.FetchAll(ctx)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			// Should not have entry for this resource type
 			Expect(resourceServer.resourceTypeIDToAlarmDefinitions).To(HaveLen(0))
@@ -233,7 +233,7 @@ var _ = Describe("ResourceServer", func() {
 			resourceServer.resourceIDToResourceTypeID[resourceID] = resourceTypeID
 
 			id, err := resourceServer.GetObjectTypeID(context.Background(), resourceID)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id).To(Equal(resourceTypeID))
 		})
 
@@ -248,7 +248,7 @@ var _ = Describe("ResourceServer", func() {
 				ResourceTypeId: resourceTypeID,
 			}
 			body, err := json.Marshal(resource)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetInternalResourceById(gomock.Any(), resourceID).Return(
 				&http.Response{
@@ -258,7 +258,7 @@ var _ = Describe("ResourceServer", func() {
 				}, nil)
 
 			id, err := resourceServer.GetObjectTypeID(context.Background(), resourceID)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id).To(Equal(resourceTypeID))
 
 			// Verify it was cached
@@ -297,7 +297,7 @@ var _ = Describe("ResourceServer", func() {
 			resourceServer.resourceTypeIDToAlarmDefinitions[resourceTypeID][alarmDefinitionIdentifier] = alarmDefinitionID
 
 			id, err := resourceServer.GetAlarmDefinitionID(context.Background(), resourceTypeID, alarmDefinitionIdentifier.Name, alarmDefinitionIdentifier.Severity)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id).To(Equal(alarmDefinitionID))
 		})
 
@@ -326,7 +326,7 @@ var _ = Describe("ResourceServer", func() {
 				},
 			}
 			body, err := json.Marshal(dictionary)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockRepo.EXPECT().GetResourceTypeAlarmDictionary(gomock.Any(), resourceTypeID).Return(
 				&http.Response{
@@ -336,7 +336,7 @@ var _ = Describe("ResourceServer", func() {
 				}, nil)
 
 			id, err := resourceServer.GetAlarmDefinitionID(context.Background(), resourceTypeID, alarmDefinitionIdentifier.Name, alarmDefinitionIdentifier.Severity)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id).To(Equal(alarmDefinitionID))
 
 			// Verify it was cached
@@ -379,12 +379,12 @@ var _ = Describe("ResourceServer", func() {
 
 			// Fetch first alarm definition
 			id1, err := resourceServer.GetAlarmDefinitionID(context.Background(), resourceTypeID, alarmDef1Identifier.Name, alarmDef1Identifier.Severity)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id1).To(Equal(alarmDef1ID))
 
 			// Fetch second alarm definition
 			id2, err := resourceServer.GetAlarmDefinitionID(context.Background(), resourceTypeID, alarmDef2Identifier.Name, alarmDef2Identifier.Severity)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(id2).To(Equal(alarmDef2ID))
 		})
 	})

--- a/internal/service/cluster/api/server_test.go
+++ b/internal/service/cluster/api/server_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Cluster Server", func() {
 					NodeClusterTypeId: testUUID,
 				})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetNodeClusterTypeAlarmDictionary500ApplicationProblemPlusJSONResponse{}))
 				Expect(resp.(apigenerated.GetNodeClusterTypeAlarmDictionary500ApplicationProblemPlusJSONResponse).Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -93,7 +93,7 @@ var _ = Describe("Cluster Server", func() {
 					NodeClusterTypeId: testUUID,
 				})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetNodeClusterTypeAlarmDictionary404ApplicationProblemPlusJSONResponse{}))
 				Expect(resp.(apigenerated.GetNodeClusterTypeAlarmDictionary404ApplicationProblemPlusJSONResponse).Status).To(Equal(http.StatusNotFound))
 			})
@@ -116,7 +116,7 @@ var _ = Describe("Cluster Server", func() {
 					NodeClusterTypeId: testUUID,
 				})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetNodeClusterTypeAlarmDictionary200JSONResponse{}))
 				Expect(resp.(apigenerated.GetNodeClusterTypeAlarmDictionary200JSONResponse).AlarmDictionaryId).To(Equal(dictID))
 			})
@@ -138,7 +138,7 @@ var _ = Describe("Cluster Server", func() {
 
 			resp, err := server.GetAlarmDictionaries(ctx, apigenerated.GetAlarmDictionariesRequestObject{})
 
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetAlarmDictionaries500ApplicationProblemPlusJSONResponse{}))
 		})
 	})
@@ -152,7 +152,7 @@ var _ = Describe("Cluster Server", func() {
 
 				resp, err := server.GetAlarmDictionaries(ctx, apigenerated.GetAlarmDictionariesRequestObject{})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetAlarmDictionaries500ApplicationProblemPlusJSONResponse{}))
 				Expect(resp.(apigenerated.GetAlarmDictionaries500ApplicationProblemPlusJSONResponse).Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -168,7 +168,7 @@ var _ = Describe("Cluster Server", func() {
 
 				resp, err := server.GetAlarmDictionaries(ctx, apigenerated.GetAlarmDictionariesRequestObject{})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetAlarmDictionaries200JSONResponse{}))
 				Expect(resp.(apigenerated.GetAlarmDictionaries200JSONResponse)).To(HaveLen(0))
 			})
@@ -200,7 +200,7 @@ var _ = Describe("Cluster Server", func() {
 
 				resp, err := server.GetAlarmDictionaries(ctx, apigenerated.GetAlarmDictionariesRequestObject{})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetAlarmDictionaries200JSONResponse{}))
 				Expect(resp.(apigenerated.GetAlarmDictionaries200JSONResponse)).To(HaveLen(1))
 				Expect(resp.(apigenerated.GetAlarmDictionaries200JSONResponse)[0].AlarmDictionaryId).To(Equal(testUUID))
@@ -220,7 +220,7 @@ var _ = Describe("Cluster Server", func() {
 
 				resp, err := server.GetAlarmDictionaries(ctx, apigenerated.GetAlarmDictionariesRequestObject{})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetAlarmDictionaries500ApplicationProblemPlusJSONResponse{}))
 				Expect(resp.(apigenerated.GetAlarmDictionaries500ApplicationProblemPlusJSONResponse).Detail).To(ContainSubstring("thanos"))
 			})
@@ -238,7 +238,7 @@ var _ = Describe("Cluster Server", func() {
 					AlarmDictionaryId: testUUID,
 				})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetAlarmDictionary500ApplicationProblemPlusJSONResponse{}))
 				Expect(resp.(apigenerated.GetAlarmDictionary500ApplicationProblemPlusJSONResponse).Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -257,7 +257,7 @@ var _ = Describe("Cluster Server", func() {
 					AlarmDictionaryId: testUUID,
 				})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetAlarmDictionary404ApplicationProblemPlusJSONResponse{}))
 				Expect(resp.(apigenerated.GetAlarmDictionary404ApplicationProblemPlusJSONResponse).Status).To(Equal(http.StatusNotFound))
 			})
@@ -281,7 +281,7 @@ var _ = Describe("Cluster Server", func() {
 					AlarmDictionaryId: testUUID,
 				})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetAlarmDictionary200JSONResponse{}))
 				Expect(resp.(apigenerated.GetAlarmDictionary200JSONResponse).AlarmDictionaryId).To(Equal(testUUID))
 				Expect(resp.(apigenerated.GetAlarmDictionary200JSONResponse).AlarmDefinition).To(HaveLen(1))
@@ -311,7 +311,7 @@ var _ = Describe("Cluster Server", func() {
 					AlarmDictionaryId: testUUID,
 				})
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(BeAssignableToTypeOf(apigenerated.GetAlarmDictionary200JSONResponse{}))
 				Expect(resp.(apigenerated.GetAlarmDictionary200JSONResponse).AlarmDefinition).To(HaveLen(2))
 			})

--- a/internal/service/common/auth/auth_rfc8705_test.go
+++ b/internal/service/common/auth/auth_rfc8705_test.go
@@ -30,13 +30,13 @@ var _ = Describe("WithClientVerification", func() {
 
 	BeforeEach(func() {
 		pemBytes, _, err := cert.GenerateSelfSignedCertKey("localhost", nil, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		var certsBytes []byte
 		for block, rest := pem.Decode(pemBytes); block != nil; block, rest = pem.Decode(rest) {
 			certsBytes = append(certsBytes, block.Bytes...)
 		}
 		testCerts, err := x509.ParseCertificates(certsBytes)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		fingerprint := sha256.Sum256(testCerts[0].Raw)
 		testCertificate = base64.StdEncoding.EncodeToString(testCerts[0].Raw)
 		testStdCertificate = ":" + testCertificate + ":"
@@ -65,7 +65,7 @@ var _ = Describe("WithClientVerification", func() {
 
 	It("authorizes a request with RFC9440 compliant headers", func() {
 		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(ok).To(BeTrue())
 		Expect(response.User.GetName()).To(Equal("test"))
 		Expect(request.Header.Get(sslClientCertKey)).To(Equal(""))
@@ -75,7 +75,7 @@ var _ = Describe("WithClientVerification", func() {
 	It("rejects a request with RFC9440 headers without certificate", func() {
 		request.Header.Del(sslClientCertKey)
 		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
-		Expect(err).ToNot(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("a client certificate is required"))
 		Expect(ok).To(BeFalse())
 		Expect(response).To(BeNil())
@@ -85,7 +85,7 @@ var _ = Describe("WithClientVerification", func() {
 		delete(noopAuthenticator.Response.User.GetExtra(), fingerprintKey)
 		tokenAuthenticator = WithClientVerification(&noopAuthenticator)
 		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(ok).To(BeTrue())
 		Expect(response.User.GetName()).To(Equal("test"))
 	})
@@ -103,7 +103,7 @@ var _ = Describe("WithClientVerification", func() {
 		cert[2] = 'B'
 		request.Header.Set(sslClientCertKey, string(cert))
 		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
-		Expect(err).ToNot(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("error parsing client certificate"))
 		Expect(ok).To(BeFalse())
 		Expect(response).To(BeNil())
@@ -116,7 +116,7 @@ var _ = Describe("WithClientVerification", func() {
 		request.Header.Set(sslClientVerifiedHeaderKey, "0")
 		request.Header.Set(sslChainDERHeaderKey, "test")
 		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(ok).To(BeTrue())
 		Expect(response.User.GetName()).To(Equal("test"))
 		Expect(request.Header.Get(sslClientDERHeaderKey)).To(Equal(""))
@@ -131,7 +131,7 @@ var _ = Describe("WithClientVerification", func() {
 		request.Header.Set(sslClientVerifiedHeaderKey, "1")
 		request.Header.Set(sslChainDERHeaderKey, "test")
 		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
-		Expect(err).ToNot(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(ok).To(BeFalse())
 		Expect(response).To(BeNil())
 	})
@@ -142,7 +142,7 @@ var _ = Describe("WithClientVerification", func() {
 		request.Header.Set(sslClientVerifiedHeaderKey, "0")
 		request.Header.Set(sslChainDERHeaderKey, "test")
 		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
-		Expect(err).ToNot(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(ok).To(BeFalse())
 		Expect(response).To(BeNil())
 	})
@@ -150,7 +150,7 @@ var _ = Describe("WithClientVerification", func() {
 	It("reject a request with mismatched fingerprints", func() {
 		noopAuthenticator.Response.User.GetExtra()[fingerprintKey] = []string{"other"}
 		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
-		Expect(err).ToNot(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("client certificate fingerprint mismatch"))
 		Expect(ok).To(BeFalse())
 		Expect(response).To(BeNil())
@@ -161,7 +161,7 @@ var _ = Describe("WithClientVerification", func() {
 	It("reject a request with multiple fingerprints", func() {
 		noopAuthenticator.Response.User.GetExtra()[fingerprintKey] = []string{"foo", "bar"}
 		response, ok, err := tokenAuthenticator.AuthenticateRequest(&request)
-		Expect(err).ToNot(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("unexpected number of fingerprint values"))
 		Expect(ok).To(BeFalse())
 		Expect(response).To(BeNil())


### PR DESCRIPTION
Replace 90 instances of non-idiomatic error assertions:
- Expect(err).To(BeNil()) → Expect(err).ToNot(HaveOccurred())
- Expect(err).ToNot(BeNil()) → Expect(err).To(HaveOccurred())

HaveOccurred() produces better failure messages (prints the error message vs just "expected nil") and is the Gomega-idiomatic pattern.