### PR TITLE
CNF-24578: add BMH/node context enrichment and standardize field naming

### DIFF
--- a/internal/hardwaremanager/controller/allocatednode_controller.go
+++ b/internal/hardwaremanager/controller/allocatednode_controller.go
@@ -129,19 +129,20 @@ func (r *AllocatedNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // CleanupForDeletedNode
 func (r *AllocatedNodeReconciler) handleAllocatedNodeDeletion(ctx context.Context, allocatednode *hwmgmtv1alpha1.AllocatedNode) (bool, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("node", allocatednode.Name))
 
-	r.Logger.InfoContext(ctx, "handleAllocatedNodeDeletion", slog.String("node", allocatednode.Name))
+	r.Logger.InfoContext(ctx, "handleAllocatedNodeDeletion")
 	bmh, err := getBMHForNode(ctx, r.NoncachedClient, allocatednode)
 	if err != nil {
 		// If BMH is not found (e.g., manually deleted), allow the AllocatedNode deletion to proceed
 		if errors.IsNotFound(err) {
 			r.Logger.InfoContext(ctx, "BMH not found, assuming manually deleted — proceeding with AllocatedNode deletion",
-				slog.String("node", allocatednode.Name),
 				slog.String("bmh", allocatednode.Spec.HwMgrNodeId))
 			return true, nil
 		}
 		return true, fmt.Errorf("failed to get BMH for node %s: %w", allocatednode.Name, err)
 	}
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	skipCleanup := allocatednode.Spec.SkipCleanup
 
@@ -155,7 +156,7 @@ func (r *AllocatedNodeReconciler) handleAllocatedNodeDeletion(ctx context.Contex
 	if !skipCleanup && isNodeProvisioningInProgress(allocatednode) {
 		// Wait for BMH to transition to Available before powering off
 		if bmh.Status.Provisioning.State != metal3v1alpha1.StateAvailable {
-			r.Logger.InfoContext(ctx, "BMH not yet Available — waiting before powering off", slog.String("bmh", bmh.Name))
+			r.Logger.InfoContext(ctx, "BMH not yet Available — waiting before powering off")
 			return false, nil
 		}
 	}

--- a/internal/hardwaremanager/controller/baremetalhost_manager.go
+++ b/internal/hardwaremanager/controller/baremetalhost_manager.go
@@ -84,6 +84,7 @@ func updateBMHMetaWithRetry(
 	metaType string, // "label" or "annotation"
 	key, value, operation string,
 ) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", name.Name))
 	// nolint: wrapcheck
 	return retry.OnError(retry.DefaultRetry, k8serrors.IsConflict, func() error {
 		// Fetch the latest version of the BMH

--- a/internal/hardwaremanager/controller/baremetalhost_manager.go
+++ b/internal/hardwaremanager/controller/baremetalhost_manager.go
@@ -84,7 +84,6 @@ func updateBMHMetaWithRetry(
 	metaType string, // "label" or "annotation"
 	key, value, operation string,
 ) error {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", name.Name))
 	// nolint: wrapcheck
 	return retry.OnError(retry.DefaultRetry, k8serrors.IsConflict, func() error {
 		// Fetch the latest version of the BMH
@@ -413,8 +412,6 @@ func processHwProfile(ctx context.Context,
 	namespace string,
 	bmh *metal3v1alpha1.BareMetalHost, profileName string,
 	postInstall, validateOnly bool) (bool, error) {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
-
 	logger.DebugContext(ctx, "Processing hardware profile for BMH",
 		slog.String("hwProfile", profileName),
 		slog.Bool("postInstall", postInstall),
@@ -507,7 +504,6 @@ func processHwProfile(ctx context.Context,
 }
 
 func checkBMHStatus(ctx context.Context, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost, state metal3v1alpha1.ProvisioningState) bool {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Check if the BMH is in  desired state
 	if bmh.Status.Provisioning.State == state {
 		logger.InfoContext(ctx, "BMH is now in desired state", slog.String("state", string(state)))
@@ -620,7 +616,6 @@ func handleTransitionNode(ctx context.Context,
 }
 
 func addRebootAnnotation(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 	logger.DebugContext(ctx, "Adding reboot annotation to BMH",
 		slog.String("annotation", BmhRebootAnnotation))
@@ -635,7 +630,6 @@ func addRebootAnnotation(ctx context.Context, c client.Client, logger *slog.Logg
 // firmware updates and adds the reboot annotation to the BMH to trigger node
 // reboot when required.
 func evaluateCRForReboot(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Check if both annotations are present
 	hasBiosAnnotation := bmh.Annotations[BiosUpdateNeededAnnotation] != ""
 	hasFirmwareAnnotation := bmh.Annotations[FirmwareUpdateNeededAnnotation] != ""
@@ -741,8 +735,6 @@ func processBMHUpdateCase(ctx context.Context,
 	}, postInstall bool,
 	nodeOps NodeOps,
 ) (ctrl.Result, error) {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
-
 	if bmh.Status.OperationalStatus == metal3v1alpha1.OperationalStatusError {
 		tolerate, err := tolerateAndAnnotateTransientBMHError(ctx, c, logger, bmh)
 		if err != nil || tolerate {
@@ -1180,7 +1172,6 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 // on the BMH so it can be restored during deprovisioning. IBI provisioning overwrites this
 // field with a secret that gets deleted when the cluster is deprovisioned.
 func saveOrigNetworkData(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Skip if the annotation already exists (re-entrant safety)
 	if _, exists := bmh.Annotations[OrigNetworkDataAnnotation]; exists {
 		return nil
@@ -1198,7 +1189,6 @@ func saveOrigNetworkData(ctx context.Context, c client.Client, logger *slog.Logg
 
 // deallocateBMH deallocates a BareMetalHost that is no longer associated with a cluster deployment.
 func deallocateBMH(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost, skipCleanup bool) error {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 
 	// Remove InfraEnvLabel: ensure the assisted-service is no longer managing PreprovisioningImage
@@ -1215,7 +1205,6 @@ func deallocateBMH(ctx context.Context, c client.Client, logger *slog.Logger, bm
 
 // markBMHAllocated sets the "allocated" label to "true" on a BareMetalHost.
 func markBMHAllocated(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Check if the BMH is already allocated to avoid unnecessary patching
 	if isBMHAllocated(bmh) {
 		logger.InfoContext(ctx, "BMH is already allocated, skipping update")
@@ -1227,7 +1216,6 @@ func markBMHAllocated(ctx context.Context, c client.Client, logger *slog.Logger,
 
 // allowHostManagement sets bmac.agent-install.openshift.io/allow-provisioned-host-management annotation on a BareMetalHost.
 func allowHostManagement(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	if val, exists := bmh.Annotations[BmhHostMgmtAnnotation]; exists && val == "" {
 		return nil
 	}
@@ -1242,7 +1230,6 @@ func isBMHDeallocated(bmh *metal3v1alpha1.BareMetalHost) bool {
 // clearBMHAnnotation clears both BmhDeallocationDoneAnnotation and BmhErrorTimestampAnnotation from a BareMetalHost in a single API call
 func clearBMHAnnotation(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
 	name := types.NamespacedName{Namespace: bmh.Namespace, Name: bmh.Name}
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	// nolint: wrapcheck
 	return retry.OnError(retry.DefaultRetry, k8serrors.IsConflict, func() error {
@@ -1308,7 +1295,6 @@ func patchBMHOnline(ctx context.Context, c client.Client, bmh *metal3v1alpha1.Ba
 }
 
 func markBMHTransitenError(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	if bmh.Annotations == nil {
 		bmh.Annotations = make(map[string]string)
 	}
@@ -1359,7 +1345,6 @@ func tolerateAndAnnotateTransientBMHError(
 	logger *slog.Logger,
 	bmh *metal3v1alpha1.BareMetalHost,
 ) (bool, error) {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	tolerate, err := isTransientBMHError(bmh)
 	if err != nil {
 		message := "error checking transient BMH error"
@@ -1385,7 +1370,6 @@ func tolerateAndAnnotateTransientBMHError(
 
 // clearBMHUpdateAnnotations removes BIOS and firmware update annotations from a BareMetalHost
 func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 	var errs []error
 

--- a/internal/hardwaremanager/controller/baremetalhost_manager.go
+++ b/internal/hardwaremanager/controller/baremetalhost_manager.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
 )
 
@@ -83,13 +84,13 @@ func updateBMHMetaWithRetry(
 	metaType string, // "label" or "annotation"
 	key, value, operation string,
 ) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", name.Name))
 	// nolint: wrapcheck
 	return retry.OnError(retry.DefaultRetry, k8serrors.IsConflict, func() error {
 		// Fetch the latest version of the BMH
 		var latestBMH metal3v1alpha1.BareMetalHost
 		if err := c.Get(ctx, name, &latestBMH); err != nil {
 			logger.ErrorContext(ctx, "Failed to fetch BMH for "+metaType+" update",
-				slog.Any("bmh", name),
 				slog.String("error", err.Error()))
 			return err
 		}
@@ -112,13 +113,11 @@ func updateBMHMetaWithRetry(
 
 		if operation == OpRemove {
 			if targetMap == nil {
-				logger.InfoContext(ctx, fmt.Sprintf("BMH has no %ss, skipping remove operation", metaType),
-					slog.Any("bmh", name))
+				logger.InfoContext(ctx, fmt.Sprintf("BMH has no %ss, skipping remove operation", metaType))
 				return nil
 			}
 			if _, exists := targetMap[key]; !exists {
 				logger.InfoContext(ctx, fmt.Sprintf("%s not present, skipping remove operation", metaType),
-					slog.Any("bmh", name),
 					slog.String(metaType, key))
 				return nil
 			}
@@ -129,7 +128,6 @@ func updateBMHMetaWithRetry(
 			if key == BmhErrorTimestampAnnotation {
 				if existingValue, exists := targetMap[key]; exists {
 					logger.InfoContext(ctx, fmt.Sprintf("%s already present with value %s, skipping add operation", metaType, existingValue),
-						slog.Any("bmh", name),
 						slog.String(metaType, key))
 					return nil
 				}
@@ -151,14 +149,12 @@ func updateBMHMetaWithRetry(
 		// Apply the patch
 		if err := c.Patch(ctx, &latestBMH, patch); err != nil {
 			logger.ErrorContext(ctx, "Failed to update BMH "+metaType,
-				slog.String("bmh", name.Name),
 				slog.String("operation", operation),
 				slog.String("error", err.Error()))
 			return fmt.Errorf("failed to %s %s on BMH %s: %w", operation, metaType, name.Name, err)
 		}
 
 		logger.InfoContext(ctx, "Successfully updated BMH "+metaType,
-			slog.String("bmh", name.Name),
 			slog.String("operation", operation))
 		return nil
 	})
@@ -249,6 +245,7 @@ func setBootMACAddressFromLabel(
 	c client.Client,
 	logger *slog.Logger,
 	bmh *metal3v1alpha1.BareMetalHost) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	// Verify hardware details are available
 	if bmh.Status.HardwareDetails == nil {
@@ -264,7 +261,6 @@ func setBootMACAddressFromLabel(
 		if !found {
 			// Label not found, but bootMACAddress is already set - this is fine
 			logger.InfoContext(ctx, "bootMACAddress already set, boot interface label not present (optional)",
-				slog.String("bmh", bmh.Name),
 				slog.String("mac", bmh.Spec.BootMACAddress))
 			return nil
 		}
@@ -292,7 +288,6 @@ func setBootMACAddressFromLabel(
 		}
 
 		logger.InfoContext(ctx, "Validated bootMACAddress matches boot interface label",
-			slog.String("bmh", bmh.Name),
 			slog.String("label", constants.BootInterfaceLabelFullKey),
 			slog.String("mac", targetMAC))
 		return nil
@@ -330,7 +325,6 @@ func setBootMACAddressFromLabel(
 		var latestBMH metal3v1alpha1.BareMetalHost
 		if err := c.Get(ctx, name, &latestBMH); err != nil {
 			logger.ErrorContext(ctx, "Failed to fetch BMH for bootMACAddress update",
-				slog.Any("bmh", name),
 				slog.String("error", err.Error()))
 			return err
 		}
@@ -343,7 +337,6 @@ func setBootMACAddressFromLabel(
 					latestBMH.Spec.BootMACAddress, constants.BootInterfaceLabelFullKey, targetMAC, latestBMH.Name)
 			}
 			logger.InfoContext(ctx, "bootMACAddress already set and validated",
-				slog.String("bmh", latestBMH.Name),
 				slog.String("mac", targetMAC))
 			return nil
 		}
@@ -357,13 +350,11 @@ func setBootMACAddressFromLabel(
 		// Apply the patch
 		if err := c.Patch(ctx, &latestBMH, patch); err != nil {
 			logger.ErrorContext(ctx, "Failed to patch BMH bootMACAddress",
-				slog.String("bmh", name.Name),
 				slog.String("error", err.Error()))
 			return fmt.Errorf("failed to patch BMH bootMACAddress %s: %w", name.Name, err)
 		}
 
 		logger.InfoContext(ctx, "Successfully set bootMACAddress from interface label",
-			slog.String("bmh", latestBMH.Name),
 			slog.String("label", constants.BootInterfaceLabelFullKey),
 			slog.String("labelValue", bootLabelValue),
 			slog.String("mac", targetMAC))
@@ -422,9 +413,9 @@ func processHwProfile(ctx context.Context,
 	namespace string,
 	bmh *metal3v1alpha1.BareMetalHost, profileName string,
 	postInstall, validateOnly bool) (bool, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	logger.DebugContext(ctx, "Processing hardware profile for BMH",
-		slog.String("bmh", bmh.Name),
 		slog.String("hwProfile", profileName),
 		slog.Bool("postInstall", postInstall),
 		slog.Bool("validateOnly", validateOnly))
@@ -438,8 +429,7 @@ func processHwProfile(ctx context.Context,
 
 	// Skip processing if no hardware profile is specified
 	if profileName == "" {
-		logger.InfoContext(ctx, "No hardware profile specified, skipping HW profile processing",
-			slog.String("bmh", bmh.Name))
+		logger.InfoContext(ctx, "No hardware profile specified, skipping HW profile processing")
 		return false, nil
 	}
 
@@ -457,32 +447,27 @@ func processHwProfile(ctx context.Context,
 	// Check if BIOS update is required
 	biosUpdateRequired := false
 	if hwProfile.Spec.Bios.Attributes != nil {
-		logger.DebugContext(ctx, "Checking if BIOS update is required",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "Checking if BIOS update is required")
 		biosUpdateRequired, err = IsBiosUpdateRequired(ctx, c, logger, bmh, hwProfile.Spec.Bios, validateOnly)
 		if err != nil {
 			return false, err
 		}
 		logger.DebugContext(ctx, "BIOS update check complete",
-			slog.String("bmh", bmh.Name),
 			slog.Bool("biosUpdateRequired", biosUpdateRequired))
 	}
 
 	// Check if firmware update is required
-	logger.DebugContext(ctx, "Checking if firmware update is required",
-		slog.String("bmh", bmh.Name))
+	logger.DebugContext(ctx, "Checking if firmware update is required")
 	firmwareUpdateRequired, err := IsFirmwareUpdateRequired(ctx, c, logger, bmh, hwProfile.Spec, validateOnly)
 	if err != nil {
 		return false, err
 	}
 	logger.DebugContext(ctx, "Firmware update check complete",
-		slog.String("bmh", bmh.Name),
 		slog.Bool("firmwareUpdateRequired", firmwareUpdateRequired))
 
 	// If nothing is required, return early
 	if !biosUpdateRequired && !firmwareUpdateRequired {
-		logger.DebugContext(ctx, "No BIOS or firmware updates required",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "No BIOS or firmware updates required")
 		return false, nil
 	}
 
@@ -501,34 +486,31 @@ func processHwProfile(ctx context.Context,
 	// If bios update is required, annotate BMH
 	if biosUpdateRequired {
 		logger.DebugContext(ctx, "BIOS update required, setting update-needed annotation",
-			slog.String("bmh", bmh.Name),
 			slog.String("annotation", BiosUpdateNeededAnnotation))
 		if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation, BiosUpdateNeededAnnotation, ValueTrue, OpAdd); err != nil {
 			return true, fmt.Errorf("failed to annotate BMH %s/%s: %w", bmh.Namespace, bmh.Name, err)
 		}
-		logger.DebugContext(ctx, "BIOS update-needed annotation set successfully",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "BIOS update-needed annotation set successfully")
 	}
 
 	// if firmware update is required, annotate BMH
 	if firmwareUpdateRequired {
 		logger.DebugContext(ctx, "Firmware update required, setting update-needed annotation",
-			slog.String("bmh", bmh.Name),
 			slog.String("annotation", FirmwareUpdateNeededAnnotation))
 		if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation, FirmwareUpdateNeededAnnotation, ValueTrue, OpAdd); err != nil {
 			return true, fmt.Errorf("failed to annotate BMH %s/%s: %w", bmh.Namespace, bmh.Name, err)
 		}
-		logger.DebugContext(ctx, "Firmware update-needed annotation set successfully",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "Firmware update-needed annotation set successfully")
 	}
 
 	return true, nil
 }
 
 func checkBMHStatus(ctx context.Context, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost, state metal3v1alpha1.ProvisioningState) bool {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Check if the BMH is in  desired state
 	if bmh.Status.Provisioning.State == state {
-		logger.InfoContext(ctx, "BMH is now in desired state", slog.String("BMH", bmh.Name), slog.Any("State", state))
+		logger.InfoContext(ctx, "BMH is now in desired state", slog.String("state", string(state)))
 		return true
 	}
 	return false
@@ -592,10 +574,12 @@ func handleTransitionNode(ctx context.Context,
 	postInstall bool,
 	nodeOps NodeOps,
 ) (ctrl.Result, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
 	bmh, err := getBMHForNode(ctx, noncachedClient, node)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get BMH for node %s: %w", node.Name, err)
 	}
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	if bmh.Annotations == nil {
 		bmh.Annotations = make(map[string]string)
@@ -636,15 +620,14 @@ func handleTransitionNode(ctx context.Context,
 }
 
 func addRebootAnnotation(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 	logger.DebugContext(ctx, "Adding reboot annotation to BMH",
-		slog.String("bmh", bmh.Name),
 		slog.String("annotation", BmhRebootAnnotation))
 	if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, "annotation", BmhRebootAnnotation, "", OpAdd); err != nil {
 		return fmt.Errorf("failed to add %s to BMH %+v: %w", BmhRebootAnnotation, bmhName, err)
 	}
-	logger.InfoContext(ctx, "Added reboot annotation to trigger firmware/BIOS update",
-		slog.String("BMH", bmh.Name))
+	logger.InfoContext(ctx, "Added reboot annotation to trigger firmware/BIOS update")
 	return nil
 }
 
@@ -652,18 +635,17 @@ func addRebootAnnotation(ctx context.Context, c client.Client, logger *slog.Logg
 // firmware updates and adds the reboot annotation to the BMH to trigger node
 // reboot when required.
 func evaluateCRForReboot(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Check if both annotations are present
 	hasBiosAnnotation := bmh.Annotations[BiosUpdateNeededAnnotation] != ""
 	hasFirmwareAnnotation := bmh.Annotations[FirmwareUpdateNeededAnnotation] != ""
 
 	logger.DebugContext(ctx, "Evaluating BMH for reboot",
-		slog.String("bmh", bmh.Name),
 		slog.Bool("hasBiosAnnotation", hasBiosAnnotation),
 		slog.Bool("hasFirmwareAnnotation", hasFirmwareAnnotation))
 
 	if !hasBiosAnnotation && !hasFirmwareAnnotation {
-		logger.DebugContext(ctx, "No update-needed annotations present, skipping reboot evaluation",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "No update-needed annotations present, skipping reboot evaluation")
 		return nil
 	}
 
@@ -672,8 +654,7 @@ func evaluateCRForReboot(ctx context.Context, c client.Client, logger *slog.Logg
 
 	// If both annotations are present, require both checks to pass
 	if hasBiosAnnotation && hasFirmwareAnnotation {
-		logger.DebugContext(ctx, "Both BIOS and firmware annotations present, checking both",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "Both BIOS and firmware annotations present, checking both")
 
 		biosChange, err = isFirmwareSettingsChangeDetectedAndValid(ctx, c, bmh)
 		if err != nil {
@@ -686,24 +667,20 @@ func evaluateCRForReboot(ctx context.Context, c client.Client, logger *slog.Logg
 		}
 
 		logger.DebugContext(ctx, "Both annotations check results",
-			slog.String("bmh", bmh.Name),
 			slog.Bool("biosChange", biosChange),
 			slog.Bool("firmwareChange", firmwareChange))
 
 		if biosChange && firmwareChange {
-			logger.DebugContext(ctx, "Both BIOS and firmware changes detected, adding reboot annotation",
-				slog.String("bmh", bmh.Name))
+			logger.DebugContext(ctx, "Both BIOS and firmware changes detected, adding reboot annotation")
 			return addRebootAnnotation(ctx, c, logger, bmh)
 		}
-		logger.DebugContext(ctx, "Not all changes detected yet, skipping reboot",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "Not all changes detected yet, skipping reboot")
 		return nil
 	}
 
 	// If only BIOS annotation is present
 	if hasBiosAnnotation {
-		logger.DebugContext(ctx, "Only BIOS annotation present, checking BIOS change",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "Only BIOS annotation present, checking BIOS change")
 
 		biosChange, err = isFirmwareSettingsChangeDetectedAndValid(ctx, c, bmh)
 		if err != nil {
@@ -711,22 +688,18 @@ func evaluateCRForReboot(ctx context.Context, c client.Client, logger *slog.Logg
 		}
 
 		logger.DebugContext(ctx, "BIOS-only check result",
-			slog.String("bmh", bmh.Name),
 			slog.Bool("biosChange", biosChange))
 
 		if biosChange {
-			logger.DebugContext(ctx, "BIOS change detected, adding reboot annotation",
-				slog.String("bmh", bmh.Name))
+			logger.DebugContext(ctx, "BIOS change detected, adding reboot annotation")
 			return addRebootAnnotation(ctx, c, logger, bmh)
 		}
-		logger.DebugContext(ctx, "BIOS change not detected yet, skipping reboot",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "BIOS change not detected yet, skipping reboot")
 	}
 
 	// If only firmware annotation is present
 	if hasFirmwareAnnotation {
-		logger.DebugContext(ctx, "Only firmware annotation present, checking firmware change",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "Only firmware annotation present, checking firmware change")
 
 		firmwareChange, err = isHostFirmwareComponentsChangeDetectedAndValid(ctx, c, bmh)
 		if err != nil {
@@ -734,16 +707,13 @@ func evaluateCRForReboot(ctx context.Context, c client.Client, logger *slog.Logg
 		}
 
 		logger.DebugContext(ctx, "Firmware-only check result",
-			slog.String("bmh", bmh.Name),
 			slog.Bool("firmwareChange", firmwareChange))
 
 		if firmwareChange {
-			logger.DebugContext(ctx, "Firmware change detected, adding reboot annotation",
-				slog.String("bmh", bmh.Name))
+			logger.DebugContext(ctx, "Firmware change detected, adding reboot annotation")
 			return addRebootAnnotation(ctx, c, logger, bmh)
 		}
-		logger.DebugContext(ctx, "Firmware change not detected yet, skipping reboot",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "Firmware change not detected yet, skipping reboot")
 	}
 
 	return nil
@@ -771,6 +741,7 @@ func processBMHUpdateCase(ctx context.Context,
 	}, postInstall bool,
 	nodeOps NodeOps,
 ) (ctrl.Result, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	if bmh.Status.OperationalStatus == metal3v1alpha1.OperationalStatusError {
 		tolerate, err := tolerateAndAnnotateTransientBMHError(ctx, c, logger, bmh)
@@ -779,7 +750,7 @@ func processBMHUpdateCase(ctx context.Context,
 		}
 
 		message := fmt.Sprintf("BMH in error state: %s", bmh.Status.ErrorType)
-		logger.WarnContext(ctx, message, slog.String("BMH", bmh.Name))
+		logger.WarnContext(ctx, message)
 
 		// Uncordon the node on day2 failure so it returns to schedulable
 		if postInstall {
@@ -793,7 +764,6 @@ func processBMHUpdateCase(ctx context.Context,
 		// Clear config-in-progress annotation before setting node to failed
 		if err := clearConfigAnnotationWithPatch(ctx, c, node); err != nil {
 			logger.ErrorContext(ctx, "Failed to clear config annotation",
-				slog.String("node", node.Name),
 				slog.String("error", err.Error()))
 			return ctrl.Result{}, err
 		}
@@ -801,7 +771,6 @@ func processBMHUpdateCase(ctx context.Context,
 		// Clear BMH update annotations to ensure clean state for retry
 		if err := clearBMHUpdateAnnotations(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "Failed to clear BMH update annotations after error",
-				slog.String("BMH", bmh.Name),
 				slog.String("error", err.Error()))
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
@@ -809,7 +778,6 @@ func processBMHUpdateCase(ctx context.Context,
 		// Clear BMH error annotation to allow future retry attempts
 		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "failed to clear BMH error annotation for future retries",
-				slog.String("BMH", bmh.Name),
 				slog.String("error", err.Error()))
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
@@ -822,7 +790,7 @@ func processBMHUpdateCase(ctx context.Context,
 		}
 		if err := hwmgrutils.SetNodeFailedStatus(ctx, c, logger, node, string(condType), message); err != nil {
 			if k8serrors.IsConflict(err) {
-				logger.WarnContext(ctx, "conflict setting node status; will retry", slog.String("node", node.Name), slog.String("error", err.Error()))
+				logger.WarnContext(ctx, "conflict setting node status; will retry", slog.String("error", err.Error()))
 				return hwmgrutils.RequeueWithShortInterval(), nil
 			}
 			// everything else here is unexpected
@@ -835,7 +803,7 @@ func processBMHUpdateCase(ctx context.Context,
 	// clear transient error annotation if BMH recovered
 	if _, hasAnnotation := bmh.Annotations[BmhErrorTimestampAnnotation]; hasAnnotation {
 		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
-			logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+			logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("error", err.Error()))
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
 	}
@@ -850,33 +818,29 @@ func processBMHUpdateCase(ctx context.Context,
 			}
 			logger.InfoContext(ctx,
 				"BMH not in 'Servicing' state yet, requeuing",
-				slog.String("BMH", bmh.Name),
 				slog.String("expected", string(metal3v1alpha1.OperationalStatusServicing)),
 				slog.String("current", string(bmh.Status.OperationalStatus)))
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
 		logger.InfoContext(ctx,
-			fmt.Sprintf("BMH transitioned to 'Servicing' state for %s update", uc.LogLabel),
-			slog.String("BMH", bmh.Name))
+			fmt.Sprintf("BMH transitioned to 'Servicing' state for %s update", uc.LogLabel))
 	} else {
 		if bmh.Status.Provisioning.State != metal3v1alpha1.StatePreparing {
 			logger.InfoContext(ctx,
 				"BMH not in 'Preparing' state yet, requeuing",
-				slog.String("BMH", bmh.Name),
 				slog.String("expected", string(metal3v1alpha1.StatePreparing)),
 				slog.String("current", string(bmh.Status.Provisioning.State)))
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
 		logger.InfoContext(ctx,
-			fmt.Sprintf("BMH transitioned to 'Preparing' state for %s update", uc.LogLabel),
-			slog.String("BMH", bmh.Name))
+			fmt.Sprintf("BMH transitioned to 'Preparing' state for %s update", uc.LogLabel))
 	}
 
 	// Remove the update-needed annotation from the BMH.
 	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 	if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation, uc.AnnotationKey, "", OpRemove); err != nil {
 		logger.WarnContext(ctx, "failed to remove annotation",
-			slog.String("BMH", bmh.Name), slog.String("Annotation", uc.AnnotationKey), slog.String("error", err.Error()))
+			slog.String("annotation", uc.AnnotationKey), slog.String("error", err.Error()))
 		return hwmgrutils.RequeueWithShortInterval(), nil
 	}
 
@@ -889,14 +853,12 @@ func processBMHUpdateCase(ctx context.Context,
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
 		logger.InfoContext(ctx,
-			fmt.Sprintf("BMH %s update initiated", uc.LogLabel),
-			slog.String("BMH", bmh.Name))
+			fmt.Sprintf("BMH %s update initiated", uc.LogLabel))
 		// Requeue to let the next reconcile handle the in-progress node
 		return hwmgrutils.RequeueWithShortInterval(), nil
 	} else {
 		logger.InfoContext(ctx,
 			"Skipping annotation; another config already in progress",
-			slog.String("BMH", bmh.Name),
 			slog.String("skipped", uc.Reason))
 	}
 
@@ -935,7 +897,8 @@ func handleBMHCompletion(ctx context.Context,
 		go func(node *hwmgmtv1alpha1.AllocatedNode) {
 			defer wg.Done()
 
-			updating, err := handleSingleNodeCompletion(ctx, c, noncachedClient, logger, namespace, node)
+			nodeCtx := logging.AppendCtx(ctx, slog.String("node", node.Name))
+			updating, err := handleSingleNodeCompletion(nodeCtx, c, noncachedClient, logger, namespace, node)
 
 			mu.Lock()
 			defer mu.Unlock()
@@ -944,8 +907,7 @@ func handleBMHCompletion(ctx context.Context,
 				anyUpdating = true
 			}
 			if err != nil {
-				logger.ErrorContext(ctx, "failed to handle single node completion",
-					slog.String("node", node.Name),
+				logger.ErrorContext(nodeCtx, "failed to handle single node completion",
 					slog.String("error", err.Error()))
 				errs = append(errs, fmt.Errorf("node %s, error: %w", node.Name, err))
 			}
@@ -970,12 +932,14 @@ func handleSingleNodeCompletion(ctx context.Context,
 	logger *slog.Logger,
 	namespace string,
 	node *hwmgmtv1alpha1.AllocatedNode) (bool, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
 
 	// Get BMH associated with the node
 	bmh, err := getBMHForNode(ctx, noncachedClient, node)
 	if err != nil {
 		return true, fmt.Errorf("failed to get BMH for node %s: %w", node.Name, err)
 	}
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	// Check if BMH has transitioned to "Available"
 	// If BMH is not available yet, update is still ongoing
@@ -991,14 +955,14 @@ func handleSingleNodeCompletion(ctx context.Context,
 				string(hwmgmtv1alpha1.Provisioned), metav1.ConditionFalse,
 				string(hwmgmtv1alpha1.Failed), errMessage.Error()); err != nil {
 				logger.ErrorContext(ctx, "failed to set node condition status",
-					slog.String("Node", node.Name), slog.String("error", err.Error()))
+					slog.String("error", err.Error()))
 			}
 			return false, errMessage
 		}
 		// if BMH is not in error state, clean up transient annotation if it exists
 		if _, hasAnnotation := bmh.Annotations[BmhErrorTimestampAnnotation]; hasAnnotation {
 			if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
-				logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+				logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("error", err.Error()))
 			}
 		}
 		return true, nil // still waiting for available
@@ -1008,7 +972,7 @@ func handleSingleNodeCompletion(ctx context.Context,
 	if _, hasAnnotation := bmh.Annotations[BmhErrorTimestampAnnotation]; hasAnnotation {
 		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "failed to clean up transient error annotation on BMH available transition",
-				slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+				slog.String("error", err.Error()))
 		}
 	}
 
@@ -1078,7 +1042,6 @@ func removeInfraEnvLabelFromPreprovisioningImage(ctx context.Context, c client.C
 		image := &metal3v1alpha1.PreprovisioningImage{}
 		if err := c.Get(ctx, name, image); err != nil {
 			logger.ErrorContext(ctx, "Failed to get PreprovisioningImage",
-				slog.String("bmh", name.String()),
 				slog.String("error", err.Error()))
 			return err
 		}
@@ -1092,13 +1055,11 @@ func removeInfraEnvLabelFromPreprovisioningImage(ctx context.Context, c client.C
 		patch := client.MergeFrom(image)
 		if err := c.Patch(ctx, patched, patch); err != nil {
 			logger.ErrorContext(ctx, "Failed to patch PreprovisioningImage",
-				slog.String("bmh", name.String()),
 				slog.String("error", err.Error()))
 			return fmt.Errorf("failed to patch PreprovisioningImage %s: %w", name.String(), err)
 		}
 
-		logger.InfoContext(ctx, "Successfully cleaned up PreprovisioningImage",
-			slog.String("bmh", name.String()))
+		logger.InfoContext(ctx, "Successfully cleaned up PreprovisioningImage")
 		return nil
 	})
 }
@@ -1121,6 +1082,7 @@ func removeInfraEnvLabel(ctx context.Context, c client.Client, logger *slog.Logg
 
 // finalizeBMHDeallocation deallocates a BareMetalHost that is no longer associated with a cluster deployment.
 func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost, skipCleanup bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 	// nolint: wrapcheck
 	return retry.OnError(retry.DefaultRetry, k8serrors.IsConflict, func() error {
@@ -1128,7 +1090,6 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 		var current metal3v1alpha1.BareMetalHost
 		if err := c.Get(ctx, name, &current); err != nil {
 			logger.ErrorContext(ctx, "Failed to get BMH",
-				slog.String("bmh", name.String()),
 				slog.String("error", err.Error()))
 			return err
 		}
@@ -1160,7 +1121,6 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 			if origValue, exists := patched.Annotations[OrigNetworkDataAnnotation]; exists {
 				if patched.Spec.PreprovisioningNetworkDataName != origValue {
 					logger.InfoContext(ctx, "Restoring PreprovisioningNetworkDataName from annotation",
-						slog.String("bmh", bmh.Name),
 						slog.String("current", patched.Spec.PreprovisioningNetworkDataName),
 						slog.String("original", origValue))
 					patched.Spec.PreprovisioningNetworkDataName = origValue
@@ -1181,7 +1141,6 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 				} else {
 					patched.Spec.PreprovisioningNetworkDataName = expectedSecretName
 					logger.InfoContext(ctx, "Restored PreprovisioningNetworkDataName from legacy secret",
-						slog.String("bmh", bmh.Name),
 						slog.String("secretName", expectedSecretName))
 				}
 			}
@@ -1208,13 +1167,11 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 		patch := client.MergeFrom(&current)
 		if err := c.Patch(ctx, patched, patch); err != nil {
 			logger.ErrorContext(ctx, "Failed to patch BMH",
-				slog.String("bmh", name.String()),
 				slog.String("error", err.Error()))
 			return fmt.Errorf("failed to patch BMH %s: %w", name.String(), err)
 		}
 
-		logger.InfoContext(ctx, "Successfully deallocated BMH",
-			slog.String("bmh", name.String()))
+		logger.InfoContext(ctx, "Successfully deallocated BMH")
 		return nil
 	})
 }
@@ -1223,6 +1180,7 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 // on the BMH so it can be restored during deprovisioning. IBI provisioning overwrites this
 // field with a secret that gets deleted when the cluster is deprovisioned.
 func saveOrigNetworkData(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Skip if the annotation already exists (re-entrant safety)
 	if _, exists := bmh.Annotations[OrigNetworkDataAnnotation]; exists {
 		return nil
@@ -1232,7 +1190,7 @@ func saveOrigNetworkData(ctx context.Context, c client.Client, logger *slog.Logg
 	value := bmh.Spec.PreprovisioningNetworkDataName
 
 	logger.InfoContext(ctx, "Saving original PreprovisioningNetworkDataName",
-		slog.String("bmh", bmh.Name), slog.String("value", value))
+		slog.String("value", value))
 
 	return updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation,
 		OrigNetworkDataAnnotation, value, OpAdd)
@@ -1240,6 +1198,7 @@ func saveOrigNetworkData(ctx context.Context, c client.Client, logger *slog.Logg
 
 // deallocateBMH deallocates a BareMetalHost that is no longer associated with a cluster deployment.
 func deallocateBMH(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost, skipCleanup bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 
 	// Remove InfraEnvLabel: ensure the assisted-service is no longer managing PreprovisioningImage
@@ -1256,9 +1215,10 @@ func deallocateBMH(ctx context.Context, c client.Client, logger *slog.Logger, bm
 
 // markBMHAllocated sets the "allocated" label to "true" on a BareMetalHost.
 func markBMHAllocated(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Check if the BMH is already allocated to avoid unnecessary patching
 	if isBMHAllocated(bmh) {
-		logger.InfoContext(ctx, "BMH is already allocated, skipping update", slog.String("bmh", bmh.Name))
+		logger.InfoContext(ctx, "BMH is already allocated, skipping update")
 		return nil // No change needed
 	}
 	name := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
@@ -1267,6 +1227,7 @@ func markBMHAllocated(ctx context.Context, c client.Client, logger *slog.Logger,
 
 // allowHostManagement sets bmac.agent-install.openshift.io/allow-provisioned-host-management annotation on a BareMetalHost.
 func allowHostManagement(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	if val, exists := bmh.Annotations[BmhHostMgmtAnnotation]; exists && val == "" {
 		return nil
 	}
@@ -1281,6 +1242,7 @@ func isBMHDeallocated(bmh *metal3v1alpha1.BareMetalHost) bool {
 // clearBMHAnnotation clears both BmhDeallocationDoneAnnotation and BmhErrorTimestampAnnotation from a BareMetalHost in a single API call
 func clearBMHAnnotation(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
 	name := types.NamespacedName{Namespace: bmh.Namespace, Name: bmh.Name}
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	// nolint: wrapcheck
 	return retry.OnError(retry.DefaultRetry, k8serrors.IsConflict, func() error {
@@ -1288,7 +1250,6 @@ func clearBMHAnnotation(ctx context.Context, c client.Client, logger *slog.Logge
 		var latestBMH metal3v1alpha1.BareMetalHost
 		if err := c.Get(ctx, name, &latestBMH); err != nil {
 			logger.ErrorContext(ctx, "Failed to fetch BMH for annotation cleanup",
-				slog.Any("bmh", name),
 				slog.String("error", err.Error()))
 			return err
 		}
@@ -1306,8 +1267,7 @@ func clearBMHAnnotation(ctx context.Context, c client.Client, logger *slog.Logge
 
 		// If no annotations to clear, skip the patch
 		if !needsUpdate {
-			logger.InfoContext(ctx, "No BMH annotations to clear, skipping update",
-				slog.Any("bmh", name))
+			logger.InfoContext(ctx, "No BMH annotations to clear, skipping update")
 			return nil
 		}
 
@@ -1323,13 +1283,11 @@ func clearBMHAnnotation(ctx context.Context, c client.Client, logger *slog.Logge
 		// Apply the patch with both changes in a single API call
 		if err := c.Patch(ctx, &latestBMH, patch); err != nil {
 			logger.ErrorContext(ctx, "Failed to clear BMH annotations",
-				slog.String("bmh", name.Name),
 				slog.String("error", err.Error()))
 			return fmt.Errorf("failed to clear BMH annotations on BMH %s: %w", name.Name, err)
 		}
 
-		logger.InfoContext(ctx, "Successfully cleared BMH annotations",
-			slog.String("bmh", name.Name))
+		logger.InfoContext(ctx, "Successfully cleared BMH annotations")
 		return nil
 	})
 }
@@ -1350,18 +1308,17 @@ func patchBMHOnline(ctx context.Context, c client.Client, bmh *metal3v1alpha1.Ba
 }
 
 func markBMHTransitenError(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	if bmh.Annotations == nil {
 		bmh.Annotations = make(map[string]string)
 	}
 	if _, exists := bmh.Annotations[BmhErrorTimestampAnnotation]; exists {
 		logger.InfoContext(ctx, "BMH already has transient error timestamp annotation, skipping",
-			slog.String("BMH", bmh.Name),
 			slog.String("timestamp", bmh.Annotations[BmhErrorTimestampAnnotation]))
 		return nil // Already marked
 	}
 	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
-	logger.InfoContext(ctx, "Adding transient error timestamp annotation to BMH",
-		slog.String("BMH", bmh.Name))
+	logger.InfoContext(ctx, "Adding transient error timestamp annotation to BMH")
 	return updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation,
 		BmhErrorTimestampAnnotation,
 		time.Now().Format(time.RFC3339), OpAdd)
@@ -1402,10 +1359,11 @@ func tolerateAndAnnotateTransientBMHError(
 	logger *slog.Logger,
 	bmh *metal3v1alpha1.BareMetalHost,
 ) (bool, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	tolerate, err := isTransientBMHError(bmh)
 	if err != nil {
 		message := "error checking transient BMH error"
-		logger.WarnContext(ctx, message, slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+		logger.WarnContext(ctx, message, slog.String("error", err.Error()))
 		return false, fmt.Errorf("%s: %w", message, err)
 	}
 
@@ -1413,11 +1371,10 @@ func tolerateAndAnnotateTransientBMHError(
 		tsStr, hasAnnotation := bmh.Annotations[BmhErrorTimestampAnnotation]
 		if err := markBMHTransitenError(ctx, c, logger, bmh); err != nil {
 			message := "failed to annotate transient BMH error"
-			logger.WarnContext(ctx, message, slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+			logger.WarnContext(ctx, message, slog.String("error", err.Error()))
 			return false, fmt.Errorf("%s: %w", message, err)
 		}
 		logger.InfoContext(ctx, "BMH in transient error — tolerating and skipping failure",
-			slog.String("BMH", bmh.Name),
 			slog.Bool("hasTimestamp", hasAnnotation),
 			slog.String("timestamp", tsStr))
 		return true, nil
@@ -1428,6 +1385,7 @@ func tolerateAndAnnotateTransientBMHError(
 
 // clearBMHUpdateAnnotations removes BIOS and firmware update annotations from a BareMetalHost
 func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slog.Logger, bmh *metal3v1alpha1.BareMetalHost) error {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 	var errs []error
 
@@ -1438,16 +1396,13 @@ func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slo
 	if _, exists := bmh.Annotations[BiosUpdateNeededAnnotation]; exists {
 		hasBios = true
 		logger.DebugContext(ctx, "Clearing BIOS update-needed annotation",
-			slog.String("bmh", bmh.Name),
 			slog.String("annotation", BiosUpdateNeededAnnotation))
 		if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation, BiosUpdateNeededAnnotation, "", OpRemove); err != nil {
 			logger.WarnContext(ctx, "Failed to remove BIOS update annotation",
-				slog.String("bmh", bmh.Name),
 				slog.String("error", err.Error()))
 			errs = append(errs, fmt.Errorf("bios annotation removal failed: %w", err))
 		} else {
-			logger.DebugContext(ctx, "BIOS update-needed annotation cleared successfully",
-				slog.String("bmh", bmh.Name))
+			logger.DebugContext(ctx, "BIOS update-needed annotation cleared successfully")
 		}
 	}
 
@@ -1455,22 +1410,18 @@ func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slo
 	if _, exists := bmh.Annotations[FirmwareUpdateNeededAnnotation]; exists {
 		hasFirmware = true
 		logger.DebugContext(ctx, "Clearing firmware update-needed annotation",
-			slog.String("bmh", bmh.Name),
 			slog.String("annotation", FirmwareUpdateNeededAnnotation))
 		if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation, FirmwareUpdateNeededAnnotation, "", OpRemove); err != nil {
 			logger.WarnContext(ctx, "Failed to remove firmware update annotation",
-				slog.String("bmh", bmh.Name),
 				slog.String("error", err.Error()))
 			errs = append(errs, fmt.Errorf("firmware annotation removal failed: %w", err))
 		} else {
-			logger.DebugContext(ctx, "Firmware update-needed annotation cleared successfully",
-				slog.String("bmh", bmh.Name))
+			logger.DebugContext(ctx, "Firmware update-needed annotation cleared successfully")
 		}
 	}
 
 	if !hasBios && !hasFirmware {
-		logger.DebugContext(ctx, "No update-needed annotations to clear",
-			slog.String("bmh", bmh.Name))
+		logger.DebugContext(ctx, "No update-needed annotations to clear")
 	}
 
 	// Return combined errors if any occurred

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -656,7 +656,6 @@ func handleNodeInProgressUpdate(ctx context.Context,
 	node *hwmgmtv1alpha1.AllocatedNode,
 	nodeOps NodeOps,
 ) (ctrl.Result, error) {
-	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
 	bmh, err := getBMHForNode(ctx, noncachedClient, node)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get BMH for AllocatedNode %s: %w", node.Name, err)
@@ -792,7 +791,6 @@ func abandonNodeUpdate(
 	node *hwmgmtv1alpha1.AllocatedNode,
 	nodeOps NodeOps,
 ) (ctrl.Result, error) {
-	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
 	bmh, err := getBMHForNode(ctx, noncachedClient, node)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get BMH for abandoned node %s: %w", node.Name, err)
@@ -851,7 +849,6 @@ func initiateNodeUpdate(ctx context.Context,
 	newHwProfile string,
 	nodeOps NodeOps,
 ) (ctrl.Result, error) {
-	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
 
 	// Clear the abandoned annotation if this node was previously abandoned due to a
 	// mid-flight profile change. The node is now being re-processed with the new profile.

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -31,6 +31,7 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 )
 
 const ConfigAnnotation = "clcm.openshift.io/config-in-progress"
@@ -52,13 +53,13 @@ func syncSkipCleanupToAllocatedNodes(
 	for i := range nodelist.Items {
 		node := &nodelist.Items[i]
 		if node.Spec.SkipCleanup != nodeAllocationRequest.Spec.SkipCleanup {
+			nodeCtx := logging.AppendCtx(ctx, slog.String("node", node.Name))
 			patch := client.MergeFrom(node.DeepCopy())
 			node.Spec.SkipCleanup = nodeAllocationRequest.Spec.SkipCleanup
 			if err := c.Patch(ctx, node, patch); err != nil {
 				return fmt.Errorf("failed to patch SkipCleanup on AllocatedNode %s: %w", node.Name, err)
 			}
-			logger.InfoContext(ctx, "Synced skipCleanup to AllocatedNode",
-				slog.String("node", node.Name),
+			logger.InfoContext(nodeCtx, "Synced skipCleanup to AllocatedNode",
 				slog.Bool("skipCleanup", nodeAllocationRequest.Spec.SkipCleanup))
 		}
 	}
@@ -111,12 +112,14 @@ func enableBMOManagementForIBINodes(
 
 	for i := range nodelist.Items {
 		node := &nodelist.Items[i]
-		bmh, err := getBMHForNode(ctx, noncachedClient, node)
+		nodeCtx := logging.AppendCtx(ctx, slog.String("node", node.Name))
+		bmh, err := getBMHForNode(nodeCtx, noncachedClient, node)
 		if err != nil {
-			logger.ErrorContext(ctx, "Failed to get BMH for node, skipping IBI management setup",
-				slog.String("node", node.Name), slog.String("error", err.Error()))
+			logger.ErrorContext(nodeCtx, "Failed to get BMH for node, skipping IBI management setup",
+				slog.String("error", err.Error()))
 			continue
 		}
+		nodeCtx = logging.AppendCtx(nodeCtx, slog.String("bmh", bmh.Name))
 
 		if !bmh.Spec.ExternallyProvisioned {
 			continue
@@ -134,22 +137,20 @@ func enableBMOManagementForIBINodes(
 		// The IBI operator creates a DataImage during installation but never deletes it.
 		// If left around, BMO will spuriously re-mount the virtual media after firmware
 		// updates, which causes stuck finalizers during deprovisioning.
-		if err := deleteDataImageIfExists(ctx, c, logger, bmh.Name, bmh.Namespace); err != nil {
+		if err := deleteDataImageIfExists(nodeCtx, c, logger, bmh.Name, bmh.Namespace); err != nil {
 			return fmt.Errorf("failed to delete DataImage for BMH %s: %w", bmh.Name, err)
 		}
 
 		if !bmh.Spec.Online {
-			logger.InfoContext(ctx, "Setting BMH online=true for IBI post-provisioning",
-				slog.String("bmh", bmh.Name))
-			if err := patchBMHOnline(ctx, c, bmh, true); err != nil {
+			logger.InfoContext(nodeCtx, "Setting BMH online=true for IBI post-provisioning")
+			if err := patchBMHOnline(nodeCtx, c, bmh, true); err != nil {
 				return fmt.Errorf("failed to set online=true on BMH %s: %w", bmh.Name, err)
 			}
 		}
 
 		if hasDetached {
-			logger.InfoContext(ctx, "Removing detached annotation for IBI post-provisioning",
-				slog.String("bmh", bmh.Name))
-			if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation,
+			logger.InfoContext(nodeCtx, "Removing detached annotation for IBI post-provisioning")
+			if err := updateBMHMetaWithRetry(nodeCtx, c, logger, bmhName, MetaTypeAnnotation,
 				metal3v1alpha1.DetachedAnnotation, "", OpRemove); err != nil {
 				return fmt.Errorf("failed to remove detached annotation from BMH %s: %w", bmh.Name, err)
 			}
@@ -655,14 +656,16 @@ func handleNodeInProgressUpdate(ctx context.Context,
 	node *hwmgmtv1alpha1.AllocatedNode,
 	nodeOps NodeOps,
 ) (ctrl.Result, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
 	bmh, err := getBMHForNode(ctx, noncachedClient, node)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get BMH for AllocatedNode %s: %w", node.Name, err)
 	}
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	// Check if the update is complete by examining the BMH operational status.
 	if bmh.Status.OperationalStatus == metal3v1alpha1.OperationalStatusOK {
-		logger.InfoContext(ctx, "BMH update complete", slog.String("BMH", bmh.Name))
+		logger.InfoContext(ctx, "BMH update complete")
 
 		// Validate node configuration (firmware versions and BIOS settings)
 		configValid, err := validateNodeConfiguration(ctx, c, noncachedClient, logger, bmh, namespace, node.Spec.HwProfile)
@@ -675,7 +678,7 @@ func handleNodeInProgressUpdate(ctx context.Context,
 
 		if _, hasAnnotation := bmh.Annotations[BmhErrorTimestampAnnotation]; hasAnnotation {
 			if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
-				logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("BMH", bmh.Name), slog.String("error", err.Error()))
+				logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("error", err.Error()))
 				return ctrl.Result{}, err
 			}
 		}
@@ -686,7 +689,7 @@ func handleNodeInProgressUpdate(ctx context.Context,
 		ready, err := nodeOps.IsNodeReady(ctx, hostname)
 		if err != nil {
 			logger.ErrorContext(ctx, "Failed to check node readiness",
-				slog.String("allocatedNode", node.Name), slog.String("error", err.Error()))
+				slog.String("error", err.Error()))
 			return hwmgrutils.RequeueWithMediumInterval(), nil
 		}
 		if !ready {
@@ -697,7 +700,7 @@ func handleNodeInProgressUpdate(ctx context.Context,
 			}
 			return hwmgrutils.RequeueWithMediumInterval(), nil
 		}
-		logger.InfoContext(ctx, "Node is ready on managed cluster", slog.String("allocatedNode", node.Name))
+		logger.InfoContext(ctx, "Node is ready on managed cluster")
 
 		if err := nodeOps.UncordonNode(ctx, node.Status.Hostname); err != nil {
 			return ctrl.Result{}, fmt.Errorf(
@@ -707,14 +710,12 @@ func handleNodeInProgressUpdate(ctx context.Context,
 
 		if err := hwmgrutils.SetNodeConfigApplied(ctx, c, noncachedClient, logger, node, node.Spec.HwProfile); err != nil {
 			logger.ErrorContext(ctx, "Failed to set node config applied",
-				slog.String("node", node.Name),
 				slog.String("error", err.Error()))
 			return ctrl.Result{}, fmt.Errorf("failed to mark node config applied %s: %w", node.Name, err)
 		}
 
 		if err := clearConfigAnnotationWithPatch(ctx, c, node); err != nil {
 			logger.ErrorContext(ctx, "Failed to clear config annotation",
-				slog.String("node", node.Name),
 				slog.String("error", err.Error()))
 			return ctrl.Result{}, err
 		}
@@ -729,7 +730,7 @@ func handleNodeInProgressUpdate(ctx context.Context,
 			return hwmgrutils.RequeueWithMediumInterval(), err
 		}
 
-		logger.InfoContext(ctx, "BMH update failed", slog.String("BMH", bmh.Name))
+		logger.InfoContext(ctx, "BMH update failed")
 
 		if err := nodeOps.UncordonNode(ctx, node.Status.Hostname); err != nil {
 			return ctrl.Result{}, fmt.Errorf(
@@ -745,7 +746,6 @@ func handleNodeInProgressUpdate(ctx context.Context,
 		// Clear BMH update annotations to ensure clean state for retry
 		if err := clearBMHUpdateAnnotations(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "Failed to clear BMH update annotations after error",
-				slog.String("BMH", bmh.Name),
 				slog.String("error", err.Error()))
 			return ctrl.Result{}, fmt.Errorf("failed to clear BMH update annotations %s:%w", bmh.Name, err)
 		}
@@ -753,7 +753,6 @@ func handleNodeInProgressUpdate(ctx context.Context,
 		// Clear BMH error annotation to allow future retry attempts
 		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "failed to clear BMH error annotation for future retries",
-				slog.String("BMH", bmh.Name),
 				slog.String("error", err.Error()))
 			return ctrl.Result{}, fmt.Errorf("failed to clear BMH error annotation %s:%w", bmh.Name, err)
 		}
@@ -761,12 +760,12 @@ func handleNodeInProgressUpdate(ctx context.Context,
 		if err := hwmgrutils.SetNodeConditionStatus(ctx, c, noncachedClient, node,
 			string(hwmgmtv1alpha1.Configured), metav1.ConditionFalse,
 			string(hwmgmtv1alpha1.Failed), BmhServicingErr); err != nil {
-			logger.ErrorContext(ctx, "failed to update AllocatedNode status", slog.String("node", node.Name), slog.String("error", err.Error()))
+			logger.ErrorContext(ctx, "failed to update AllocatedNode status", slog.String("error", err.Error()))
 			return ctrl.Result{}, fmt.Errorf("failed to update AllocatedNode status %s:%w", node.Name, err)
 		}
 
 		// Successfully handled BMH error state: updated node status and cleared annotations
-		logger.InfoContext(ctx, "Successfully handled BMH error state", slog.String("BMH", bmh.Name))
+		logger.InfoContext(ctx, "Successfully handled BMH error state")
 		return ctrl.Result{}, fmt.Errorf("bmh %s/%s is in error state, node status updated to Failed", bmh.Namespace, bmh.Name)
 	}
 
@@ -775,7 +774,7 @@ func handleNodeInProgressUpdate(ctx context.Context,
 		node.Spec.HwProfile, string(hwmgmtv1alpha1.NodeWaitingBMHComplete)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update node condition for waiting BMH: %w", err)
 	}
-	logger.InfoContext(ctx, "BMH config in progress", slog.String("bmh", bmh.Name))
+	logger.InfoContext(ctx, "BMH config in progress")
 	return hwmgrutils.RequeueWithMediumInterval(), nil
 }
 
@@ -793,10 +792,12 @@ func abandonNodeUpdate(
 	node *hwmgmtv1alpha1.AllocatedNode,
 	nodeOps NodeOps,
 ) (ctrl.Result, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
 	bmh, err := getBMHForNode(ctx, noncachedClient, node)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get BMH for abandoned node %s: %w", node.Name, err)
 	}
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	// Don't interrupt if BMH is actively servicing or preparing — the hardware
 	// operation is underway and must exit the state on its own (complete, fail,
@@ -804,17 +805,14 @@ func abandonNodeUpdate(
 	if bmh.Status.OperationalStatus == metal3v1alpha1.OperationalStatusServicing ||
 		bmh.Status.Provisioning.State == metal3v1alpha1.StatePreparing {
 		logger.InfoContext(ctx, "Desired hardware profile changed but metal3 is actively processing the current update, cannot abandon yet, waiting for completion",
-			slog.String("node", node.Name),
 			slog.String("currentProfile", node.Spec.HwProfile),
 			slog.String("desiredProfile", newHwProfile),
-			slog.String("bmh", bmh.Name),
 			slog.String("bmhOperationalStatus", string(bmh.Status.OperationalStatus)),
 			slog.String("bmhProvisioningState", string(bmh.Status.Provisioning.State)))
 		return hwmgrutils.RequeueWithMediumInterval(), nil
 	}
 
 	logger.InfoContext(ctx, "Desired profile changed during in-progress update, abandoning current update",
-		slog.String("node", node.Name),
 		slog.String("currentProfile", node.Spec.HwProfile),
 		slog.String("desiredProfile", newHwProfile))
 
@@ -853,6 +851,7 @@ func initiateNodeUpdate(ctx context.Context,
 	newHwProfile string,
 	nodeOps NodeOps,
 ) (ctrl.Result, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
 
 	// Clear the abandoned annotation if this node was previously abandoned due to a
 	// mid-flight profile change. The node is now being re-processed with the new profile.
@@ -864,6 +863,7 @@ func initiateNodeUpdate(ctx context.Context,
 	if err != nil {
 		return hwmgrutils.RequeueWithShortInterval(), fmt.Errorf("failed to get BMH for AllocatedNode %s: %w", node.Name, err)
 	}
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	logger.InfoContext(ctx, "Issuing profile update to AllocatedNode",
 		slog.String("hwMgrNodeId", node.Spec.HwMgrNodeId),
 		slog.String("curHwProfile", node.Spec.HwProfile),
@@ -877,7 +877,7 @@ func initiateNodeUpdate(ctx context.Context,
 		return ctrl.Result{}, fmt.Errorf("failed to evaluate HW profile for node (%s): %w", node.Name, err)
 	}
 	if !updateNeeded {
-		logger.InfoContext(ctx, "No HW changes needed, marking node config applied", slog.String("node", node.Name))
+		logger.InfoContext(ctx, "No HW changes needed, marking node config applied")
 		if err := hwmgrutils.SetNodeConfigApplied(ctx, c, noncachedClient, logger, node, newHwProfile); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to mark node config applied: %w", err)
 		}
@@ -887,7 +887,7 @@ func initiateNodeUpdate(ctx context.Context,
 
 	// Step 2: Cordon and drain before applying HW changes if drain is not skipped.
 	if !nodeOps.SkipDrain() {
-		logger.InfoContext(ctx, "Proceeding with node drain", slog.String("node", node.Name), slog.String("hostname", node.Status.Hostname))
+		logger.InfoContext(ctx, "Proceeding with node drain", slog.String("hostname", node.Status.Hostname))
 		// Update the condition message to indicate draining is in progress.
 		if err := hwmgrutils.SetNodeConfigUpdatePending(ctx, c, noncachedClient, logger, node, newHwProfile,
 			string(hwmgmtv1alpha1.NodeDraining)); err != nil {
@@ -895,7 +895,6 @@ func initiateNodeUpdate(ctx context.Context,
 		}
 		if err := nodeOps.DrainNode(ctx, node.Status.Hostname); err != nil {
 			logger.ErrorContext(ctx, "Drain failed, will retry",
-				slog.String("node", node.Name),
 				slog.String("hostname", node.Status.Hostname),
 				slog.String("error", err.Error()))
 			return hwmgrutils.RequeueWithMediumInterval(), nil
@@ -903,7 +902,7 @@ func initiateNodeUpdate(ctx context.Context,
 	}
 
 	// Step 3: Apply HW profile changes (create/update HFS/HFC/HUP, annotate BMH).
-	logger.InfoContext(ctx, "Applying HW profile", slog.String("node", node.Name), slog.String("hwProfile", newHwProfile))
+	logger.InfoContext(ctx, "Applying HW profile", slog.String("hwProfile", newHwProfile))
 	validateOnly = false
 	updateRequired, err := processHwProfileWithHandledError(ctx, c, noncachedClient, logger, namespace,
 		bmh, node, newHwProfile, true, validateOnly)
@@ -1152,6 +1151,7 @@ func executeNodeUpdates(
 		go func(nodeToProcess nodeAction) {
 			defer wg.Done()
 
+			nodeCtx := logging.AppendCtx(ctx, slog.String("node", nodeToProcess.node.Name))
 			var res ctrl.Result
 			var err error
 
@@ -1162,22 +1162,22 @@ func executeNodeUpdates(
 			// update so the node can be re-processed with the new profile.
 			switch nodeToProcess.actionType {
 			case actionInitiate:
-				res, err = initiateNodeUpdate(ctx, c, noncachedClient, logger,
+				res, err = initiateNodeUpdate(nodeCtx, c, noncachedClient, logger,
 					namespace, nodeToProcess.node, newHwProfile, nodeOps)
 			case actionTransition:
 				if nodeToProcess.node.Spec.HwProfile != newHwProfile {
-					res, err = abandonNodeUpdate(ctx, c, noncachedClient, logger,
+					res, err = abandonNodeUpdate(nodeCtx, c, noncachedClient, logger,
 						newHwProfile, nodeToProcess.node, nodeOps)
 				} else {
-					res, err = handleTransitionNode(ctx, c, noncachedClient, logger,
+					res, err = handleTransitionNode(nodeCtx, c, noncachedClient, logger,
 						namespace, nodeToProcess.node, true, nodeOps)
 				}
 			case actionInProgressUpdate:
 				if nodeToProcess.node.Spec.HwProfile != newHwProfile {
-					res, err = abandonNodeUpdate(ctx, c, noncachedClient, logger,
+					res, err = abandonNodeUpdate(nodeCtx, c, noncachedClient, logger,
 						newHwProfile, nodeToProcess.node, nodeOps)
 				} else {
-					res, err = handleNodeInProgressUpdate(ctx, c, noncachedClient, logger,
+					res, err = handleNodeInProgressUpdate(nodeCtx, c, noncachedClient, logger,
 						namespace, nodeToProcess.node, nodeOps)
 				}
 			}
@@ -1186,8 +1186,7 @@ func executeNodeUpdates(
 			defer mu.Unlock()
 
 			if err != nil {
-				logger.ErrorContext(ctx, "Node processing error",
-					slog.String("node", nodeToProcess.node.Name),
+				logger.ErrorContext(nodeCtx, "Node processing error",
 					slog.String("error", err.Error()))
 				errs = append(errs, fmt.Errorf("node %s, error: %w", nodeToProcess.node.Name, err))
 			}
@@ -1591,8 +1590,9 @@ func processNodeAllocationRequestAllocation(
 			go func(bmh *metal3v1alpha1.BareMetalHost) {
 				defer wg.Done()
 
+				bmhCtx := logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 				nodeName, err := allocateBMHToNodeAllocationRequest(
-					ctx, c, noncachedClient, logger, namespace,
+					bmhCtx, c, noncachedClient, logger, namespace,
 					bmh, nodeAllocationRequest, nodeGroup,
 				)
 
@@ -1603,8 +1603,7 @@ func processNodeAllocationRequestAllocation(
 					allocatedNames = append(allocatedNames, nodeName)
 				}
 				if err != nil {
-					logger.ErrorContext(ctx, "Failed to allocate BMH to NodeAllocationRequest",
-						slog.String("bmh", bmh.Name),
+					logger.ErrorContext(bmhCtx, "Failed to allocate BMH to NodeAllocationRequest",
 						slog.String("error", err.Error()))
 					errs = append(errs, fmt.Errorf("bmh %s, error: %w", bmh.Name, err))
 				}
@@ -1657,6 +1656,7 @@ func validateFirmwareVersions(
 	namespace string,
 	hwProfileName string,
 ) (bool, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	// 1) Fetch HardwareProfile
 	prof := &hwmgmtv1alpha1.HardwareProfile{}
@@ -1684,8 +1684,7 @@ func validateFirmwareVersions(
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Profile expects versions but HFC absent -> not valid yet
-			logger.InfoContext(ctx, "HostFirmwareComponents not found while versions are specified; not valid yet",
-				slog.String("bmh", bmh.Name))
+			logger.InfoContext(ctx, "HostFirmwareComponents not found while versions are specified; not valid yet")
 			return false, nil
 		}
 		return false, fmt.Errorf("get HostFirmwareComponents %s/%s: %w", bmh.Namespace, bmh.Name, err)
@@ -1703,25 +1702,22 @@ func validateFirmwareVersions(
 		have, ok := actual[k]
 		if !ok {
 			logger.InfoContext(ctx, "Firmware component missing in HFC",
-				slog.String("component", k),
-				slog.String("bmh", bmh.Name))
+				slog.String("component", k))
 			return false, nil
 		}
 		if have != want {
 			logger.InfoContext(ctx, "Firmware version mismatch",
 				slog.String("component", k),
 				slog.String("current", have),
-				slog.String("expected", want),
-				slog.String("bmh", bmh.Name))
+				slog.String("expected", want))
 			return false, nil
 		}
 		logger.DebugContext(ctx, "Firmware version matches",
 			slog.String("component", k),
-			slog.String("version", have),
-			slog.String("bmh", bmh.Name))
+			slog.String("version", have))
 	}
 
-	logger.InfoContext(ctx, "All required firmware versions match", slog.String("bmh", bmh.Name))
+	logger.InfoContext(ctx, "All required firmware versions match")
 	return true, nil
 }
 
@@ -1748,6 +1744,7 @@ func validateAppliedBiosSettings(
 	namespace string,
 	hwProfileName string,
 ) (bool, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	// 1) Fetch HardwareProfile
 	prof := &hwmgmtv1alpha1.HardwareProfile{}
@@ -1767,8 +1764,7 @@ func validateAppliedBiosSettings(
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Profile expects BIOS settings but HFS absent -> not valid yet
-			logger.InfoContext(ctx, "HostFirmwareSettings not found while BIOS settings are specified; not valid yet",
-				slog.String("bmh", bmh.Name))
+			logger.InfoContext(ctx, "HostFirmwareSettings not found while BIOS settings are specified; not valid yet")
 			return false, nil
 		}
 		return false, fmt.Errorf("get HostFirmwareSettings %s/%s: %w", bmh.Namespace, bmh.Name, err)
@@ -1779,8 +1775,7 @@ func validateAppliedBiosSettings(
 		actualValue, exists := hfs.Status.Settings[key]
 		if !exists {
 			logger.InfoContext(ctx, "BIOS setting missing in HFS status",
-				slog.String("setting", key),
-				slog.String("bmh", bmh.Name))
+				slog.String("setting", key))
 			return false, nil
 		}
 
@@ -1789,18 +1784,16 @@ func validateAppliedBiosSettings(
 			logger.InfoContext(ctx, "BIOS setting value mismatch",
 				slog.String("setting", key),
 				slog.String("current", actualValue),
-				slog.String("expected", expectedValue.String()),
-				slog.String("bmh", bmh.Name))
+				slog.String("expected", expectedValue.String()))
 			return false, nil
 		}
 
 		logger.DebugContext(ctx, "BIOS setting matches",
 			slog.String("setting", key),
-			slog.String("value", actualValue),
-			slog.String("bmh", bmh.Name))
+			slog.String("value", actualValue))
 	}
 
-	logger.InfoContext(ctx, "All required BIOS settings match", slog.String("bmh", bmh.Name))
+	logger.InfoContext(ctx, "All required BIOS settings match")
 
 	// 5) Validate NIC firmware if specified
 	if len(prof.Spec.NicFirmware) > 0 {
@@ -1809,8 +1802,7 @@ func validateAppliedBiosSettings(
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				// Profile expects NIC firmware but HFC absent -> not valid yet
-				logger.InfoContext(ctx, "HostFirmwareComponents not found while NIC firmware is specified; not valid yet",
-					slog.String("bmh", bmh.Name))
+				logger.InfoContext(ctx, "HostFirmwareComponents not found while NIC firmware is specified; not valid yet")
 				return false, nil
 			}
 			return false, fmt.Errorf("get HostFirmwareComponents %s/%s: %w", bmh.Namespace, bmh.Name, err)
@@ -1835,18 +1827,16 @@ func validateAppliedBiosSettings(
 				logger.InfoContext(ctx, "NIC firmware version not found in any nic: component",
 					slog.Int("nicIndex", i),
 					slog.String("expected", nic.Version),
-					slog.String("normalizedExpected", normalizedExpected),
-					slog.String("bmh", bmh.Name))
+					slog.String("normalizedExpected", normalizedExpected))
 				return false, nil
 			}
 
 			logger.DebugContext(ctx, "NIC firmware version matches",
 				slog.Int("nicIndex", i),
-				slog.String("version", nic.Version),
-				slog.String("bmh", bmh.Name))
+				slog.String("version", nic.Version))
 		}
 
-		logger.InfoContext(ctx, "All required NIC firmware versions match", slog.String("bmh", bmh.Name))
+		logger.InfoContext(ctx, "All required NIC firmware versions match")
 	}
 
 	return true, nil
@@ -1870,17 +1860,16 @@ func validateNodeConfiguration(
 	namespace string,
 	hwProfileName string,
 ) (bool, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Validate firmware versions
 	firmwareValid, err := validateFirmwareVersions(ctx, c, noncachedClient, logger, bmh, namespace, hwProfileName)
 	if err != nil {
 		logger.ErrorContext(ctx, "Failed to validate firmware versions",
-			slog.String("BMH", bmh.Name),
 			slog.String("error", err.Error()))
 		return false, err
 	}
 	if !firmwareValid {
-		logger.InfoContext(ctx, "Firmware versions not yet updated, continuing to poll",
-			slog.String("BMH", bmh.Name))
+		logger.InfoContext(ctx, "Firmware versions not yet updated, continuing to poll")
 		return false, nil
 	}
 
@@ -1888,17 +1877,15 @@ func validateNodeConfiguration(
 	biosValid, err := validateAppliedBiosSettings(ctx, c, noncachedClient, logger, bmh, namespace, hwProfileName)
 	if err != nil {
 		logger.ErrorContext(ctx, "Failed to validate BIOS settings",
-			slog.String("BMH", bmh.Name),
 			slog.String("error", err.Error()))
 		return false, err
 	}
 	if !biosValid {
-		logger.InfoContext(ctx, "BIOS settings not yet updated, continuing to poll",
-			slog.String("BMH", bmh.Name))
+		logger.InfoContext(ctx, "BIOS settings not yet updated, continuing to poll")
 		return false, nil
 	}
 
-	logger.InfoContext(ctx, "Firmware versions and BIOS settings validated successfully", slog.String("BMH", bmh.Name))
+	logger.InfoContext(ctx, "Firmware versions and BIOS settings validated successfully")
 	return true, nil
 }
 
@@ -1921,23 +1908,24 @@ func clearBMHUpdateAnnotationsForNAR(
 
 	var errs []error
 	for _, node := range nodeList.Items {
+		nodeCtx := logging.AppendCtx(ctx, slog.String("node", node.Name))
 		// Get BMH for this node
-		bmh, err := getBMHForNode(ctx, c, &node)
+		bmh, err := getBMHForNode(nodeCtx, c, &node)
 		if err != nil {
-			logger.ErrorContext(ctx, "Failed to get BMH for annotation clear",
-				slog.String("allocatedNode", node.Name), slog.String("error", err.Error()))
+			logger.ErrorContext(nodeCtx, "Failed to get BMH for annotation clear",
+				slog.String("error", err.Error()))
 			errs = append(errs, fmt.Errorf("failed to get BMH for AllocatedNode %s: %w", node.Name, err))
 			continue
 		}
+		nodeCtx = logging.AppendCtx(nodeCtx, slog.String("bmh", bmh.Name))
 
 		// Clear update annotations from BMH
-		if err := clearBMHUpdateAnnotations(ctx, c, logger, bmh); err != nil {
-			logger.ErrorContext(ctx, "Failed to clear BMH update annotations",
-				slog.String("bmh", bmh.Name), slog.String("error", err.Error()))
+		if err := clearBMHUpdateAnnotations(nodeCtx, c, logger, bmh); err != nil {
+			logger.ErrorContext(nodeCtx, "Failed to clear BMH update annotations",
+				slog.String("error", err.Error()))
 			errs = append(errs, fmt.Errorf("failed to clear BMH update annotations for BMH %s: %w", bmh.Name, err))
 		} else {
-			logger.InfoContext(ctx, "Cleared BMH update annotations",
-				slog.String("bmh", bmh.Name))
+			logger.InfoContext(nodeCtx, "Cleared BMH update annotations")
 		}
 	}
 

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -1656,7 +1656,6 @@ func validateFirmwareVersions(
 	namespace string,
 	hwProfileName string,
 ) (bool, error) {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	// 1) Fetch HardwareProfile
 	prof := &hwmgmtv1alpha1.HardwareProfile{}
@@ -1744,7 +1743,6 @@ func validateAppliedBiosSettings(
 	namespace string,
 	hwProfileName string,
 ) (bool, error) {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 
 	// 1) Fetch HardwareProfile
 	prof := &hwmgmtv1alpha1.HardwareProfile{}
@@ -1860,7 +1858,6 @@ func validateNodeConfiguration(
 	namespace string,
 	hwProfileName string,
 ) (bool, error) {
-	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Validate firmware versions
 	firmwareValid, err := validateFirmwareVersions(ctx, c, noncachedClient, logger, bmh, namespace, hwProfileName)
 	if err != nil {

--- a/internal/hardwaremanager/controller/hostfirmwarecomponents_manager.go
+++ b/internal/hardwaremanager/controller/hostfirmwarecomponents_manager.go
@@ -22,6 +22,7 @@ import (
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
 )
 
@@ -85,6 +86,7 @@ func convertToFirmwareUpdates(spec hwmgmtv1alpha1.HardwareProfileSpec) []metal3v
 func isHostFirmwareComponentsChangeDetectedAndValid(ctx context.Context,
 	c client.Client,
 	bmh *metal3v1alpha1.BareMetalHost) (bool, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Extract logger from context
 	logger := slog.Default()
 	if ctxLogger, ok := ctx.Value(any("logger")).(*slog.Logger); ok && ctxLogger != nil {
@@ -108,7 +110,6 @@ func isHostFirmwareComponentsChangeDetectedAndValid(ctx context.Context,
 	observed := changeDetectedCond.ObservedGeneration == hfc.Generation
 
 	logger.DebugContext(ctx, "Evaluating HostFirmwareComponents change",
-		slog.String("bmh", bmh.Name),
 		slog.String("hfc", hfc.Name),
 		slog.Int64("hfcGeneration", hfc.Generation),
 		slog.String("changeDetectedStatus", string(changeDetectedCond.Status)),

--- a/internal/hardwaremanager/controller/hostfirmwarecomponents_manager.go
+++ b/internal/hardwaremanager/controller/hostfirmwarecomponents_manager.go
@@ -326,7 +326,7 @@ func IsFirmwareUpdateRequired(ctx context.Context,
 		if _, err := createHostFirmwareComponents(ctx, c, bmh, spec); err != nil {
 			return false, fmt.Errorf("failed to create HostFirmwareComponents: %w", err)
 		}
-		logger.InfoContext(ctx, "Successfully created HostFirmwareComponents", slog.String("HFC", bmh.Name))
+		logger.InfoContext(ctx, "Successfully created HostFirmwareComponents")
 		return true, nil
 	}
 

--- a/internal/hardwaremanager/controller/hostfirmwaresettings_manager.go
+++ b/internal/hardwaremanager/controller/hostfirmwaresettings_manager.go
@@ -22,6 +22,7 @@ import (
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
 )
 
@@ -127,6 +128,7 @@ func IsBiosUpdateRequired(ctx context.Context,
 func isFirmwareSettingsChangeDetectedAndValid(ctx context.Context,
 	c client.Client,
 	bmh *metal3v1alpha1.BareMetalHost) (bool, error) {
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	// Extract logger from context
 	logger := slog.Default()
 	if ctxLogger, ok := ctx.Value(any("logger")).(*slog.Logger); ok && ctxLogger != nil {

--- a/internal/hardwaremanager/controller/hostfirmwaresettings_manager.go
+++ b/internal/hardwaremanager/controller/hostfirmwaresettings_manager.go
@@ -151,7 +151,6 @@ func isFirmwareSettingsChangeDetectedAndValid(ctx context.Context,
 	observed := changeDetectedCond.ObservedGeneration == hfs.Generation
 
 	logger.DebugContext(ctx, "Evaluating BIOS/FirmwareSettings change",
-		slog.String("bmh", bmh.Name),
 		slog.String("hfs", hfs.Name),
 		slog.Int64("hfsGeneration", hfs.Generation),
 		slog.String("changeDetectedStatus", string(changeDetectedCond.Status)),

--- a/internal/hardwaremanager/controller/hostupdatepolicy_manager.go
+++ b/internal/hardwaremanager/controller/hostupdatepolicy_manager.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 )
 
 func createOrUpdateHostUpdatePolicy(ctx context.Context,
@@ -37,8 +38,8 @@ func createOrUpdateHostUpdatePolicy(ctx context.Context,
 		return fmt.Errorf("bmh cannot be nil")
 	}
 
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	logger.DebugContext(ctx, "Creating or updating HostUpdatePolicy",
-		slog.String("bmh", bmh.Name),
 		slog.Bool("firmwareUpdateRequired", firmwareUpdateRequired),
 		slog.Bool("biosUpdateRequired", biosUpdateRequired))
 
@@ -75,7 +76,6 @@ func createOrUpdateHostUpdatePolicy(ctx context.Context,
 	}
 
 	logger.DebugContext(ctx, "Desired HostUpdatePolicy spec",
-		slog.String("bmh", bmh.Name),
 		slog.String("desiredFirmwareUpdates", string(desiredSpec.FirmwareUpdates)),
 		slog.String("desiredFirmwareSettings", string(desiredSpec.FirmwareSettings)))
 

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -114,7 +114,7 @@ func (r *NodeAllocationRequestReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Add object-specific context and hardware-specific context
 	ctx = ctlrutils.AddObjectContext(ctx, nodeAllocationRequest)
-	ctx = logging.AppendCtx(ctx, slog.String("ClusterID", nodeAllocationRequest.Spec.ClusterId))
+	ctx = logging.AppendCtx(ctx, slog.String("clusterId", nodeAllocationRequest.Spec.ClusterId))
 	ctx = logging.AppendCtx(ctx, slog.String("startingResourceVersion", nodeAllocationRequest.ResourceVersion))
 
 	r.Logger.InfoContext(ctx, "Fetched NodeAllocationRequest successfully")

--- a/internal/service/cluster/collector/collector_alarms.go
+++ b/internal/service/cluster/collector/collector_alarms.go
@@ -106,7 +106,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 	var filteredNodeClusterTypes []models.NodeClusterType
 	for _, nodeClusterType := range nodeClusterTypes {
 		if nodeClusterType.Extensions == nil {
-			slog.Error("no extensions found for node cluster type", "NodeClusterType ID", nodeClusterType.NodeClusterTypeID)
+			slog.Error("no extensions found for node cluster type", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID)
 			continue
 		}
 
@@ -114,7 +114,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 		if alarmDictionaryIDString != nil {
 			id, err := uuid.Parse(alarmDictionaryIDString.(string))
 			if err != nil {
-				slog.Error("error parsing alarm dictionary ID", "NodeClusterType ID", nodeClusterType.NodeClusterTypeID, "error", err)
+				slog.Error("error parsing alarm dictionary ID", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID, "error", err)
 				continue
 			}
 			(*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension] = id
@@ -180,12 +180,12 @@ func (d *AlarmsDataSource) makeNodeClusterTypeIDToMonitoringRules(ctx context.Co
 	// Collect results
 	for res := range resultChannel {
 		if res.err != nil {
-			slog.ErrorContext(ctx, "error fetching rules for node cluster type", "NodeClusterType ID", res.nodeClusterTypeID, "error", res.err)
+			slog.ErrorContext(ctx, "error fetching rules for node cluster type", "nodeClusterTypeId", res.nodeClusterTypeID, "error", res.err)
 			continue
 		}
 
 		nodeClusterTypeIDToMonitoringRules[res.nodeClusterTypeID] = res.rules
-		slog.InfoContext(ctx, "loaded rules for node cluster type", "NodeClusterType ID", res.nodeClusterTypeID, "rules count", len(res.rules))
+		slog.InfoContext(ctx, "loaded rules for node cluster type", "nodeClusterTypeId", res.nodeClusterTypeID, "rules count", len(res.rules))
 	}
 
 	return nodeClusterTypeIDToMonitoringRules
@@ -291,7 +291,7 @@ func (d *AlarmsDataSource) buildAlarmDictionaryIDToAlarmDefinitions(nodeClusterT
 	alarmDictionaryIDToAlarmDefinitions := make(map[uuid.UUID][]models.AlarmDefinition)
 	for _, nodeClusterType := range nodeClusterTypes {
 		if _, ok := nodeClusterTypeIDToMonitoringRules[nodeClusterType.NodeClusterTypeID]; !ok {
-			slog.Warn("no monitoring rules found for node cluster type", "NodeClusterType ID", nodeClusterType.NodeClusterTypeID)
+			slog.Warn("no monitoring rules found for node cluster type", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID)
 			continue
 		}
 
@@ -299,18 +299,18 @@ func (d *AlarmsDataSource) buildAlarmDictionaryIDToAlarmDefinitions(nodeClusterT
 		extensions, err := getVendorExtensions(nodeClusterType)
 		if err != nil {
 			// Should never happen
-			slog.Error("error getting vendor extensions", "NodeClusterType ID", nodeClusterType.NodeClusterTypeID, "error", err)
+			slog.Error("error getting vendor extensions", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID, "error", err)
 			continue
 		}
 
 		// Only process node cluster types with an alarm dictionary ID
 		alarmDictionaryID, ok := (*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension].(uuid.UUID)
 		if !ok || alarmDictionaryID == uuid.Nil {
-			slog.Error("no alarm dictionary ID found for node cluster type", "NodeClusterType ID", nodeClusterType.NodeClusterTypeID)
+			slog.Error("no alarm dictionary ID found for node cluster type", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID)
 			continue
 		}
 
-		slog.Debug("filtering rules for node cluster type", "NodeClusterType ID", nodeClusterType.NodeClusterTypeID)
+		slog.Debug("filtering rules for node cluster type", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID)
 		// Remove conflicting rules before creating alarm definitions
 		filteredRules := d.getFilteredRules(nodeClusterTypeIDToMonitoringRules[nodeClusterType.NodeClusterTypeID])
 
@@ -422,13 +422,13 @@ func (d *AlarmsDataSource) makeAlarmDictionaries(nodeClusterTypes []models.NodeC
 		extensions, err := getVendorExtensions(nodeClusterType)
 		if err != nil {
 			// Should never happen
-			slog.Error("error getting vendor extensions", "NodeClusterType ID", nodeClusterType.NodeClusterTypeID, "error", err)
+			slog.Error("error getting vendor extensions", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID, "error", err)
 			continue
 		}
 
 		alarmDictionaryID, ok := (*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension].(uuid.UUID)
 		if !ok || alarmDictionaryID == uuid.Nil {
-			slog.Error("no alarm dictionary ID found for node cluster type", "NodeClusterType ID", nodeClusterType.NodeClusterTypeID)
+			slog.Error("no alarm dictionary ID found for node cluster type", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID)
 			continue
 		}
 

--- a/internal/service/cluster/collector/collector_alarms.go
+++ b/internal/service/cluster/collector/collector_alarms.go
@@ -106,7 +106,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 	var filteredNodeClusterTypes []models.NodeClusterType
 	for _, nodeClusterType := range nodeClusterTypes {
 		if nodeClusterType.Extensions == nil {
-			slog.Error("no extensions found for node cluster type", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID)
+			slog.Error("no extensions found for node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
 			continue
 		}
 
@@ -114,7 +114,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 		if alarmDictionaryIDString != nil {
 			id, err := uuid.Parse(alarmDictionaryIDString.(string))
 			if err != nil {
-				slog.Error("error parsing alarm dictionary ID", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID, "error", err)
+				slog.Error("error parsing alarm dictionary ID", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
 				continue
 			}
 			(*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension] = id
@@ -180,12 +180,12 @@ func (d *AlarmsDataSource) makeNodeClusterTypeIDToMonitoringRules(ctx context.Co
 	// Collect results
 	for res := range resultChannel {
 		if res.err != nil {
-			slog.ErrorContext(ctx, "error fetching rules for node cluster type", "nodeClusterTypeId", res.nodeClusterTypeID, "error", res.err)
+			slog.ErrorContext(ctx, "error fetching rules for node cluster type", "nodeClusterTypeID", res.nodeClusterTypeID, "error", res.err)
 			continue
 		}
 
 		nodeClusterTypeIDToMonitoringRules[res.nodeClusterTypeID] = res.rules
-		slog.InfoContext(ctx, "loaded rules for node cluster type", "nodeClusterTypeId", res.nodeClusterTypeID, "rules count", len(res.rules))
+		slog.InfoContext(ctx, "loaded rules for node cluster type", "nodeClusterTypeID", res.nodeClusterTypeID, "rules count", len(res.rules))
 	}
 
 	return nodeClusterTypeIDToMonitoringRules
@@ -291,7 +291,7 @@ func (d *AlarmsDataSource) buildAlarmDictionaryIDToAlarmDefinitions(nodeClusterT
 	alarmDictionaryIDToAlarmDefinitions := make(map[uuid.UUID][]models.AlarmDefinition)
 	for _, nodeClusterType := range nodeClusterTypes {
 		if _, ok := nodeClusterTypeIDToMonitoringRules[nodeClusterType.NodeClusterTypeID]; !ok {
-			slog.Warn("no monitoring rules found for node cluster type", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID)
+			slog.Warn("no monitoring rules found for node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
 			continue
 		}
 
@@ -299,18 +299,18 @@ func (d *AlarmsDataSource) buildAlarmDictionaryIDToAlarmDefinitions(nodeClusterT
 		extensions, err := getVendorExtensions(nodeClusterType)
 		if err != nil {
 			// Should never happen
-			slog.Error("error getting vendor extensions", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID, "error", err)
+			slog.Error("error getting vendor extensions", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
 			continue
 		}
 
 		// Only process node cluster types with an alarm dictionary ID
 		alarmDictionaryID, ok := (*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension].(uuid.UUID)
 		if !ok || alarmDictionaryID == uuid.Nil {
-			slog.Error("no alarm dictionary ID found for node cluster type", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID)
+			slog.Error("no alarm dictionary ID found for node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
 			continue
 		}
 
-		slog.Debug("filtering rules for node cluster type", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID)
+		slog.Debug("filtering rules for node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
 		// Remove conflicting rules before creating alarm definitions
 		filteredRules := d.getFilteredRules(nodeClusterTypeIDToMonitoringRules[nodeClusterType.NodeClusterTypeID])
 
@@ -422,13 +422,13 @@ func (d *AlarmsDataSource) makeAlarmDictionaries(nodeClusterTypes []models.NodeC
 		extensions, err := getVendorExtensions(nodeClusterType)
 		if err != nil {
 			// Should never happen
-			slog.Error("error getting vendor extensions", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID, "error", err)
+			slog.Error("error getting vendor extensions", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
 			continue
 		}
 
 		alarmDictionaryID, ok := (*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension].(uuid.UUID)
 		if !ok || alarmDictionaryID == uuid.Nil {
-			slog.Error("no alarm dictionary ID found for node cluster type", "nodeClusterTypeId", nodeClusterType.NodeClusterTypeID)
+			slog.Error("no alarm dictionary ID found for node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
 			continue
 		}
 

--- a/internal/service/resources/collector/collector_hwmgr.go
+++ b/internal/service/resources/collector/collector_hwmgr.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	hwmgrcontroller "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/controller"
+	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/async"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/models"
 )
@@ -269,7 +270,9 @@ func (d *HardwareDataSource) HandleSyncComplete(ctx context.Context, objectType 
 // handleBMHEvent handles a BMH watch event by building the full resource
 // from BMH + HardwareData + AllocatedNode and sending events to the collector.
 func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1alpha1.BareMetalHost, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleBMHEvent", "bmh", bmh.Namespace+"/"+bmh.Name, "type", eventType)
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
+	ctx = logging.AppendCtx(ctx, slog.String("bmhNamespace", bmh.Namespace))
+	slog.DebugContext(ctx, "handleBMHEvent", "type", eventType)
 
 	resourceID := uuid.MustParse(string(bmh.UID))
 
@@ -278,8 +281,7 @@ func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1al
 	}
 
 	if !hwmgrcontroller.IncludeInInventory(bmh) {
-		slog.DebugContext(ctx, "BMH not included in inventory, treating as deletion",
-			"bmh", bmh.Namespace+"/"+bmh.Name)
+		slog.DebugContext(ctx, "BMH not included in inventory, treating as deletion")
 		return d.sendDeleteEvent(ctx, resourceID)
 	}
 
@@ -289,12 +291,14 @@ func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1al
 // handleHardwareDataEvent handles a HardwareData watch event by looking up
 // the corresponding BMH and rebuilding the resource.
 func (d *HardwareDataSource) handleHardwareDataEvent(ctx context.Context, hwdata *metal3v1alpha1.HardwareData, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleHardwareDataEvent", "hwdata", hwdata.Namespace+"/"+hwdata.Name, "type", eventType)
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", hwdata.Name))
+	ctx = logging.AppendCtx(ctx, slog.String("bmhNamespace", hwdata.Namespace))
+	slog.DebugContext(ctx, "handleHardwareDataEvent", "type", eventType)
 
 	var bmh metal3v1alpha1.BareMetalHost
 	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: hwdata.Name, Namespace: hwdata.Namespace}, &bmh); err != nil {
 		if errors.IsNotFound(err) {
-			slog.DebugContext(ctx, "BMH not found for HardwareData, skipping", "hwdata", hwdata.Namespace+"/"+hwdata.Name)
+			slog.DebugContext(ctx, "BMH not found for HardwareData, skipping")
 			return uuid.Nil, nil
 		}
 		return uuid.Nil, fmt.Errorf("failed to get BMH for HardwareData %s/%s: %w", hwdata.Namespace, hwdata.Name, err)
@@ -310,19 +314,23 @@ func (d *HardwareDataSource) handleHardwareDataEvent(ctx context.Context, hwdata
 // handleAllocatedNodeEvent handles an AllocatedNode watch event by looking up
 // the corresponding BMH and rebuilding the resource.
 func (d *HardwareDataSource) handleAllocatedNodeEvent(ctx context.Context, node *hwmgmtv1alpha1.AllocatedNode, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleAllocatedNodeEvent", "node", node.Namespace+"/"+node.Name, "type", eventType)
+	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
+	slog.DebugContext(ctx, "handleAllocatedNodeEvent", "type", eventType)
 
 	bmhName := node.Spec.HwMgrNodeId
 	bmhNamespace := node.Spec.HwMgrNodeNs
 	if bmhName == "" || bmhNamespace == "" {
-		slog.DebugContext(ctx, "AllocatedNode missing BMH reference, skipping", "node", node.Namespace+"/"+node.Name)
+		slog.DebugContext(ctx, "AllocatedNode missing BMH reference, skipping")
 		return uuid.Nil, nil
 	}
+
+	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmhName))
+	ctx = logging.AppendCtx(ctx, slog.String("bmhNamespace", bmhNamespace))
 
 	var bmh metal3v1alpha1.BareMetalHost
 	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: bmhName, Namespace: bmhNamespace}, &bmh); err != nil {
 		if errors.IsNotFound(err) {
-			slog.DebugContext(ctx, "BMH not found for AllocatedNode, skipping", "bmh", bmhNamespace+"/"+bmhName)
+			slog.DebugContext(ctx, "BMH not found for AllocatedNode, skipping")
 			return uuid.Nil, nil
 		}
 		return uuid.Nil, fmt.Errorf("failed to get BMH for AllocatedNode %s/%s: %w", node.Namespace, node.Name, err)


### PR DESCRIPTION
Add logging.AppendCtx() for bmh and node names at function entry points throughout the hardware manager controller. This eliminates ~100 redundant explicit bmh/node attributes from individual log calls — the data is now automatically included via context in all downstream logs.

Context enrichment added to 30+ functions in:
- baremetalhost_manager.go: all functions receiving bmh parameter
- helpers.go: node processing functions (handleNodeInProgressUpdate, initiateNodeUpdate, executeNodeUpdates, etc.)
- allocatednode_controller.go: handleAllocatedNodeDeletion
- hostfirmwarecomponents_manager.go, hostfirmwaresettings_manager.go, hostupdatepolicy_manager.go: BMH processing functions

Field naming standardized to camelCase:
- "BMH" → "bmh" (baremetalhost_manager.go, helpers.go)
- "ClusterID" → "clusterId" (nodeallocationrequest_controller.go)
- "NodeClusterType ID" → "nodeClusterTypeId" (collector_alarms.go)
- "State" → "state", "Annotation" → "annotation"