### PR TITLE
CNF-24288: wire context-aware logging handler into all pods (Phase 1)

### DIFF
--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -158,6 +158,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 
 	// Get the dependencies from the context:
 	logger := internal.LoggerFromContext(ctx)
+	slog.SetDefault(logger)
 
 	// Configure klog to use our structured logger for vendor modules:
 	klog.SetSlogLogger(logger)

--- a/internal/hardwaremanager/cmd/start_hardwaremanager.go
+++ b/internal/hardwaremanager/cmd/start_hardwaremanager.go
@@ -125,6 +125,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	ctx := cmd.Context()
 
 	logger := internal.LoggerFromContext(ctx)
+	slog.SetDefault(logger)
 
 	klog.SetSlogLogger(logger)
 	logAdapter := logr.FromSlogHandler(logger.Handler())

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -57,6 +57,11 @@ func (h LoggingContextHandler) WithGroup(name string) slog.Handler {
 	return LoggingContextHandler{handler: h.handler.WithGroup(name), level: h.level}
 }
 
+// NewContextHandler wraps a base slog.Handler with context attribute extraction.
+func NewContextHandler(base slog.Handler, level slog.Level) *LoggingContextHandler {
+	return &LoggingContextHandler{handler: base, level: level}
+}
+
 // AppendCtx adds an slog attribute to the provided context so that it will be
 // included in any Record created with such context
 func AppendCtx(ctx context.Context, attr slog.Attr) context.Context {

--- a/internal/service/alarms/cmd/root.go
+++ b/internal/service/alarms/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -32,10 +33,11 @@ func GetAlarmRootCmd() *cobra.Command {
 }
 
 func configureAlarmLogger() {
-	l := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slog.LevelDebug,
 		AddSource: true,
-	}))
+	})
+	l := slog.New(logging.NewContextHandler(baseHandler, slog.LevelDebug))
 	slog.SetDefault(l)
 	slog.Info("Alarm server global logger configured")
 }

--- a/internal/service/alarms/cmd/serve.go
+++ b/internal/service/alarms/cmd/serve.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openshift-kni/oran-o2ims/internal/cmd/server"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 )
@@ -29,10 +30,11 @@ var alarmsServe = &cobra.Command{
 	Use:   "serve",
 	Short: "Start alarms server",
 	Run: func(cmd *cobra.Command, args []string) {
-		// Configure structured logging for this service
-		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		// Configure structured logging for this service with context support
+		baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelInfo,
-		}))
+		})
+		logger := slog.New(logging.NewContextHandler(baseHandler, slog.LevelInfo))
 		slog.SetDefault(logger)
 		klog.SetSlogLogger(logger)
 

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -188,11 +188,8 @@ func Serve(config *api.AlarmsServerConfig) error {
 		},
 	)
 
-	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug,
-	}))
+	// Use the default logger (configured with context support in cmd/serve.go)
+	logger := slog.Default()
 	filterAdapter, err := middleware.NewFilterAdapterFromSwagger(logger, swagger)
 	if err != nil {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)

--- a/internal/service/artifacts/cmd/root.go
+++ b/internal/service/artifacts/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -32,10 +33,11 @@ func GetArtifactsRootCmd() *cobra.Command {
 }
 
 func configureArtifactsLogger() {
-	l := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slog.LevelDebug,
 		AddSource: true,
-	}))
+	})
+	l := slog.New(logging.NewContextHandler(baseHandler, slog.LevelDebug))
 	slog.SetDefault(l)
 	slog.Info("Artifacts server global logger configured")
 }

--- a/internal/service/artifacts/cmd/serve.go
+++ b/internal/service/artifacts/cmd/serve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	artifacts "github.com/openshift-kni/oran-o2ims/internal/service/artifacts"
 	"github.com/openshift-kni/oran-o2ims/internal/service/artifacts/api"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
