### PR TITLE
CNF-22111: remove skipRange for release-4.22 (no upgrade from <4.22)

### DIFF
--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -9,14 +9,12 @@ entries:
     # Channel entries for 'stable' channel
   - entries:
       - name: o-cloud-manager.v4.22.0
-        skipRange: '>=4.21.0 <4.23.0'
     name: stable
     package: o-cloud-manager
     schema: olm.channel
     # Channel entries for '4.22' channel
   - entries:
       - name: o-cloud-manager.v4.22.0
-        skipRange: '>=4.21.0 <4.23.0'
     name: "4.22"
     package: o-cloud-manager
     schema: olm.channel


### PR DESCRIPTION
There is no supported operator upgrade from <4.22 to 4.22+. Remove skipRange from both stable and 4.22 channel entries so that no automatic upgrade path exists from older versions.

Assisted-By: Claude (Anthropic)