### PR TITLE
CNF-24288: add context enrichment and fix log quality issues (Phase 3)

### DIFF
--- a/internal/controllers/utils/integration_test.go
+++ b/internal/controllers/utils/integration_test.go
@@ -95,7 +95,6 @@ func TestControllerLoggingIntegration(t *testing.T) {
 	expectedContext := map[string]interface{}{
 		// From LogReconcileStart
 		LogAttrResource:  "ClusterTemplate",
-		"name":           "my-cluster-template",
 		LogAttrNamespace: "test-namespace",
 		LogAttrAction:    "reconcile_start",
 

--- a/internal/controllers/utils/logging.go
+++ b/internal/controllers/utils/logging.go
@@ -36,7 +36,6 @@ const (
 // LogReconcileStart adds standard reconciliation context and logs start message
 func LogReconcileStart(ctx context.Context, logger *slog.Logger, req ctrl.Request, resourceType string) context.Context {
 	ctx = logging.AppendCtx(ctx, slog.String(LogAttrResource, resourceType))
-	ctx = logging.AppendCtx(ctx, slog.String("name", req.Name))
 	ctx = logging.AppendCtx(ctx, slog.String(LogAttrNamespace, req.Namespace))
 	ctx = logging.AppendCtx(ctx, slog.String(LogAttrAction, "reconcile_start"))
 

--- a/internal/controllers/utils/logging_test.go
+++ b/internal/controllers/utils/logging_test.go
@@ -78,7 +78,6 @@ func TestLogReconcileStart(t *testing.T) {
 	// Check that our context attributes are present
 	expectedAttrs := map[string]interface{}{
 		LogAttrResource:  "TestResource",
-		"name":           "test-resource",
 		LogAttrNamespace: "test-namespace",
 		LogAttrAction:    "reconcile_start",
 	}

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -402,7 +402,6 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestSpecChanged
 			hwmgmtv1alpha1.Configured, hwmgmtv1alpha1.ConditionReason(reason), status, message); updateErr != nil {
 
 			r.Logger.ErrorContext(ctx, "Failed to update aggregated NodeAllocationRequest status",
-				slog.String("NodeAllocationRequest", nodeAllocationRequest.Name),
 				slog.String("error", updateErr.Error()))
 
 			if err == nil {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -63,18 +63,25 @@ func NewContextHandler(base slog.Handler, level slog.Level) *LoggingContextHandl
 }
 
 // AppendCtx adds an slog attribute to the provided context so that it will be
-// included in any Record created with such context
+// included in any Record created with such context. If an attribute with the
+// same key already exists, it is replaced rather than duplicated.
 func AppendCtx(ctx context.Context, attr slog.Attr) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
 	if v, ok := ctx.Value(slogFields).([]slog.Attr); ok {
-		v = append(v, attr)
-		return context.WithValue(ctx, slogFields, v)
+		newV := make([]slog.Attr, len(v))
+		copy(newV, v)
+		for i, existing := range newV {
+			if existing.Key == attr.Key {
+				newV[i] = attr
+				return context.WithValue(ctx, slogFields, newV)
+			}
+		}
+		newV = append(newV, attr)
+		return context.WithValue(ctx, slogFields, newV)
 	}
 
-	v := []slog.Attr{}
-	v = append(v, attr)
-	return context.WithValue(ctx, slogFields, v)
+	return context.WithValue(ctx, slogFields, []slog.Attr{attr})
 }

--- a/internal/service/alarms/api/server.go
+++ b/internal/service/alarms/api/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	api "github.com/openshift-kni/oran-o2ims/internal/service/alarms/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/alertmanager"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/db/models"
@@ -121,6 +122,10 @@ func (a *AlarmsServer) GetSubscriptions(ctx context.Context, request api.GetSubs
 
 // CreateSubscription handles an API request to create an Alarm Subscription
 func (a *AlarmsServer) CreateSubscription(ctx context.Context, request api.CreateSubscriptionRequestObject) (api.CreateSubscriptionResponseObject, error) {
+	if request.Body.ConsumerSubscriptionId != nil {
+		ctx = logging.AppendCtx(ctx, slog.String("consumerSubscriptionId", request.Body.ConsumerSubscriptionId.String()))
+	}
+
 	// Block API if GlobalCloudID is not set
 	if a.GlobalCloudID == uuid.Nil {
 		return api.CreateSubscription409ApplicationProblemPlusJSONResponse(common.ProblemDetails{
@@ -163,6 +168,8 @@ func (a *AlarmsServer) CreateSubscription(ctx context.Context, request api.Creat
 
 // DeleteSubscription handles an API request to delete an Alarm Subscription
 func (a *AlarmsServer) DeleteSubscription(ctx context.Context, request api.DeleteSubscriptionRequestObject) (api.DeleteSubscriptionResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("alarmSubscriptionId", request.AlarmSubscriptionId.String()))
+
 	count, err := a.AlarmsRepository.DeleteAlarmSubscription(ctx, request.AlarmSubscriptionId)
 	if err != nil {
 		return api.DeleteSubscription500ApplicationProblemPlusJSONResponse(common.ProblemDetails{
@@ -190,12 +197,14 @@ func (a *AlarmsServer) DeleteSubscription(ctx context.Context, request api.Delet
 		Removed:      true,
 		Subscription: models.ConvertAlertSubToNotificationSub(&models.AlarmSubscription{SubscriptionID: request.AlarmSubscriptionId}),
 	})
-	slog.InfoContext(ctx, "Successfully deleted Alarm Subscription", "alarmSubscriptionId", request.AlarmSubscriptionId.String())
+	slog.InfoContext(ctx, "Successfully deleted Alarm Subscription")
 	return api.DeleteSubscription200Response{}, nil
 }
 
 // GetSubscription handles an API request to retrieve an Alarm Subscription
 func (a *AlarmsServer) GetSubscription(ctx context.Context, request api.GetSubscriptionRequestObject) (api.GetSubscriptionResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("alarmSubscriptionId", request.AlarmSubscriptionId.String()))
+
 	record, err := a.AlarmsRepository.GetAlarmSubscription(ctx, request.AlarmSubscriptionId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		return api.GetSubscription404ApplicationProblemPlusJSONResponse(common.ProblemDetails{
@@ -238,6 +247,8 @@ func (a *AlarmsServer) GetAlarms(ctx context.Context, request api.GetAlarmsReque
 
 // GetAlarm handles an API request to retrieve an Alarm Event Record
 func (a *AlarmsServer) GetAlarm(ctx context.Context, request api.GetAlarmRequestObject) (api.GetAlarmResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("alarmEventRecordId", request.AlarmEventRecordId.String()))
+
 	record, err := a.AlarmsRepository.GetAlarmEventRecord(ctx, request.AlarmEventRecordId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		// Nothing found
@@ -258,6 +269,8 @@ func (a *AlarmsServer) GetAlarm(ctx context.Context, request api.GetAlarmRequest
 
 // PatchAlarm handles an API request to patch an Alarm Event Record
 func (a *AlarmsServer) PatchAlarm(ctx context.Context, request api.PatchAlarmRequestObject) (api.PatchAlarmResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("alarmEventRecordId", request.AlarmEventRecordId.String()))
+
 	// Fetch the Alarm Event Record to be patched
 	record, err := a.AlarmsRepository.GetAlarmEventRecord(ctx, request.AlarmEventRecordId)
 	if errors.Is(err, svcutils.ErrNotFound) {
@@ -366,7 +379,7 @@ func (a *AlarmsServer) PatchAlarm(ctx context.Context, request api.PatchAlarmReq
 		return nil, fmt.Errorf("failed to patch Alarm Event Record: %w", err)
 	}
 
-	slog.DebugContext(ctx, "Alarm acknowledged/cleared", "alarmEventRecordId", updated.AlarmEventRecordID, "alarmAcknowledged", updated.AlarmAcknowledged, "alarmAcknowledgedTime", updated.AlarmAcknowledgedTime,
+	slog.DebugContext(ctx, "Alarm acknowledged/cleared", "alarmAcknowledged", updated.AlarmAcknowledged, "alarmAcknowledgedTime", updated.AlarmAcknowledgedTime,
 		"alarmClearedTime", updated.AlarmClearedTime, "perceivedSeverity", updated.PerceivedSeverity, "alarmChangedTime", updated.AlarmChangedTime)
 
 	return api.PatchAlarm200JSONResponse{AlarmAcknowledged: request.Body.AlarmAcknowledged, PerceivedSeverity: request.Body.PerceivedSeverity}, nil

--- a/internal/service/alarms/api/server_test.go
+++ b/internal/service/alarms/api/server_test.go
@@ -67,7 +67,7 @@ var _ = Describe("AlarmsServer", func() {
 		When("alarm not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					GetAlarmEventRecord(ctx, testUUID).
+					GetAlarmEventRecord(gomock.Any(), testUUID).
 					Return(nil, svcutils.ErrNotFound)
 
 				resp, err := server.GetAlarm(ctx, alarmapi.GetAlarmRequestObject{
@@ -83,7 +83,7 @@ var _ = Describe("AlarmsServer", func() {
 		When("alarm is found", func() {
 			It("returns 200 response with alarm", func() {
 				mockRepo.EXPECT().
-					GetAlarmEventRecord(ctx, testUUID).
+					GetAlarmEventRecord(gomock.Any(), testUUID).
 					Return(&models.AlarmEventRecord{AlarmEventRecordID: testUUID}, nil)
 
 				resp, err := server.GetAlarm(ctx, alarmapi.GetAlarmRequestObject{
@@ -98,7 +98,7 @@ var _ = Describe("AlarmsServer", func() {
 		When("repository is unavailable", func() {
 			It("returns error", func() {
 				mockRepo.EXPECT().
-					GetAlarmEventRecord(ctx, testUUID).
+					GetAlarmEventRecord(gomock.Any(), testUUID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetAlarm(ctx, alarmapi.GetAlarmRequestObject{
@@ -184,7 +184,7 @@ var _ = Describe("AlarmsServer", func() {
 				}
 
 				mockRepo.EXPECT().
-					CreateAlarmSubscription(ctx, gomock.Any()).
+					CreateAlarmSubscription(gomock.Any(), gomock.Any()).
 					Return(nil, &pgconn.PgError{Code: "23505", ConstraintName: "unique_callback"})
 
 				resp, err := server.CreateSubscription(ctx, alarmapi.CreateSubscriptionRequestObject{

--- a/internal/service/artifacts/api/server.go
+++ b/internal/service/artifacts/api/server.go
@@ -10,12 +10,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/google/uuid"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -107,6 +109,7 @@ func (r *ArtifactsServer) GetManagedInfrastructureTemplates(
 // (GET /o2ims-infrastructureArtifacts/v1/managedInfrastructureTemplates/{managedInfrastructureTemplateId})
 func (r *ArtifactsServer) GetManagedInfrastructureTemplate(
 	ctx context.Context, request api.GetManagedInfrastructureTemplateRequestObject) (api.GetManagedInfrastructureTemplateResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("managedInfrastructureTemplateId", request.ManagedInfrastructureTemplateId))
 
 	clusterTemplatesItems, err := getClusterTemplateById(ctx, r.HubClient, request.ManagedInfrastructureTemplateId)
 	if err != nil {
@@ -137,6 +140,7 @@ func (r *ArtifactsServer) GetManagedInfrastructureTemplate(
 func (r *ArtifactsServer) GetManagedInfrastructureTemplateDefaults(
 	ctx context.Context,
 	request api.GetManagedInfrastructureTemplateDefaultsRequestObject) (api.GetManagedInfrastructureTemplateDefaultsResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("managedInfrastructureTemplateId", request.ManagedInfrastructureTemplateId))
 
 	clusterTemplatesItems, err := getClusterTemplateById(ctx, r.HubClient, request.ManagedInfrastructureTemplateId)
 	if err != nil {

--- a/internal/service/cluster/api/server.go
+++ b/internal/service/cluster/api/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	api "github.com/openshift-kni/oran-o2ims/internal/service/cluster/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/repo"
@@ -120,6 +121,8 @@ func (r *ClusterServer) GetClusterResourceTypes(ctx context.Context, request api
 
 // GetClusterResourceType receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ClusterServer) GetClusterResourceType(ctx context.Context, request api.GetClusterResourceTypeRequestObject) (api.GetClusterResourceTypeResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("clusterResourceTypeId", request.ClusterResourceTypeId.String()))
+
 	record, err := r.Repo.GetClusterResourceType(ctx, request.ClusterResourceTypeId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		return api.GetClusterResourceType404ApplicationProblemPlusJSONResponse{
@@ -168,6 +171,8 @@ func (r *ClusterServer) GetClusterResources(ctx context.Context, request api.Get
 
 // GetClusterResource receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ClusterServer) GetClusterResource(ctx context.Context, request api.GetClusterResourceRequestObject) (api.GetClusterResourceResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("clusterResourceId", request.ClusterResourceId.String()))
+
 	record, err := r.Repo.GetClusterResource(ctx, request.ClusterResourceId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		return api.GetClusterResource404ApplicationProblemPlusJSONResponse{
@@ -216,6 +221,8 @@ func (r *ClusterServer) GetNodeClusterTypes(ctx context.Context, request api.Get
 
 // GetNodeClusterType receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ClusterServer) GetNodeClusterType(ctx context.Context, request api.GetNodeClusterTypeRequestObject) (api.GetNodeClusterTypeResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("nodeClusterTypeId", request.NodeClusterTypeId.String()))
+
 	record, err := r.Repo.GetNodeClusterType(ctx, request.NodeClusterTypeId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		return api.GetNodeClusterType404ApplicationProblemPlusJSONResponse{
@@ -241,6 +248,8 @@ func (r *ClusterServer) GetNodeClusterType(ctx context.Context, request api.GetN
 
 // GetNodeClusterTypeAlarmDictionary receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ClusterServer) GetNodeClusterTypeAlarmDictionary(ctx context.Context, request api.GetNodeClusterTypeAlarmDictionaryRequestObject) (api.GetNodeClusterTypeAlarmDictionaryResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("nodeClusterTypeId", request.NodeClusterTypeId.String()))
+
 	data, err := r.AlarmDicts.Get(ctx)
 	if err != nil {
 		return api.GetNodeClusterTypeAlarmDictionary500ApplicationProblemPlusJSONResponse{
@@ -304,6 +313,8 @@ func (r *ClusterServer) GetNodeClusters(ctx context.Context, request api.GetNode
 
 // GetNodeCluster receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ClusterServer) GetNodeCluster(ctx context.Context, request api.GetNodeClusterRequestObject) (api.GetNodeClusterResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("nodeClusterId", request.NodeClusterId.String()))
+
 	record, err := r.Repo.GetNodeCluster(ctx, request.NodeClusterId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		return api.GetNodeCluster404ApplicationProblemPlusJSONResponse{
@@ -414,6 +425,10 @@ func (r *ClusterServer) validateSubscription(ctx context.Context, request api.Cr
 
 // CreateSubscription receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ClusterServer) CreateSubscription(ctx context.Context, request api.CreateSubscriptionRequestObject) (api.CreateSubscriptionResponseObject, error) {
+	if request.Body.ConsumerSubscriptionId != nil {
+		ctx = logging.AppendCtx(ctx, slog.String("consumerSubscriptionId", request.Body.ConsumerSubscriptionId.String()))
+	}
+
 	consumerSubscriptionId := "<null>"
 	if request.Body.ConsumerSubscriptionId != nil {
 		consumerSubscriptionId = request.Body.ConsumerSubscriptionId.String()
@@ -471,6 +486,8 @@ func (r *ClusterServer) CreateSubscription(ctx context.Context, request api.Crea
 
 // GetSubscription receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ClusterServer) GetSubscription(ctx context.Context, request api.GetSubscriptionRequestObject) (api.GetSubscriptionResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("subscriptionId", request.SubscriptionId.String()))
+
 	record, err := r.Repo.GetSubscription(ctx, request.SubscriptionId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		return api.GetSubscription404ApplicationProblemPlusJSONResponse{
@@ -496,6 +513,8 @@ func (r *ClusterServer) GetSubscription(ctx context.Context, request api.GetSubs
 
 // DeleteSubscription receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ClusterServer) DeleteSubscription(ctx context.Context, request api.DeleteSubscriptionRequestObject) (api.DeleteSubscriptionResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("subscriptionId", request.SubscriptionId.String()))
+
 	count, err := r.Repo.DeleteSubscription(ctx, request.SubscriptionId)
 	if err != nil {
 		return api.DeleteSubscription500ApplicationProblemPlusJSONResponse{
@@ -543,6 +562,8 @@ func (r *ClusterServer) GetAlarmDictionaries(ctx context.Context, _ api.GetAlarm
 
 // GetAlarmDictionary receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ClusterServer) GetAlarmDictionary(ctx context.Context, request api.GetAlarmDictionaryRequestObject) (api.GetAlarmDictionaryResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("alarmDictionaryId", request.AlarmDictionaryId.String()))
+
 	data, err := r.AlarmDicts.Get(ctx)
 	if err != nil {
 		return api.GetAlarmDictionary500ApplicationProblemPlusJSONResponse{

--- a/internal/service/cluster/api/server_test.go
+++ b/internal/service/cluster/api/server_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Cluster Server", func() {
 		When("cache loading fails", func() {
 			It("returns internal server error", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetNodeClusterTypeAlarmDictionary(ctx, apigenerated.GetNodeClusterTypeAlarmDictionaryRequestObject{
@@ -83,10 +83,10 @@ var _ = Describe("Cluster Server", func() {
 		When("node cluster type not found in cache", func() {
 			It("returns 404 not found response", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{}, nil)
 				mockRepo.EXPECT().
-					GetThanosAlarmDefinitions(ctx).
+					GetThanosAlarmDefinitions(gomock.Any()).
 					Return([]models.AlarmDefinition{}, nil)
 
 				resp, err := server.GetNodeClusterTypeAlarmDictionary(ctx, apigenerated.GetNodeClusterTypeAlarmDictionaryRequestObject{
@@ -103,13 +103,13 @@ var _ = Describe("Cluster Server", func() {
 			It("returns 200 OK", func() {
 				dictID := uuid.New()
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{{AlarmDictionaryID: dictID, NodeClusterTypeID: testUUID}}, nil)
 				mockRepo.EXPECT().
-					GetThanosAlarmDefinitions(ctx).
+					GetThanosAlarmDefinitions(gomock.Any()).
 					Return([]models.AlarmDefinition{}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID).
 					Return([]models.AlarmDefinition{}, nil)
 
 				resp, err := server.GetNodeClusterTypeAlarmDictionary(ctx, apigenerated.GetNodeClusterTypeAlarmDictionaryRequestObject{
@@ -127,13 +127,13 @@ var _ = Describe("Cluster Server", func() {
 		It("returns 500 when alarm definitions query fails during cache load", func() {
 			dictID := uuid.New()
 			mockRepo.EXPECT().
-				GetAlarmDictionaries(ctx).
+				GetAlarmDictionaries(gomock.Any()).
 				Return([]models.AlarmDictionary{{AlarmDictionaryID: dictID}}, nil)
 			mockRepo.EXPECT().
-				GetThanosAlarmDefinitions(ctx).
+				GetThanosAlarmDefinitions(gomock.Any()).
 				Return([]models.AlarmDefinition{}, nil)
 			mockRepo.EXPECT().
-				GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID).
+				GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID).
 				Return(nil, fmt.Errorf("definitions query failed"))
 
 			resp, err := server.GetAlarmDictionaries(ctx, apigenerated.GetAlarmDictionariesRequestObject{})
@@ -147,7 +147,7 @@ var _ = Describe("Cluster Server", func() {
 		When("cache loading fails", func() {
 			It("returns internal server error", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetAlarmDictionaries(ctx, apigenerated.GetAlarmDictionariesRequestObject{})
@@ -160,10 +160,10 @@ var _ = Describe("Cluster Server", func() {
 		When("repository does not have alarm dictionaries", func() {
 			It("returns 200 OK empty list", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{}, nil)
 				mockRepo.EXPECT().
-					GetThanosAlarmDefinitions(ctx).
+					GetThanosAlarmDefinitions(gomock.Any()).
 					Return([]models.AlarmDefinition{}, nil)
 
 				resp, err := server.GetAlarmDictionaries(ctx, apigenerated.GetAlarmDictionariesRequestObject{})
@@ -179,7 +179,7 @@ var _ = Describe("Cluster Server", func() {
 
 			It("returns 200 OK", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{
 						{
 							AlarmDictionaryID: testUUID,
@@ -187,11 +187,11 @@ var _ = Describe("Cluster Server", func() {
 					}, nil)
 
 				mockRepo.EXPECT().
-					GetThanosAlarmDefinitions(ctx).
+					GetThanosAlarmDefinitions(gomock.Any()).
 					Return([]models.AlarmDefinition{}, nil)
 
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, testUUID).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), testUUID).
 					Return([]models.AlarmDefinition{
 						{
 							AlarmDefinitionID: alarmDefinitionUUID,
@@ -212,10 +212,10 @@ var _ = Describe("Cluster Server", func() {
 		When("GetThanosAlarmDefinitions returns error", func() {
 			It("returns 500 internal server error", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{}, nil)
 				mockRepo.EXPECT().
-					GetThanosAlarmDefinitions(ctx).
+					GetThanosAlarmDefinitions(gomock.Any()).
 					Return(nil, fmt.Errorf("thanos db error"))
 
 				resp, err := server.GetAlarmDictionaries(ctx, apigenerated.GetAlarmDictionariesRequestObject{})
@@ -231,7 +231,7 @@ var _ = Describe("Cluster Server", func() {
 		When("cache loading fails", func() {
 			It("returns internal server error", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetAlarmDictionary(ctx, apigenerated.GetAlarmDictionaryRequestObject{
@@ -247,10 +247,10 @@ var _ = Describe("Cluster Server", func() {
 		When("alarm dictionary not found in cache", func() {
 			It("returns 404 not found response", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{}, nil)
 				mockRepo.EXPECT().
-					GetThanosAlarmDefinitions(ctx).
+					GetThanosAlarmDefinitions(gomock.Any()).
 					Return([]models.AlarmDefinition{}, nil)
 
 				resp, err := server.GetAlarmDictionary(ctx, apigenerated.GetAlarmDictionaryRequestObject{
@@ -268,13 +268,13 @@ var _ = Describe("Cluster Server", func() {
 
 			It("returns 200 OK", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{{AlarmDictionaryID: testUUID}}, nil)
 				mockRepo.EXPECT().
-					GetThanosAlarmDefinitions(ctx).
+					GetThanosAlarmDefinitions(gomock.Any()).
 					Return([]models.AlarmDefinition{}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, testUUID).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), testUUID).
 					Return([]models.AlarmDefinition{{AlarmDefinitionID: alarmDefinitionUUID}}, nil)
 
 				resp, err := server.GetAlarmDictionary(ctx, apigenerated.GetAlarmDictionaryRequestObject{
@@ -294,15 +294,15 @@ var _ = Describe("Cluster Server", func() {
 				thanosDefUUID := uuid.New()
 
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{{AlarmDictionaryID: testUUID}}, nil)
 				mockRepo.EXPECT().
-					GetThanosAlarmDefinitions(ctx).
+					GetThanosAlarmDefinitions(gomock.Any()).
 					Return([]models.AlarmDefinition{
 						{AlarmDefinitionID: thanosDefUUID, AlarmName: "ViolatedPolicyReport"},
 					}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, testUUID).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), testUUID).
 					Return([]models.AlarmDefinition{
 						{AlarmDefinitionID: dictDefUUID},
 					}, nil)
@@ -379,7 +379,7 @@ var _ = Describe("Cluster Server", func() {
 				}
 
 				mockRepo.EXPECT().
-					CreateSubscription(ctx, gomock.Any()).
+					CreateSubscription(gomock.Any(), gomock.Any()).
 					Return(nil, fmt.Errorf("unique_callback constraint violation"))
 
 				resp, err := server.CreateSubscription(ctx, apigenerated.CreateSubscriptionRequestObject{

--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/repo"
 	commonapi "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
@@ -501,6 +502,8 @@ func (c *Collector) deleteRelatedClusterResources(ctx context.Context, nodeClust
 
 // handleAsyncNodeClusterEvent handles an async handleWatchEvent received for a NodeCluster object.
 func (c *Collector) handleAsyncNodeClusterEvent(ctx context.Context, dataSource ClusterDataSource, nodeCluster models.NodeCluster, deleted bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("nodeClusterID", nodeCluster.NodeClusterID.String()))
+	ctx = logging.AppendCtx(ctx, slog.Bool("deleted", deleted))
 	if deleted {
 		// Handle the NodeCluster deletion, but first delete all subtending ClusterResources
 		if err := c.deleteRelatedClusterResources(ctx, nodeCluster); err != nil {
@@ -540,6 +543,8 @@ func (c *Collector) handleAsyncNodeClusterEvent(ctx context.Context, dataSource 
 
 // handleAsyncClusterResourceEvent handles an async handleWatchEvent received for a ClusterResource object.
 func (c *Collector) handleAsyncClusterResourceEvent(ctx context.Context, dataSource ClusterDataSource, clusterResource models.ClusterResource, deleted bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("clusterResourceID", clusterResource.ClusterResourceID.String()))
+	ctx = logging.AppendCtx(ctx, slog.Bool("deleted", deleted))
 	if deleted {
 		dataChangeEvent, err := svcutils.DeleteObjectWithChangeEvent(
 			ctx, c.pool, clusterResource, clusterResource.ClusterResourceID, nil, func(object interface{}) any {

--- a/internal/service/common/api/middleware/middleware.go
+++ b/internal/service/common/api/middleware/middleware.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	oapimiddleware "github.com/oapi-codegen/nethttp-middleware"
 	hwmgrcontroller "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/controller"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 )
 
 type Middleware = func(http.Handler) http.Handler
@@ -50,11 +51,16 @@ func LogDuration() Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			startTime := time.Now()
+			ctx := r.Context()
+			ctx = logging.AppendCtx(ctx, slog.String("method", r.Method))
+			ctx = logging.AppendCtx(ctx, slog.String("url", r.RequestURI))
+			r = r.WithContext(ctx)
+
 			d := durationLogger{
 				ResponseWriter: w,
 			}
 			next.ServeHTTP(&d, r)
-			slog.DebugContext(r.Context(), "Request completed", "method", r.Method, "url", r.RequestURI, "status", d.statusCode, "duration", time.Since(startTime).String())
+			slog.DebugContext(r.Context(), "Request completed", "status", d.statusCode, "duration", time.Since(startTime).String())
 		})
 	}
 }
@@ -121,8 +127,6 @@ func getOranErrHandler() oapimiddleware.ErrorHandlerWithOpts {
 	return func(_ context.Context, err error, w http.ResponseWriter, r *http.Request, opts oapimiddleware.ErrorHandlerOpts) {
 		slog.WarnContext(r.Context(), "OpenAPI validation failed",
 			"error", err.Error(),
-			"method", r.Method,
-			"path", r.URL.Path,
 			"status", opts.StatusCode,
 		)
 		ProblemDetails(w, err.Error(), opts.StatusCode)
@@ -134,8 +138,6 @@ func GetOranReqErrFunc() func(w http.ResponseWriter, r *http.Request, err error)
 	return func(w http.ResponseWriter, r *http.Request, err error) {
 		slog.WarnContext(r.Context(), "OpenAPI request validation failed",
 			"error", err.Error(),
-			"method", r.Method,
-			"path", r.URL.Path,
 			"status", http.StatusBadRequest,
 		)
 		msg := err.Error()

--- a/internal/service/common/api/middleware/middleware.go
+++ b/internal/service/common/api/middleware/middleware.go
@@ -53,7 +53,7 @@ func LogDuration() Middleware {
 			startTime := time.Now()
 			ctx := r.Context()
 			ctx = logging.AppendCtx(ctx, slog.String("method", r.Method))
-			ctx = logging.AppendCtx(ctx, slog.String("url", r.RequestURI))
+			ctx = logging.AppendCtx(ctx, slog.String("url", r.URL.Path))
 			r = r.WithContext(ctx)
 
 			d := durationLogger{

--- a/internal/service/common/api/middleware/middleware_test.go
+++ b/internal/service/common/api/middleware/middleware_test.go
@@ -54,8 +54,6 @@ var _ = Describe("Validation error logging", func() {
 			Expect(logEntry).To(HaveKeyWithValue("level", "WARN"))
 			Expect(logEntry).To(HaveKeyWithValue("msg", "OpenAPI validation failed"))
 			Expect(logEntry).To(HaveKeyWithValue("error", "request body has an error"))
-			Expect(logEntry).To(HaveKeyWithValue("method", "POST"))
-			Expect(logEntry).To(HaveKeyWithValue("path", "/o2ims-infrastructureInventory/v1/resourcePools"))
 			Expect(logEntry).To(HaveKeyWithValue("status", BeNumerically("==", http.StatusBadRequest)))
 		})
 	})
@@ -75,8 +73,6 @@ var _ = Describe("Validation error logging", func() {
 			Expect(logEntry).To(HaveKeyWithValue("level", "WARN"))
 			Expect(logEntry).To(HaveKeyWithValue("msg", "OpenAPI request validation failed"))
 			Expect(logEntry).To(HaveKeyWithValue("error", "parameter 'filter' has invalid value"))
-			Expect(logEntry).To(HaveKeyWithValue("method", "GET"))
-			Expect(logEntry).To(HaveKeyWithValue("path", "/o2ims-infrastructureInventory/v1/deploymentManagers"))
 			Expect(logEntry).To(HaveKeyWithValue("status", BeNumerically("==", http.StatusBadRequest)))
 		})
 

--- a/internal/service/provisioning/api/server.go
+++ b/internal/service/provisioning/api/server.go
@@ -17,6 +17,7 @@ import (
 
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -111,6 +112,8 @@ func (r *ProvisioningServer) GetProvisioningRequests(ctx context.Context, reques
 
 // GetProvisioningRequest handles an API request to retrieve a provisioning request
 func (r *ProvisioningServer) GetProvisioningRequest(ctx context.Context, request api.GetProvisioningRequestRequestObject) (api.GetProvisioningRequestResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("provisioningRequestId", request.ProvisioningRequestId.String()))
+
 	provisioningRequest := provisioningv1alpha1.ProvisioningRequest{}
 	err := r.HubClient.Get(ctx, types.NamespacedName{Name: request.ProvisioningRequestId.String()}, &provisioningRequest)
 	if err != nil {
@@ -136,6 +139,8 @@ func (r *ProvisioningServer) GetProvisioningRequest(ctx context.Context, request
 
 // CreateProvisioningRequest handles an API request to create provisioning requests
 func (r *ProvisioningServer) CreateProvisioningRequest(ctx context.Context, request api.CreateProvisioningRequestRequestObject) (api.CreateProvisioningRequestResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("provisioningRequestId", request.Body.ProvisioningRequestId.String()))
+
 	provisioningRequest, err := convertProvisioningRequestApiToCR(*request.Body)
 	if err != nil {
 		return nil, err
@@ -176,7 +181,7 @@ func (r *ProvisioningServer) CreateProvisioningRequest(ctx context.Context, requ
 		return nil, err
 	}
 
-	slog.InfoContext(ctx, "Created ProvisioningRequest", "provisioningRequestId", request.Body.ProvisioningRequestId.String())
+	slog.InfoContext(ctx, "Created ProvisioningRequest")
 	location := fmt.Sprintf("%s/provisioningRequests/%s", constants.O2IMSProvisioningBaseURL, request.Body.ProvisioningRequestId)
 	return api.CreateProvisioningRequest201JSONResponse{
 		Body: provisioningRequestInfo,
@@ -188,6 +193,8 @@ func (r *ProvisioningServer) CreateProvisioningRequest(ctx context.Context, requ
 
 // UpdateProvisioningRequest handles an API request to update a provisioning request
 func (r *ProvisioningServer) UpdateProvisioningRequest(ctx context.Context, request api.UpdateProvisioningRequestRequestObject) (api.UpdateProvisioningRequestResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("provisioningRequestId", request.ProvisioningRequestId.String()))
+
 	if request.Body.ProvisioningRequestId.String() != request.ProvisioningRequestId.String() {
 		return api.UpdateProvisioningRequest422ApplicationProblemPlusJSONResponse(common.ProblemDetails{
 			Detail: "the provisioningRequestId in the request body must match the provisioningRequestId in the request path",
@@ -255,12 +262,14 @@ func (r *ProvisioningServer) UpdateProvisioningRequest(ctx context.Context, requ
 		return nil, err
 	}
 
-	slog.InfoContext(ctx, "Updated ProvisioningRequest", "provisioningRequestId", request.ProvisioningRequestId.String())
+	slog.InfoContext(ctx, "Updated ProvisioningRequest")
 	return api.UpdateProvisioningRequest200JSONResponse(provisioningRequestInfo), nil
 }
 
 // DeleteProvisioningRequest handles an API request to delete a provisioning request
 func (r *ProvisioningServer) DeleteProvisioningRequest(ctx context.Context, request api.DeleteProvisioningRequestRequestObject) (api.DeleteProvisioningRequestResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("provisioningRequestId", request.ProvisioningRequestId.String()))
+
 	err := r.HubClient.Delete(ctx, &provisioningv1alpha1.ProvisioningRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: request.ProvisioningRequestId.String(),
@@ -278,7 +287,7 @@ func (r *ProvisioningServer) DeleteProvisioningRequest(ctx context.Context, requ
 		}
 		return nil, fmt.Errorf("failed to delete ProvisioningRequest (%s): %w", request.ProvisioningRequestId.String(), err)
 	}
-	slog.InfoContext(ctx, "The deletion request for ProvisioningRequest has been sent successfully", "provisioningRequestId", request.ProvisioningRequestId.String())
+	slog.InfoContext(ctx, "The deletion request for ProvisioningRequest has been sent successfully")
 	location := fmt.Sprintf("%s/provisioningRequests/%s", constants.O2IMSProvisioningBaseURL, request.ProvisioningRequestId)
 	return api.DeleteProvisioningRequest202Response{
 		Headers: api.DeleteProvisioningRequest202ResponseHeaders{

--- a/internal/service/resources/api/server.go
+++ b/internal/service/resources/api/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	commonapi "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/cache"
@@ -112,6 +113,8 @@ func (r *ResourceServer) GetAlarmDictionaries(ctx context.Context, _ api.GetAlar
 }
 
 func (r *ResourceServer) GetAlarmDictionary(ctx context.Context, request api.GetAlarmDictionaryRequestObject) (api.GetAlarmDictionaryResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("alarmDictionaryId", request.AlarmDictionaryId.String()))
+
 	data, err := r.AlarmDicts.Get(ctx)
 	if err != nil {
 		return api.GetAlarmDictionary500ApplicationProblemPlusJSONResponse{
@@ -138,6 +141,8 @@ func (r *ResourceServer) GetAlarmDictionary(ctx context.Context, request api.Get
 }
 
 func (r *ResourceServer) GetResourceTypeAlarmDictionary(ctx context.Context, request api.GetResourceTypeAlarmDictionaryRequestObject) (api.GetResourceTypeAlarmDictionaryResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("resourceTypeId", request.ResourceTypeId.String()))
+
 	data, err := r.AlarmDicts.Get(ctx)
 	if err != nil {
 		return api.GetResourceTypeAlarmDictionary500ApplicationProblemPlusJSONResponse{
@@ -238,6 +243,8 @@ func (r *ResourceServer) GetDeploymentManagers(ctx context.Context, request api.
 
 // GetDeploymentManager receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ResourceServer) GetDeploymentManager(ctx context.Context, request api.GetDeploymentManagerRequestObject) (api.GetDeploymentManagerResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("deploymentManagerId", request.DeploymentManagerId.String()))
+
 	record, err := r.Repo.GetDeploymentManager(ctx, request.DeploymentManagerId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		return api.GetDeploymentManager404ApplicationProblemPlusJSONResponse{
@@ -300,6 +307,10 @@ func (r *ResourceServer) validateSubscription(ctx context.Context, request api.C
 
 // CreateSubscription receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ResourceServer) CreateSubscription(ctx context.Context, request api.CreateSubscriptionRequestObject) (api.CreateSubscriptionResponseObject, error) {
+	if request.Body.ConsumerSubscriptionId != nil {
+		ctx = logging.AppendCtx(ctx, slog.String("consumerSubscriptionId", request.Body.ConsumerSubscriptionId.String()))
+	}
+
 	consumerSubscriptionId := "<null>"
 	if request.Body.ConsumerSubscriptionId != nil {
 		consumerSubscriptionId = request.Body.ConsumerSubscriptionId.String()
@@ -357,6 +368,8 @@ func (r *ResourceServer) CreateSubscription(ctx context.Context, request api.Cre
 
 // GetSubscription receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ResourceServer) GetSubscription(ctx context.Context, request api.GetSubscriptionRequestObject) (api.GetSubscriptionResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("subscriptionId", request.SubscriptionId.String()))
+
 	record, err := r.Repo.GetSubscription(ctx, request.SubscriptionId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		return api.GetSubscription404ApplicationProblemPlusJSONResponse{
@@ -382,6 +395,8 @@ func (r *ResourceServer) GetSubscription(ctx context.Context, request api.GetSub
 
 // DeleteSubscription receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ResourceServer) DeleteSubscription(ctx context.Context, request api.DeleteSubscriptionRequestObject) (api.DeleteSubscriptionResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("subscriptionId", request.SubscriptionId.String()))
+
 	count, err := r.Repo.DeleteSubscription(ctx, request.SubscriptionId)
 	if err != nil {
 		return api.DeleteSubscription500ApplicationProblemPlusJSONResponse{
@@ -442,6 +457,8 @@ func (r *ResourceServer) GetResourcePools(ctx context.Context, request api.GetRe
 
 // GetResourcePool receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ResourceServer) GetResourcePool(ctx context.Context, request api.GetResourcePoolRequestObject) (api.GetResourcePoolResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("resourcePoolId", request.ResourcePoolId.String()))
+
 	record, err := r.Repo.GetResourcePool(ctx, request.ResourcePoolId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		return api.GetResourcePool404ApplicationProblemPlusJSONResponse{
@@ -467,6 +484,8 @@ func (r *ResourceServer) GetResourcePool(ctx context.Context, request api.GetRes
 
 // GetResources receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ResourceServer) GetResources(ctx context.Context, request api.GetResourcesRequestObject) (api.GetResourcesResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("resourcePoolId", request.ResourcePoolId.String()))
+
 	options := commonapi.NewFieldOptions(request.Params.AllFields, request.Params.Fields, request.Params.ExcludeFields)
 	if err := options.Validate(api.Resource{}); err != nil {
 		return api.GetResources400ApplicationProblemPlusJSONResponse{
@@ -518,6 +537,9 @@ func (r *ResourceServer) GetResources(ctx context.Context, request api.GetResour
 
 // GetResource receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ResourceServer) GetResource(ctx context.Context, request api.GetResourceRequestObject) (api.GetResourceResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("resourcePoolId", request.ResourcePoolId.String()))
+	ctx = logging.AppendCtx(ctx, slog.String("resourceId", request.ResourceId.String()))
+
 	// First, find the pool
 	if exists, err := r.Repo.ResourcePoolExists(ctx, request.ResourcePoolId); err == nil && !exists {
 		return api.GetResource404ApplicationProblemPlusJSONResponse{
@@ -607,6 +629,8 @@ func (r *ResourceServer) GetResourceTypes(ctx context.Context, request api.GetRe
 
 // GetResourceType receives the API request to this endpoint, executes the request, and responds appropriately
 func (r *ResourceServer) GetResourceType(ctx context.Context, request api.GetResourceTypeRequestObject) (api.GetResourceTypeResponseObject, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("resourceTypeId", request.ResourceTypeId.String()))
+
 	record, err := r.Repo.GetResourceType(ctx, request.ResourceTypeId)
 	if errors.Is(err, svcutils.ErrNotFound) {
 		return api.GetResourceType404ApplicationProblemPlusJSONResponse{

--- a/internal/service/resources/api/server_test.go
+++ b/internal/service/resources/api/server_test.go
@@ -151,7 +151,7 @@ var _ = Describe("ResourceServer", func() {
 		When("deployment manager is found", func() {
 			It("returns 200 response with deployment manager", func() {
 				mockRepo.EXPECT().
-					GetDeploymentManager(ctx, testUUID).
+					GetDeploymentManager(gomock.Any(), testUUID).
 					Return(&models.DeploymentManager{DeploymentManagerID: testUUID, Name: "test-dm"}, nil)
 
 				resp, err := server.GetDeploymentManager(ctx, apiGenerated.GetDeploymentManagerRequestObject{
@@ -167,7 +167,7 @@ var _ = Describe("ResourceServer", func() {
 		When("deployment manager not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					GetDeploymentManager(ctx, testUUID).
+					GetDeploymentManager(gomock.Any(), testUUID).
 					Return(nil, svcutils.ErrNotFound)
 
 				resp, err := server.GetDeploymentManager(ctx, apiGenerated.GetDeploymentManagerRequestObject{
@@ -184,7 +184,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetDeploymentManager(ctx, testUUID).
+					GetDeploymentManager(gomock.Any(), testUUID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetDeploymentManager(ctx, apiGenerated.GetDeploymentManagerRequestObject{
@@ -203,7 +203,7 @@ var _ = Describe("ResourceServer", func() {
 		When("deployment managers are found", func() {
 			It("returns 200 response with list", func() {
 				mockRepo.EXPECT().
-					GetDeploymentManagers(ctx).
+					GetDeploymentManagers(gomock.Any()).
 					Return([]models.DeploymentManager{
 						{DeploymentManagerID: testUUID, Name: "dm-1"},
 						{DeploymentManagerID: uuid.New(), Name: "dm-2"},
@@ -224,7 +224,7 @@ var _ = Describe("ResourceServer", func() {
 		When("no deployment managers exist", func() {
 			It("returns 200 response with empty list", func() {
 				mockRepo.EXPECT().
-					GetDeploymentManagers(ctx).
+					GetDeploymentManagers(gomock.Any()).
 					Return([]models.DeploymentManager{}, nil)
 
 				resp, err := server.GetDeploymentManagers(ctx, apiGenerated.GetDeploymentManagersRequestObject{})
@@ -239,7 +239,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetDeploymentManagers(ctx).
+					GetDeploymentManagers(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetDeploymentManagers(ctx, apiGenerated.GetDeploymentManagersRequestObject{})
@@ -335,7 +335,7 @@ var _ = Describe("ResourceServer", func() {
 				}
 
 				mockRepo.EXPECT().
-					CreateSubscription(ctx, gomock.Any()).
+					CreateSubscription(gomock.Any(), gomock.Any()).
 					Return(nil, fmt.Errorf("unique_callback constraint violation"))
 
 				resp, err := serverWithProvider.CreateSubscription(ctx, apiGenerated.CreateSubscriptionRequestObject{
@@ -359,7 +359,7 @@ var _ = Describe("ResourceServer", func() {
 		When("subscription is found", func() {
 			It("returns 200 response with subscription", func() {
 				mockRepo.EXPECT().
-					GetSubscription(ctx, testUUID).
+					GetSubscription(gomock.Any(), testUUID).
 					Return(&commonmodels.Subscription{SubscriptionID: &testUUID, Callback: "https://example.com/callback"}, nil)
 
 				resp, err := server.GetSubscription(ctx, apiGenerated.GetSubscriptionRequestObject{
@@ -375,7 +375,7 @@ var _ = Describe("ResourceServer", func() {
 		When("subscription not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					GetSubscription(ctx, testUUID).
+					GetSubscription(gomock.Any(), testUUID).
 					Return(nil, svcutils.ErrNotFound)
 
 				resp, err := server.GetSubscription(ctx, apiGenerated.GetSubscriptionRequestObject{
@@ -392,7 +392,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetSubscription(ctx, testUUID).
+					GetSubscription(gomock.Any(), testUUID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetSubscription(ctx, apiGenerated.GetSubscriptionRequestObject{
@@ -413,7 +413,7 @@ var _ = Describe("ResourceServer", func() {
 				subID1 := uuid.New()
 				subID2 := uuid.New()
 				mockRepo.EXPECT().
-					GetSubscriptions(ctx).
+					GetSubscriptions(gomock.Any()).
 					Return([]commonmodels.Subscription{
 						{SubscriptionID: &subID1, Callback: "https://example.com/callback1"},
 						{SubscriptionID: &subID2, Callback: "https://example.com/callback2"},
@@ -434,7 +434,7 @@ var _ = Describe("ResourceServer", func() {
 		When("no subscriptions exist", func() {
 			It("returns 200 response with empty list", func() {
 				mockRepo.EXPECT().
-					GetSubscriptions(ctx).
+					GetSubscriptions(gomock.Any()).
 					Return([]commonmodels.Subscription{}, nil)
 
 				resp, err := server.GetSubscriptions(ctx, apiGenerated.GetSubscriptionsRequestObject{})
@@ -449,7 +449,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetSubscriptions(ctx).
+					GetSubscriptions(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetSubscriptions(ctx, apiGenerated.GetSubscriptionsRequestObject{})
@@ -481,7 +481,7 @@ var _ = Describe("ResourceServer", func() {
 		When("subscription exists and is deleted", func() {
 			It("returns 200 response", func() {
 				mockRepo.EXPECT().
-					DeleteSubscription(ctx, testUUID).
+					DeleteSubscription(gomock.Any(), testUUID).
 					Return(int64(1), nil)
 
 				resp, err := server.DeleteSubscription(ctx, apiGenerated.DeleteSubscriptionRequestObject{
@@ -497,7 +497,7 @@ var _ = Describe("ResourceServer", func() {
 		When("subscription not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					DeleteSubscription(ctx, testUUID).
+					DeleteSubscription(gomock.Any(), testUUID).
 					Return(int64(0), nil)
 
 				resp, err := server.DeleteSubscription(ctx, apiGenerated.DeleteSubscriptionRequestObject{
@@ -514,7 +514,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					DeleteSubscription(ctx, testUUID).
+					DeleteSubscription(gomock.Any(), testUUID).
 					Return(int64(0), fmt.Errorf("db error"))
 
 				resp, err := server.DeleteSubscription(ctx, apiGenerated.DeleteSubscriptionRequestObject{
@@ -536,7 +536,7 @@ var _ = Describe("ResourceServer", func() {
 		When("resource pool is found", func() {
 			It("returns 200 response with resource pool", func() {
 				mockRepo.EXPECT().
-					GetResourcePool(ctx, testUUID).
+					GetResourcePool(gomock.Any(), testUUID).
 					Return(&models.ResourcePool{ResourcePoolID: testUUID, Name: "test-pool"}, nil)
 
 				resp, err := server.GetResourcePool(ctx, apiGenerated.GetResourcePoolRequestObject{
@@ -552,7 +552,7 @@ var _ = Describe("ResourceServer", func() {
 		When("resource pool not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					GetResourcePool(ctx, testUUID).
+					GetResourcePool(gomock.Any(), testUUID).
 					Return(nil, svcutils.ErrNotFound)
 
 				resp, err := server.GetResourcePool(ctx, apiGenerated.GetResourcePoolRequestObject{
@@ -569,7 +569,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetResourcePool(ctx, testUUID).
+					GetResourcePool(gomock.Any(), testUUID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetResourcePool(ctx, apiGenerated.GetResourcePoolRequestObject{
@@ -588,7 +588,7 @@ var _ = Describe("ResourceServer", func() {
 		When("resource pools are found", func() {
 			It("returns 200 response with list", func() {
 				mockRepo.EXPECT().
-					GetResourcePools(ctx).
+					GetResourcePools(gomock.Any()).
 					Return([]models.ResourcePool{
 						{ResourcePoolID: testUUID, Name: "pool-1"},
 						{ResourcePoolID: uuid.New(), Name: "pool-2"},
@@ -609,7 +609,7 @@ var _ = Describe("ResourceServer", func() {
 		When("no resource pools exist", func() {
 			It("returns 200 response with empty list", func() {
 				mockRepo.EXPECT().
-					GetResourcePools(ctx).
+					GetResourcePools(gomock.Any()).
 					Return([]models.ResourcePool{}, nil)
 
 				resp, err := server.GetResourcePools(ctx, apiGenerated.GetResourcePoolsRequestObject{})
@@ -624,7 +624,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetResourcePools(ctx).
+					GetResourcePools(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetResourcePools(ctx, apiGenerated.GetResourcePoolsRequestObject{})
@@ -666,10 +666,10 @@ var _ = Describe("ResourceServer", func() {
 		When("resource is found", func() {
 			It("returns 200 response with resource", func() {
 				mockRepo.EXPECT().
-					ResourcePoolExists(ctx, poolID).
+					ResourcePoolExists(gomock.Any(), poolID).
 					Return(true, nil)
 				mockRepo.EXPECT().
-					GetResource(ctx, resourceID).
+					GetResource(gomock.Any(), resourceID).
 					Return(&models.Resource{ResourceID: resourceID, ResourcePoolID: poolID}, nil)
 
 				resp, err := server.GetResource(ctx, apiGenerated.GetResourceRequestObject{
@@ -686,7 +686,7 @@ var _ = Describe("ResourceServer", func() {
 		When("resource pool does not exist", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					ResourcePoolExists(ctx, poolID).
+					ResourcePoolExists(gomock.Any(), poolID).
 					Return(false, nil)
 
 				resp, err := server.GetResource(ctx, apiGenerated.GetResourceRequestObject{
@@ -705,10 +705,10 @@ var _ = Describe("ResourceServer", func() {
 		When("resource not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					ResourcePoolExists(ctx, poolID).
+					ResourcePoolExists(gomock.Any(), poolID).
 					Return(true, nil)
 				mockRepo.EXPECT().
-					GetResource(ctx, resourceID).
+					GetResource(gomock.Any(), resourceID).
 					Return(nil, svcutils.ErrNotFound)
 
 				resp, err := server.GetResource(ctx, apiGenerated.GetResourceRequestObject{
@@ -726,7 +726,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error checking pool", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					ResourcePoolExists(ctx, poolID).
+					ResourcePoolExists(gomock.Any(), poolID).
 					Return(false, fmt.Errorf("db error"))
 
 				resp, err := server.GetResource(ctx, apiGenerated.GetResourceRequestObject{
@@ -744,10 +744,10 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error getting resource", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					ResourcePoolExists(ctx, poolID).
+					ResourcePoolExists(gomock.Any(), poolID).
 					Return(true, nil)
 				mockRepo.EXPECT().
-					GetResource(ctx, resourceID).
+					GetResource(gomock.Any(), resourceID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetResource(ctx, apiGenerated.GetResourceRequestObject{
@@ -775,10 +775,10 @@ var _ = Describe("ResourceServer", func() {
 				resourceID1 := uuid.New()
 				resourceID2 := uuid.New()
 				mockRepo.EXPECT().
-					ResourcePoolExists(ctx, poolID).
+					ResourcePoolExists(gomock.Any(), poolID).
 					Return(true, nil)
 				mockRepo.EXPECT().
-					GetResourcePoolResources(ctx, poolID).
+					GetResourcePoolResources(gomock.Any(), poolID).
 					Return([]models.Resource{
 						{ResourceID: resourceID1, ResourcePoolID: poolID},
 						{ResourceID: resourceID2, ResourcePoolID: poolID},
@@ -801,7 +801,7 @@ var _ = Describe("ResourceServer", func() {
 		When("resource pool does not exist", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					ResourcePoolExists(ctx, poolID).
+					ResourcePoolExists(gomock.Any(), poolID).
 					Return(false, nil)
 
 				resp, err := server.GetResources(ctx, apiGenerated.GetResourcesRequestObject{
@@ -818,10 +818,10 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					ResourcePoolExists(ctx, poolID).
+					ResourcePoolExists(gomock.Any(), poolID).
 					Return(true, nil)
 				mockRepo.EXPECT().
-					GetResourcePoolResources(ctx, poolID).
+					GetResourcePoolResources(gomock.Any(), poolID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetResources(ctx, apiGenerated.GetResourcesRequestObject{
@@ -857,7 +857,7 @@ var _ = Describe("ResourceServer", func() {
 		When("resource is found", func() {
 			It("returns 200 response with resource", func() {
 				mockRepo.EXPECT().
-					GetResource(ctx, testUUID).
+					GetResource(gomock.Any(), testUUID).
 					Return(&models.Resource{ResourceID: testUUID}, nil)
 
 				resp, err := server.GetInternalResourceById(ctx, apiGenerated.GetInternalResourceByIdRequestObject{
@@ -873,7 +873,7 @@ var _ = Describe("ResourceServer", func() {
 		When("resource not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					GetResource(ctx, testUUID).
+					GetResource(gomock.Any(), testUUID).
 					Return(nil, svcutils.ErrNotFound)
 
 				resp, err := server.GetInternalResourceById(ctx, apiGenerated.GetInternalResourceByIdRequestObject{
@@ -890,7 +890,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetResource(ctx, testUUID).
+					GetResource(gomock.Any(), testUUID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetInternalResourceById(ctx, apiGenerated.GetInternalResourceByIdRequestObject{
@@ -912,10 +912,10 @@ var _ = Describe("ResourceServer", func() {
 		When("resource type is found without alarm dictionary", func() {
 			It("returns 200 response with resource type", func() {
 				mockRepo.EXPECT().
-					GetResourceType(ctx, testUUID).
+					GetResourceType(gomock.Any(), testUUID).
 					Return(&models.ResourceType{ResourceTypeID: testUUID, Name: "test-type"}, nil)
 				mockRepo.EXPECT().
-					GetResourceTypeAlarmDictionary(ctx, testUUID).
+					GetResourceTypeAlarmDictionary(gomock.Any(), testUUID).
 					Return([]models.AlarmDictionary{}, nil)
 
 				resp, err := server.GetResourceType(ctx, apiGenerated.GetResourceTypeRequestObject{
@@ -932,10 +932,10 @@ var _ = Describe("ResourceServer", func() {
 			It("returns 200 response with resource type and dictionary ID", func() {
 				dictID := uuid.New()
 				mockRepo.EXPECT().
-					GetResourceType(ctx, testUUID).
+					GetResourceType(gomock.Any(), testUUID).
 					Return(&models.ResourceType{ResourceTypeID: testUUID, Name: "test-type"}, nil)
 				mockRepo.EXPECT().
-					GetResourceTypeAlarmDictionary(ctx, testUUID).
+					GetResourceTypeAlarmDictionary(gomock.Any(), testUUID).
 					Return([]models.AlarmDictionary{{AlarmDictionaryID: dictID, ResourceTypeID: testUUID}}, nil)
 
 				resp, err := server.GetResourceType(ctx, apiGenerated.GetResourceTypeRequestObject{
@@ -953,7 +953,7 @@ var _ = Describe("ResourceServer", func() {
 		When("resource type not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					GetResourceType(ctx, testUUID).
+					GetResourceType(gomock.Any(), testUUID).
 					Return(nil, svcutils.ErrNotFound)
 
 				resp, err := server.GetResourceType(ctx, apiGenerated.GetResourceTypeRequestObject{
@@ -970,7 +970,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetResourceType(ctx, testUUID).
+					GetResourceType(gomock.Any(), testUUID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetResourceType(ctx, apiGenerated.GetResourceTypeRequestObject{
@@ -989,13 +989,13 @@ var _ = Describe("ResourceServer", func() {
 		When("resource types are found without alarm dictionaries", func() {
 			It("returns 200 response with list", func() {
 				mockRepo.EXPECT().
-					GetResourceTypes(ctx).
+					GetResourceTypes(gomock.Any()).
 					Return([]models.ResourceType{
 						{ResourceTypeID: testUUID, Name: "type-1"},
 						{ResourceTypeID: uuid.New(), Name: "type-2"},
 					}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{}, nil)
 
 				resp, err := server.GetResourceTypes(ctx, apiGenerated.GetResourceTypesRequestObject{})
@@ -1015,12 +1015,12 @@ var _ = Describe("ResourceServer", func() {
 				typeID := uuid.New()
 				dictID := uuid.New()
 				mockRepo.EXPECT().
-					GetResourceTypes(ctx).
+					GetResourceTypes(gomock.Any()).
 					Return([]models.ResourceType{
 						{ResourceTypeID: typeID, Name: "type-1"},
 					}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{
 						{AlarmDictionaryID: dictID, ResourceTypeID: typeID},
 					}, nil)
@@ -1041,10 +1041,10 @@ var _ = Describe("ResourceServer", func() {
 		When("no resource types exist", func() {
 			It("returns 200 response with empty list", func() {
 				mockRepo.EXPECT().
-					GetResourceTypes(ctx).
+					GetResourceTypes(gomock.Any()).
 					Return([]models.ResourceType{}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{}, nil)
 
 				resp, err := server.GetResourceTypes(ctx, apiGenerated.GetResourceTypesRequestObject{})
@@ -1059,7 +1059,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error getting resource types", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetResourceTypes(ctx).
+					GetResourceTypes(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetResourceTypes(ctx, apiGenerated.GetResourceTypesRequestObject{})
@@ -1073,12 +1073,12 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error getting alarm dictionaries", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetResourceTypes(ctx).
+					GetResourceTypes(gomock.Any()).
 					Return([]models.ResourceType{
 						{ResourceTypeID: testUUID, Name: "type-1"},
 					}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetResourceTypes(ctx, apiGenerated.GetResourceTypesRequestObject{})
@@ -1114,10 +1114,10 @@ var _ = Describe("ResourceServer", func() {
 		When("alarm dictionary is found", func() {
 			It("returns 200 response with alarm dictionary", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{{AlarmDictionaryID: testUUID, ResourceTypeID: uuid.New()}}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, testUUID).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), testUUID).
 					Return([]models.AlarmDefinition{}, nil)
 
 				resp, err := server.GetAlarmDictionary(ctx, apiGenerated.GetAlarmDictionaryRequestObject{
@@ -1133,7 +1133,7 @@ var _ = Describe("ResourceServer", func() {
 		When("alarm dictionary not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{}, nil)
 
 				resp, err := server.GetAlarmDictionary(ctx, apiGenerated.GetAlarmDictionaryRequestObject{
@@ -1150,7 +1150,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetAlarmDictionary(ctx, apiGenerated.GetAlarmDictionaryRequestObject{
@@ -1171,16 +1171,16 @@ var _ = Describe("ResourceServer", func() {
 				dictID1 := uuid.New()
 				dictID2 := uuid.New()
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{
 						{AlarmDictionaryID: dictID1},
 						{AlarmDictionaryID: dictID2},
 					}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID1).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID1).
 					Return([]models.AlarmDefinition{}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID2).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID2).
 					Return([]models.AlarmDefinition{}, nil)
 
 				resp, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
@@ -1198,7 +1198,7 @@ var _ = Describe("ResourceServer", func() {
 		When("no alarm dictionaries exist", func() {
 			It("returns 200 response with empty list", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{}, nil)
 
 				resp, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
@@ -1213,7 +1213,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
@@ -1230,11 +1230,11 @@ var _ = Describe("ResourceServer", func() {
 			dictID := uuid.New()
 			rtID := uuid.New()
 			mockRepo.EXPECT().
-				GetAlarmDictionaries(ctx).
+				GetAlarmDictionaries(gomock.Any()).
 				Return([]models.AlarmDictionary{{AlarmDictionaryID: dictID, ResourceTypeID: rtID}}, nil).
 				Times(1)
 			mockRepo.EXPECT().
-				GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID).
+				GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID).
 				Return([]models.AlarmDefinition{}, nil).
 				Times(1)
 
@@ -1255,22 +1255,22 @@ var _ = Describe("ResourceServer", func() {
 
 			gomock.InOrder(
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{{AlarmDictionaryID: dictID1, ResourceTypeID: rtID1}}, nil),
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID1).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID1).
 					Return([]models.AlarmDefinition{}, nil),
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{
 						{AlarmDictionaryID: dictID1, ResourceTypeID: rtID1},
 						{AlarmDictionaryID: dictID2, ResourceTypeID: rtID2},
 					}, nil),
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID1).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID1).
 					Return([]models.AlarmDefinition{}, nil),
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID2).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID2).
 					Return([]models.AlarmDefinition{}, nil),
 			)
 
@@ -1289,10 +1289,10 @@ var _ = Describe("ResourceServer", func() {
 			dictID := uuid.New()
 			rtID := uuid.New()
 			mockRepo.EXPECT().
-				GetAlarmDictionaries(ctx).
+				GetAlarmDictionaries(gomock.Any()).
 				Return([]models.AlarmDictionary{{AlarmDictionaryID: dictID, ResourceTypeID: rtID}}, nil)
 			mockRepo.EXPECT().
-				GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID).
+				GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID).
 				Return([]models.AlarmDefinition{}, nil)
 
 			byID, err := server.GetAlarmDictionary(ctx, apiGenerated.GetAlarmDictionaryRequestObject{
@@ -1313,10 +1313,10 @@ var _ = Describe("ResourceServer", func() {
 		It("returns 500 when alarm definitions query fails during cache load", func() {
 			dictID := uuid.New()
 			mockRepo.EXPECT().
-				GetAlarmDictionaries(ctx).
+				GetAlarmDictionaries(gomock.Any()).
 				Return([]models.AlarmDictionary{{AlarmDictionaryID: dictID, ResourceTypeID: uuid.New()}}, nil)
 			mockRepo.EXPECT().
-				GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID).
+				GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID).
 				Return(nil, fmt.Errorf("definitions query failed"))
 
 			resp, err := server.GetAlarmDictionaries(ctx, apiGenerated.GetAlarmDictionariesRequestObject{})
@@ -1330,10 +1330,10 @@ var _ = Describe("ResourceServer", func() {
 			It("returns 200 response with alarm dictionary", func() {
 				dictID := uuid.New()
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{{AlarmDictionaryID: dictID, ResourceTypeID: testUUID}}, nil)
 				mockRepo.EXPECT().
-					GetAlarmDefinitionsByAlarmDictionaryID(ctx, dictID).
+					GetAlarmDefinitionsByAlarmDictionaryID(gomock.Any(), dictID).
 					Return([]models.AlarmDefinition{}, nil)
 
 				resp, err := server.GetResourceTypeAlarmDictionary(ctx, apiGenerated.GetResourceTypeAlarmDictionaryRequestObject{
@@ -1349,7 +1349,7 @@ var _ = Describe("ResourceServer", func() {
 		When("no alarm dictionary exists for resource type", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return([]models.AlarmDictionary{}, nil)
 
 				resp, err := server.GetResourceTypeAlarmDictionary(ctx, apiGenerated.GetResourceTypeAlarmDictionaryRequestObject{
@@ -1366,7 +1366,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetAlarmDictionaries(ctx).
+					GetAlarmDictionaries(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetResourceTypeAlarmDictionary(ctx, apiGenerated.GetResourceTypeAlarmDictionaryRequestObject{
@@ -1394,10 +1394,10 @@ var _ = Describe("ResourceServer", func() {
 		When("location is found", func() {
 			It("returns 200 response with location", func() {
 				mockRepo.EXPECT().
-					GetLocation(ctx, globalLocationID).
+					GetLocation(gomock.Any(), globalLocationID).
 					Return(&models.Location{GlobalLocationID: globalLocationID, Name: "Test Location"}, nil)
 				mockRepo.EXPECT().
-					GetOCloudSiteIDsForLocation(ctx, globalLocationID).
+					GetOCloudSiteIDsForLocation(gomock.Any(), globalLocationID).
 					Return([]uuid.UUID{uuid.New()}, nil)
 
 				resp, err := server.GetLocation(ctx, apiGenerated.GetLocationRequestObject{
@@ -1413,7 +1413,7 @@ var _ = Describe("ResourceServer", func() {
 		When("location not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					GetLocation(ctx, globalLocationID).
+					GetLocation(gomock.Any(), globalLocationID).
 					Return(nil, svcutils.ErrNotFound)
 
 				resp, err := server.GetLocation(ctx, apiGenerated.GetLocationRequestObject{
@@ -1430,7 +1430,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error getting location", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetLocation(ctx, globalLocationID).
+					GetLocation(gomock.Any(), globalLocationID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetLocation(ctx, apiGenerated.GetLocationRequestObject{
@@ -1447,10 +1447,10 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error getting site IDs", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetLocation(ctx, globalLocationID).
+					GetLocation(gomock.Any(), globalLocationID).
 					Return(&models.Location{GlobalLocationID: globalLocationID, Name: "Test Location"}, nil)
 				mockRepo.EXPECT().
-					GetOCloudSiteIDsForLocation(ctx, globalLocationID).
+					GetOCloudSiteIDsForLocation(gomock.Any(), globalLocationID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetLocation(ctx, apiGenerated.GetLocationRequestObject{
@@ -1472,13 +1472,13 @@ var _ = Describe("ResourceServer", func() {
 				loc2 := "LOC-002"
 				siteID := uuid.New()
 				mockRepo.EXPECT().
-					GetLocations(ctx).
+					GetLocations(gomock.Any()).
 					Return([]models.Location{
 						{GlobalLocationID: loc1, Name: "Location 1"},
 						{GlobalLocationID: loc2, Name: "Location 2"},
 					}, nil)
 				mockRepo.EXPECT().
-					GetAllOCloudSiteIDsByLocation(ctx).
+					GetAllOCloudSiteIDsByLocation(gomock.Any()).
 					Return(map[string][]uuid.UUID{
 						loc1: {siteID},
 						// loc2 has no sites
@@ -1499,10 +1499,10 @@ var _ = Describe("ResourceServer", func() {
 		When("no locations exist", func() {
 			It("returns 200 response with empty list", func() {
 				mockRepo.EXPECT().
-					GetLocations(ctx).
+					GetLocations(gomock.Any()).
 					Return([]models.Location{}, nil)
 				mockRepo.EXPECT().
-					GetAllOCloudSiteIDsByLocation(ctx).
+					GetAllOCloudSiteIDsByLocation(gomock.Any()).
 					Return(map[string][]uuid.UUID{}, nil)
 
 				resp, err := server.GetLocations(ctx, apiGenerated.GetLocationsRequestObject{})
@@ -1517,7 +1517,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error on GetLocations", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetLocations(ctx).
+					GetLocations(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetLocations(ctx, apiGenerated.GetLocationsRequestObject{})
@@ -1532,12 +1532,12 @@ var _ = Describe("ResourceServer", func() {
 		When("GetAllOCloudSiteIDsByLocation fails", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetLocations(ctx).
+					GetLocations(gomock.Any()).
 					Return([]models.Location{
 						{GlobalLocationID: testLocationID, Name: "Location 1"},
 					}, nil)
 				mockRepo.EXPECT().
-					GetAllOCloudSiteIDsByLocation(ctx).
+					GetAllOCloudSiteIDsByLocation(gomock.Any()).
 					Return(nil, fmt.Errorf("connection timeout"))
 
 				resp, err := server.GetLocations(ctx, apiGenerated.GetLocationsRequestObject{})
@@ -1558,10 +1558,10 @@ var _ = Describe("ResourceServer", func() {
 		When("O-Cloud site is found", func() {
 			It("returns 200 response with site", func() {
 				mockRepo.EXPECT().
-					GetOCloudSite(ctx, testUUID).
+					GetOCloudSite(gomock.Any(), testUUID).
 					Return(&models.OCloudSite{OCloudSiteID: testUUID, Name: "test-site"}, nil)
 				mockRepo.EXPECT().
-					GetResourcePoolIDsForSite(ctx, testUUID).
+					GetResourcePoolIDsForSite(gomock.Any(), testUUID).
 					Return([]uuid.UUID{uuid.New()}, nil)
 
 				resp, err := server.GetOCloudSite(ctx, apiGenerated.GetOCloudSiteRequestObject{
@@ -1577,7 +1577,7 @@ var _ = Describe("ResourceServer", func() {
 		When("O-Cloud site not found", func() {
 			It("returns 404 response", func() {
 				mockRepo.EXPECT().
-					GetOCloudSite(ctx, testUUID).
+					GetOCloudSite(gomock.Any(), testUUID).
 					Return(nil, svcutils.ErrNotFound)
 
 				resp, err := server.GetOCloudSite(ctx, apiGenerated.GetOCloudSiteRequestObject{
@@ -1594,7 +1594,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error getting site", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetOCloudSite(ctx, testUUID).
+					GetOCloudSite(gomock.Any(), testUUID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetOCloudSite(ctx, apiGenerated.GetOCloudSiteRequestObject{
@@ -1611,10 +1611,10 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error getting pool IDs", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetOCloudSite(ctx, testUUID).
+					GetOCloudSite(gomock.Any(), testUUID).
 					Return(&models.OCloudSite{OCloudSiteID: testUUID, Name: "test-site"}, nil)
 				mockRepo.EXPECT().
-					GetResourcePoolIDsForSite(ctx, testUUID).
+					GetResourcePoolIDsForSite(gomock.Any(), testUUID).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetOCloudSite(ctx, apiGenerated.GetOCloudSiteRequestObject{
@@ -1636,13 +1636,13 @@ var _ = Describe("ResourceServer", func() {
 				siteID2 := uuid.New()
 				poolID := uuid.New()
 				mockRepo.EXPECT().
-					GetOCloudSites(ctx).
+					GetOCloudSites(gomock.Any()).
 					Return([]models.OCloudSite{
 						{OCloudSiteID: siteID1, Name: "site-1"},
 						{OCloudSiteID: siteID2, Name: "site-2"},
 					}, nil)
 				mockRepo.EXPECT().
-					GetAllResourcePoolIDsBySite(ctx).
+					GetAllResourcePoolIDsBySite(gomock.Any()).
 					Return(map[uuid.UUID][]uuid.UUID{
 						siteID1: {poolID},
 						// siteID2 has no pools
@@ -1663,10 +1663,10 @@ var _ = Describe("ResourceServer", func() {
 		When("no O-Cloud sites exist", func() {
 			It("returns 200 response with empty list", func() {
 				mockRepo.EXPECT().
-					GetOCloudSites(ctx).
+					GetOCloudSites(gomock.Any()).
 					Return([]models.OCloudSite{}, nil)
 				mockRepo.EXPECT().
-					GetAllResourcePoolIDsBySite(ctx).
+					GetAllResourcePoolIDsBySite(gomock.Any()).
 					Return(map[uuid.UUID][]uuid.UUID{}, nil)
 
 				resp, err := server.GetOCloudSites(ctx, apiGenerated.GetOCloudSitesRequestObject{})
@@ -1681,7 +1681,7 @@ var _ = Describe("ResourceServer", func() {
 		When("repository returns error on GetOCloudSites", func() {
 			It("returns 500 response", func() {
 				mockRepo.EXPECT().
-					GetOCloudSites(ctx).
+					GetOCloudSites(gomock.Any()).
 					Return(nil, fmt.Errorf("db error"))
 
 				resp, err := server.GetOCloudSites(ctx, apiGenerated.GetOCloudSitesRequestObject{})
@@ -1697,12 +1697,12 @@ var _ = Describe("ResourceServer", func() {
 			It("returns 500 response", func() {
 				siteID := uuid.New()
 				mockRepo.EXPECT().
-					GetOCloudSites(ctx).
+					GetOCloudSites(gomock.Any()).
 					Return([]models.OCloudSite{
 						{OCloudSiteID: siteID, Name: "site-1"},
 					}, nil)
 				mockRepo.EXPECT().
-					GetAllResourcePoolIDsBySite(ctx).
+					GetAllResourcePoolIDsBySite(gomock.Any()).
 					Return(nil, fmt.Errorf("query timeout"))
 
 				resp, err := server.GetOCloudSites(ctx, apiGenerated.GetOCloudSitesRequestObject{})

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	commonapi "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/async"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
@@ -168,6 +169,8 @@ func (c *Collector) watchForChanges(ctx context.Context) error {
 
 // handleAsyncResourceTypeEvent handles an async event for a ResourceType object.
 func (c *Collector) handleAsyncResourceTypeEvent(ctx context.Context, resourceType models.ResourceType, deleted bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("resourceTypeID", resourceType.ResourceTypeID.String()))
+	ctx = logging.AppendCtx(ctx, slog.Bool("deleted", deleted))
 	var dataChangeEvent *models2.DataChangeEvent
 	var err error
 
@@ -202,6 +205,9 @@ func (c *Collector) handleAsyncResourceTypeEvent(ctx context.Context, resourceTy
 
 // handleAsyncResourceEvent handles an async event for a Resource object.
 func (c *Collector) handleAsyncResourceEvent(ctx context.Context, resource models.Resource, deleted bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("resourceID", resource.ResourceID.String()))
+	ctx = logging.AppendCtx(ctx, slog.String("resourcePoolID", resource.ResourcePoolID.String()))
+	ctx = logging.AppendCtx(ctx, slog.Bool("deleted", deleted))
 	var dataChangeEvent *models2.DataChangeEvent
 	var err error
 
@@ -380,6 +386,8 @@ func (c *Collector) handleAsyncEvent(ctx context.Context, event *async.AsyncChan
 
 // handleAsyncDeploymentManagerEvent handles an async event received for a ClusterResource object.
 func (c *Collector) handleAsyncDeploymentManagerEvent(ctx context.Context, deploymentManager models.DeploymentManager, deleted bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("deploymentManagerID", deploymentManager.DeploymentManagerID.String()))
+	ctx = logging.AppendCtx(ctx, slog.Bool("deleted", deleted))
 	var dataChangeEvent *models2.DataChangeEvent
 	var err error
 	if deleted {
@@ -439,6 +447,8 @@ func (c *Collector) oCloudSiteAPIForChangeEvent(ctx context.Context, record *mod
 
 // handleAsyncLocationEvent handles an async event received for a Location object.
 func (c *Collector) handleAsyncLocationEvent(ctx context.Context, location models.Location, deleted bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("locationID", location.GlobalLocationID))
+	ctx = logging.AppendCtx(ctx, slog.Bool("deleted", deleted))
 	var dataChangeEvent *models2.DataChangeEvent
 	var err error
 	converter := func(object interface{}) any {
@@ -469,6 +479,8 @@ func (c *Collector) handleAsyncLocationEvent(ctx context.Context, location model
 
 // handleAsyncOCloudSiteEvent handles an async event received for an OCloudSite object.
 func (c *Collector) handleAsyncOCloudSiteEvent(ctx context.Context, site models.OCloudSite, deleted bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("oCloudSiteID", site.OCloudSiteID.String()))
+	ctx = logging.AppendCtx(ctx, slog.Bool("deleted", deleted))
 	var dataChangeEvent *models2.DataChangeEvent
 	var err error
 
@@ -583,6 +595,8 @@ func (c *Collector) handleOCloudSiteSyncCompletion(ctx context.Context, ids []an
 
 // handleAsyncResourcePoolEvent handles an async event received for a ResourcePool object.
 func (c *Collector) handleAsyncResourcePoolEvent(ctx context.Context, pool models.ResourcePool, deleted bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("resourcePoolID", pool.ResourcePoolID.String()))
+	ctx = logging.AppendCtx(ctx, slog.Bool("deleted", deleted))
 	var dataChangeEvent *models2.DataChangeEvent
 	var err error
 	converter := func(object interface{}) any {


### PR DESCRIPTION
Add logging.AppendCtx() calls to enrich log context with resource- specific identifiers at API handler entry points, collector callbacks, and middleware. All downstream log calls within these scopes automatically include the enriched context fields.

Context enrichment:
- Middleware: LogDuration adds method and url to context for all requests
- API handlers (30 handlers across 5 services): resource-specific IDs added at handler entry (provisioningRequestId, subscriptionId, resourcePoolId, alarmEventRecordId, etc.)
- Collector callbacks (8 handlers across 2 collectors): resource IDs and deleted flag added at callback entry

Log quality fixes found during production log review:
- Fix AppendCtx to replace existing keys instead of blindly appending, preventing duplicate JSON keys (e.g., "phase" was accumulating across reconciliation phases, producing entries with 6 duplicate "phase" keys)
- Remove "name" from LogReconcileStart context since controller- runtime already injects its own "name" field, causing collisions
- Remove redundant attributes from individual log calls where the data is now in context (provisioning API, alarms API, middleware error handlers, NAR controller)

Test updates:
- Update mock expectations in API server tests to use gomock.Any() for context parameter since handlers now enrich context via AppendCtx before calling repository methods
- Remove "method" and "path" assertions from middleware error handler tests since those fields now come from LogDuration context, not explicit attributes
- Update logging unit and integration tests to reflect removal of "name" from LogReconcileStart context