### PR TITLE
CNF-24288: convert slog calls to context variants and add sloglint check (Phase 2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -120,6 +120,8 @@ linters:
               - must not contain line breaks
           severity: warning
           disabled: false
+    sloglint:
+      context: scope
     wrapcheck:
       ignore-sigs:
         - .Errorf(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,13 @@ issues during code review.
   `NamespacedName`. `ProvisioningRequest` is cluster-scoped (`scope: Cluster`
   in the CRD) and has no namespace.
 
+## Logging Conventions
+
+- Use context-aware slog calls (`slog.InfoContext(ctx, ...)`,
+  `slog.ErrorContext(ctx, ...)`, etc.) whenever a `ctx` variable is in
+  scope. The `sloglint` linter enforces this. Use `logging.AppendCtx()`
+  to add structured attributes to the context at entry points.
+
 ## Test Conventions
 
 - Use `.ToNot()` for negated Gomega assertions, not `.NotTo()` or

--- a/internal/controllers/provisioningrequest_clusterconfig.go
+++ b/internal/controllers/provisioningrequest_clusterconfig.go
@@ -432,7 +432,7 @@ func (t *provisioningRequestReconcilerTask) addPostProvisioningLabels(ctx contex
 	if len(agents.Items) == 0 {
 		// No Agents found — this is expected for IBI-provisioned clusters which
 		// do not use assisted-service. Skip Agent labeling and return.
-		t.logger.Info(fmt.Sprintf(
+		t.logger.InfoContext(ctx, fmt.Sprintf(
 			"No Agents found in the %s namespace, skipping Agent labeling (expected for IBI clusters)",
 			mcl.Name))
 		return nil

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -1069,7 +1069,7 @@ func (r *ProvisioningRequestReconciler) handleFinalizer(
 
 		// Deletion has completed. Remove provisioningRequestFinalizer. Once all finalizers have been
 		// removed, the object will be deleted.
-		r.Logger.Info("Dependents have been deleted. Removing provisioningRequest finalizer", "name", provisioningRequest.Name)
+		r.Logger.InfoContext(ctx, "Dependents have been deleted. Removing provisioningRequest finalizer", "name", provisioningRequest.Name)
 		patch := client.MergeFrom(provisioningRequest.DeepCopy())
 		if controllerutil.RemoveFinalizer(provisioningRequest, provisioningv1alpha1.ProvisioningRequestFinalizer) {
 			if err := r.Patch(ctx, provisioningRequest, patch); err != nil {
@@ -1205,13 +1205,13 @@ func (r *ProvisioningRequestReconciler) handleProvisioningRequestDeletion(
 		// Deleting cluster namespace will delete all resources within it, including
 		// ClusterInstance and ImageBasedGroupUpgrade.
 		if ns.DeletionTimestamp.IsZero() {
-			r.Logger.Info(fmt.Sprintf("Deleting Cluster Namespace (%s)", ns.Name))
+			r.Logger.InfoContext(ctx, fmt.Sprintf("Deleting Cluster Namespace (%s)", ns.Name))
 			copiedNamespace := ns
 			if err := r.Client.Delete(ctx, &copiedNamespace); client.IgnoreNotFound(err) != nil {
 				return false, fmt.Errorf("failed to delete namespace: %w", err)
 			}
 		}
-		r.Logger.Info(fmt.Sprintf("Waiting for Cluster Namespace (%s) to be deleted", ns.Name))
+		r.Logger.InfoContext(ctx, fmt.Sprintf("Waiting for Cluster Namespace (%s) to be deleted", ns.Name))
 		deleteCompleted = false
 	}
 

--- a/internal/controllers/provisioningrequest_setup.go
+++ b/internal/controllers/provisioningrequest_setup.go
@@ -190,8 +190,8 @@ func (r *ProvisioningRequestReconciler) SetupWithManager(mgr ctrl.Manager) error
 // reconciliation requests for the corresponding ProvisioningRequest.
 // Since NAR name = PR name (1:1 relationship), the mapping is direct.
 func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForNAR(
-	_ context.Context, obj client.Object) []reconcile.Request {
-	r.Logger.Info(
+	ctx context.Context, obj client.Object) []reconcile.Request {
+	r.Logger.InfoContext(ctx,
 		"[enqueueProvisioningRequestForNAR] NAR status changed, triggering PR reconciliation",
 		"name", obj.GetName())
 	return []reconcile.Request{
@@ -218,7 +218,7 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForClusterTemp
 		clusterTemplateRefName := GetClusterTemplateRefName(
 			provisioningRequest.Spec.TemplateName, provisioningRequest.Spec.TemplateVersion)
 		if clusterTemplateRefName == obj.GetName() {
-			r.Logger.Info(
+			r.Logger.InfoContext(ctx,
 				"[enqueueProvisioningRequestForClusterTemplate] Add new reconcile request for ProvisioningRequest ",
 				"name", provisioningRequest.Name)
 			requests = append(requests, reconcile.Request{
@@ -250,14 +250,14 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForManagedClus
 			// Return as this ManagedCluster is not deployed/managed by ClusterInstance.
 			return nil
 		}
-		r.Logger.Error("[enqueueProvisioningRequestForManagedCluster] Error getting ClusterInstance. ", "Error: ", err)
+		r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForManagedCluster] Error getting ClusterInstance. ", "Error: ", err)
 		return nil
 	}
 
 	// Get the ProvisioningRequest name.
 	crName, nameExists := clusterInstance.GetLabels()[provisioningv1alpha1.ProvisioningRequestNameLabel]
 	if nameExists {
-		r.Logger.Info(
+		r.Logger.InfoContext(ctx,
 			"[enqueueProvisioningRequestForManagedCluster] Add new reconcile request for ProvisioningRequest",
 			"name", crName)
 		requests = append(requests, reconcile.Request{
@@ -300,13 +300,13 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForPolicy(
 				// The provisioning request could have been deleted
 				return nil
 			}
-			r.Logger.Error("[enqueueProvisioningRequestForPolicy] Error getting ProvisioningRequest. ", "Error: ", err)
+			r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForPolicy] Error getting ProvisioningRequest. ", "Error: ", err)
 			return nil
 		}
 
 		clusterTemplates := &provisioningv1alpha1.ClusterTemplateList{}
 		if err := r.List(ctx, clusterTemplates); err != nil {
-			r.Logger.Error("[enqueueProvisioningRequestForPolicy] Error listing ClusterTemplates. ", "Error: ", err)
+			r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForPolicy] Error listing ClusterTemplates. ", "Error: ", err)
 			return nil
 		}
 
@@ -323,7 +323,7 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForPolicy(
 
 		_, parentPolicyNs := ctlrutils.GetParentPolicyNameAndNamespace(obj.GetName())
 		if ctlrutils.IsParentPolicyInZtpClusterTemplateNs(parentPolicyNs, ctRefNamespace) {
-			r.Logger.Info(
+			r.Logger.InfoContext(ctx,
 				"[enqueueProvisioningRequestForPolicy] Add new reconcile request for ProvisioningRequest ",
 				"name", provisioningRequest, "policyName", obj.GetName())
 			requests = append(requests, reconcile.Request{

--- a/internal/controllers/provisioningrequest_validation.go
+++ b/internal/controllers/provisioningrequest_validation.go
@@ -278,7 +278,7 @@ func (t *provisioningRequestReconcilerTask) validateAndMergeHwMgmtInput(
 		t.timeouts.hardwareProvisioning = timeout
 	}
 
-	t.logger.Info(
+	t.logger.InfoContext(ctx,
 		fmt.Sprintf("Merged hwMgmt default data with hwMgmtParameters for ProvisioningRequest"),
 		slog.String("name", t.object.Name),
 	)
@@ -441,7 +441,7 @@ func (t *provisioningRequestReconcilerTask) getMergedClusterInputData(
 		return nil, ctlrutils.NewInputError("failed to merge data for %s: %s", templateParam, err.Error())
 	}
 
-	t.logger.Info(
+	t.logger.InfoContext(ctx,
 		fmt.Sprintf("Merged the %s default data with the clusterTemplateInput data for ProvisioningRequest", templateParam),
 		slog.String("name", t.object.Name),
 	)

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -40,7 +40,7 @@ type NodeAllocationRequestReconciler struct {
 }
 
 func (r *NodeAllocationRequestReconciler) SetupIndexer(ctx context.Context) error {
-	r.Logger.Info("SetupIndexer Start")
+	r.Logger.InfoContext(ctx, "SetupIndexer Start")
 	if err := hwmgrutils.RegisterAllocatedNodeFieldIndexer(ctx, r.Manager.GetFieldIndexer()); err != nil {
 		return fmt.Errorf("failed to setup node indexer: %w", err)
 	}

--- a/internal/service/alarms/api/server.go
+++ b/internal/service/alarms/api/server.go
@@ -131,7 +131,7 @@ func (a *AlarmsServer) CreateSubscription(ctx context.Context, request api.Creat
 
 	// Validate the subscription
 	if err := commonapi.ValidateCallbackURL(ctx, a.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback); err != nil {
-		slog.Error("callback URL validation failed", "error", err)
+		slog.ErrorContext(ctx, "callback URL validation failed", "error", err)
 		return api.CreateSubscription400ApplicationProblemPlusJSONResponse{
 			Detail: "callback URL validation failed",
 			Status: http.StatusBadRequest,
@@ -157,7 +157,7 @@ func (a *AlarmsServer) CreateSubscription(ctx context.Context, request api.Creat
 		Removed:      false,
 		Subscription: models.ConvertAlertSubToNotificationSub(record),
 	})
-	slog.Info("Successfully created Alarm Subscription", "record", record)
+	slog.InfoContext(ctx, "Successfully created Alarm Subscription", "record", record)
 	return api.CreateSubscription201JSONResponse(models.ConvertSubscriptionModelToApi(*record)), nil
 }
 
@@ -190,7 +190,7 @@ func (a *AlarmsServer) DeleteSubscription(ctx context.Context, request api.Delet
 		Removed:      true,
 		Subscription: models.ConvertAlertSubToNotificationSub(&models.AlarmSubscription{SubscriptionID: request.AlarmSubscriptionId}),
 	})
-	slog.Info("Successfully deleted Alarm Subscription", "alarmSubscriptionId", request.AlarmSubscriptionId.String())
+	slog.InfoContext(ctx, "Successfully deleted Alarm Subscription", "alarmSubscriptionId", request.AlarmSubscriptionId.String())
 	return api.DeleteSubscription200Response{}, nil
 }
 
@@ -366,7 +366,7 @@ func (a *AlarmsServer) PatchAlarm(ctx context.Context, request api.PatchAlarmReq
 		return nil, fmt.Errorf("failed to patch Alarm Event Record: %w", err)
 	}
 
-	slog.Debug("Alarm acknowledged/cleared", "alarmEventRecordId", updated.AlarmEventRecordID, "alarmAcknowledged", updated.AlarmAcknowledged, "alarmAcknowledgedTime", updated.AlarmAcknowledgedTime,
+	slog.DebugContext(ctx, "Alarm acknowledged/cleared", "alarmEventRecordId", updated.AlarmEventRecordID, "alarmAcknowledged", updated.AlarmAcknowledged, "alarmAcknowledgedTime", updated.AlarmAcknowledgedTime,
 		"alarmClearedTime", updated.AlarmClearedTime, "perceivedSeverity", updated.PerceivedSeverity, "alarmChangedTime", updated.AlarmChangedTime)
 
 	return api.PatchAlarm200JSONResponse{AlarmAcknowledged: request.Body.AlarmAcknowledged, PerceivedSeverity: request.Body.PerceivedSeverity}, nil
@@ -434,7 +434,7 @@ func (a *AlarmsServer) PatchAlarmServiceConfiguration(ctx context.Context, reque
 		return nil, fmt.Errorf("failed to start cleanup cronjob during AlarmServiceConfiguration patch: %w", err)
 	}
 
-	slog.Debug("Alarm Service Configuration patched", "retentionPeriod", patched.RetentionPeriod, "extensions", patched.Extensions)
+	slog.DebugContext(ctx, "Alarm Service Configuration patched", "retentionPeriod", patched.RetentionPeriod, "extensions", patched.Extensions)
 	return api.PatchAlarmServiceConfiguration200JSONResponse(models.ConvertServiceConfigurationToAPI(*patched)), nil
 }
 
@@ -477,7 +477,7 @@ func (a *AlarmsServer) UpdateAlarmServiceConfiguration(ctx context.Context, requ
 		return nil, fmt.Errorf("failed to start cleanup cronjob during AlarmServiceConfiguration update: %w", err)
 	}
 
-	slog.Debug("Alarm Service Configuration updated", "retentionPeriod", updated.RetentionPeriod, "extensions", updated.Extensions)
+	slog.DebugContext(ctx, "Alarm Service Configuration updated", "retentionPeriod", updated.RetentionPeriod, "extensions", updated.Extensions)
 	return api.UpdateAlarmServiceConfiguration200JSONResponse(models.ConvertServiceConfigurationToAPI(*updated)), nil
 
 }
@@ -489,12 +489,12 @@ func (a *AlarmsServer) AmNotification(ctx context.Context, request api.AmNotific
 
 	if err := alertmanager.HandleAlerts(ctx, a.Infrastructure.ClusterServer, a.Infrastructure.ResourceServer, a.AlarmsRepository, &request.Body.Alerts, alertmanager.Webhook); err != nil {
 		msg := "failed to handle alerts"
-		slog.Error(msg, "error", err)
+		slog.ErrorContext(ctx, msg, "error", err)
 		return nil, fmt.Errorf("%s: %w", msg, err)
 	}
 
 	// Subscriber notification sent async
-	slog.Info("Successfully handled all alertmanager alerts")
+	slog.InfoContext(ctx, "Successfully handled all alertmanager alerts")
 	return api.AmNotification200Response{}, nil
 }
 

--- a/internal/service/alarms/internal/alertmanager/api.go
+++ b/internal/service/alarms/internal/alertmanager/api.go
@@ -71,19 +71,19 @@ func (c *AMClient) RunAlertSyncScheduler(ctx context.Context, interval time.Dura
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	slog.Info("Alert sync scheduler started", "interval", interval.String())
+	slog.InfoContext(ctx, "Alert sync scheduler started", "interval", interval.String())
 
 	// Continue syncing at regular intervals until context is canceled
 	for {
 		select {
 		case <-ticker.C:
-			slog.Info("Running scheduled alert sync")
+			slog.InfoContext(ctx, "Running scheduled alert sync")
 			if err := c.SyncAlerts(ctx); err != nil {
-				slog.Error("failed to sync alerts", "error", err)
+				slog.ErrorContext(ctx, "failed to sync alerts", "error", err)
 				// Continue running even if a sync fails
 			}
 		case <-ctx.Done():
-			slog.Info("Alert sync scheduler shutting down")
+			slog.InfoContext(ctx, "Alert sync scheduler shutting down")
 			return nil
 		}
 	}
@@ -105,7 +105,7 @@ func (c *AMClient) SyncAlerts(ctx context.Context) error {
 		}
 	}
 
-	slog.Info("Alertmanager synced successfully")
+	slog.InfoContext(ctx, "Alertmanager synced successfully")
 	return nil
 }
 
@@ -160,7 +160,7 @@ func (c *AMClient) getAlerts(ctx context.Context) ([]APIAlert, error) {
 	}
 	defer func(Body io.ReadCloser) {
 		if err := Body.Close(); err != nil {
-			slog.Error("failed to close response body during AM get call", "error", err.Error())
+			slog.ErrorContext(ctx, "failed to close response body during AM get call", "error", err.Error())
 		}
 	}(resp.Body)
 
@@ -181,7 +181,7 @@ func (c *AMClient) getAlerts(ctx context.Context) ([]APIAlert, error) {
 		return nil, fmt.Errorf("error parsing response: %w, body: %s", err, string(body))
 	}
 
-	slog.Info("Got alerts with AM API", "alerts", len(alerts))
+	slog.InfoContext(ctx, "Got alerts with AM API", "alerts", len(alerts))
 	return alerts, nil
 }
 

--- a/internal/service/alarms/internal/alertmanager/config.go
+++ b/internal/service/alarms/internal/alertmanager/config.go
@@ -78,7 +78,7 @@ func Setup(ctx context.Context) error {
 		return fmt.Errorf("failed to update secret %s/%s: %w", ACMObsAMNamespace, ACMObsAMSecretName, err)
 	}
 
-	slog.Info("Successfully merged with existing alertmanager")
+	slog.InfoContext(ctx, "Successfully merged with existing alertmanager")
 	return nil
 }
 

--- a/internal/service/alarms/internal/alertmanager/converter.go
+++ b/internal/service/alarms/internal/alertmanager/converter.go
@@ -29,7 +29,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 		if alert.StartsAt != nil && !alert.StartsAt.IsZero() {
 			record.AlarmRaisedTime = *alert.StartsAt
 		} else {
-			slog.Error("Alert StartsAt is required, skipping.", "alert", alert)
+			slog.ErrorContext(ctx, "Alert StartsAt is required, skipping.", "alert", alert)
 			continue
 		}
 
@@ -48,7 +48,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 				record.PerceivedSeverity = ps
 			}
 		} else {
-			slog.Error("Alert Status is required, skipping.", "alert", alert)
+			slog.ErrorContext(ctx, "Alert Status is required, skipping.", "alert", alert)
 			continue
 		}
 
@@ -56,7 +56,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 		if alert.Fingerprint != nil {
 			record.Fingerprint = *alert.Fingerprint
 		} else {
-			slog.Error("Alert Fingerprint is required, skipping.", "alert", alert)
+			slog.ErrorContext(ctx, "Alert Fingerprint is required, skipping.", "alert", alert)
 			continue
 		}
 
@@ -90,7 +90,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 		if record.ObjectID != nil {
 			objectTypeID, err := infrastructureClient.GetObjectTypeID(ctx, *record.ObjectID)
 			if err != nil {
-				slog.Warn("Could not get object type ID", "objectID", record.ObjectID, "err", err.Error())
+				slog.WarnContext(ctx, "Could not get object type ID", "objectID", record.ObjectID, "err", err.Error())
 			} else {
 				record.ObjectTypeID = &objectTypeID
 			}
@@ -102,7 +102,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 			_, severity := getPerceivedSeverity(labels)
 			alarmDefinitionID, err := infrastructureClient.GetAlarmDefinitionID(ctx, *record.ObjectTypeID, getAlertName(labels), severity)
 			if err != nil {
-				slog.Warn("Could not get alarm definition ID", "objectTypeID", *record.ObjectTypeID, "name", getAlertName(labels), "severity", severity, "err", err.Error())
+				slog.WarnContext(ctx, "Could not get alarm definition ID", "objectTypeID", *record.ObjectTypeID, "name", getAlertName(labels), "severity", severity, "err", err.Error())
 			} else {
 				record.AlarmDefinitionID = &alarmDefinitionID
 			}
@@ -112,7 +112,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 		records = append(records, record)
 	}
 
-	slog.Info("Converted alerts", "records", len(records))
+	slog.InfoContext(ctx, "Converted alerts", "records", len(records))
 	return records
 }
 

--- a/internal/service/alarms/internal/alertmanager/handler.go
+++ b/internal/service/alarms/internal/alertmanager/handler.go
@@ -62,6 +62,6 @@ func HandleAlerts(ctx context.Context, clusterServer, resourceServer infrastruct
 		return fmt.Errorf("failed to handle alerts from %s: %w", string(source), err)
 	}
 
-	slog.Info("Successfully handled AlarmEventRecords", "source_type", string(source))
+	slog.InfoContext(ctx, "Successfully handled AlarmEventRecords", "source_type", string(source))
 	return nil
 }

--- a/internal/service/alarms/internal/db/repo/alarms_repository.go
+++ b/internal/service/alarms/internal/db/repo/alarms_repository.go
@@ -64,13 +64,13 @@ func (ar *AlarmsRepository) CreateServiceConfiguration(ctx context.Context, defa
 
 	// Return record if it already exists
 	if len(records) == 1 {
-		slog.Debug("Service configuration already exists")
+		slog.DebugContext(ctx, "Service configuration already exists")
 		return &records[0], nil
 	}
 
 	// If there are more than one record, pick the first one and delete the rest
 	if len(records) > 1 {
-		slog.Debug("Multiple service configurations found, deleting all but the first")
+		slog.DebugContext(ctx, "Multiple service configurations found, deleting all but the first")
 
 		ids := make([]any, 0, len(records)-1)
 		for i := 1; i < len(records); i++ {
@@ -85,7 +85,7 @@ func (ar *AlarmsRepository) CreateServiceConfiguration(ctx context.Context, defa
 		return &records[0], nil
 	}
 
-	slog.Debug("Creating new service configuration")
+	slog.DebugContext(ctx, "Creating new service configuration")
 
 	// Create a new record
 	record := models.ServiceConfiguration{
@@ -128,7 +128,7 @@ func (ar *AlarmsRepository) GetAlarmSubscription(ctx context.Context, id uuid.UU
 // UpsertAlarmEventCaaSRecord insert and updating an AlarmEventRecord.
 func (ar *AlarmsRepository) UpsertAlarmEventCaaSRecord(ctx context.Context, tx pgx.Tx, records []models.AlarmEventRecord, generationID int64) error {
 	if len(records) == 0 {
-		slog.Warn("No records for events upsert")
+		slog.WarnContext(ctx, "No records for events upsert")
 		return nil
 	}
 
@@ -228,7 +228,7 @@ func (ar *AlarmsRepository) ResolveStaleAlarmEventCaaSRecord(ctx context.Context
 	}
 
 	if len(records) > 0 {
-		slog.Info("Successfully resolved stale CaaS (alertmanager) alarmeventrecords", "records", len(records))
+		slog.InfoContext(ctx, "Successfully resolved stale CaaS (alertmanager) alarmeventrecords", "records", len(records))
 	}
 	return nil
 }

--- a/internal/service/alarms/internal/infrastructure/clusterserver.go
+++ b/internal/service/alarms/internal/infrastructure/clusterserver.go
@@ -96,7 +96,7 @@ func (r *ClusterServer) Setup() error {
 
 // FetchAll fetches all necessary data from the cluster server
 func (r *ClusterServer) FetchAll(ctx context.Context) error {
-	slog.Info("Getting all objects from the cluster server")
+	slog.InfoContext(ctx, "Getting all objects from the cluster server")
 
 	// List node clusters
 	nodeClusters, err := r.getNodeClusters(ctx)
@@ -123,7 +123,7 @@ func (r *ClusterServer) FetchAll(ctx context.Context) error {
 	r.nodeClusterTypeIDToAlarmDictionaryID = r.buildNodeClusterTypeIDToAlarmDictionaryID(nodeClusterTypes)
 	r.alarmDictionaryIDToAlarmDefinitions = r.buildAlarmDictionaryIDToAlarmDefinitions(alarmDictionaries)
 
-	slog.Info("Successfully synced ClusterServer objects")
+	slog.InfoContext(ctx, "Successfully synced ClusterServer objects")
 	return nil
 }
 
@@ -135,7 +135,7 @@ func (r *ClusterServer) GetObjectTypeID(ctx context.Context, nodeClusterID uuid.
 
 	nodeClusterTypeID, ok := r.nodeClusterIDToNodeClusterTypeID[nodeClusterID]
 	if !ok {
-		slog.Info("Node cluster ID not found in cache", "nodeClusterID", nodeClusterID)
+		slog.InfoContext(ctx, "Node cluster ID not found in cache", "nodeClusterID", nodeClusterID)
 
 		// Try to fetch it from the server
 		nodeCluster, err := r.getNodeCluster(ctx, nodeClusterID)
@@ -145,7 +145,7 @@ func (r *ClusterServer) GetObjectTypeID(ctx context.Context, nodeClusterID uuid.
 
 		nodeClusterTypeID = nodeCluster.NodeClusterTypeId
 		r.nodeClusterIDToNodeClusterTypeID[nodeClusterID] = nodeClusterTypeID
-		slog.Info("Mapping node cluster ID to node cluster type ID", "nodeClusterID", nodeClusterID, "nodeClusterTypeID", nodeClusterTypeID)
+		slog.InfoContext(ctx, "Mapping node cluster ID to node cluster type ID", "nodeClusterID", nodeClusterID, "nodeClusterTypeID", nodeClusterTypeID)
 	}
 
 	return nodeClusterTypeID, nil
@@ -159,7 +159,7 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 
 	alarmDictionaryID, ok := r.nodeClusterTypeIDToAlarmDictionaryID[nodeClusterTypeID]
 	if !ok {
-		slog.Info("Node Cluster Type ID not found in cache", "nodeClusterTypeID", nodeClusterTypeID)
+		slog.InfoContext(ctx, "Node Cluster Type ID not found in cache", "nodeClusterTypeID", nodeClusterTypeID)
 
 		// Try to fetch it from the server
 		nodeClusterType, err := r.getNodeClusterType(ctx, nodeClusterTypeID)
@@ -173,13 +173,13 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 		}
 
 		r.nodeClusterTypeIDToAlarmDictionaryID[nodeClusterTypeID] = alarmDictionaryID
-		slog.Info("Mapping node cluster type ID to alarm dictionary ID", "nodeClusterTypeID", nodeClusterTypeID, "alarmDictionaryID", alarmDictionaryID)
+		slog.InfoContext(ctx, "Mapping node cluster type ID to alarm dictionary ID", "nodeClusterTypeID", nodeClusterTypeID, "alarmDictionaryID", alarmDictionaryID)
 	}
 
 	definitionsResynced := false
 	alarmDefinitions, ok := r.alarmDictionaryIDToAlarmDefinitions[alarmDictionaryID]
 	if !ok {
-		slog.Info("Alarm dictionary ID not found in cache", "alarmDictionaryID", alarmDictionaryID)
+		slog.InfoContext(ctx, "Alarm dictionary ID not found in cache", "alarmDictionaryID", alarmDictionaryID)
 
 		// Try to fetch it from the server
 		alarmDictionary, err := r.getAlarmDictionary(ctx, alarmDictionaryID)
@@ -190,7 +190,7 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 		definitionsResynced = true
 		alarmDefinitions = getAlarmDefinitionsFromAlarmDictionary(alarmDictionary)
 		r.alarmDictionaryIDToAlarmDefinitions[alarmDictionaryID] = alarmDefinitions
-		slog.Info("Mapping alarm dictionary ID to alarm definitions", "alarmDictionaryID", alarmDictionaryID)
+		slog.InfoContext(ctx, "Mapping alarm dictionary ID to alarm definitions", "alarmDictionaryID", alarmDictionaryID)
 	}
 
 	uniqueAlarmDefinitionIdentifier := AlarmDefinitionUniqueIdentifier{
@@ -202,7 +202,7 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 	if !ok {
 		if !definitionsResynced {
 			// Resync definitions and try again. It is possible that cache is not up to date
-			slog.Debug("Resynced alarm definitions", "alarmDictionaryID", alarmDictionaryID, "uniqueAlarmDefinitionIdentifier", uniqueAlarmDefinitionIdentifier)
+			slog.DebugContext(ctx, "Resynced alarm definitions", "alarmDictionaryID", alarmDictionaryID, "uniqueAlarmDefinitionIdentifier", uniqueAlarmDefinitionIdentifier)
 
 			alarmDictionary, err := r.getAlarmDictionary(ctx, alarmDictionaryID)
 			if err != nil {
@@ -211,7 +211,7 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 
 			alarmDefinitions = getAlarmDefinitionsFromAlarmDictionary(alarmDictionary)
 			r.alarmDictionaryIDToAlarmDefinitions[alarmDictionaryID] = alarmDefinitions
-			slog.Info("Mapping alarm dictionary ID to alarm definitions", "alarmDictionaryID", alarmDictionaryID)
+			slog.InfoContext(ctx, "Mapping alarm dictionary ID to alarm definitions", "alarmDictionaryID", alarmDictionaryID)
 
 			alarmDefinitionID, ok = alarmDefinitions[uniqueAlarmDefinitionIdentifier]
 			if ok {
@@ -227,7 +227,7 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 
 // Sync starts the sync process for the cluster server objects
 func (r *ClusterServer) Sync(ctx context.Context) {
-	slog.Info("Starting sync process for cluster server objects")
+	slog.InfoContext(ctx, "Starting sync process for cluster server objects")
 
 	// First fetch of all objects.
 	// When doing a clean deployment cluster server may not be ready which results incomplete data during startup Alerts sync
@@ -235,7 +235,7 @@ func (r *ClusterServer) Sync(ctx context.Context) {
 	// This is edge case and even if the Cluster server cant come up within retry time, we can still continue
 	// But once it does come up, user may get unwanted "CHANGED" alerts
 	if err := r.FetchAllWithRetry(ctx, 3); err != nil {
-		slog.Error("Failed to run initial sync for cluster server objects", "error", err)
+		slog.ErrorContext(ctx, "Failed to run initial sync for cluster server objects", "error", err)
 	}
 
 	go func() {
@@ -245,12 +245,12 @@ func (r *ClusterServer) Sync(ctx context.Context) {
 		for {
 			select {
 			case <-ctx.Done():
-				slog.Info("Stopping sync process for cluster server objects")
+				slog.InfoContext(ctx, "Stopping sync process for cluster server objects")
 				return
 			case <-ticker.C:
-				slog.Info("Syncing ClusterServer objects")
+				slog.InfoContext(ctx, "Syncing ClusterServer objects")
 				if err := r.FetchAll(ctx); err != nil {
-					slog.Error("Failed to sync cluster server objects", "error", err)
+					slog.ErrorContext(ctx, "Failed to sync cluster server objects", "error", err)
 				}
 			}
 		}
@@ -276,7 +276,7 @@ func (r *ClusterServer) FetchAllWithRetry(ctx context.Context, maxRetries int) e
 		}
 
 		// Wait before retrying with exponential backoff
-		slog.Warn("Fetch operation failed", "attempt", attempt+1, "maxRetries", maxRetries, "error", err)
+		slog.WarnContext(ctx, "Fetch operation failed", "attempt", attempt+1, "maxRetries", maxRetries, "error", err)
 		select {
 		case <-time.After(backoff):
 			backoff *= 2
@@ -303,7 +303,7 @@ func (r *ClusterServer) getNodeClusters(ctx context.Context) ([]NodeCluster, err
 		return nil, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.Info("Got node clusters", "count", len(*resp.JSON200))
+	slog.InfoContext(ctx, "Got node clusters", "count", len(*resp.JSON200))
 	return *resp.JSON200, nil
 }
 
@@ -322,7 +322,7 @@ func (r *ClusterServer) getNodeCluster(ctx context.Context, nodeClusterID uuid.U
 		return NodeCluster{}, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.Info("Got node cluster", "nodeClusterID", nodeClusterID)
+	slog.InfoContext(ctx, "Got node cluster", "nodeClusterID", nodeClusterID)
 	return *resp.JSON200, nil
 }
 
@@ -341,7 +341,7 @@ func (r *ClusterServer) getNodeClusterTypes(ctx context.Context) ([]NodeClusterT
 		return nil, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.Info("Got node cluster types", "count", len(*resp.JSON200))
+	slog.InfoContext(ctx, "Got node cluster types", "count", len(*resp.JSON200))
 	return *resp.JSON200, nil
 }
 
@@ -360,7 +360,7 @@ func (r *ClusterServer) getNodeClusterType(ctx context.Context, nodeClusterTypeI
 		return NodeClusterType{}, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.Info("Got node cluster type", "nodeClusterTypeID", nodeClusterTypeID)
+	slog.InfoContext(ctx, "Got node cluster type", "nodeClusterTypeID", nodeClusterTypeID)
 	return *resp.JSON200, nil
 }
 
@@ -379,7 +379,7 @@ func (r *ClusterServer) getAlarmDictionaries(ctx context.Context) ([]AlarmDictio
 		return nil, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.Info("Got alarm dictionaries", "count", len(*resp.JSON200))
+	slog.InfoContext(ctx, "Got alarm dictionaries", "count", len(*resp.JSON200))
 	return *resp.JSON200, nil
 }
 
@@ -398,7 +398,7 @@ func (r *ClusterServer) getAlarmDictionary(ctx context.Context, alarmDictionaryI
 		return AlarmDictionary{}, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.Info("Got alarm dictionary", "alarmDictionaryID", alarmDictionaryID)
+	slog.InfoContext(ctx, "Got alarm dictionary", "alarmDictionaryID", alarmDictionaryID)
 	return *resp.JSON200, nil
 }
 

--- a/internal/service/alarms/internal/infrastructure/resourceserver.go
+++ b/internal/service/alarms/internal/infrastructure/resourceserver.go
@@ -92,7 +92,7 @@ func (r *ResourceServer) Setup() error {
 
 // FetchAll fetches all necessary data from the resource server
 func (r *ResourceServer) FetchAll(ctx context.Context) error {
-	slog.Info("Getting all objects from the resource server")
+	slog.InfoContext(ctx, "Getting all objects from the resource server")
 
 	// Fetch all resource types
 	resourceTypes, err := r.getResourceTypes(ctx)
@@ -106,24 +106,24 @@ func (r *ResourceServer) FetchAll(ctx context.Context) error {
 		// Fetch the real alarm dictionary for this resource type
 		resp, err := r.client.GetResourceTypeAlarmDictionaryWithResponse(ctx, resourceType.ResourceTypeId)
 		if err != nil {
-			slog.Warn("Failed to get alarm dictionary for resource type", "resourceTypeID", resourceType.ResourceTypeId, "error", err)
+			slog.WarnContext(ctx, "Failed to get alarm dictionary for resource type", "resourceTypeID", resourceType.ResourceTypeId, "error", err)
 			continue
 		}
 
 		if resp.StatusCode() != http.StatusOK {
-			slog.Warn("Unexpected status code getting alarm dictionary", "resourceTypeID", resourceType.ResourceTypeId, "statusCode", resp.StatusCode())
+			slog.WarnContext(ctx, "Unexpected status code getting alarm dictionary", "resourceTypeID", resourceType.ResourceTypeId, "statusCode", resp.StatusCode())
 			continue
 		}
 
 		if resp.JSON200 == nil {
-			slog.Debug("No alarm dictionary available for resource type", "resourceTypeID", resourceType.ResourceTypeId)
+			slog.DebugContext(ctx, "No alarm dictionary available for resource type", "resourceTypeID", resourceType.ResourceTypeId)
 			continue
 		}
 
 		// Build alarm definitions from the real alarm dictionary
 		alarmDefinitions := buildAlarmDefinitionsFromDictionary(*resp.JSON200)
 		newResourceTypeIDToAlarmDefinitions[resourceType.ResourceTypeId] = alarmDefinitions
-		slog.Info("Mapping resource type ID to alarm definitions", "resourceTypeID", resourceType.ResourceTypeId, "alarmDictionaryID", resp.JSON200.AlarmDictionaryId, "definitionCount", len(alarmDefinitions))
+		slog.InfoContext(ctx, "Mapping resource type ID to alarm definitions", "resourceTypeID", resourceType.ResourceTypeId, "alarmDictionaryID", resp.JSON200.AlarmDictionaryId, "definitionCount", len(alarmDefinitions))
 	}
 
 	// Atomically update the maps while holding lock
@@ -133,7 +133,7 @@ func (r *ResourceServer) FetchAll(ctx context.Context) error {
 	r.resourceIDToResourceTypeID = make(map[uuid.UUID]uuid.UUID)
 	r.Unlock()
 
-	slog.Info("Successfully synced ResourceServer objects")
+	slog.InfoContext(ctx, "Successfully synced ResourceServer objects")
 	return nil
 }
 
@@ -149,7 +149,7 @@ func (r *ResourceServer) GetObjectTypeID(ctx context.Context, resourceID uuid.UU
 	}
 
 	// Not in cache, fetch from resource server
-	slog.Info("Resource ID not found in cache, fetching from resource server", "resourceID", resourceID)
+	slog.InfoContext(ctx, "Resource ID not found in cache, fetching from resource server", "resourceID", resourceID)
 	resource, err := r.getResource(ctx, resourceID)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("failed to get resource: %w", err)
@@ -157,7 +157,7 @@ func (r *ResourceServer) GetObjectTypeID(ctx context.Context, resourceID uuid.UU
 
 	// Cache the mapping
 	r.resourceIDToResourceTypeID[resourceID] = resource.ResourceTypeId
-	slog.Info("Mapping resource ID to resource type ID", "resourceID", resourceID, "resourceTypeID", resource.ResourceTypeId)
+	slog.InfoContext(ctx, "Mapping resource ID to resource type ID", "resourceID", resourceID, "resourceTypeID", resource.ResourceTypeId)
 
 	return resource.ResourceTypeId, nil
 }
@@ -170,7 +170,7 @@ func (r *ResourceServer) GetAlarmDefinitionID(ctx context.Context, resourceTypeI
 
 	alarmDefinitions, ok := r.resourceTypeIDToAlarmDefinitions[resourceTypeID]
 	if !ok {
-		slog.Info("Resource type ID not found in cache, fetching from resource server", "resourceTypeID", resourceTypeID)
+		slog.InfoContext(ctx, "Resource type ID not found in cache, fetching from resource server", "resourceTypeID", resourceTypeID)
 
 		// Try to fetch the alarm dictionary from the server
 		resp, err := r.client.GetResourceTypeAlarmDictionaryWithResponse(ctx, resourceTypeID)
@@ -191,7 +191,7 @@ func (r *ResourceServer) GetAlarmDefinitionID(ctx context.Context, resourceTypeI
 
 		// Cache the alarm definitions
 		r.resourceTypeIDToAlarmDefinitions[resourceTypeID] = alarmDefinitions
-		slog.Info("Mapping resource type ID to alarm definitions", "resourceTypeID", resourceTypeID, "alarmDictionaryID", resp.JSON200.AlarmDictionaryId, "definitionCount", len(alarmDefinitions))
+		slog.InfoContext(ctx, "Mapping resource type ID to alarm definitions", "resourceTypeID", resourceTypeID, "alarmDictionaryID", resp.JSON200.AlarmDictionaryId, "definitionCount", len(alarmDefinitions))
 	}
 
 	uniqueIdentifier := AlarmDefinitionUniqueIdentifier{
@@ -201,7 +201,7 @@ func (r *ResourceServer) GetAlarmDefinitionID(ctx context.Context, resourceTypeI
 
 	alarmDefinitionID, ok := alarmDefinitions[uniqueIdentifier]
 	if !ok {
-		slog.Info("Alarm definition not found in cache", "name", name, "severity", severity, "resourceTypeID", resourceTypeID)
+		slog.InfoContext(ctx, "Alarm definition not found in cache", "name", name, "severity", severity, "resourceTypeID", resourceTypeID)
 		return uuid.Nil, fmt.Errorf("alarm definition not found: name=%s, severity=%s", name, severity)
 	}
 
@@ -216,7 +216,7 @@ func (r *ResourceServer) FetchAllWithRetry(ctx context.Context, retries int) err
 		if err == nil {
 			return nil
 		}
-		slog.Error("Failed to fetch all objects from resource server, retrying", "attempt", i+1, "error", err)
+		slog.ErrorContext(ctx, "Failed to fetch all objects from resource server, retrying", "attempt", i+1, "error", err)
 		time.Sleep(5 * time.Second)
 	}
 	return fmt.Errorf("failed to fetch all objects after %d retries: %w", retries, err)
@@ -224,7 +224,7 @@ func (r *ResourceServer) FetchAllWithRetry(ctx context.Context, retries int) err
 
 // Sync starts a background process to populate and keep up-to-date a local cache with data from the resource server
 func (r *ResourceServer) Sync(ctx context.Context) {
-	slog.Info("Starting sync process for resource server objects")
+	slog.InfoContext(ctx, "Starting sync process for resource server objects")
 
 	// First fetch of all objects.
 	// When doing a clean deployment resource server may not be ready which results incomplete data during startup Alerts sync
@@ -232,7 +232,7 @@ func (r *ResourceServer) Sync(ctx context.Context) {
 	// This is edge case and even if the Resource server cant come up within retry time, we can still continue
 	// But once it does come up, user may get unwanted "CHANGED" alerts
 	if err := r.FetchAllWithRetry(ctx, 3); err != nil {
-		slog.Error("Failed to run initial sync for resource server objects", "error", err)
+		slog.ErrorContext(ctx, "Failed to run initial sync for resource server objects", "error", err)
 	}
 
 	go func() {
@@ -242,12 +242,12 @@ func (r *ResourceServer) Sync(ctx context.Context) {
 		for {
 			select {
 			case <-ctx.Done():
-				slog.Info("Stopping sync process for resource server objects")
+				slog.InfoContext(ctx, "Stopping sync process for resource server objects")
 				return
 			case <-ticker.C:
-				slog.Info("Syncing resource server objects")
+				slog.InfoContext(ctx, "Syncing resource server objects")
 				if err := r.FetchAll(ctx); err != nil {
-					slog.Error("Failed to sync resource server objects", "error", err)
+					slog.ErrorContext(ctx, "Failed to sync resource server objects", "error", err)
 				}
 			}
 		}
@@ -272,7 +272,7 @@ func (r *ResourceServer) getResourceTypes(ctx context.Context) ([]generated.Reso
 		return nil, fmt.Errorf("empty response from resource server")
 	}
 
-	slog.Info("Got resource types", "count", len(*resp.JSON200))
+	slog.InfoContext(ctx, "Got resource types", "count", len(*resp.JSON200))
 	return *resp.JSON200, nil
 }
 
@@ -294,7 +294,7 @@ func (r *ResourceServer) getResource(ctx context.Context, resourceID uuid.UUID) 
 		return nil, fmt.Errorf("empty response from resource server")
 	}
 
-	slog.Info("Got resource", "resourceID", resourceID)
+	slog.InfoContext(ctx, "Got resource", "resourceID", resourceID)
 	return resp.JSON200, nil
 }
 

--- a/internal/service/alarms/internal/listener/pg_listener.go
+++ b/internal/service/alarms/internal/listener/pg_listener.go
@@ -61,7 +61,7 @@ func processOutboxNotification(ctx context.Context, pool *pgxpool.Pool, n *notif
 	}
 
 	if len(dataChangeEvents) > 0 && caller == "backup" {
-		slog.Warn("outbox is expected to empty but found at least one data change event when running a backup loop")
+		slog.WarnContext(ctx, "outbox is expected to empty but found at least one data change event when running a backup loop")
 	}
 
 	// Finally construct notifications from data change events
@@ -81,6 +81,6 @@ func processOutboxNotification(ctx context.Context, pool *pgxpool.Pool, n *notif
 		n.Notify(ctx, &notification)
 	}
 
-	slog.Info("Successfully processed outbox notifications", "caller", caller)
+	slog.InfoContext(ctx, "Successfully processed outbox notifications", "caller", caller)
 	return nil
 }

--- a/internal/service/alarms/internal/notifier_provider/notification.go
+++ b/internal/service/alarms/internal/notifier_provider/notification.go
@@ -48,7 +48,7 @@ func (n *NotificationStorageProvider) GetNotifications(ctx context.Context) ([]n
 	for _, record := range records {
 		notification, err := models.DataChangeEventToNotification(&record, n.globalCloudID)
 		if err != nil {
-			slog.Warn("failed to convert alarm event to notification", "err", err)
+			slog.WarnContext(ctx, "failed to convert alarm event to notification", "err", err)
 			continue
 		}
 		if notification != nil {
@@ -57,7 +57,7 @@ func (n *NotificationStorageProvider) GetNotifications(ctx context.Context) ([]n
 	}
 
 	if len(notifications) == 0 {
-		slog.Info("No notifications")
+		slog.InfoContext(ctx, "No notifications")
 	}
 
 	return notifications, nil

--- a/internal/service/alarms/internal/notifier_provider/subscription.go
+++ b/internal/service/alarms/internal/notifier_provider/subscription.go
@@ -41,7 +41,7 @@ func (s *SubscriptionStorageProvider) GetSubscriptions(ctx context.Context) ([]n
 		return []notifier.SubscriptionInfo{}, fmt.Errorf("failed to get all subscriptions: %w", err)
 	}
 	if len(records) == 0 {
-		slog.Info("No subscriptions to notify")
+		slog.InfoContext(ctx, "No subscriptions to notify")
 		return subscriptions, nil
 	}
 
@@ -50,7 +50,7 @@ func (s *SubscriptionStorageProvider) GetSubscriptions(ctx context.Context) ([]n
 		subscriptions = append(subscriptions, *models.ConvertAlertSubToNotificationSub(&record))
 	}
 
-	slog.Info("Found subscriptions to notify", "count", len(subscriptions))
+	slog.InfoContext(ctx, "Found subscriptions to notify", "count", len(subscriptions))
 	return subscriptions, nil
 }
 
@@ -75,7 +75,7 @@ func (s *SubscriptionStorageProvider) UpdateSubscription(ctx context.Context, su
 		return fmt.Errorf("update subscription failed for %s: %w", subscription.SubscriptionID, err)
 	}
 
-	slog.Info("Subscription cursor updated", "to", subscription.EventCursor)
+	slog.InfoContext(ctx, "Subscription cursor updated", "to", subscription.EventCursor)
 	return nil
 }
 

--- a/internal/service/alarms/internal/serviceconfig/serviceconfig.go
+++ b/internal/service/alarms/internal/serviceconfig/serviceconfig.go
@@ -102,7 +102,7 @@ func (c *Config) EnsureCleanupCronJob(ctx context.Context, sc *models.ServiceCon
 		return fmt.Errorf("failed to apply cronjob: %w", err)
 	}
 
-	slog.Info("Successfully ensured cleanup cronjob and associated resources",
+	slog.InfoContext(ctx, "Successfully ensured cleanup cronjob and associated resources",
 		"cronjob", cronJob.Name, "configmap", configMap.Name)
 	return nil
 }
@@ -126,7 +126,7 @@ func (c *Config) generateConfigMapWithSql(ctx context.Context, sc *models.Servic
 
 // getCleanUpPgSQL returns sql string to do alarms events cleanup based on service config
 func getCleanUpPgSQL(ctx context.Context, sc *models.ServiceConfiguration) (string, error) {
-	slog.Info("Using service config to generating sql", "serviceConfig", sc)
+	slog.InfoContext(ctx, "Using service config to generating sql", "serviceConfig", sc)
 
 	// This should be checked earlier as well but double-checking here since sql is sensitive to it
 	// A "0" basically means delete everything before now()

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -78,13 +78,13 @@ func Serve(config *api.AlarmsServerConfig) error {
 	// Recovery defer to print panic strace
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("something went wrong", "stacktrace", string(debug.Stack()))
+			slog.ErrorContext(ctx, "something went wrong", "stacktrace", string(debug.Stack()))
 		}
 	}()
 
 	go func() {
 		sig := <-shutdown
-		slog.Info("Shutdown signal received", "signal", sig)
+		slog.InfoContext(ctx, "Shutdown signal received", "signal", sig)
 		cancel()
 	}()
 
@@ -111,9 +111,9 @@ func Serve(config *api.AlarmsServerConfig) error {
 		// Wait for either close completion or timeout
 		select {
 		case <-closeComplete:
-			slog.Info("Closed DB connection")
+			slog.InfoContext(ctx, "Closed DB connection")
 		case <-time.After(5 * time.Second):
-			slog.Warn("DB connection close timed out")
+			slog.WarnContext(ctx, "DB connection close timed out")
 		}
 	}()
 	alarmRepository := &repo.AlarmsRepository{
@@ -162,9 +162,9 @@ func Serve(config *api.AlarmsServerConfig) error {
 	alarmServer.Wg.Add(1)
 	go func() {
 		defer alarmServer.Wg.Done()
-		slog.Info("Starting alarms subs notifier")
+		slog.InfoContext(ctx, "Starting alarms subs notifier")
 		if err := newNotifier.Run(ctx); err != nil {
-			slog.Error("notifier error", "error", err)
+			slog.ErrorContext(ctx, "notifier error", "error", err)
 		}
 	}()
 
@@ -173,7 +173,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 	go func() {
 		defer alarmServer.Wg.Done()
 		listener.ListenForAlarmsPgChannels(ctx, pool, newNotifier, globalCloudID)
-		slog.Info("Done listening to alarms pg channels")
+		slog.InfoContext(ctx, "Done listening to alarms pg channels")
 	}()
 
 	// Configure server and start alarms cleanup cronjob
@@ -260,7 +260,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 	}
 	// Init server
 	go func() {
-		slog.Info(fmt.Sprintf("Listening on %s", srv.Addr))
+		slog.InfoContext(ctx, fmt.Sprintf("Listening on %s", srv.Addr))
 		// Cert/Key files aren't needed here since they've been added to the tls.Config above.
 		if err := srv.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErrors <- err
@@ -272,7 +272,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 	case err := <-serverErrors:
 		return fmt.Errorf("error starting server: %w", err)
 	case <-ctx.Done():
-		slog.Info("Shutting down server")
+		slog.InfoContext(ctx, "Shutting down server")
 		if err := gracefulShutdownWithTasks(srv, &alarmServer); err != nil {
 			return fmt.Errorf("error shutting down server: %w", err)
 		}
@@ -311,7 +311,7 @@ func ConfigAlarmServerCleanup(ctx context.Context, alarmServer *api.AlarmsServer
 	if err != nil {
 		return fmt.Errorf("failed to create alarm service configuration: %w", err)
 	}
-	slog.Info("Alarm Service configuration created/found", "retentionPeriod", serviceConfig.RetentionPeriod, "extensions", serviceConfig.Extensions)
+	slog.InfoContext(ctx, "Alarm Service configuration created/found", "retentionPeriod", serviceConfig.RetentionPeriod, "extensions", serviceConfig.Extensions)
 
 	// Init ServiceConfig and start cronjob
 	alarmServer.ServiceConfig, err = serviceconfig.LoadEnvConfig()
@@ -328,7 +328,7 @@ func ConfigAlarmServerCleanup(ctx context.Context, alarmServer *api.AlarmsServer
 	if err := alarmServer.ServiceConfig.EnsureCleanupCronJob(ctx, serviceConfig); err != nil {
 		return fmt.Errorf("failed to start alarms cleanup cron job: %w", err)
 	}
-	slog.Info("Successfully created initial set of cronjob and resources")
+	slog.InfoContext(ctx, "Successfully created initial set of cronjob and resources")
 
 	return nil
 }
@@ -343,7 +343,7 @@ func startAlertmanager(ctx context.Context, alarmServer *api.AlarmsServer) error
 
 	// Run the first sync - running it outside also makes sure connectivity is good before server starts listening
 	c := alertmanager.NewAlertmanagerClient(hubclient, alarmServer.AlarmsRepository, alarmServer.Infrastructure)
-	slog.Info("Running initial alert sync")
+	slog.InfoContext(ctx, "Running initial alert sync")
 	if err := c.SyncAlerts(ctx); err != nil {
 		return fmt.Errorf("failed to run initial alert sync: %w", err)
 	}
@@ -354,7 +354,7 @@ func startAlertmanager(ctx context.Context, alarmServer *api.AlarmsServer) error
 		defer alarmServer.Wg.Done()
 		if err := c.RunAlertSyncScheduler(ctx, 1*time.Hour); err != nil {
 			if !errors.Is(err, context.Canceled) {
-				slog.Error("failed to run alert sync scheduler", "error", err)
+				slog.ErrorContext(ctx, "failed to run alert sync scheduler", "error", err)
 			}
 		}
 	}()
@@ -364,6 +364,6 @@ func startAlertmanager(ctx context.Context, alarmServer *api.AlarmsServer) error
 		return fmt.Errorf("error configuring alert manager: %w", err)
 	}
 
-	slog.Info("Successfully did the first sync and configured alertmanager")
+	slog.InfoContext(ctx, "Successfully did the first sync and configured alertmanager")
 	return nil
 }

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -66,7 +66,7 @@ func Serve(config *api.ArtifactsServerConfig) error {
 
 	go func() {
 		sig := <-shutdown
-		slog.Info("Shutdown signal received", "signal", sig)
+		slog.InfoContext(ctx, "Shutdown signal received", "signal", sig)
 		cancel()
 	}()
 
@@ -157,7 +157,7 @@ func Serve(config *api.ArtifactsServerConfig) error {
 
 	// Start server
 	go func() {
-		slog.Info(fmt.Sprintf("Listening on %s", srv.Addr))
+		slog.InfoContext(ctx, fmt.Sprintf("Listening on %s", srv.Addr))
 		// Cert/Key files aren't needed here since they've been added to the tls.Config above.
 		if err := srv.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErrors <- err
@@ -169,7 +169,7 @@ func Serve(config *api.ArtifactsServerConfig) error {
 	case err := <-serverErrors:
 		return fmt.Errorf("error starting server: %w", err)
 	case <-ctx.Done():
-		slog.Info("Shutting down server")
+		slog.InfoContext(ctx, "Shutting down server")
 		if err := common.GracefulShutdown(srv); err != nil {
 			return fmt.Errorf("error shutting down server: %w", err)
 		}

--- a/internal/service/cluster/api/server.go
+++ b/internal/service/cluster/api/server.go
@@ -405,7 +405,7 @@ func (r *ClusterServer) GetSubscriptions(ctx context.Context, request api.GetSub
 // validateSubscription validates a subscription before accepting the request
 func (r *ClusterServer) validateSubscription(ctx context.Context, request api.CreateSubscriptionRequestObject) error {
 	if err := commonapi.ValidateCallbackURL(ctx, r.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback); err != nil {
-		slog.Error("callback URL validation failed", "error", err)
+		slog.ErrorContext(ctx, "callback URL validation failed", "error", err)
 		return fmt.Errorf("callback URL validation failed")
 	}
 	// TODO: add validation of filter and move to common if filter syntax is the same for all servers
@@ -448,7 +448,7 @@ func (r *ClusterServer) CreateSubscription(ctx context.Context, request api.Crea
 				Status: http.StatusBadRequest,
 			}, nil
 		}
-		slog.Error("error writing database record", "target", record, "error", err.Error())
+		slog.ErrorContext(ctx, "error writing database record", "target", record, "error", err.Error())
 		return api.CreateSubscription500ApplicationProblemPlusJSONResponse{
 			AdditionalAttributes: &map[string]string{
 				"consumerSubscriptionId": consumerSubscriptionId,

--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -98,12 +98,12 @@ func (c *Collector) Run(ctx context.Context) error {
 		select {
 		case event := <-c.asyncChangeEvents:
 			if err := c.handleAsyncEvent(ctx, event); err != nil {
-				slog.Error("failed to handle async change", "handleWatchEvent", event, "error", err)
+				slog.ErrorContext(ctx, "failed to handle async change", "handleWatchEvent", event, "error", err)
 			}
 		case <-time.After(pollingDelay):
 			c.execute(ctx)
 		case <-ctx.Done():
-			slog.Info("Context terminated; collector exiting")
+			slog.InfoContext(ctx, "Context terminated; collector exiting")
 			return nil
 		}
 	}
@@ -111,7 +111,7 @@ func (c *Collector) Run(ctx context.Context) error {
 
 // init runs the onetime initialization steps for the collector
 func (c *Collector) init(ctx context.Context) error {
-	slog.Info("initializing data collector")
+	slog.InfoContext(ctx, "initializing data collector")
 
 	for _, d := range c.dataSources {
 		err := c.initDataSource(ctx, d)
@@ -140,12 +140,12 @@ func (c *Collector) initDataSource(ctx context.Context, dataSource DataSource) e
 		}
 
 		dataSource.Init(*result.DataSourceID, 0, c.asyncChangeEvents)
-		slog.Info("created new data source", "name", name, "uuid", *result.DataSourceID)
+		slog.InfoContext(ctx, "created new data source", "name", name, "uuid", *result.DataSourceID)
 	case err != nil:
 		return fmt.Errorf("failed to get data source %q: %w", name, err)
 	default:
 		dataSource.Init(*record.DataSourceID, record.GenerationID, c.asyncChangeEvents)
-		slog.Info("restored data source",
+		slog.InfoContext(ctx, "restored data source",
 			"name", name, "uuid", record.DataSourceID, "generation", record.GenerationID)
 	}
 
@@ -161,7 +161,7 @@ func (c *Collector) watchForChanges(ctx context.Context) error {
 		}
 
 		if err := d.(WatchableDataSource).Watch(ctx); err != nil {
-			slog.Error("failed to watch for changes", "source", d.Name(), "error", err)
+			slog.ErrorContext(ctx, "failed to watch for changes", "source", d.Name(), "error", err)
 			return fmt.Errorf("failed to watch for changes: %w", err)
 		}
 	}
@@ -171,7 +171,7 @@ func (c *Collector) watchForChanges(ctx context.Context) error {
 // execute runs a single iteration of the main loop.  It does not return an error because all errors should be handled
 // gracefully.  If a truly unrecoverable error happens then a panic should be used to restart the process.
 func (c *Collector) execute(ctx context.Context) {
-	slog.Debug("collector loop running", "sources", len(c.dataSources))
+	slog.DebugContext(ctx, "collector loop running", "sources", len(c.dataSources))
 	for _, d := range c.dataSources {
 		// Skip K8S data source since it is handled by the reflector
 		if _, ok := d.(*K8SDataSource); ok {
@@ -179,14 +179,14 @@ func (c *Collector) execute(ctx context.Context) {
 		}
 
 		d.IncrGenerationID()
-		slog.Debug("collecting data from data source", "source", d.Name(), "generationID", d.GetGenerationID())
+		slog.DebugContext(ctx, "collecting data from data source", "source", d.Name(), "generationID", d.GetGenerationID())
 		if err := c.executeOneDataSource(ctx, d); err != nil {
-			slog.Warn("failed to collect data from data source", "source", d.Name(), "error", err)
+			slog.WarnContext(ctx, "failed to collect data from data source", "source", d.Name(), "error", err)
 		} else {
-			slog.Debug("collected data from data source", "source", d.Name())
+			slog.DebugContext(ctx, "collected data from data source", "source", d.Name())
 		}
 	}
-	slog.Debug("collector loop complete", "sources", len(c.dataSources))
+	slog.DebugContext(ctx, "collector loop complete", "sources", len(c.dataSources))
 }
 
 // executeOneDataSource runs a single iteration of the main loop for a specific data source instance.
@@ -212,7 +212,7 @@ func (c *Collector) executeOneDataSource(ctx context.Context, dataSource DataSou
 	nodeClusterTypes = nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes)
 
 	if len(nodeClusterTypes) == 0 {
-		slog.Info("no node cluster types to process")
+		slog.InfoContext(ctx, "no node cluster types to process")
 		return nil
 	}
 
@@ -244,7 +244,7 @@ func (c *Collector) executeOneDataSource(ctx context.Context, dataSource DataSou
 		return fmt.Errorf("failed to purge stale alarm dictionaries: %w", err)
 	}
 
-	slog.Info("Alarm dictionaries synced", "generationID", ds.GetGenerationID())
+	slog.InfoContext(ctx, "Alarm dictionaries synced", "generationID", ds.GetGenerationID())
 	return nil
 }
 
@@ -291,7 +291,7 @@ func (c *Collector) linkClusterResources(ctx context.Context, nodeCluster *model
 	if err != nil {
 		return fmt.Errorf("failed to set node cluster ID: %w", err)
 	}
-	slog.Info("set node cluster id value on cluster resources", "name", nodeCluster.Name, "count", count)
+	slog.InfoContext(ctx, "set node cluster id value on cluster resources", "name", nodeCluster.Name, "count", count)
 	return nil
 }
 
@@ -353,7 +353,7 @@ func (c *Collector) findDataSource(dataSourceID uuid.UUID) DataSource {
 // handleNodeClusterSyncCompletion handles the end of sync for NodeCluster objects.  It deletes any NodeCluster objects
 // not included in the set of keys received during the sync operation.
 func (c *Collector) handleNodeClusterSyncCompletion(ctx context.Context, ids []any) error {
-	slog.Debug("Handling end of sync for NodeCluster instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for NodeCluster instances", "count", len(ids))
 	records, err := c.repository.GetNodeClustersNotIn(ctx, ids)
 	if err != nil {
 		return fmt.Errorf("failed to get stale node clusters: %w", err)
@@ -382,7 +382,7 @@ func (c *Collector) handleNodeClusterSyncCompletion(ctx context.Context, ids []a
 	}
 
 	if count > 0 {
-		slog.Info("Deleted stale node cluster records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale node cluster records", "count", count)
 	}
 
 	return nil
@@ -391,7 +391,7 @@ func (c *Collector) handleNodeClusterSyncCompletion(ctx context.Context, ids []a
 // handleClusterResourceSyncCompletion handles the end of sync for ClusterResource objects.  It deletes any
 // ClusterResource objects not included in the set of keys received during the sync operation.
 func (c *Collector) handleClusterResourceSyncCompletion(ctx context.Context, ids []any) error {
-	slog.Debug("Handling end of sync for ClusterResource instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for ClusterResource instances", "count", len(ids))
 	records, err := c.repository.GetClusterResourcesNotIn(ctx, ids)
 	if err != nil {
 		return fmt.Errorf("failed to get stale cluster resources: %w", err)
@@ -415,7 +415,7 @@ func (c *Collector) handleClusterResourceSyncCompletion(ctx context.Context, ids
 	}
 
 	if count > 0 {
-		slog.Info("Deleted stale cluster resource records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale cluster resource records", "count", count)
 	}
 
 	return nil
@@ -478,7 +478,7 @@ func (c *Collector) deleteRelatedClusterResources(ctx context.Context, nodeClust
 		return fmt.Errorf("failed to get cluster resources for node_cluster_id %s: %w", nodeCluster.NodeClusterID, err)
 	}
 
-	slog.Debug("deleting related cluster resources", "node_cluster_id", nodeCluster.NodeClusterID, "count", len(resources))
+	slog.DebugContext(ctx, "deleting related cluster resources", "node_cluster_id", nodeCluster.NodeClusterID, "count", len(resources))
 
 	for _, resource := range resources {
 		dataChangeEvent, err := svcutils.DeleteObjectWithChangeEvent(
@@ -562,7 +562,7 @@ func (c *Collector) handleAsyncClusterResourceEvent(ctx context.Context, dataSou
 	if errors.Is(err, svcutils.ErrNotFound) {
 		// Agents will finish being installed before the Managed Cluster is completely provisioned, therefore, we have to
 		// link them after the fact, so here we just skip them.
-		slog.Warn("no node cluster found", "name", clusterResource.NodeClusterName, "resource", clusterResource.Name)
+		slog.WarnContext(ctx, "no node cluster found", "name", clusterResource.NodeClusterName, "resource", clusterResource.Name)
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("failed to get node cluster '%s': %w", clusterResource.NodeClusterName, err)
@@ -579,7 +579,7 @@ func (c *Collector) handleAsyncClusterResourceEvent(ctx context.Context, dataSou
 
 // syncThanosAlarmDefinitions fetches Thanos rules and syncs alarm definitions to the database
 func (c *Collector) syncThanosAlarmDefinitions(ctx context.Context, ds *AlarmsDataSource) error {
-	slog.Info("Syncing Thanos alarm definitions")
+	slog.InfoContext(ctx, "Syncing Thanos alarm definitions")
 
 	rules, err := ds.collectThanosRules(ctx)
 	if err != nil {
@@ -587,7 +587,7 @@ func (c *Collector) syncThanosAlarmDefinitions(ctx context.Context, ds *AlarmsDa
 	}
 
 	if len(rules) == 0 {
-		slog.Info("No Thanos rules found in config maps")
+		slog.InfoContext(ctx, "No Thanos rules found in config maps")
 
 		count, err := c.repository.DeleteThanosAlarmDefinitions(ctx)
 		if err != nil {
@@ -595,7 +595,7 @@ func (c *Collector) syncThanosAlarmDefinitions(ctx context.Context, ds *AlarmsDa
 		}
 
 		if count != 0 {
-			slog.Info("Deleted Thanos alarm definitions", "count", count)
+			slog.InfoContext(ctx, "Deleted Thanos alarm definitions", "count", count)
 		}
 
 		return nil
@@ -620,17 +620,17 @@ func (c *Collector) syncThanosAlarmDefinitions(ctx context.Context, ds *AlarmsDa
 
 	count, err := c.repository.DeleteThanosAlarmDefinitionsNotIn(ctx, alarmDefinitionIDs)
 	if err != nil {
-		slog.Error("failed to delete outdated thanos alarm definitions", "error", err)
+		slog.ErrorContext(ctx, "failed to delete outdated thanos alarm definitions", "error", err)
 		return nil
 	}
 
-	slog.Info("Thanos alarm definitions synced", "upserted count", len(alarmDefinitionRecords), "deleted count", count)
+	slog.InfoContext(ctx, "Thanos alarm definitions synced", "upserted count", len(alarmDefinitionRecords), "deleted count", count)
 	return nil
 }
 
 // syncManagedClusterAlarmDefinitions fetches Prometheus rules and syncs alarm definitions to the database
 func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *AlarmsDataSource, nodeClusterTypes []models.NodeClusterType) error {
-	slog.Info("Syncing managed cluster alarm definitions", "nodeClusterTypes", len(nodeClusterTypes))
+	slog.InfoContext(ctx, "Syncing managed cluster alarm definitions", "nodeClusterTypes", len(nodeClusterTypes))
 
 	// Fetch prometheus rules and build a map of alarm definitions
 	alarmDictionaryIDToAlarmDefinitions, err := ds.makeAlarmDictionaryIDToAlarmDefinitions(ctx, nodeClusterTypes)
@@ -649,7 +649,7 @@ func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *
 		g.Go(func() error {
 			alarmDefinitionRecords, err := c.repository.UpsertAlarmDefinitions(ctx, alarmDictionaryIDToAlarmDefinitions[alarmDictionaryID])
 			if err != nil {
-				slog.Error("failed to upsert alarm definitions", "alarmDictionaryID", alarmDictionaryID, "error", err)
+				slog.ErrorContext(ctx, "failed to upsert alarm definitions", "alarmDictionaryID", alarmDictionaryID, "error", err)
 				return nil
 			}
 
@@ -661,16 +661,16 @@ func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *
 
 			count, err := c.repository.DeleteAlarmDefinitionsNotIn(ctx, alarmDefinitionIDs, alarmDictionaryID)
 			if err != nil {
-				slog.Error("failed to delete non-valid alarm definitions", "alarmDictionaryID", alarmDictionaryID, "error", err)
+				slog.ErrorContext(ctx, "failed to delete non-valid alarm definitions", "alarmDictionaryID", alarmDictionaryID, "error", err)
 				return nil
 			}
 
-			slog.Info("Alarm definitions synced", "alarmDictionaryID", alarmDictionaryID, "upserted count", len(alarmDefinitionRecords), "deleted count", count)
+			slog.InfoContext(ctx, "Alarm definitions synced", "alarmDictionaryID", alarmDictionaryID, "upserted count", len(alarmDefinitionRecords), "deleted count", count)
 			return nil
 		})
 	}
 
-	slog.Info("Waiting for all alarm definitions to be processed")
+	slog.InfoContext(ctx, "Waiting for all alarm definitions to be processed")
 
 	_ = g.Wait()
 
@@ -679,7 +679,7 @@ func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *
 
 // syncAlarmDictionaries syncs alarm dictionaries to the database
 func (c *Collector) syncAlarmDictionaries(ctx context.Context, ds *AlarmsDataSource, nodeClusterTypes []models.NodeClusterType) error {
-	slog.Info("Syncing alarm dictionaries", "nodeClusterTypes", len(nodeClusterTypes))
+	slog.InfoContext(ctx, "Syncing alarm dictionaries", "nodeClusterTypes", len(nodeClusterTypes))
 
 	alarmDictionaries := ds.makeAlarmDictionaries(nodeClusterTypes)
 
@@ -700,7 +700,7 @@ func (c *Collector) syncAlarmDictionaries(ctx context.Context, ds *AlarmsDataSou
 		g.Go(func() error {
 			alarmDefinitions, err := c.repository.GetAlarmDefinitionsByAlarmDictionaryID(ctx, alarmDictionary.AlarmDictionaryID)
 			if err != nil {
-				slog.Error("failed to get alarm definitions", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID, "error", err)
+				slog.ErrorContext(ctx, "failed to get alarm definitions", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID, "error", err)
 				return nil
 			}
 
@@ -714,7 +714,7 @@ func (c *Collector) syncAlarmDictionaries(ctx context.Context, ds *AlarmsDataSou
 					return models.AlarmDictionaryToModel(&record, alarmDefinitions)
 				})
 			if err != nil {
-				slog.Error("failed to persist node cluster type'", "error", err)
+				slog.ErrorContext(ctx, "failed to persist node cluster type'", "error", err)
 				return nil
 			}
 
@@ -728,7 +728,7 @@ func (c *Collector) syncAlarmDictionaries(ctx context.Context, ds *AlarmsDataSou
 		})
 	}
 
-	slog.Info("Waiting for all alarm dictionaries to be processed")
+	slog.InfoContext(ctx, "Waiting for all alarm dictionaries to be processed")
 
 	_ = g.Wait()
 
@@ -741,7 +741,7 @@ func (c *Collector) syncAlarmDictionaries(ctx context.Context, ds *AlarmsDataSou
 }
 
 func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsDataSource) error {
-	slog.Info("Purging stale alarm dictionaries")
+	slog.InfoContext(ctx, "Purging stale alarm dictionaries")
 
 	// Purge alarm dictionaries that have missed more than 2 generations
 	staleAlarmDictionaries, err := c.repository.FindStaleAlarmDictionaries(ctx, ds.GetID(), ds.GetGenerationID()-1)
@@ -750,7 +750,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 	}
 
 	if len(staleAlarmDictionaries) == 0 {
-		slog.Info("No stale alarm dictionaries found")
+		slog.InfoContext(ctx, "No stale alarm dictionaries found")
 		return nil
 	}
 
@@ -764,7 +764,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 		g.Go(func() error {
 			alarmDefinitions, err := c.repository.GetAlarmDefinitionsByAlarmDictionaryID(ctx, alarmDictionary.AlarmDictionaryID)
 			if err != nil {
-				slog.Error("failed to get alarm definitions", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID, "error", err)
+				slog.ErrorContext(ctx, "failed to get alarm definitions", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID, "error", err)
 				return nil
 			}
 
@@ -773,7 +773,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 				return models.AlarmDictionaryToModel(&record, alarmDefinitions)
 			})
 			if err != nil {
-				slog.Error("failed to delete stale alarm dictionary", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID, "error", err)
+				slog.ErrorContext(ctx, "failed to delete stale alarm dictionary", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID, "error", err)
 				return nil
 			}
 
@@ -781,12 +781,12 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 				c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 			}
 
-			slog.Info("Stale alarm dictionary purged", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID)
+			slog.InfoContext(ctx, "Stale alarm dictionary purged", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID)
 			return nil
 		})
 	}
 
-	slog.Info("Waiting for all stale alarm dictionaries to be processed")
+	slog.InfoContext(ctx, "Waiting for all stale alarm dictionaries to be processed")
 
 	_ = g.Wait()
 
@@ -795,7 +795,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 
 // handleAsyncAlarmDictionaryAndDefinitionsCreation handles the creation of alarm dictionary and definitions triggered by a new node cluster type
 func (c *Collector) handleAsyncAlarmDictionaryAndDefinitionsCreation(ctx context.Context, nodeClusterType *models.NodeClusterType) {
-	slog.Info("Creating alarm dictionary and definitions", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
+	slog.InfoContext(ctx, "Creating alarm dictionary and definitions", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
 
 	var alarmsDataSource *AlarmsDataSource
 	for i := range c.dataSources {
@@ -808,23 +808,23 @@ func (c *Collector) handleAsyncAlarmDictionaryAndDefinitionsCreation(ctx context
 	// Create and persist Alarm Dictionary without Alarm Definitions
 	err := c.syncAlarmDictionaries(ctx, alarmsDataSource, []models.NodeClusterType{*nodeClusterType})
 	if err != nil {
-		slog.Error("failed to create alarm dictionary", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
+		slog.ErrorContext(ctx, "failed to create alarm dictionary", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
 		return
 	}
 
 	// Collect and persist Alarm Definitions
 	err = c.syncManagedClusterAlarmDefinitions(ctx, alarmsDataSource, []models.NodeClusterType{*nodeClusterType})
 	if err != nil {
-		slog.Error("failed to create alarm definitions", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
+		slog.ErrorContext(ctx, "failed to create alarm definitions", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
 		return
 	}
 
 	// Sync Alarm Dictionary to include Alarm Definitions
 	err = c.syncAlarmDictionaries(ctx, alarmsDataSource, []models.NodeClusterType{*nodeClusterType})
 	if err != nil {
-		slog.Error("failed to update alarm dictionary", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
+		slog.ErrorContext(ctx, "failed to update alarm dictionary", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
 		return
 	}
 
-	slog.Info("Alarm dictionary and definitions created", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
+	slog.InfoContext(ctx, "Alarm dictionary and definitions created", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
 }

--- a/internal/service/cluster/collector/collector_alarms.go
+++ b/internal/service/cluster/collector/collector_alarms.go
@@ -88,7 +88,7 @@ func (d *AlarmsDataSource) IncrGenerationID() int {
 
 // makeAlarmDictionaryIDToAlarmDefinitions fetches monitoring rules for each node cluster type and builds a map of alarm dictionary ID to alarm definitions
 func (d *AlarmsDataSource) makeAlarmDictionaryIDToAlarmDefinitions(ctx context.Context, nodeClusterTypes []models.NodeClusterType) (map[uuid.UUID][]models.AlarmDefinition, error) {
-	slog.Info("making alarm dictionary ID to alarm definitions map", "nodeClusterTypes count", len(nodeClusterTypes))
+	slog.InfoContext(ctx, "making alarm dictionary ID to alarm definitions map", "nodeClusterTypes count", len(nodeClusterTypes))
 
 	// Fetch prometheus rules from managed clusters and hub
 	nodeClusterTypeIDToMonitoringRules := d.makeNodeClusterTypeIDToMonitoringRules(ctx, nodeClusterTypes)
@@ -127,7 +127,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 
 // makeNodeClusterTypeIDToMonitoringRules fetches monitoring rules for each node cluster type
 func (d *AlarmsDataSource) makeNodeClusterTypeIDToMonitoringRules(ctx context.Context, nodeClusterTypes []models.NodeClusterType) map[uuid.UUID][]monitoringv1.Rule {
-	slog.Info("making node cluster type ID to monitoring rules map", "nodeClusterTypes count", len(nodeClusterTypes))
+	slog.InfoContext(ctx, "making node cluster type ID to monitoring rules map", "nodeClusterTypes count", len(nodeClusterTypes))
 
 	nodeClusterTypeIDToMonitoringRules := make(map[uuid.UUID][]monitoringv1.Rule)
 
@@ -180,12 +180,12 @@ func (d *AlarmsDataSource) makeNodeClusterTypeIDToMonitoringRules(ctx context.Co
 	// Collect results
 	for res := range resultChannel {
 		if res.err != nil {
-			slog.Error("error fetching rules for node cluster type", "NodeClusterType ID", res.nodeClusterTypeID, "error", res.err)
+			slog.ErrorContext(ctx, "error fetching rules for node cluster type", "NodeClusterType ID", res.nodeClusterTypeID, "error", res.err)
 			continue
 		}
 
 		nodeClusterTypeIDToMonitoringRules[res.nodeClusterTypeID] = res.rules
-		slog.Info("loaded rules for node cluster type", "NodeClusterType ID", res.nodeClusterTypeID, "rules count", len(res.rules))
+		slog.InfoContext(ctx, "loaded rules for node cluster type", "NodeClusterType ID", res.nodeClusterTypeID, "rules count", len(res.rules))
 	}
 
 	return nodeClusterTypeIDToMonitoringRules
@@ -198,7 +198,7 @@ func (d *AlarmsDataSource) processHub(ctx context.Context) ([]monitoringv1.Rule,
 		return nil, err
 	}
 
-	slog.Debug("fetched rules for Hub cluster", "rules count", len(rules))
+	slog.DebugContext(ctx, "fetched rules for Hub cluster", "rules count", len(rules))
 	return rules, nil
 }
 
@@ -222,7 +222,7 @@ func (d *AlarmsDataSource) processManagedCluster(ctx context.Context, version st
 		return nil, err
 	}
 
-	slog.Debug("fetched rules for managed cluster", "cluster", cluster.Name, "version", version, "rules count", len(rules))
+	slog.DebugContext(ctx, "fetched rules for managed cluster", "cluster", cluster.Name, "version", version, "rules count", len(rules))
 	return rules, nil
 }
 
@@ -482,7 +482,7 @@ type Rule struct {
 
 // collectThanosRules collects Thanos rules from the config maps
 func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoringv1.Rule, error) {
-	slog.Info("Collecting Thanos rules")
+	slog.InfoContext(ctx, "Collecting Thanos rules")
 	var rules []monitoringv1.Rule
 
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, clients.SingleRequestTimeout)
@@ -497,7 +497,7 @@ func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoring
 		}, configMap)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				slog.Warn("Config map not found", "configMap", configMapName)
+				slog.WarnContext(ctx, "Config map not found", "configMap", configMapName)
 				continue
 			}
 
@@ -513,7 +513,7 @@ func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoring
 			var spec RuleSpec
 			err = yaml.Unmarshal([]byte(rulSpec), &spec)
 			if err != nil {
-				slog.Error("failed to unmarshal thanos prometheus rules spec", "configMap", configMapName, "error", err)
+				slog.ErrorContext(ctx, "failed to unmarshal thanos prometheus rules spec", "configMap", configMapName, "error", err)
 				continue
 			}
 
@@ -533,11 +533,11 @@ func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoring
 				}
 			}
 		} else {
-			slog.Warn("No data found in thanos config map", "configMap", configMapName)
+			slog.WarnContext(ctx, "No data found in thanos config map", "configMap", configMapName)
 		}
 	}
 
-	slog.Debug("Collected thanos rules", "rules count", len(rules))
+	slog.DebugContext(ctx, "Collected thanos rules", "rules count", len(rules))
 
 	// Expand rules with templated severity into multiple static rules
 	expandedRules := d.expandTemplatedSeverity(rules)

--- a/internal/service/cluster/collector/collector_k8s.go
+++ b/internal/service/cluster/collector/collector_k8s.go
@@ -367,13 +367,13 @@ func isLocalCluster(cluster *v1.ManagedCluster) bool {
 
 // handleClusterWatchEvent handles an async event received from the managed cluster watcher
 func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1.ManagedCluster, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleWatchEvent received for managed cluster", "agent", cluster.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", "agent", cluster.Name, "type", eventType)
 
 	if eventType != async.Deleted {
 		condition := meta.FindStatusCondition(cluster.Status.Conditions, "ManagedClusterConditionAvailable")
 		if condition == nil || condition.Status == metav1.ConditionFalse {
 			// This cluster is not yet available, so filter it out.
-			slog.Debug("Managed cluster is not available; skipping", "cluster", cluster.Name, "condition", condition)
+			slog.DebugContext(ctx, "Managed cluster is not available; skipping", "cluster", cluster.Name, "condition", condition)
 			return uuid.Nil, nil
 		}
 
@@ -382,7 +382,7 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 			// provisioning request has completed, but the local-cluster will never have this, so we continue without it.
 			if _, found := cluster.Labels[ctlrutils.ClusterTemplateArtifactsLabel]; !found {
 				// The provisioning request which is managing the installation of this cluster is not yet fulfilled
-				slog.Debug("Cluster provisioning request is not yet fulfilled; skipping", "cluster", cluster.Name)
+				slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", "cluster", cluster.Name)
 				return uuid.Nil, nil
 			}
 		}
@@ -395,7 +395,7 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing to async event channel; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing to async event channel; aborting")
 		return uuid.Nil, fmt.Errorf("context cancelled; aborting")
 	case d.asyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,
@@ -407,19 +407,19 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 
 // handleAgentWatchEvent handles an async event received from the agent watcher
 func (d *K8SDataSource) handleAgentWatchEvent(ctx context.Context, agent *v1beta1.Agent, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleWatchEvent received for agent", "agent", agent.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleWatchEvent received for agent", "agent", agent.Name, "type", eventType)
 
 	if eventType != async.Deleted {
 		condition := conditionsv1.FindStatusCondition(agent.Status.Conditions, "Installed")
 		if condition == nil || condition.Status == corev1.ConditionFalse {
 			// This cluster is not yet available, so filter it out.
-			slog.Debug("Agent installation is not yet completed; skipping", "agent", agent.Name, "condition", condition)
+			slog.DebugContext(ctx, "Agent installation is not yet completed; skipping", "agent", agent.Name, "condition", condition)
 			return uuid.Nil, nil
 		}
 
 		if _, found := agent.Labels[ctlrutils.ClusterTemplateArtifactsLabel]; !found {
 			// The provisioning request which is managing the installation of this agent is not yet fulfilled
-			slog.Debug("Cluster provisioning request is not yet fulfilled; skipping", "agent", agent.Name)
+			slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", "agent", agent.Name)
 			return uuid.Nil, nil
 		}
 	}
@@ -431,7 +431,7 @@ func (d *K8SDataSource) handleAgentWatchEvent(ctx context.Context, agent *v1beta
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing to async event channel; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing to async event channel; aborting")
 		return uuid.Nil, fmt.Errorf("context cancelled; aborting")
 	case d.asyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,
@@ -443,7 +443,7 @@ func (d *K8SDataSource) handleAgentWatchEvent(ctx context.Context, agent *v1beta
 
 // HandleAsyncEvent handles an add/update/delete to an object received by from the Reflector.
 func (d *K8SDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleWatchEvent received for store adapter", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	slog.DebugContext(ctx, "handleWatchEvent received for store adapter", "type", eventType, "object", fmt.Sprintf("%T", obj))
 	switch value := obj.(type) {
 	case *v1.ManagedCluster:
 		return d.handleClusterWatchEvent(ctx, value, eventType)
@@ -451,7 +451,7 @@ func (d *K8SDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, e
 		return d.handleAgentWatchEvent(ctx, value, eventType)
 	default:
 		// We are only watching for specific event types so this should happen.
-		slog.Warn("Unknown object type", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type", "type", fmt.Sprintf("%T", obj))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -466,13 +466,13 @@ func (d *K8SDataSource) HandleSyncComplete(ctx context.Context, objectType runti
 		object = models.ClusterResource{}
 	default:
 		// This should never happen since we watch for specific types
-		slog.Warn("Unknown object type", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type", "type", fmt.Sprintf("%T", objectType))
 		return nil
 	}
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing to async event channel; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing to async event channel; aborting")
 		return fmt.Errorf("context cancelled; aborting")
 	case d.asyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,
@@ -492,7 +492,7 @@ func (d *K8SDataSource) Watch(ctx context.Context) error {
 	stopCh := make(chan struct{})
 	go func() {
 		<-ctx.Done()
-		slog.Info("context canceled; stopping reflectors")
+		slog.InfoContext(ctx, "context canceled; stopping reflectors")
 		close(stopCh)
 	}()
 
@@ -523,11 +523,11 @@ func (d *K8SDataSource) Watch(ctx context.Context) error {
 
 		clusterStore := async.NewReflectorStore(&v1.ManagedCluster{})
 		clusterReflector := cache.NewNamedReflector(clusterReflectorName, &clusterLister, &v1.ManagedCluster{}, clusterStore, time.Duration(0))
-		slog.Info("starting cluster reflector")
+		slog.InfoContext(ctx, "starting cluster reflector")
 		go clusterReflector.Run(stopCh)
 
 		// Start monitoring the store to process incoming events
-		slog.Info("starting to receive from cluster reflector store")
+		slog.InfoContext(ctx, "starting to receive from cluster reflector store")
 		go clusterStore.Receive(ctx, d)
 
 		// We need the clusters to be retrieved before we handle any agents since they are dependent.
@@ -556,11 +556,11 @@ func (d *K8SDataSource) Watch(ctx context.Context) error {
 
 		agentStore := async.NewReflectorStore(&v1beta1.Agent{})
 		agentReflector := cache.NewNamedReflector(agentReflectorName, &agentLister, &v1beta1.Agent{}, agentStore, time.Duration(0))
-		slog.Info("starting agent reflector")
+		slog.InfoContext(ctx, "starting agent reflector")
 		go agentReflector.Run(stopCh)
 
 		// Start monitoring the store to process incoming events
-		slog.Info("starting to receive from agent reflector store")
+		slog.InfoContext(ctx, "starting to receive from agent reflector store")
 		go agentStore.Receive(ctx, d)
 	}()
 

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -74,7 +74,7 @@ func Serve(config *api.ClusterServerConfig) error {
 
 	go func() {
 		sig := <-shutdown
-		slog.Info("Shutdown signal received", "signal", sig)
+		slog.InfoContext(ctx, "Shutdown signal received", "signal", sig)
 		cancel()
 	}()
 
@@ -89,7 +89,7 @@ func Serve(config *api.ClusterServerConfig) error {
 		return fmt.Errorf("failed to connected to DB: %w", err)
 	}
 	defer func() {
-		slog.Info("Closing DB connection")
+		slog.InfoContext(ctx, "Closing DB connection")
 		pool.Close()
 	}()
 
@@ -214,7 +214,7 @@ func Serve(config *api.ClusterServerConfig) error {
 	// Start resource notifier
 	notifierErrors := make(chan error, 1)
 	go func() {
-		slog.Info("Starting cluster notifier")
+		slog.InfoContext(ctx, "Starting cluster notifier")
 		if err := clusterNotifier.Run(ctx); err != nil {
 			notifierErrors <- err
 		}
@@ -223,7 +223,7 @@ func Serve(config *api.ClusterServerConfig) error {
 	// Start resource collector
 	collectorErrors := make(chan error, 1)
 	go func() {
-		slog.Info("Starting cluster collector")
+		slog.InfoContext(ctx, "Starting cluster collector")
 		if err := clusterCollector.Run(ctx); err != nil {
 			collectorErrors <- err
 		}
@@ -232,7 +232,7 @@ func Serve(config *api.ClusterServerConfig) error {
 	// Start server
 	serverErrors := make(chan error, 1)
 	go func() {
-		slog.Info(fmt.Sprintf("Listening on %s", srv.Addr))
+		slog.InfoContext(ctx, fmt.Sprintf("Listening on %s", srv.Addr))
 		// Cert/Key files aren't needed here since they've been added to the tls.Config above.
 		if err := srv.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErrors <- err
@@ -243,9 +243,9 @@ func Serve(config *api.ClusterServerConfig) error {
 		// Cancel the context in case it wasn't already canceled
 		cancel()
 		// Shutdown the http server
-		slog.Info("Shutting down server")
+		slog.InfoContext(ctx, "Shutting down server")
 		if err := common.GracefulShutdown(srv); err != nil {
-			slog.Error("error shutting down server", "error", err)
+			slog.ErrorContext(ctx, "error shutting down server", "error", err)
 		}
 	}()
 
@@ -258,7 +258,7 @@ func Serve(config *api.ClusterServerConfig) error {
 	case err := <-notifierErrors:
 		return fmt.Errorf("error starting notifier: %w", err)
 	case <-ctx.Done():
-		slog.Info("Process shutting down")
+		slog.InfoContext(ctx, "Process shutting down")
 	}
 
 	return nil

--- a/internal/service/common/api/middleware/filtering.go
+++ b/internal/service/common/api/middleware/filtering.go
@@ -238,7 +238,7 @@ func ResponseFilter(adapter *FilterAdapter) Middleware {
 			var err error
 			query, err := url.ParseQuery(r.URL.RawQuery)
 			if err != nil {
-				slog.Error("failed to parse query", "RawQuery", r.URL.RawQuery, "err", err)
+				slog.ErrorContext(r.Context(), "failed to parse query", "RawQuery", r.URL.RawQuery, "err", err)
 				_ = adapter.Error(
 					w,
 					"failed to parse query parameters",
@@ -252,7 +252,7 @@ func ResponseFilter(adapter *FilterAdapter) Middleware {
 				for _, value := range values {
 					result, err := adapter.ParseFilter(value)
 					if err != nil {
-						slog.Error("failed to parse filter", "value", value, "err", err)
+						slog.ErrorContext(r.Context(), "failed to parse filter", "value", value, "err", err)
 						msg := err.Error()
 						if isParserError(err) {
 							msg = "invalid filter syntax"

--- a/internal/service/common/api/middleware/middleware.go
+++ b/internal/service/common/api/middleware/middleware.go
@@ -54,7 +54,7 @@ func LogDuration() Middleware {
 				ResponseWriter: w,
 			}
 			next.ServeHTTP(&d, r)
-			slog.Debug("Request completed", "method", r.Method, "url", r.RequestURI, "status", d.statusCode, "duration", time.Since(startTime).String())
+			slog.DebugContext(r.Context(), "Request completed", "method", r.Method, "url", r.RequestURI, "status", d.statusCode, "duration", time.Since(startTime).String())
 		})
 	}
 }
@@ -119,7 +119,7 @@ func ProblemDetails(w http.ResponseWriter, body string, code int) {
 // getOranErrHandler override default validation error to allow for O-RAN specific error
 func getOranErrHandler() oapimiddleware.ErrorHandlerWithOpts {
 	return func(_ context.Context, err error, w http.ResponseWriter, r *http.Request, opts oapimiddleware.ErrorHandlerOpts) {
-		slog.Warn("OpenAPI validation failed",
+		slog.WarnContext(r.Context(), "OpenAPI validation failed",
 			"error", err.Error(),
 			"method", r.Method,
 			"path", r.URL.Path,
@@ -132,7 +132,7 @@ func getOranErrHandler() oapimiddleware.ErrorHandlerWithOpts {
 // GetOranReqErrFunc override default validation errors to allow for O-RAN specific struct
 func GetOranReqErrFunc() func(w http.ResponseWriter, r *http.Request, err error) {
 	return func(w http.ResponseWriter, r *http.Request, err error) {
-		slog.Warn("OpenAPI request validation failed",
+		slog.WarnContext(r.Context(), "OpenAPI request validation failed",
 			"error", err.Error(),
 			"method", r.Method,
 			"path", r.URL.Path,

--- a/internal/service/common/api/utils.go
+++ b/internal/service/common/api/utils.go
@@ -63,7 +63,7 @@ func CheckCallbackReachabilityGET(ctx context.Context, client *http.Client, call
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()
 		if err != nil {
-			slog.Warn("failed to close response body", "error", err)
+			slog.WarnContext(ctx, "failed to close response body", "error", err)
 		}
 	}(resp.Body)
 
@@ -71,7 +71,7 @@ func CheckCallbackReachabilityGET(ctx context.Context, client *http.Client, call
 		return fmt.Errorf("unexpected status code: got %d, expected %d", resp.StatusCode, http.StatusNoContent)
 	}
 
-	slog.Info("Reachability check passed", "status", resp.StatusCode)
+	slog.InfoContext(ctx, "Reachability check passed", "status", resp.StatusCode)
 	return nil
 }
 
@@ -86,6 +86,6 @@ func GracefulShutdown(srv *http.Server) error {
 		return fmt.Errorf("failed graceful shutdown: %w", err)
 	}
 
-	slog.Info("Server gracefully stopped")
+	slog.InfoContext(ctx, "Server gracefully stopped")
 	return nil
 }

--- a/internal/service/common/async/store.go
+++ b/internal/service/common/async/store.go
@@ -129,14 +129,14 @@ func (c *ReflectorStore) handleOperations(ctx context.Context, handler AsyncEven
 		case Updated, Deleted:
 			_, err := handler.HandleAsyncEvent(ctx, o.objects[0], o.eventType)
 			if err != nil {
-				slog.Warn("Failed to handle event", "event", o.eventType, "error", err)
+				slog.WarnContext(ctx, "Failed to handle event", "event", o.eventType, "error", err)
 			}
 		case SyncComplete:
 			keys := make([]uuid.UUID, 0)
 			for _, obj := range o.objects {
 				key, err := handler.HandleAsyncEvent(ctx, obj, Updated)
 				if err != nil {
-					slog.Warn("Failed to handle event", "error", err)
+					slog.WarnContext(ctx, "Failed to handle event", "error", err)
 					continue
 				}
 				if key != uuid.Nil {
@@ -146,7 +146,7 @@ func (c *ReflectorStore) handleOperations(ctx context.Context, handler AsyncEven
 			}
 			err := handler.HandleSyncComplete(ctx, c.ObjectType, keys)
 			if err != nil {
-				slog.Warn("Failed to handle sync completion", "error", err)
+				slog.WarnContext(ctx, "Failed to handle sync completion", "error", err)
 			}
 		}
 	}
@@ -158,7 +158,7 @@ func (c *ReflectorStore) Receive(ctx context.Context, handler AsyncEventHandler)
 	for {
 		select {
 		case <-ctx.Done():
-			slog.Info("stopping store adapter; context canceled")
+			slog.InfoContext(ctx, "stopping store adapter; context canceled")
 			// Mark as closed before closing the channel to prevent enqueue from sending
 			c.mutex.Lock()
 			c.closed = true

--- a/internal/service/common/auth/auth.go
+++ b/internal/service/common/auth/auth.go
@@ -36,13 +36,13 @@ func Authenticator(oauthHandler, kubernetesHandler authenticator.Request) middle
 
 			response, ok, err := handler.AuthenticateRequest(req)
 			if err != nil {
-				slog.Warn("authentication failed", "error", err, "method", req.Method, "path", req.URL.Path)
+				slog.WarnContext(req.Context(), "authentication failed", "error", err, "method", req.Method, "path", req.URL.Path)
 				middleware.ProblemDetails(w, fmt.Sprintf("failed to authenticate request: %v", err), http.StatusUnauthorized)
 				return
 			}
 
 			if !ok {
-				slog.Warn("authentication rejected", "method", req.Method, "path", req.URL.Path)
+				slog.WarnContext(req.Context(), "authentication rejected", "method", req.Method, "path", req.URL.Path)
 				middleware.ProblemDetails(w, "unable to authenticate request", http.StatusUnauthorized)
 				return
 			}
@@ -98,14 +98,14 @@ func Authorizer(kubernetesAuthorizer authorizer.Authorizer) middleware.Middlewar
 			decision, reason, err := kubernetesAuthorizer.Authorize(req.Context(), attributes)
 			if err != nil {
 				msg := fmt.Sprintf("Authorization for user '%s' failed", attributes.User.GetName())
-				slog.Error(msg, "user", user, "verb", attributes.Verb, "path", attributes.Path, "error", err)
+				slog.ErrorContext(req.Context(), msg, "user", user, "verb", attributes.Verb, "path", attributes.Path, "error", err)
 				middleware.ProblemDetails(w, msg, http.StatusInternalServerError)
 				return
 			}
 
 			if decision != authorizer.DecisionAllow {
 				msg := fmt.Sprintf("Authorization not allowed for user '%s'", attributes.User.GetName())
-				slog.Debug(msg, "user", user, "verb", attributes.Verb, "path", attributes.Path, "decision", decision, "reason", reason)
+				slog.DebugContext(req.Context(), msg, "user", user, "verb", attributes.Verb, "path", attributes.Path, "decision", decision, "reason", reason)
 				middleware.ProblemDetails(w, msg, http.StatusForbidden)
 				return
 			}

--- a/internal/service/common/auth/auth_rfc8705.go
+++ b/internal/service/common/auth/auth_rfc8705.go
@@ -57,7 +57,7 @@ func getClientCertificate(req *http.Request) ([]byte, bool, error) {
 		certString = req.Header.Get(sslClientDERHeaderKey)
 		if certString == "" {
 			// This is unexpected
-			slog.Error("No client certificate found, but verification passed", "header", sslClientDERHeaderKey)
+			slog.ErrorContext(req.Context(), "No client certificate found, but verification passed", "header", sslClientDERHeaderKey)
 			return nil, false, nil
 		}
 
@@ -149,7 +149,7 @@ func (w *withClientVerification) AuthenticateRequest(req *http.Request) (*authen
 
 	clientFingerprint, present, err := getClientCertificateFingerprint(req)
 	if err != nil {
-		slog.Error("error extracting client certificate fingerprint", "error", err)
+		slog.ErrorContext(req.Context(), "error extracting client certificate fingerprint", "error", err)
 		return nil, false, err
 	}
 
@@ -158,12 +158,12 @@ func (w *withClientVerification) AuthenticateRequest(req *http.Request) (*authen
 	}
 
 	if len(tokenFingerprintValues) != 1 {
-		slog.Error("unexpected number of fingerprint values", "values", tokenFingerprintValues)
+		slog.ErrorContext(req.Context(), "unexpected number of fingerprint values", "values", tokenFingerprintValues)
 		return nil, false, fmt.Errorf("unexpected number of fingerprint values")
 	}
 
 	if tokenFingerprintValues[0] != "" && tokenFingerprintValues[0] != clientFingerprint {
-		slog.Debug("fingerprint values do not match", "client", clientFingerprint, "token", tokenFingerprintValues[0])
+		slog.DebugContext(req.Context(), "fingerprint values do not match", "client", clientFingerprint, "token", tokenFingerprintValues[0])
 		return nil, false, fmt.Errorf("client certificate fingerprint mismatch")
 	}
 

--- a/internal/service/common/cache/cache.go
+++ b/internal/service/common/cache/cache.go
@@ -66,7 +66,7 @@ func (c *Entry[T]) Get(ctx context.Context) (T, error) {
 		c.expiresAt = time.Now().Add(c.maxAge)
 	}
 
-	slog.Info("Cache populated", "cache", c.name)
+	slog.InfoContext(ctx, "Cache populated", "cache", c.name)
 	return c.data, nil
 }
 

--- a/internal/service/common/clients/k8s/k8s.go
+++ b/internal/service/common/clients/k8s/k8s.go
@@ -165,7 +165,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object) err
 
 	if err := c.Get(ctx, key, existing); err != nil {
 		if errors.IsNotFound(err) { // Create if not found, otherwise return error
-			slog.Info("Creating a new resource", "gvk", obj.GetObjectKind().GroupVersionKind().String(),
+			slog.InfoContext(ctx, "Creating a new resource", "gvk", obj.GetObjectKind().GroupVersionKind().String(),
 				"namespace", obj.GetNamespace(), "name", obj.GetName())
 			return c.Create(ctx, obj) //nolint:wrapcheck
 		}
@@ -174,7 +174,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object) err
 
 	// Update existing object
 	obj.SetResourceVersion(existing.GetResourceVersion())
-	slog.Info("Updating an existing resource", "gvk", obj.GetObjectKind().GroupVersionKind().String(),
+	slog.InfoContext(ctx, "Updating an existing resource", "gvk", obj.GetObjectKind().GroupVersionKind().String(),
 		"namespace", obj.GetNamespace(), "name", obj.GetName())
 	return c.Update(ctx, obj) //nolint:wrapcheck
 }

--- a/internal/service/common/db/postgres.go
+++ b/internal/service/common/db/postgres.go
@@ -61,7 +61,7 @@ func NewPgxPool(ctx context.Context, cfg PgConfig) (*pgxpool.Pool, error) {
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
-	slog.Info("Database connection pool established")
+	slog.InfoContext(ctx, "Database connection pool established")
 	return pool, nil
 }
 

--- a/internal/service/common/listener/pg_listener_manager.go
+++ b/internal/service/common/listener/pg_listener_manager.go
@@ -80,10 +80,10 @@ func (lm *Manager) listenChannel(ctx context.Context, channel string, handler No
 			// Wait before retrying to avoid busy-looping.
 			select {
 			case <-ctx.Done():
-				slog.Info("Listener is shutting down", "channel", channel)
+				slog.InfoContext(ctx, "Listener is shutting down", "channel", channel)
 				return
 			case <-time.After(time.Minute):
-				slog.Error("failed to listen to pg channel, retrying", "channel", channel, "error", err)
+				slog.ErrorContext(ctx, "failed to listen to pg channel, retrying", "channel", channel, "error", err)
 			}
 		}
 	}
@@ -101,16 +101,16 @@ func (lm *Manager) listenAndProcess(ctx context.Context, channel string, handler
 		return fmt.Errorf("failed to set up listener on %s: %w", channel, err)
 	}
 
-	slog.Info("Listening for notifications", "channel", channel)
+	slog.InfoContext(ctx, "Listening for notifications", "channel", channel)
 	for {
 		notification, err := conn.Conn().WaitForNotification(ctx)
 		if err != nil {
 			return fmt.Errorf("failed waiting for notification on %s: %w", channel, err)
 		}
-		slog.Debug("Received notification from PG", "channel", channel, "payload", notification.Payload)
+		slog.DebugContext(ctx, "Received notification from PG", "channel", channel, "payload", notification.Payload)
 		// Process the notification payload using the registered handler.
 		if err := handler(ctx, notification); err != nil {
-			slog.Error("Failed to process notification", "channel", channel, "error", err)
+			slog.ErrorContext(ctx, "Failed to process notification", "channel", channel, "error", err)
 		}
 	}
 }
@@ -126,7 +126,7 @@ func (lm *Manager) startChannelCatchUp(ctx context.Context, channel string, inte
 			return
 		case <-ticker.C:
 			if err := catchUp(ctx); err != nil {
-				slog.Error("Catch-up processing failed", "channel", channel, "error", err)
+				slog.ErrorContext(ctx, "Catch-up processing failed", "channel", channel, "error", err)
 			}
 		}
 	}

--- a/internal/service/common/notifier/event.go
+++ b/internal/service/common/notifier/event.go
@@ -42,7 +42,7 @@ func sendNotification(ctx context.Context, client *http.Client, url string, even
 	}
 	defer func(Body io.ReadCloser) {
 		if err := Body.Close(); err != nil {
-			slog.Error("failed to close response body", "error", err)
+			slog.ErrorContext(ctx, "failed to close response body", "error", err)
 		}
 	}(response.Body)
 
@@ -58,7 +58,7 @@ func sendNotification(ctx context.Context, client *http.Client, url string, even
 // to the worker that this current event is complete
 func processEvent(ctx context.Context, logger *slog.Logger, client *http.Client,
 	completionChannel chan *SubscriptionJobComplete, event Notification, subscriptionID uuid.UUID, url string) {
-	logger.Info("processing data change event",
+	logger.InfoContext(ctx, "processing data change event",
 		"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
 
 	_ = callUrl(ctx, logger, client, url, event)
@@ -82,36 +82,36 @@ func callUrl(ctx context.Context, logger *slog.Logger, client *http.Client, url 
 
 		if nonRetryErr := isRetryableError(err); nonRetryErr != nil {
 			msg := "error sending notification; non retryable error"
-			logger.Error(msg, "error", nonRetryErr,
+			logger.ErrorContext(ctx, msg, "error", nonRetryErr,
 				"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
 			return fmt.Errorf("%s: %w", msg, err)
 		}
 
-		logger.Warn("failed to send notification", "error", err,
+		logger.WarnContext(ctx, "failed to send notification", "error", err,
 			"notificationID", event.NotificationID, "sequenceID", event.SequenceID, "delay", delay.String(), "attemptsRemaining", maxRetries-attempt-1)
 
 		if attempt < maxRetries-1 { // Skip delay for final attempt since no further retries will occur
 			select {
 			case <-ctx.Done():
-				logger.Warn("context canceled while sending notification",
+				logger.WarnContext(ctx, "context canceled while sending notification",
 					"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
 				break
 			case <-time.After(delay):
 				delay *= 2
-				logger.Debug("retrying notification",
+				logger.DebugContext(ctx, "retrying notification",
 					"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
 			}
 		}
 	}
 
 	if err != nil {
-		logger.Error("error sending notification; retries exceeded", "error", err,
+		logger.ErrorContext(ctx, "error sending notification; retries exceeded", "error", err,
 			"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
 		// TODO: If we were able to send this one then we are not likely to be able to send any
 		//  of the others so perhaps we should purge our queue, or enter a longer backoff period.
 		return fmt.Errorf("error sending notification; retries exceeded: %w", err)
 	} else {
-		logger.Info("notification sent",
+		logger.InfoContext(ctx, "notification sent",
 			"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
 	}
 

--- a/internal/service/common/notifier/notifier.go
+++ b/internal/service/common/notifier/notifier.go
@@ -118,20 +118,20 @@ func (n *Notifier) Run(ctx context.Context) error {
 		select {
 		case e := <-n.subscriptionJobCompleteChannel:
 			if err := n.handleSubscriptionJobCompleteEvent(ctx, e); err != nil {
-				slog.Error("failed to handle subscription job complete event", "error", err)
+				slog.ErrorContext(ctx, "failed to handle subscription job complete event", "error", err)
 			}
 		case e := <-n.notificationChannel:
 			if err := n.handleNotification(ctx, e); err != nil {
-				slog.Error("failed to handle notification",
+				slog.ErrorContext(ctx, "failed to handle notification",
 					"NotificationID", e.NotificationID, "sequenceID", e.SequenceID, "error", err)
 			}
 		case e := <-n.subscriptionChannel:
 			if err := n.handleSubscriptionEvent(ctx, e); err != nil {
-				slog.Error("failed to handle subscription event", "error", err)
+				slog.ErrorContext(ctx, "failed to handle subscription event", "error", err)
 			}
 		case <-ctx.Done():
 			n.shutdownWorkers()
-			slog.Info("context terminated; notifier exiting")
+			slog.InfoContext(ctx, "context terminated; notifier exiting")
 			return nil
 		}
 	}
@@ -146,7 +146,7 @@ func (n *Notifier) shutdownWorkers() {
 
 // init runs the onetime initialization steps for the notifier
 func (n *Notifier) init(ctx context.Context) error {
-	slog.Info("initializing notifier")
+	slog.InfoContext(ctx, "initializing notifier")
 	if err := n.loadSubscriptions(ctx); err != nil {
 		return fmt.Errorf("failed to load subscriptions: %w", err)
 	}
@@ -158,7 +158,7 @@ func (n *Notifier) init(ctx context.Context) error {
 
 // loadEvents loads the current set of notifications from the database
 func (n *Notifier) loadEvents(ctx context.Context) error {
-	slog.Info("loading events")
+	slog.InfoContext(ctx, "loading events")
 
 	notifications, err := n.notificationProvider.GetNotifications(ctx)
 	if err != nil {
@@ -177,13 +177,13 @@ func (n *Notifier) loadEvents(ctx context.Context) error {
 		}
 	}
 
-	slog.Info("loaded events", "count", len(notifications))
+	slog.InfoContext(ctx, "loaded events", "count", len(notifications))
 	return nil
 }
 
 // loadSubscriptions loads the current set of subscriptions from the database
 func (n *Notifier) loadSubscriptions(ctx context.Context) error {
-	slog.Info("loading subscriptions")
+	slog.InfoContext(ctx, "loading subscriptions")
 
 	subscriptions, err := n.subscriptionProvider.GetSubscriptions(ctx)
 	if err != nil {
@@ -200,7 +200,7 @@ func (n *Notifier) loadSubscriptions(ctx context.Context) error {
 		go n.workers[subscriptionID].Run()
 	}
 
-	slog.Info("subscriptions loaded", "count", len(n.workers))
+	slog.InfoContext(ctx, "subscriptions loaded", "count", len(n.workers))
 
 	return nil
 }
@@ -210,20 +210,20 @@ func (n *Notifier) Notify(ctx context.Context, event *Notification) {
 	select {
 	case n.notificationChannel <- event:
 	case <-ctx.Done():
-		slog.Info("context terminated; aborting Notify attempt")
+		slog.InfoContext(ctx, "context terminated; aborting Notify attempt")
 	}
 }
 
 // handleNotification handles an incoming notification
 func (n *Notifier) handleNotification(ctx context.Context, event *Notification) error {
-	slog.Info("handling notification", "NotificationID", event.NotificationID, "sequenceID", event.SequenceID)
+	slog.InfoContext(ctx, "handling notification", "NotificationID", event.NotificationID, "sequenceID", event.SequenceID)
 
 	count := 0
 	for _, worker := range n.workers {
 		if n.subscriptionProvider.Matches(worker.subscription, event) {
 			clone, err := n.subscriptionProvider.Transform(worker.subscription, event)
 			if err != nil {
-				slog.Error("failed to transform notification", "subscription", worker.subscription.SubscriptionID, "error", err)
+				slog.ErrorContext(ctx, "failed to transform notification", "subscription", worker.subscription.SubscriptionID, "error", err)
 				continue
 			}
 			worker.NewNotification(clone)
@@ -233,7 +233,7 @@ func (n *Notifier) handleNotification(ctx context.Context, event *Notification) 
 
 	if count == 0 {
 		// No subscriptions matched just delete the event
-		slog.Debug("no matching subscriptions; deleting event",
+		slog.DebugContext(ctx, "no matching subscriptions; deleting event",
 			"NotificationID", event.NotificationID, "sequenceID", event.SequenceID)
 		if err := n.notificationProvider.DeleteNotification(ctx, event.NotificationID); err != nil {
 			return fmt.Errorf("failed to delete notification: %w", err)
@@ -241,7 +241,7 @@ func (n *Notifier) handleNotification(ctx context.Context, event *Notification) 
 		return nil
 	}
 
-	slog.Info("notification dispatched",
+	slog.InfoContext(ctx, "notification dispatched",
 		"NotificationID", event.NotificationID, "sequenceID", event.SequenceID,
 		"subscribers", count)
 
@@ -253,7 +253,7 @@ func (n *Notifier) SubscriptionEvent(ctx context.Context, event *SubscriptionEve
 	select {
 	case n.subscriptionChannel <- event:
 	case <-ctx.Done():
-		slog.Info("context terminated; aborting SubscriptionEvent attempt")
+		slog.InfoContext(ctx, "context terminated; aborting SubscriptionEvent attempt")
 	}
 }
 
@@ -286,7 +286,7 @@ func (n *Notifier) releaseNotifications(ctx context.Context, events []*Notificat
 	for _, event := range events {
 		err := n.releaseNotification(ctx, event.NotificationID, event.SequenceID)
 		if err != nil {
-			slog.Error("failed to release event", "error", err)
+			slog.ErrorContext(ctx, "failed to release event", "error", err)
 		}
 	}
 }
@@ -294,13 +294,13 @@ func (n *Notifier) releaseNotifications(ctx context.Context, events []*Notificat
 // handleSubscriptionEvent handles an incoming subscription change event
 func (n *Notifier) handleSubscriptionEvent(ctx context.Context, event *SubscriptionEvent) error {
 	subscriptionID := event.Subscription.SubscriptionID
-	slog.Info("Handling subscription event", "removed", event.Removed, "subscription", event.Subscription)
+	slog.InfoContext(ctx, "Handling subscription event", "removed", event.Removed, "subscription", event.Subscription)
 
 	if event.Removed {
 		// The subscription has been removed.  Cleanup any associated data.
 		worker, found := n.workers[subscriptionID]
 		if !found {
-			slog.Debug("subscription worker not found", "subscriptionID", subscriptionID)
+			slog.DebugContext(ctx, "subscription worker not found", "subscriptionID", subscriptionID)
 			return nil
 		}
 
@@ -319,13 +319,13 @@ func (n *Notifier) handleSubscriptionEvent(ctx context.Context, event *Subscript
 		go worker.Run()
 	}
 
-	slog.Info("subscription event handled", "workers", len(n.workers))
+	slog.InfoContext(ctx, "subscription event handled", "workers", len(n.workers))
 	return nil
 }
 
 // handleSubscriptionJobCompleteEvent handles a job completion event, removes the subscriber from the event job,
 func (n *Notifier) handleSubscriptionJobCompleteEvent(ctx context.Context, event *SubscriptionJobComplete) error {
-	slog.Debug("handling subscription job complete event",
+	slog.DebugContext(ctx, "handling subscription job complete event",
 		"NotificationID", event.notificationID, "subscriptionID", event.subscriptionID)
 
 	// Lookup the subscription worker for this event
@@ -338,7 +338,7 @@ func (n *Notifier) handleSubscriptionJobCompleteEvent(ctx context.Context, event
 		}
 	} else {
 		// Likely has been deleted and this is a race condition.
-		slog.Debug("subscription worker not found", "subscriptionID", event.subscriptionID)
+		slog.DebugContext(ctx, "subscription worker not found", "subscriptionID", event.subscriptionID)
 	}
 
 	return n.releaseNotification(ctx, event.notificationID, event.sequenceID)

--- a/internal/service/common/repo/notifications.go
+++ b/internal/service/common/repo/notifications.go
@@ -52,7 +52,7 @@ func (p *NotificationStorageProvider) GetNotifications(ctx context.Context) ([]n
 // that the notification has been seen by all subscriptions.
 func (p *NotificationStorageProvider) DeleteNotification(ctx context.Context, notificationID uuid.UUID) error {
 	// This event has been consumed by all subscriptions
-	slog.Debug("notification sent to all subscribers; deleting",
+	slog.DebugContext(ctx, "notification sent to all subscribers; deleting",
 		"NotificationID", notificationID)
 
 	_, err := p.repository.DeleteDataChangeEvent(ctx, notificationID)

--- a/internal/service/common/repo/repository.go
+++ b/internal/service/common/repo/repository.go
@@ -201,7 +201,7 @@ func updateHighWatermark(ctx context.Context, tx pgx.Tx, dataChangeEvents []comm
 		return fmt.Errorf("failed to execute queryUpdateHighWater: %w", err)
 	}
 
-	slog.Debug("high-watermark", "from", highWatermark, "to", updateHighWatermark.LastEventID)
+	slog.DebugContext(ctx, "high-watermark", "from", highWatermark, "to", updateHighWatermark.LastEventID)
 
 	return nil
 }

--- a/internal/service/common/utils/config.go
+++ b/internal/service/common/utils/config.go
@@ -196,7 +196,7 @@ func (c *CommonServerConfig) CreateOAuthConfig(ctx context.Context) (*ctlrutils.
 			return nil, fmt.Errorf("failed to read CA bundle file '%s': %w", c.TLS.CABundleFile, err)
 		}
 		config.TLSConfig = &ctlrutils.TLSConfig{CaBundle: bytes}
-		slog.Debug("using CA bundle", "path", c.TLS.CABundleFile)
+		slog.DebugContext(ctx, "using CA bundle", "path", c.TLS.CABundleFile)
 	}
 
 	if c.TLS.ClientCertFile != "" && c.TLS.ClientKeyFile != "" {
@@ -209,7 +209,7 @@ func (c *CommonServerConfig) CreateOAuthConfig(ctx context.Context) (*ctlrutils.
 			config.TLSConfig = &ctlrutils.TLSConfig{}
 		}
 		config.TLSConfig.ClientCert = dynamicClientCert
-		slog.Debug("using TLS client config", "cert", c.TLS.ClientCertFile, ",key", c.TLS.ClientKeyFile)
+		slog.DebugContext(ctx, "using TLS client config", "cert", c.TLS.ClientCertFile, ",key", c.TLS.ClientKeyFile)
 
 		// Run the controller so that it monitors for file changes
 		go dynamicClientCert.Run(ctx, 1)

--- a/internal/service/common/utils/persist.go
+++ b/internal/service/common/utils/persist.go
@@ -59,7 +59,7 @@ func PersistObject[T db.Model, K PrimaryKeyType](ctx context.Context, tx pgx.Tx,
 			return nil, nil, fmt.Errorf("failed to create object '%s/%v': %w", object.TableName(), key, err)
 		}
 
-		slog.Debug("object inserted", "table", object.TableName(), "key", key, "record", after)
+		slog.DebugContext(ctx, "object inserted", "table", object.TableName(), "key", key, "record", after)
 		return nil, after, nil
 	}
 
@@ -75,7 +75,7 @@ func PersistObject[T db.Model, K PrimaryKeyType](ctx context.Context, tx pgx.Tx,
 	if len(tags) == 0 {
 		// This shouldn't happen since the generation id always changes
 		after = before
-		slog.Warn("no change detected on persisted object", "table", object.TableName(), "key", key)
+		slog.WarnContext(ctx, "no change detected on persisted object", "table", object.TableName(), "key", key)
 		return before, after, nil
 	}
 
@@ -84,7 +84,7 @@ func PersistObject[T db.Model, K PrimaryKeyType](ctx context.Context, tx pgx.Tx,
 		return nil, nil, fmt.Errorf("failed to update object '%s/%v': %w", object.TableName(), key, err)
 	}
 
-	slog.Debug("object updated",
+	slog.DebugContext(ctx, "object updated",
 		"table", object.TableName(), "key", key, "before", before, "after", after, "columns", tags.Fields())
 
 	return before, after, nil

--- a/internal/service/common/utils/repository.go
+++ b/internal/service/common/utils/repository.go
@@ -233,7 +233,7 @@ func Exists[T db.Model, K PrimaryKeyType](ctx context.Context, db DBQuery, key K
 		return false, fmt.Errorf("failed to build query: %w", err)
 	}
 
-	slog.Debug("executing query", "sql", sql, "args", args)
+	slog.DebugContext(ctx, "executing query", "sql", sql, "args", args)
 
 	var result bool
 	err = db.QueryRow(ctx, sql, args...).Scan(&result)
@@ -259,7 +259,7 @@ func ExecuteCollectExactlyOneRow[T db.Model](ctx context.Context, db DBQuery, sq
 	record, err = pgx.CollectExactlyOneRow(rows, pgx.RowToStructByNameLax[T])
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			slog.Debug("no record found", "table", record.TableName())
+			slog.DebugContext(ctx, "no record found", "table", record.TableName())
 			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("failed to execute query: %w", err)

--- a/internal/service/provisioning/api/server.go
+++ b/internal/service/provisioning/api/server.go
@@ -176,7 +176,7 @@ func (r *ProvisioningServer) CreateProvisioningRequest(ctx context.Context, requ
 		return nil, err
 	}
 
-	slog.Info("Created ProvisioningRequest", "provisioningRequestId", request.Body.ProvisioningRequestId.String())
+	slog.InfoContext(ctx, "Created ProvisioningRequest", "provisioningRequestId", request.Body.ProvisioningRequestId.String())
 	location := fmt.Sprintf("%s/provisioningRequests/%s", constants.O2IMSProvisioningBaseURL, request.Body.ProvisioningRequestId)
 	return api.CreateProvisioningRequest201JSONResponse{
 		Body: provisioningRequestInfo,
@@ -255,7 +255,7 @@ func (r *ProvisioningServer) UpdateProvisioningRequest(ctx context.Context, requ
 		return nil, err
 	}
 
-	slog.Info("Updated ProvisioningRequest", "provisioningRequestId", request.ProvisioningRequestId.String())
+	slog.InfoContext(ctx, "Updated ProvisioningRequest", "provisioningRequestId", request.ProvisioningRequestId.String())
 	return api.UpdateProvisioningRequest200JSONResponse(provisioningRequestInfo), nil
 }
 
@@ -278,7 +278,7 @@ func (r *ProvisioningServer) DeleteProvisioningRequest(ctx context.Context, requ
 		}
 		return nil, fmt.Errorf("failed to delete ProvisioningRequest (%s): %w", request.ProvisioningRequestId.String(), err)
 	}
-	slog.Info("The deletion request for ProvisioningRequest has been sent successfully", "provisioningRequestId", request.ProvisioningRequestId.String())
+	slog.InfoContext(ctx, "The deletion request for ProvisioningRequest has been sent successfully", "provisioningRequestId", request.ProvisioningRequestId.String())
 	location := fmt.Sprintf("%s/provisioningRequests/%s", constants.O2IMSProvisioningBaseURL, request.ProvisioningRequestId)
 	return api.DeleteProvisioningRequest202Response{
 		Headers: api.DeleteProvisioningRequest202ResponseHeaders{

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -63,7 +63,7 @@ func Serve(config *api.ProvisioningServerConfig) error {
 
 	go func() {
 		sig := <-shutdown
-		slog.Info("Shutdown signal received", "signal", sig)
+		slog.InfoContext(ctx, "Shutdown signal received", "signal", sig)
 		cancel()
 	}()
 
@@ -153,7 +153,7 @@ func Serve(config *api.ProvisioningServerConfig) error {
 	serverErrors := make(chan error, 1)
 	// Start server
 	go func() {
-		slog.Info(fmt.Sprintf("Listening on %s", srv.Addr))
+		slog.InfoContext(ctx, fmt.Sprintf("Listening on %s", srv.Addr))
 		// Cert/Key files aren't needed here since they've been added to the tls.Config above.
 		if err := srv.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErrors <- err
@@ -165,7 +165,7 @@ func Serve(config *api.ProvisioningServerConfig) error {
 	case err := <-serverErrors:
 		return fmt.Errorf("error starting server: %w", err)
 	case <-ctx.Done():
-		slog.Info("Shutting down server")
+		slog.InfoContext(ctx, "Shutting down server")
 		if err := common.GracefulShutdown(srv); err != nil {
 			return fmt.Errorf("error shutting down server: %w", err)
 		}

--- a/internal/service/resources/api/server.go
+++ b/internal/service/resources/api/server.go
@@ -290,7 +290,7 @@ func (r *ResourceServer) GetSubscriptions(ctx context.Context, request api.GetSu
 // validateSubscription validates a subscription before accepting the request
 func (r *ResourceServer) validateSubscription(ctx context.Context, request api.CreateSubscriptionRequestObject) error {
 	if err := commonapi.ValidateCallbackURL(ctx, r.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback); err != nil {
-		slog.Error("callback URL validation failed", "error", err)
+		slog.ErrorContext(ctx, "callback URL validation failed", "error", err)
 		return fmt.Errorf("callback URL validation failed")
 	}
 
@@ -334,7 +334,7 @@ func (r *ResourceServer) CreateSubscription(ctx context.Context, request api.Cre
 				Status: http.StatusBadRequest,
 			}, nil
 		}
-		slog.Error("error writing database record", "target", record, "error", err.Error())
+		slog.ErrorContext(ctx, "error writing database record", "target", record, "error", err.Error())
 		return api.CreateSubscription500ApplicationProblemPlusJSONResponse{
 			AdditionalAttributes: &map[string]string{
 				"consumerSubscriptionId": consumerSubscriptionId,

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -100,10 +100,10 @@ func (c *Collector) Run(ctx context.Context) error {
 		select {
 		case event := <-c.AsyncChangeEvents:
 			if err := c.handleAsyncEvent(ctx, event); err != nil {
-				slog.Error("failed to handle async change", "event", event, "error", err)
+				slog.ErrorContext(ctx, "failed to handle async change", "event", event, "error", err)
 			}
 		case <-ctx.Done():
-			slog.Info("Context terminated; collector exiting")
+			slog.InfoContext(ctx, "Context terminated; collector exiting")
 			return nil
 		}
 	}
@@ -111,7 +111,7 @@ func (c *Collector) Run(ctx context.Context) error {
 
 // init runs the onetime initialization steps for the collector
 func (c *Collector) init(ctx context.Context) error {
-	slog.Info("initializing data collector")
+	slog.InfoContext(ctx, "initializing data collector")
 
 	for _, d := range c.dataSources {
 		err := c.initDataSource(ctx, d)
@@ -140,12 +140,12 @@ func (c *Collector) initDataSource(ctx context.Context, dataSource DataSource) e
 		}
 
 		dataSource.Init(*result.DataSourceID, 0, c.AsyncChangeEvents)
-		slog.Info("created new data source", "name", name, "uuid", *result.DataSourceID)
+		slog.InfoContext(ctx, "created new data source", "name", name, "uuid", *result.DataSourceID)
 	case err != nil:
 		return fmt.Errorf("failed to get data source %q: %w", name, err)
 	default:
 		dataSource.Init(*record.DataSourceID, record.GenerationID, c.AsyncChangeEvents)
-		slog.Info("restored data source",
+		slog.InfoContext(ctx, "restored data source",
 			"name", name, "uuid", record.DataSourceID, "generation", record.GenerationID)
 	}
 	return nil
@@ -235,7 +235,7 @@ func (c *Collector) handleAsyncResourceEvent(ctx context.Context, resource model
 // handleResourceSyncCompletion handles the sync completion for Resource objects
 // by purging resources and resource types not in the key set.
 func (c *Collector) handleResourceSyncCompletion(ctx context.Context, ids []any) error {
-	slog.Debug("Handling end of sync for Resource instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for Resource instances", "count", len(ids))
 	c.invalidateAlarmDictCache()
 
 	// Purge stale resources
@@ -261,7 +261,7 @@ func (c *Collector) handleResourceSyncCompletion(ctx context.Context, ids []any)
 	}
 
 	if resourceCount > 0 {
-		slog.Info("Deleted stale resources", "count", resourceCount)
+		slog.InfoContext(ctx, "Deleted stale resources", "count", resourceCount)
 	}
 
 	return nil
@@ -273,7 +273,7 @@ func (c *Collector) getAlarmDictionaryID(ctx context.Context, resourceTypeID uui
 	if c.alarmDictCache == nil {
 		alarmDictionaries, err := c.repository.GetAlarmDictionaries(ctx)
 		if err != nil {
-			slog.Warn("failed to fetch alarm dictionaries", "error", err)
+			slog.WarnContext(ctx, "failed to fetch alarm dictionaries", "error", err)
 			return nil
 		}
 		c.alarmDictCache = make(map[string]*uuid.UUID)
@@ -296,7 +296,7 @@ func (c *Collector) invalidateAlarmDictCache() {
 // handleDeploymentManagerSyncCompletion handles the end of sync for DeploymentManager objects.  It deletes any
 // DeploymentManager objects not included in the set of keys received during the sync operation.
 func (c *Collector) handleDeploymentManagerSyncCompletion(ctx context.Context, ids []any) error {
-	slog.Debug("Handling end of sync for DeploymentManager instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for DeploymentManager instances", "count", len(ids))
 	records, err := c.repository.GetDeploymentManagersNotIn(ctx, ids)
 	if err != nil {
 		return fmt.Errorf("failed to get stale deployment managers: %w", err)
@@ -320,7 +320,7 @@ func (c *Collector) handleDeploymentManagerSyncCompletion(ctx context.Context, i
 	}
 
 	if count > 0 {
-		slog.Info("Deleted stale deployment manager records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale deployment manager records", "count", count)
 	}
 
 	return nil
@@ -503,7 +503,7 @@ func (c *Collector) handleAsyncOCloudSiteEvent(ctx context.Context, site models.
 
 // handleLocationSyncCompletion handles the sync completion for Location objects.
 func (c *Collector) handleLocationSyncCompletion(ctx context.Context, keys []uuid.UUID) error {
-	slog.Debug("Handling end of sync for Location instances", "count", len(keys))
+	slog.DebugContext(ctx, "Handling end of sync for Location instances", "count", len(keys))
 
 	// Create a set of tracking UUIDs for fast lookup
 	keySet := make(map[uuid.UUID]struct{}, len(keys))
@@ -542,7 +542,7 @@ func (c *Collector) handleLocationSyncCompletion(ctx context.Context, keys []uui
 	}
 
 	if count > 0 {
-		slog.Info("Deleted stale location records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale location records", "count", count)
 	}
 
 	return nil
@@ -550,7 +550,7 @@ func (c *Collector) handleLocationSyncCompletion(ctx context.Context, keys []uui
 
 // handleOCloudSiteSyncCompletion handles the sync completion for OCloudSite objects.
 func (c *Collector) handleOCloudSiteSyncCompletion(ctx context.Context, ids []any) error {
-	slog.Debug("Handling end of sync for OCloudSite instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for OCloudSite instances", "count", len(ids))
 
 	records, err := c.repository.GetOCloudSitesNotIn(ctx, ids)
 	if err != nil {
@@ -575,7 +575,7 @@ func (c *Collector) handleOCloudSiteSyncCompletion(ctx context.Context, ids []an
 	}
 
 	if count > 0 {
-		slog.Info("Deleted stale OCloudSite records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale OCloudSite records", "count", count)
 	}
 
 	return nil
@@ -625,30 +625,30 @@ func (c *Collector) rebuildResourcesForPool(ctx context.Context, poolName string
 
 		results, err := handler.BuildResourcesForPool(ctx, poolName)
 		if err != nil {
-			slog.Error("failed to rebuild resources for pool", "pool", poolName, "error", err)
+			slog.ErrorContext(ctx, "failed to rebuild resources for pool", "pool", poolName, "error", err)
 			continue
 		}
 
 		for i := range results {
 			if err := c.handleAsyncResourceTypeEvent(ctx, results[i].ResourceType, false); err != nil {
-				slog.Error("failed to persist resource type during pool rebuild",
+				slog.ErrorContext(ctx, "failed to persist resource type during pool rebuild",
 					"pool", poolName, "error", err)
 			}
 			if err := c.handleAsyncResourceEvent(ctx, results[i].Resource, false); err != nil {
-				slog.Error("failed to persist resource during pool rebuild",
+				slog.ErrorContext(ctx, "failed to persist resource during pool rebuild",
 					"pool", poolName, "error", err)
 			}
 		}
 
 		if len(results) > 0 {
-			slog.Info("Rebuilt resources for pool", "pool", poolName, "count", len(results))
+			slog.InfoContext(ctx, "Rebuilt resources for pool", "pool", poolName, "count", len(results))
 		}
 	}
 }
 
 // handleResourcePoolSyncCompletion handles the sync completion for ResourcePool objects.
 func (c *Collector) handleResourcePoolSyncCompletion(ctx context.Context, ids []any) error {
-	slog.Debug("Handling end of sync for ResourcePool instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for ResourcePool instances", "count", len(ids))
 
 	records, err := c.repository.GetResourcePoolsNotIn(ctx, ids)
 	if err != nil {
@@ -673,7 +673,7 @@ func (c *Collector) handleResourcePoolSyncCompletion(ctx context.Context, ids []
 	}
 
 	if count > 0 {
-		slog.Info("Deleted stale ResourcePool records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale ResourcePool records", "count", count)
 	}
 
 	return nil

--- a/internal/service/resources/collector/collector_hwmgr.go
+++ b/internal/service/resources/collector/collector_hwmgr.go
@@ -129,7 +129,7 @@ func (d *HardwareDataSource) Watch(ctx context.Context) error {
 	stopCh := make(chan struct{})
 	go func() {
 		<-ctx.Done()
-		slog.Info("context canceled; stopping hardware data source reflectors")
+		slog.InfoContext(ctx, "context canceled; stopping hardware data source reflectors")
 		close(stopCh)
 	}()
 
@@ -162,7 +162,7 @@ func (d *HardwareDataSource) watchBMH(ctx context.Context, stopCh <-chan struct{
 
 	store := async.NewReflectorStore(&metal3v1alpha1.BareMetalHost{})
 	reflector := cache.NewNamedReflector(bmhReflectorName, &lister, &metal3v1alpha1.BareMetalHost{}, store, time.Duration(0))
-	slog.Info("starting BMH reflector")
+	slog.InfoContext(ctx, "starting BMH reflector")
 	go reflector.Run(stopCh)
 	go store.Receive(ctx, d)
 }
@@ -189,7 +189,7 @@ func (d *HardwareDataSource) watchHardwareData(ctx context.Context, stopCh <-cha
 
 	store := async.NewReflectorStore(&metal3v1alpha1.HardwareData{})
 	reflector := cache.NewNamedReflector(hwdataReflectorName, &lister, &metal3v1alpha1.HardwareData{}, store, time.Duration(0))
-	slog.Info("starting HardwareData reflector")
+	slog.InfoContext(ctx, "starting HardwareData reflector")
 	go reflector.Run(stopCh)
 	go store.Receive(ctx, d)
 }
@@ -216,7 +216,7 @@ func (d *HardwareDataSource) watchAllocatedNodes(ctx context.Context, stopCh <-c
 
 	store := async.NewReflectorStore(&hwmgmtv1alpha1.AllocatedNode{})
 	reflector := cache.NewNamedReflector(allocatednodeReflectorName, &lister, &hwmgmtv1alpha1.AllocatedNode{}, store, time.Duration(0))
-	slog.Info("starting AllocatedNode reflector")
+	slog.InfoContext(ctx, "starting AllocatedNode reflector")
 	go reflector.Run(stopCh)
 	go store.Receive(ctx, d)
 }
@@ -231,7 +231,7 @@ func (d *HardwareDataSource) HandleAsyncEvent(ctx context.Context, obj interface
 	case *hwmgmtv1alpha1.AllocatedNode:
 		return d.handleAllocatedNodeEvent(ctx, value, eventType)
 	default:
-		slog.Warn("Unknown object type in HardwareDataSource", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type in HardwareDataSource", "type", fmt.Sprintf("%T", obj))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -243,7 +243,7 @@ func (d *HardwareDataSource) HandleAsyncEvent(ctx context.Context, obj interface
 func (d *HardwareDataSource) HandleSyncComplete(ctx context.Context, objectType runtime.Object, keys []uuid.UUID) error {
 	switch objectType.(type) {
 	case *metal3v1alpha1.BareMetalHost:
-		slog.Info("BMH sync complete", "resourceCount", len(keys))
+		slog.InfoContext(ctx, "BMH sync complete", "resourceCount", len(keys))
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("context cancelled; aborting")
@@ -255,13 +255,13 @@ func (d *HardwareDataSource) HandleSyncComplete(ctx context.Context, objectType 
 			return nil
 		}
 	case *metal3v1alpha1.HardwareData:
-		slog.Info("HardwareData sync complete")
+		slog.InfoContext(ctx, "HardwareData sync complete")
 		return nil
 	case *hwmgmtv1alpha1.AllocatedNode:
-		slog.Info("AllocatedNode sync complete")
+		slog.InfoContext(ctx, "AllocatedNode sync complete")
 		return nil
 	default:
-		slog.Warn("Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
 		return nil
 	}
 }
@@ -269,7 +269,7 @@ func (d *HardwareDataSource) HandleSyncComplete(ctx context.Context, objectType 
 // handleBMHEvent handles a BMH watch event by building the full resource
 // from BMH + HardwareData + AllocatedNode and sending events to the collector.
 func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1alpha1.BareMetalHost, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleBMHEvent", "bmh", bmh.Namespace+"/"+bmh.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleBMHEvent", "bmh", bmh.Namespace+"/"+bmh.Name, "type", eventType)
 
 	resourceID := uuid.MustParse(string(bmh.UID))
 
@@ -278,7 +278,7 @@ func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1al
 	}
 
 	if !hwmgrcontroller.IncludeInInventory(bmh) {
-		slog.Debug("BMH not included in inventory, treating as deletion",
+		slog.DebugContext(ctx, "BMH not included in inventory, treating as deletion",
 			"bmh", bmh.Namespace+"/"+bmh.Name)
 		return d.sendDeleteEvent(ctx, resourceID)
 	}
@@ -289,12 +289,12 @@ func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1al
 // handleHardwareDataEvent handles a HardwareData watch event by looking up
 // the corresponding BMH and rebuilding the resource.
 func (d *HardwareDataSource) handleHardwareDataEvent(ctx context.Context, hwdata *metal3v1alpha1.HardwareData, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleHardwareDataEvent", "hwdata", hwdata.Namespace+"/"+hwdata.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleHardwareDataEvent", "hwdata", hwdata.Namespace+"/"+hwdata.Name, "type", eventType)
 
 	var bmh metal3v1alpha1.BareMetalHost
 	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: hwdata.Name, Namespace: hwdata.Namespace}, &bmh); err != nil {
 		if errors.IsNotFound(err) {
-			slog.Debug("BMH not found for HardwareData, skipping", "hwdata", hwdata.Namespace+"/"+hwdata.Name)
+			slog.DebugContext(ctx, "BMH not found for HardwareData, skipping", "hwdata", hwdata.Namespace+"/"+hwdata.Name)
 			return uuid.Nil, nil
 		}
 		return uuid.Nil, fmt.Errorf("failed to get BMH for HardwareData %s/%s: %w", hwdata.Namespace, hwdata.Name, err)
@@ -310,19 +310,19 @@ func (d *HardwareDataSource) handleHardwareDataEvent(ctx context.Context, hwdata
 // handleAllocatedNodeEvent handles an AllocatedNode watch event by looking up
 // the corresponding BMH and rebuilding the resource.
 func (d *HardwareDataSource) handleAllocatedNodeEvent(ctx context.Context, node *hwmgmtv1alpha1.AllocatedNode, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleAllocatedNodeEvent", "node", node.Namespace+"/"+node.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleAllocatedNodeEvent", "node", node.Namespace+"/"+node.Name, "type", eventType)
 
 	bmhName := node.Spec.HwMgrNodeId
 	bmhNamespace := node.Spec.HwMgrNodeNs
 	if bmhName == "" || bmhNamespace == "" {
-		slog.Debug("AllocatedNode missing BMH reference, skipping", "node", node.Namespace+"/"+node.Name)
+		slog.DebugContext(ctx, "AllocatedNode missing BMH reference, skipping", "node", node.Namespace+"/"+node.Name)
 		return uuid.Nil, nil
 	}
 
 	var bmh metal3v1alpha1.BareMetalHost
 	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: bmhName, Namespace: bmhNamespace}, &bmh); err != nil {
 		if errors.IsNotFound(err) {
-			slog.Debug("BMH not found for AllocatedNode, skipping", "bmh", bmhNamespace+"/"+bmhName)
+			slog.DebugContext(ctx, "BMH not found for AllocatedNode, skipping", "bmh", bmhNamespace+"/"+bmhName)
 			return uuid.Nil, nil
 		}
 		return uuid.Nil, fmt.Errorf("failed to get BMH for AllocatedNode %s/%s: %w", node.Namespace, node.Name, err)
@@ -362,7 +362,7 @@ func (d *HardwareDataSource) buildAndSendResource(ctx context.Context, bmh *meta
 	poolUID := hwmgrcontroller.GetResourceInfoResourcePoolUID(bmh, poolNameToUID)
 	if poolUID == "" {
 		poolName := bmh.Labels[constants.LabelResourcePoolName]
-		slog.Warn("skipping BMH: unresolved resourcePoolId (will retry on pool creation)",
+		slog.WarnContext(ctx, "skipping BMH: unresolved resourcePoolId (will retry on pool creation)",
 			"bmh", bmh.Namespace+"/"+bmh.Name, "poolName", poolName)
 		return uuid.Nil, nil
 	}
@@ -427,7 +427,7 @@ func (d *HardwareDataSource) findAllocatedNodeForBMH(ctx context.Context, bmh *m
 	var node hwmgmtv1alpha1.AllocatedNode
 	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: bmh.Namespace}, &node); err != nil {
 		if !errors.IsNotFound(err) {
-			slog.Warn("failed to get AllocatedNode for BMH",
+			slog.WarnContext(ctx, "failed to get AllocatedNode for BMH",
 				"bmh", bmh.Namespace+"/"+bmh.Name, "node", nodeName, "error", err)
 		}
 		return nil
@@ -483,7 +483,7 @@ func (d *HardwareDataSource) BuildResourcesForPool(ctx context.Context, poolName
 		var hwdata metal3v1alpha1.HardwareData
 		if err := d.hubClient.Get(ctx, types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}, &hwdata); err != nil {
 			if !errors.IsNotFound(err) {
-				slog.Warn("failed to get HardwareData during pool rebuild",
+				slog.WarnContext(ctx, "failed to get HardwareData during pool rebuild",
 					"bmh", bmh.Namespace+"/"+bmh.Name, "error", err)
 			}
 			hwdata = metal3v1alpha1.HardwareData{}
@@ -494,7 +494,7 @@ func (d *HardwareDataSource) BuildResourcesForPool(ctx context.Context, poolName
 		resource := d.convertResource(&resourceInfo)
 		resourceType, err := d.MakeResourceType(resource)
 		if err != nil {
-			slog.Warn("failed to make resource type during pool rebuild",
+			slog.WarnContext(ctx, "failed to make resource type during pool rebuild",
 				"bmh", bmh.Namespace+"/"+bmh.Name, "error", err)
 			continue
 		}

--- a/internal/service/resources/collector/collector_k8s.go
+++ b/internal/service/resources/collector/collector_k8s.go
@@ -206,7 +206,7 @@ func (d *K8SDataSource) convertManagedClusterToDeploymentManager(ctx context.Con
 	err := d.getKubeconfig(ctx, cluster.Name, extensions)
 	if err != nil {
 		// TODO: turn this back into an error once we fix getting the Kubeconfig for the local-cluster
-		slog.Warn("failed to get deployment manager extensions", "cluster", cluster.Name, "error", err)
+		slog.WarnContext(ctx, "failed to get deployment manager extensions", "cluster", cluster.Name, "error", err)
 	}
 
 	// Generate a unique UUID scoped to a different namespace so that it does not collide with the NodeCluster which
@@ -232,19 +232,19 @@ func (d *K8SDataSource) convertManagedClusterToDeploymentManager(ctx context.Con
 
 // handleClusterWatchEvent handles an async event received from the managed cluster watcher
 func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1.ManagedCluster, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleWatchEvent received for managed cluster", "agent", cluster.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", "agent", cluster.Name, "type", eventType)
 
 	if eventType != async.Deleted {
 		condition := meta.FindStatusCondition(cluster.Status.Conditions, "ManagedClusterConditionAvailable")
 		if condition == nil || condition.Status == metav1.ConditionFalse {
 			// This cluster is not yet available, so filter it out.
-			slog.Debug("Managed cluster is not available; skipping", "cluster", cluster.Name, "condition", condition)
+			slog.DebugContext(ctx, "Managed cluster is not available; skipping", "cluster", cluster.Name, "condition", condition)
 			return uuid.Nil, nil
 		}
 
 		if _, found := cluster.Labels[ctlrutils.ClusterTemplateArtifactsLabel]; !found {
 			// The provisioning request which is managing the installation of this cluster is not yet fulfilled
-			slog.Debug("Cluster provisioning request is not yet fulfilled; skipping", "cluster", cluster.Name)
+			slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", "cluster", cluster.Name)
 			return uuid.Nil, nil
 		}
 	}
@@ -256,7 +256,7 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing to async event channel; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing to async event channel; aborting")
 		return uuid.Nil, fmt.Errorf("context cancelled; aborting")
 	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,
@@ -268,13 +268,13 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 
 // HandleAsyncEvent handles an add/update/delete to an object received by from the Reflector.
 func (d *K8SDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleWatchEvent received for store adapter", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	slog.DebugContext(ctx, "handleWatchEvent received for store adapter", "type", eventType, "object", fmt.Sprintf("%T", obj))
 	switch value := obj.(type) {
 	case *v1.ManagedCluster:
 		return d.handleClusterWatchEvent(ctx, value, eventType)
 	default:
 		// We are only watching for specific event types so this should happen.
-		slog.Warn("Unknown object type", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type", "type", fmt.Sprintf("%T", obj))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -287,13 +287,13 @@ func (d *K8SDataSource) HandleSyncComplete(ctx context.Context, objectType runti
 		object = models.DeploymentManager{}
 	default:
 		// This should never happen since we watch for specific types
-		slog.Warn("Unknown object type", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type", "type", fmt.Sprintf("%T", objectType))
 		return nil
 	}
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing to async event channel; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing to async event channel; aborting")
 		return fmt.Errorf("context cancelled; aborting")
 	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,
@@ -313,7 +313,7 @@ func (d *K8SDataSource) Watch(ctx context.Context) error {
 	stopCh := make(chan struct{})
 	go func() {
 		<-ctx.Done()
-		slog.Info("context canceled; stopping reflectors")
+		slog.InfoContext(ctx, "context canceled; stopping reflectors")
 		close(stopCh)
 	}()
 
@@ -340,11 +340,11 @@ func (d *K8SDataSource) Watch(ctx context.Context) error {
 
 	store := async.NewReflectorStore(&v1.ManagedCluster{})
 	reflector := cache.NewNamedReflector(clusterReflectorName, &lister, &v1.ManagedCluster{}, store, time.Duration(0))
-	slog.Info("starting cluster reflector")
+	slog.InfoContext(ctx, "starting cluster reflector")
 	go reflector.Run(stopCh)
 
 	// Start monitoring the store to process incoming events
-	slog.Info("starting to receive from cluster reflector store")
+	slog.InfoContext(ctx, "starting to receive from cluster reflector store")
 	go store.Receive(ctx, d)
 
 	return nil

--- a/internal/service/resources/collector/collector_location.go
+++ b/internal/service/resources/collector/collector_location.go
@@ -90,7 +90,7 @@ func (d *LocationDataSource) Watch(ctx context.Context) error {
 	stopCh := make(chan struct{})
 	go func() {
 		<-ctx.Done()
-		slog.Info("context canceled; stopping location reflector")
+		slog.InfoContext(ctx, "context canceled; stopping location reflector")
 		close(stopCh)
 	}()
 
@@ -118,11 +118,11 @@ func (d *LocationDataSource) Watch(ctx context.Context) error {
 	// Start the Reflector
 	store := async.NewReflectorStore(&inventoryv1alpha1.Location{})
 	reflector := cache.NewNamedReflector(locationReflectorName, &lister, &inventoryv1alpha1.Location{}, store, time.Duration(0))
-	slog.Info("starting location reflector")
+	slog.InfoContext(ctx, "starting location reflector")
 	go reflector.Run(stopCh)
 
 	// Start monitoring the store to process incoming events
-	slog.Info("starting to receive from location reflector store")
+	slog.InfoContext(ctx, "starting to receive from location reflector store")
 	go store.Receive(ctx, d)
 
 	return nil
@@ -130,13 +130,13 @@ func (d *LocationDataSource) Watch(ctx context.Context) error {
 
 // HandleAsyncEvent handles an add/update/delete event received from the Reflector.
 func (d *LocationDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleAsyncEvent received for location", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	slog.DebugContext(ctx, "handleAsyncEvent received for location", "type", eventType, "object", fmt.Sprintf("%T", obj))
 
 	switch value := obj.(type) {
 	case *inventoryv1alpha1.Location:
 		return d.handleLocationWatchEvent(ctx, value, eventType)
 	default:
-		slog.Warn("Unknown object type in LocationDataSource", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type in LocationDataSource", "type", fmt.Sprintf("%T", obj))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -148,13 +148,13 @@ func (d *LocationDataSource) HandleSyncComplete(ctx context.Context, objectType 
 	case *inventoryv1alpha1.Location:
 		object = models.Location{}
 	default:
-		slog.Warn("Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
 		return nil
 	}
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing location sync complete event; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing location sync complete event; aborting")
 		return fmt.Errorf("context cancelled; aborting")
 	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,
@@ -167,12 +167,12 @@ func (d *LocationDataSource) HandleSyncComplete(ctx context.Context, objectType 
 
 // handleLocationWatchEvent handles an async event received for a Location CR
 func (d *LocationDataSource) handleLocationWatchEvent(ctx context.Context, location *inventoryv1alpha1.Location, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleLocationWatchEvent received", "name", location.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleLocationWatchEvent received", "name", location.Name, "type", eventType)
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.
 	if eventType != async.Deleted && !inventoryv1alpha1.IsResourceReady(location.Status.Conditions) {
-		slog.Debug("Location not ready, treating as deletion",
+		slog.DebugContext(ctx, "Location not ready, treating as deletion",
 			"name", location.Name,
 			"reason", inventoryv1alpha1.GetReadyReason(location.Status.Conditions))
 		eventType = async.Deleted
@@ -185,7 +185,7 @@ func (d *LocationDataSource) handleLocationWatchEvent(ctx context.Context, locat
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing to async event channel; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing to async event channel; aborting")
 		return uuid.Nil, fmt.Errorf("context cancelled; aborting")
 	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,

--- a/internal/service/resources/collector/collector_ocloudsite.go
+++ b/internal/service/resources/collector/collector_ocloudsite.go
@@ -89,7 +89,7 @@ func (d *OCloudSiteDataSource) Watch(ctx context.Context) error {
 	stopCh := make(chan struct{})
 	go func() {
 		<-ctx.Done()
-		slog.Info("context canceled; stopping ocloudsite reflector")
+		slog.InfoContext(ctx, "context canceled; stopping ocloudsite reflector")
 		close(stopCh)
 	}()
 
@@ -117,11 +117,11 @@ func (d *OCloudSiteDataSource) Watch(ctx context.Context) error {
 	// Start the Reflector
 	store := async.NewReflectorStore(&inventoryv1alpha1.OCloudSite{})
 	reflector := cache.NewNamedReflector(oCloudSiteReflectorName, &lister, &inventoryv1alpha1.OCloudSite{}, store, time.Duration(0))
-	slog.Info("starting ocloudsite reflector")
+	slog.InfoContext(ctx, "starting ocloudsite reflector")
 	go reflector.Run(stopCh)
 
 	// Start monitoring the store to process incoming events
-	slog.Info("starting to receive from ocloudsite reflector store")
+	slog.InfoContext(ctx, "starting to receive from ocloudsite reflector store")
 	go store.Receive(ctx, d)
 
 	return nil
@@ -129,13 +129,13 @@ func (d *OCloudSiteDataSource) Watch(ctx context.Context) error {
 
 // HandleAsyncEvent handles an add/update/delete event received from the Reflector.
 func (d *OCloudSiteDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleAsyncEvent received for ocloudsite", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	slog.DebugContext(ctx, "handleAsyncEvent received for ocloudsite", "type", eventType, "object", fmt.Sprintf("%T", obj))
 
 	switch value := obj.(type) {
 	case *inventoryv1alpha1.OCloudSite:
 		return d.handleOCloudSiteWatchEvent(ctx, value, eventType)
 	default:
-		slog.Warn("Unknown object type in OCloudSiteDataSource", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type in OCloudSiteDataSource", "type", fmt.Sprintf("%T", obj))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -147,13 +147,13 @@ func (d *OCloudSiteDataSource) HandleSyncComplete(ctx context.Context, objectTyp
 	case *inventoryv1alpha1.OCloudSite:
 		object = models.OCloudSite{}
 	default:
-		slog.Warn("Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
 		return nil
 	}
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing ocloudsite sync complete event; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing ocloudsite sync complete event; aborting")
 		return fmt.Errorf("context cancelled; aborting")
 	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,
@@ -166,12 +166,12 @@ func (d *OCloudSiteDataSource) HandleSyncComplete(ctx context.Context, objectTyp
 
 // handleOCloudSiteWatchEvent handles an async event received for an OCloudSite CR
 func (d *OCloudSiteDataSource) handleOCloudSiteWatchEvent(ctx context.Context, site *inventoryv1alpha1.OCloudSite, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleOCloudSiteWatchEvent received", "name", site.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleOCloudSiteWatchEvent received", "name", site.Name, "type", eventType)
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.
 	if eventType != async.Deleted && !inventoryv1alpha1.IsResourceReady(site.Status.Conditions) {
-		slog.Debug("OCloudSite not ready, treating as deletion",
+		slog.DebugContext(ctx, "OCloudSite not ready, treating as deletion",
 			"name", site.Name,
 			"reason", inventoryv1alpha1.GetReadyReason(site.Status.Conditions))
 		eventType = async.Deleted
@@ -184,7 +184,7 @@ func (d *OCloudSiteDataSource) handleOCloudSiteWatchEvent(ctx context.Context, s
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing to async event channel; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing to async event channel; aborting")
 		return uuid.Nil, fmt.Errorf("context cancelled; aborting")
 	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,

--- a/internal/service/resources/collector/collector_resourcepool.go
+++ b/internal/service/resources/collector/collector_resourcepool.go
@@ -89,7 +89,7 @@ func (d *ResourcePoolDataSource) Watch(ctx context.Context) error {
 	stopCh := make(chan struct{})
 	go func() {
 		<-ctx.Done()
-		slog.Info("context canceled; stopping resourcepool reflector")
+		slog.InfoContext(ctx, "context canceled; stopping resourcepool reflector")
 		close(stopCh)
 	}()
 
@@ -117,11 +117,11 @@ func (d *ResourcePoolDataSource) Watch(ctx context.Context) error {
 	// Start the Reflector
 	store := async.NewReflectorStore(&inventoryv1alpha1.ResourcePool{})
 	reflector := cache.NewNamedReflector(resourcePoolReflectorName, &lister, &inventoryv1alpha1.ResourcePool{}, store, time.Duration(0))
-	slog.Info("starting resourcepool reflector")
+	slog.InfoContext(ctx, "starting resourcepool reflector")
 	go reflector.Run(stopCh)
 
 	// Start monitoring the store to process incoming events
-	slog.Info("starting to receive from resourcepool reflector store")
+	slog.InfoContext(ctx, "starting to receive from resourcepool reflector store")
 	go store.Receive(ctx, d)
 
 	return nil
@@ -129,13 +129,13 @@ func (d *ResourcePoolDataSource) Watch(ctx context.Context) error {
 
 // HandleAsyncEvent handles an add/update/delete event received from the Reflector.
 func (d *ResourcePoolDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleAsyncEvent received for resourcepool", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	slog.DebugContext(ctx, "handleAsyncEvent received for resourcepool", "type", eventType, "object", fmt.Sprintf("%T", obj))
 
 	switch value := obj.(type) {
 	case *inventoryv1alpha1.ResourcePool:
 		return d.handleResourcePoolWatchEvent(ctx, value, eventType)
 	default:
-		slog.Warn("Unknown object type in ResourcePoolDataSource", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type in ResourcePoolDataSource", "type", fmt.Sprintf("%T", obj))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -147,13 +147,13 @@ func (d *ResourcePoolDataSource) HandleSyncComplete(ctx context.Context, objectT
 	case *inventoryv1alpha1.ResourcePool:
 		object = models.ResourcePool{}
 	default:
-		slog.Warn("Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
 		return nil
 	}
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing resourcepool sync complete event; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing resourcepool sync complete event; aborting")
 		return fmt.Errorf("context cancelled; aborting")
 	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,
@@ -166,12 +166,12 @@ func (d *ResourcePoolDataSource) HandleSyncComplete(ctx context.Context, objectT
 
 // handleResourcePoolWatchEvent handles an async event received for a ResourcePool CR
 func (d *ResourcePoolDataSource) handleResourcePoolWatchEvent(ctx context.Context, pool *inventoryv1alpha1.ResourcePool, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.Debug("handleResourcePoolWatchEvent received", "name", pool.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleResourcePoolWatchEvent received", "name", pool.Name, "type", eventType)
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.
 	if eventType != async.Deleted && !inventoryv1alpha1.IsResourceReady(pool.Status.Conditions) {
-		slog.Debug("ResourcePool not ready, treating as deletion",
+		slog.DebugContext(ctx, "ResourcePool not ready, treating as deletion",
 			"name", pool.Name,
 			"reason", inventoryv1alpha1.GetReadyReason(pool.Status.Conditions))
 		eventType = async.Deleted
@@ -185,7 +185,7 @@ func (d *ResourcePoolDataSource) handleResourcePoolWatchEvent(ctx context.Contex
 
 	select {
 	case <-ctx.Done():
-		slog.Info("context cancelled while writing to async event channel; aborting")
+		slog.InfoContext(ctx, "context cancelled while writing to async event channel; aborting")
 		return uuid.Nil, fmt.Errorf("context cancelled; aborting")
 	case d.AsyncChangeEvents <- &async.AsyncChangeEvent{
 		DataSourceID: d.dataSourceID,

--- a/internal/service/resources/listener/alarms_sync.go
+++ b/internal/service/resources/listener/alarms_sync.go
@@ -32,14 +32,14 @@ const (
 
 // syncAlarmDictionaryForResourceType syncs the alarm dictionary for a specific resource type
 func syncAlarmDictionaryForResourceType(ctx context.Context, repository *repo.ResourcesRepository, resourceTypeID uuid.UUID) error {
-	slog.Info("Syncing alarm dictionary for resource type", "resource_type_id", resourceTypeID)
+	slog.InfoContext(ctx, "Syncing alarm dictionary for resource type", "resource_type_id", resourceTypeID)
 
 	// Get the resource type
 	resourceType, err := repository.GetResourceType(ctx, resourceTypeID)
 	if err != nil {
 		if errors.Is(err, svcutils.ErrNotFound) {
 			// Resource type was deleted, alarm dictionary will be cascade deleted
-			slog.Info("Resource type not found, skipping alarm dictionary sync",
+			slog.InfoContext(ctx, "Resource type not found, skipping alarm dictionary sync",
 				"resource_type_id", resourceTypeID)
 			return nil
 		}
@@ -77,7 +77,7 @@ func syncAlarmDictionaryForResourceType(ctx context.Context, repository *repo.Re
 			return fmt.Errorf("failed to upsert alarm definitions: %w", err)
 		}
 
-		slog.Info("Successfully synced alarm dictionary", "resource_type_id",
+		slog.InfoContext(ctx, "Successfully synced alarm dictionary", "resource_type_id",
 			resourceTypeID, "alarm_dict_id", result.AlarmDictionaryID, "definitions_count", len(alarmDefs))
 		return nil
 	}); err != nil {
@@ -114,7 +114,7 @@ func getIronicPrometheusRules(ctx context.Context, cl client.Client) ([]monitori
 		}
 	}
 
-	slog.Info("Fetched hardware monitoring Prometheus rules", "count", len(rules))
+	slog.InfoContext(ctx, "Fetched hardware monitoring Prometheus rules", "count", len(rules))
 	return rules, nil
 }
 

--- a/internal/service/resources/listener/pg_listener.go
+++ b/internal/service/resources/listener/pg_listener.go
@@ -31,12 +31,12 @@ type ResourceTypeChangeNotification struct {
 // The onResourceTypeChanged callback is invoked whenever a resource_type_changed notification
 // is received or the periodic catch-up sync runs, allowing callers to invalidate caches.
 func ListenForResourcePgChannels(ctx context.Context, pool *pgxpool.Pool, repository *repo.ResourcesRepository, onResourceTypeChanged func()) {
-	slog.Info("Starting PostgreSQL listener for resource server")
+	slog.InfoContext(ctx, "Starting PostgreSQL listener for resource server")
 
 	// Sync existing ResourceTypes on startup to handle any that were created before listener started
 	// This prevents race condition where collector creates ResourceTypes before listener is ready
 	if err := syncExistingResourceTypes(ctx, repository); err != nil {
-		slog.Error("Failed to sync existing resource types on startup", "error", err)
+		slog.ErrorContext(ctx, "Failed to sync existing resource types on startup", "error", err)
 	}
 
 	// Initialize the generic listener manager
@@ -71,13 +71,13 @@ func ListenForResourcePgChannels(ctx context.Context, pool *pgxpool.Pool, reposi
 
 	// Block until the context is canceled
 	<-ctx.Done()
-	slog.Info("PostgreSQL listener for resource server shutting down")
+	slog.InfoContext(ctx, "PostgreSQL listener for resource server shutting down")
 	lm.Wait()
 }
 
 // processResourceTypeChangeNotification handles resource_type_changed notifications
 func processResourceTypeChangeNotification(ctx context.Context, repository *repo.ResourcesRepository, pgNotification *pgconn.Notification) error {
-	slog.Debug("Received resource_type_changed notification")
+	slog.DebugContext(ctx, "Received resource_type_changed notification")
 
 	// Parse the notification payload
 	var notification ResourceTypeChangeNotification
@@ -85,7 +85,7 @@ func processResourceTypeChangeNotification(ctx context.Context, repository *repo
 		return fmt.Errorf("failed to unmarshal resource_type_changed notification: %w", err)
 	}
 
-	slog.Info("Processing resource type change",
+	slog.InfoContext(ctx, "Processing resource type change",
 		"resource_type_id", notification.ResourceTypeID,
 		"change_type", notification.ChangeType)
 
@@ -93,14 +93,14 @@ func processResourceTypeChangeNotification(ctx context.Context, repository *repo
 	switch notification.ChangeType {
 	case "deleted":
 		// CASCADE delete in the database schema handles alarm dictionary cleanup
-		slog.Info("Resource type deleted, alarm dictionary will be cascade deleted",
+		slog.InfoContext(ctx, "Resource type deleted, alarm dictionary will be cascade deleted",
 			"resource_type_id", notification.ResourceTypeID)
 		return nil
 
 	case "created", "updated":
 		// Sync alarm dictionary for this resource type
 		if err := syncAlarmDictionaryForResourceType(ctx, repository, notification.ResourceTypeID); err != nil {
-			slog.Error("Failed to sync alarm dictionary for resource type",
+			slog.ErrorContext(ctx, "Failed to sync alarm dictionary for resource type",
 				"resource_type_id", notification.ResourceTypeID,
 				"error", err)
 			return fmt.Errorf("failed to sync alarm dictionary: %w", err)
@@ -108,7 +108,7 @@ func processResourceTypeChangeNotification(ctx context.Context, repository *repo
 		return nil
 
 	default:
-		slog.Warn("Unknown resource type change type", "change_type", notification.ChangeType)
+		slog.WarnContext(ctx, "Unknown resource type change type", "change_type", notification.ChangeType)
 		return nil
 	}
 }
@@ -116,24 +116,24 @@ func processResourceTypeChangeNotification(ctx context.Context, repository *repo
 // syncExistingResourceTypes syncs alarm dictionaries for all existing resource types
 // Called on startup and periodically (every 15min) to handle missed notifications or failures
 func syncExistingResourceTypes(ctx context.Context, repository *repo.ResourcesRepository) error {
-	slog.Debug("Syncing alarm dictionaries for existing resource types")
+	slog.DebugContext(ctx, "Syncing alarm dictionaries for existing resource types")
 
 	resourceTypes, err := repository.GetResourceTypes(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get resource types: %w", err)
 	}
 
-	slog.Debug("Found existing resource types", "count", len(resourceTypes))
+	slog.DebugContext(ctx, "Found existing resource types", "count", len(resourceTypes))
 
 	for _, rt := range resourceTypes {
 		if err := syncAlarmDictionaryForResourceType(ctx, repository, rt.ResourceTypeID); err != nil {
-			slog.Error("Failed to sync alarm dictionary for existing resource type",
+			slog.ErrorContext(ctx, "Failed to sync alarm dictionary for existing resource type",
 				"resource_type_id", rt.ResourceTypeID,
 				"error", err)
 			// Continue with other resource types even if one fails
 		}
 	}
 
-	slog.Debug("Completed sync of existing resource types", "count", len(resourceTypes))
+	slog.DebugContext(ctx, "Completed sync of existing resource types", "count", len(resourceTypes))
 	return nil
 }

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -74,7 +74,7 @@ func Serve(config *api.ResourceServerConfig) error {
 
 	go func() {
 		sig := <-shutdown
-		slog.Info("Shutdown signal received", "signal", sig)
+		slog.InfoContext(ctx, "Shutdown signal received", "signal", sig)
 		cancel()
 	}()
 
@@ -89,7 +89,7 @@ func Serve(config *api.ResourceServerConfig) error {
 		return fmt.Errorf("failed to connected to DB: %w", err)
 	}
 	defer func() {
-		slog.Info("Closing DB connection")
+		slog.InfoContext(ctx, "Closing DB connection")
 		pool.Close()
 	}()
 
@@ -256,7 +256,7 @@ func Serve(config *api.ResourceServerConfig) error {
 	// Start resource notifier
 	notifierErrors := make(chan error, 1)
 	go func() {
-		slog.Info("Starting resource notifier")
+		slog.InfoContext(ctx, "Starting resource notifier")
 		if err := resourceNotifier.Run(ctx); err != nil {
 			notifierErrors <- err
 		}
@@ -265,7 +265,7 @@ func Serve(config *api.ResourceServerConfig) error {
 	// Start resource collector
 	collectorErrors := make(chan error, 1)
 	go func() {
-		slog.Info("Starting resource collector")
+		slog.InfoContext(ctx, "Starting resource collector")
 		if err := resourceCollector.Run(ctx); err != nil {
 			collectorErrors <- err
 		}
@@ -273,15 +273,15 @@ func Serve(config *api.ResourceServerConfig) error {
 
 	// Start PostgreSQL listener for resource type changes
 	go func() {
-		slog.Info("Starting PostgreSQL listener for resource type changes")
+		slog.InfoContext(ctx, "Starting PostgreSQL listener for resource type changes")
 		listener.ListenForResourcePgChannels(ctx, pool, repository, server.InvalidateAlarmDictCache)
-		slog.Info("PostgreSQL listener stopped")
+		slog.InfoContext(ctx, "PostgreSQL listener stopped")
 	}()
 
 	// Start server
 	serverErrors := make(chan error, 1)
 	go func() {
-		slog.Info(fmt.Sprintf("Listening on %s", srv.Addr))
+		slog.InfoContext(ctx, fmt.Sprintf("Listening on %s", srv.Addr))
 		// Cert/Key files aren't needed here since they've been added to the tls.Config above.
 		if err := srv.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErrors <- err
@@ -292,9 +292,9 @@ func Serve(config *api.ResourceServerConfig) error {
 		// Cancel the context in case it wasn't already canceled
 		cancel()
 		// Shutdown the http server
-		slog.Info("Shutting down server")
+		slog.InfoContext(ctx, "Shutting down server")
 		if err := common.GracefulShutdown(srv); err != nil {
-			slog.Error("error shutting down server", "error", err)
+			slog.ErrorContext(ctx, "error shutting down server", "error", err)
 		}
 	}()
 
@@ -307,7 +307,7 @@ func Serve(config *api.ResourceServerConfig) error {
 	case err := <-notifierErrors:
 		return fmt.Errorf("error starting notifier: %w", err)
 	case <-ctx.Done():
-		slog.Info("Process shutting down")
+		slog.InfoContext(ctx, "Process shutting down")
 	}
 
 	return nil


### PR DESCRIPTION
Convert 360+ direct slog.Info/Error/Warn/Debug calls to their context-aware equivalents (slog.InfoContext/ErrorContext/etc.) across the service layer, controllers, and hardware manager. This enables context attribute extraction once LoggingContextHandler is wired in (Phase 1, PR #2690).

Add sloglint context=scope check to .golangci.yml to enforce context variants wherever a ctx variable is in scope, preventing regression. Add logging convention to AGENTS.md for AI code review tools.

~80 calls remain unconverted where no ctx variable is available (Cobra command handlers, init functions, helpers without context parameters). These will be addressed in Phase 3 when context is threaded through to those locations.