@@ -26,10 +27,11 @@ var artifactsServer = &cobra.Command{
 	Use:   "serve",
 	Short: "Start artifacts server",
 	Run: func(cmd *cobra.Command, args []string) {
-		// Configure structured logging for this service
-		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		// Configure structured logging for this service with context support
+		baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelInfo,
-		}))
+		})
+		logger := slog.New(logging.NewContextHandler(baseHandler, slog.LevelInfo))
 		slog.SetDefault(logger)
 		klog.SetSlogLogger(logger)
 

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -89,11 +89,8 @@ func Serve(config *api.ArtifactsServerConfig) error {
 		},
 	)
 
-	// Create a new logger to be passed where a logger is needed.
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug, // TODO: set with server args
-	}))
+	// Use the default logger (configured with context support in cmd/serve.go)
+	logger := slog.Default()
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters.
 	filterAdapter, err := middleware.NewFilterAdapterFromSwagger(logger, swagger)

--- a/internal/service/cluster/cmd/root.go
+++ b/internal/service/cluster/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -32,10 +33,11 @@ func GetClusterRootCmd() *cobra.Command {
 }
 
 func configureDefaultLogger() {
-	l := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slog.LevelDebug,
 		AddSource: true,
-	}))
+	})
+	l := slog.New(logging.NewContextHandler(baseHandler, slog.LevelDebug))
 	slog.SetDefault(l)
 	slog.Info("Cluster server global logger configured")
 }

--- a/internal/service/cluster/cmd/serve.go
+++ b/internal/service/cluster/cmd/serve.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openshift-kni/oran-o2ims/internal/cmd/server"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/api"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
@@ -28,10 +29,11 @@ var clusterServer = &cobra.Command{
 	Use:   "serve",
 	Short: "Start cluster server",
 	Run: func(cmd *cobra.Command, args []string) {
-		// Configure structured logging for this service
-		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		// Configure structured logging for this service with context support
+		baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelInfo,
-		}))
+		})
+		logger := slog.New(logging.NewContextHandler(baseHandler, slog.LevelInfo))
 		slog.SetDefault(logger)
 		klog.SetSlogLogger(logger)
 

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -148,11 +148,8 @@ func Serve(config *api.ClusterServerConfig) error {
 		},
 	)
 
-	// Create a new logger to be passed to things that need a logger
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug, // TODO: set with server args
-	}))
+	// Use the default logger (configured with context support in cmd/serve.go)
+	logger := slog.Default()
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters
 	filterAdapter, err := middleware.NewFilterAdapterFromSwagger(logger, swagger)

--- a/internal/service/common/notifier/notifier_worker.go
+++ b/internal/service/common/notifier/notifier_worker.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -68,12 +67,8 @@ func NewSubscriptionWorker(ctx context.Context, clientProvider ClientProvider, s
 		return nil, fmt.Errorf("failed to setup client: %w", err)
 	}
 
-	// Set up a custom logger to include the subscription info so it doesn't need to be repeated
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug, // TODO: set log level from server args
-	}))
-	logger = logger.With("subscription", subscription.SubscriptionID)
+	// Use the default logger with subscription context pre-attached
+	logger := slog.Default().With("subscription", subscription.SubscriptionID)
 
 	workerCtx, cancel := context.WithCancel(ctx)
 	return &SubscriptionWorker{

--- a/internal/service/provisioning/cmd/root.go
+++ b/internal/service/provisioning/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -32,10 +33,11 @@ func GetProvisioningRootCmd() *cobra.Command {
 }
 
 func configureProvisioningLogger() {
-	l := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slog.LevelDebug,
 		AddSource: true,
-	}))
+	})
+	l := slog.New(logging.NewContextHandler(baseHandler, slog.LevelDebug))
 	slog.SetDefault(l)
 	slog.Info("Provisioning server global logger configured")
 }

--- a/internal/service/provisioning/cmd/serve.go
+++ b/internal/service/provisioning/cmd/serve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/provisioning"
 	"github.com/openshift-kni/oran-o2ims/internal/service/provisioning/api"
