### PR TITLE
CNF-24580: suppress duplicate alarm rule WARN logs

### DIFF
--- a/internal/service/cluster/collector/collector_alarms.go
+++ b/internal/service/cluster/collector/collector_alarms.go
@@ -344,6 +344,7 @@ func (d *AlarmsDataSource) getFilteredRules(monitoringRules []monitoringv1.Rule)
 
 	var filteredRules []monitoringv1.Rule
 	exist := make(map[uniqueAlarm]bool)
+	var duplicateNames []string
 
 	for _, rule := range monitoringRules {
 		severity, ok := rule.Labels["severity"]
@@ -360,9 +361,14 @@ func (d *AlarmsDataSource) getFilteredRules(monitoringRules []monitoringv1.Rule)
 			exist[key] = true
 			filteredRules = append(filteredRules, rule)
 		} else {
-			slog.Warn("Duplicate rules found", slog.Any("rule", rule))
+			duplicateNames = append(duplicateNames, rule.Alert)
 		}
 	}
+
+	if len(duplicateNames) > 0 {
+		slog.Debug("Filtered duplicate rules", slog.Int("count", len(duplicateNames)), slog.Any("alerts", duplicateNames))
+	}
+
 	return filteredRules
 }
 


### PR DESCRIPTION
Replace per-rule WARN logging of duplicate Prometheus rules with a single DEBUG-level summary after filtering. Previously, each duplicate rule was logged individually at WARN level with the full rule body (PromQL expression, labels, annotations), producing ~48 WARN entries per 60-second sync cycle with identical duplicates every time.

Now logs a single DEBUG entry with the count and alert names of duplicates found. Duplicates are expected (same rules appear on multiple managed clusters) and not actionable, so WARN was the wrong level.