### PR TITLE
Ignore forge directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage/
 # AI agents
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Forge SDLC
+.forge/


### PR DESCRIPTION
Forge writes files in the .forge directory to pass information between the worker and runner processes.  These files need to be ignored by git.  Forge has code to automatically exclude it but it appears to be flaky so using this as a more reliable mechanism.