### PR TITLE
CNF-24579: reduce hardware manager polling log verbosity

### DIFF
--- a/internal/hardwaremanager/controller/baremetalhost_manager.go
+++ b/internal/hardwaremanager/controller/baremetalhost_manager.go
@@ -868,7 +868,7 @@ func handleBMHCompletion(ctx context.Context,
 	namespace string,
 	nodelist *hwmgmtv1alpha1.AllocatedNodeList) (bool, error) {
 
-	logger.InfoContext(ctx, "Checking for nodes with config in progress")
+	logger.DebugContext(ctx, "Checking for nodes with config in progress")
 
 	// Find all nodes that are in InProgress state or have no condition
 	nodes := findNodesInProgress(nodelist)
@@ -876,7 +876,7 @@ func handleBMHCompletion(ctx context.Context,
 		return false, nil // no node is in config progress
 	}
 
-	logger.InfoContext(ctx, "Handling nodes for completion", slog.Int("count", len(nodes)))
+	logger.DebugContext(ctx, "Handling nodes for completion", slog.Int("count", len(nodes)))
 	var (
 		wg          sync.WaitGroup
 		mu          sync.Mutex

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -1702,7 +1702,7 @@ func validateFirmwareVersions(
 			return false, nil
 		}
 		if have != want {
-			logger.InfoContext(ctx, "Firmware version mismatch",
+			logger.DebugContext(ctx, "Firmware version mismatch",
 				slog.String("component", k),
 				slog.String("current", have),
 				slog.String("expected", want))
@@ -1863,7 +1863,7 @@ func validateNodeConfiguration(
 		return false, err
 	}
 	if !firmwareValid {
-		logger.InfoContext(ctx, "Firmware versions not yet updated, continuing to poll")
+		logger.DebugContext(ctx, "Firmware versions not yet updated, continuing to poll")
 		return false, nil
 	}
 

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -432,7 +432,7 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestProcessing(
 	nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest,
 ) (ctrl.Result, error) {
 
-	r.Logger.InfoContext(ctx, "Handling NodeAllocationRequest Processing")
+	r.Logger.DebugContext(ctx, "Handling NodeAllocationRequest Processing")
 
 	// New API: returns (ctrl.Result, full bool, error)
 	res, full, err := checkNodeAllocationRequestProgress(
@@ -462,10 +462,10 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestProcessing(
 
 	if res.Requeue || res.RequeueAfter > 0 {
 		if res.RequeueAfter > 0 {
-			r.Logger.InfoContext(ctx, "Progress detected; requeueing",
+			r.Logger.DebugContext(ctx, "Progress detected; requeueing",
 				slog.Duration("after", res.RequeueAfter))
 		} else {
-			r.Logger.InfoContext(ctx, "Progress detected; requeueing immediately")
+			r.Logger.DebugContext(ctx, "Progress detected; requeueing immediately")
 		}
 
 		if err := hwmgrutils.UpdateNodeAllocationRequestStatusCondition(
@@ -554,7 +554,7 @@ func (r *NodeAllocationRequestReconciler) checkHardwareTimeout(
 		}
 		deadline := nar.Status.HardwareOperationStartTime.Time.Add(timeout)
 		elapsed := now.Sub(nar.Status.HardwareOperationStartTime.Time)
-		r.Logger.InfoContext(ctx, "Checking provisioning timeout",
+		r.Logger.DebugContext(ctx, "Checking provisioning timeout",
 			slog.Time("now", now),
 			slog.Time("startTime", nar.Status.HardwareOperationStartTime.Time),
 			slog.Time("deadline", deadline),
@@ -590,7 +590,7 @@ func (r *NodeAllocationRequestReconciler) checkHardwareTimeout(
 		}
 		deadline := nar.Status.HardwareOperationStartTime.Time.Add(timeout)
 		elapsed := now.Sub(nar.Status.HardwareOperationStartTime.Time)
-		r.Logger.InfoContext(ctx, "Checking configuration timeout",
+		r.Logger.DebugContext(ctx, "Checking configuration timeout",
 			slog.Time("now", now),
 			slog.Time("startTime", nar.Status.HardwareOperationStartTime.Time),
 			slog.Time("deadline", deadline),


### PR DESCRIPTION
Change recurring polling logs from INFO to DEBUG level in the hardware manager controller. These messages fire every 15 seconds during firmware update polling, producing 11 INFO lines per cycle that dominated the hardware manager logs with repetitive information.

Changed to DEBUG:
- "Firmware version mismatch" — fires per mismatched component
- "Firmware versions not yet updated, continuing to poll"
- "Checking for nodes with config in progress"
- "Handling nodes for completion"
- "Handling NodeAllocationRequest Processing"
- "Progress detected; requeueing"
- "Checking provisioning timeout" — also removed redundant "now" field (log timestamp serves the same purpose)

State-change logs remain at INFO (e.g., "BMH is now in desired state") since they fire once per transition and are operationally useful.