### PR TITLE
CNF-24577: move database query logging from INFO to DEBUG level

### DIFF
--- a/internal/service/common/db/postgres.go
+++ b/internal/service/common/db/postgres.go
@@ -161,15 +161,13 @@ var customLogger = tracelog.LoggerFunc(func(ctx context.Context, level tracelog.
 
 func convertLogLevel(level tracelog.LogLevel) slog.Level {
 	switch level {
-	case tracelog.LogLevelTrace, tracelog.LogLevelDebug:
+	case tracelog.LogLevelTrace, tracelog.LogLevelDebug, tracelog.LogLevelInfo:
 		return slog.LevelDebug
-	case tracelog.LogLevelInfo:
-		return slog.LevelInfo
 	case tracelog.LogLevelWarn:
 		return slog.LevelWarn
 	case tracelog.LogLevelError:
 		return slog.LevelError
 	default:
-		return slog.LevelInfo
+		return slog.LevelDebug
 	}
 }


### PR DESCRIPTION
Map pgx's LogLevelInfo to slog.LevelDebug so normal database queries, prepared statements, and connection pool events are logged at DEBUG instead of INFO. This eliminates 80-98% of the noise in API server logs — previously, SQL query logging dominated all three API server log outputs, drowning out application-level messages.

Slow queries (>100ms) and error queries still escalate to WARN/ERROR via the performance threshold checks in the custom logger.