@@ -26,10 +27,11 @@ var provisioningServe = &cobra.Command{
 	Use:   "serve",
 	Short: "Start provisioning server",
 	Run: func(cmd *cobra.Command, args []string) {
-		// Configure structured logging for this service
-		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		// Configure structured logging for this service with context support
+		baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelInfo,
-		}))
+		})
+		logger := slog.New(logging.NewContextHandler(baseHandler, slog.LevelInfo))
 		slog.SetDefault(logger)
 		klog.SetSlogLogger(logger)
 

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -86,11 +86,8 @@ func Serve(config *api.ProvisioningServerConfig) error {
 		},
 	)
 
-	// Create a new logger to be passed where a logger is needed.
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug, // TODO: set with server args
-	}))
+	// Use the default logger (configured with context support in cmd/serve.go)
+	logger := slog.Default()
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters.
 	filterAdapter, err := middleware.NewFilterAdapterFromSwagger(logger, swagger)

--- a/internal/service/resources/cmd/root.go
+++ b/internal/service/resources/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -32,10 +33,11 @@ func GetResourcesRootCmd() *cobra.Command {
 }
 
 func configureResourcesLogger() {
-	l := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slog.LevelDebug,
 		AddSource: true,
-	}))
+	})
+	l := slog.New(logging.NewContextHandler(baseHandler, slog.LevelDebug))
 	slog.SetDefault(l)
 	slog.Info("Resource server global logger configured")
 }

--- a/internal/service/resources/cmd/serve.go
+++ b/internal/service/resources/cmd/serve.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openshift-kni/oran-o2ims/internal/cmd/server"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/api"
@@ -29,10 +30,11 @@ var resourceServer = &cobra.Command{
 	Use:   "serve",
 	Short: "Start resource server",
 	Run: func(cmd *cobra.Command, args []string) {
-		// Configure structured logging for this service
-		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		// Configure structured logging for this service with context support
+		baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelInfo,
-		}))
+		})
+		logger := slog.New(logging.NewContextHandler(baseHandler, slog.LevelInfo))
 		slog.SetDefault(logger)
 		klog.SetSlogLogger(logger)
 

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -190,11 +190,8 @@ func Serve(config *api.ResourceServerConfig) error {
 		},
 	)
 
-	// Create a new logger to be passed to things that need a logger
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     slog.LevelDebug, // TODO: set with server args
-	}))
+	// Use the default logger (configured with context support in cmd/serve.go)
+	logger := slog.Default()
 
 	// Create a response filter filterAdapter that can support the 'filter' and '*fields' query parameters
 	filterAdapter, err := middleware.NewFilterAdapterFromSwagger(logger, swagger)


### PR DESCRIPTION
## Summary

Wire the existing `LoggingContextHandler` into all pods so that context attributes
added via `logging.AppendCtx()` are included in log output when using
`slog.InfoContext(ctx, ...)` and similar context-aware calls.

This is Phase 1 of the context-aware logging work ([CNF-24288](https://redhat.atlassian.net/browse/CNF-24288)). Phase 2
(PR #2696) converts existing `slog.Info()` calls to `slog.InfoContext()`.

## Changes

- Add `logging.NewContextHandler()` constructor for external use
- Wrap `slog.SetDefault()` with `LoggingContextHandler` in all service
  `cmd/root.go` and `cmd/serve.go` files
- Add `slog.SetDefault()` to controller manager and hardware manager pods
  (previously missing)
- Replace duplicate `slog.NewJSONHandler` loggers in `serve.go` files and
  `notifier_worker.go` with `slog.Default()` so all logging goes through
  the single context-aware handler
- `cmd/serve.go` log level remains `LevelInfo` (matching original);
  `root.go` keeps `LevelDebug` for early startup logging only

🤖 Generated with [Claude Code](https://claude.com/claude-code)