### PR TITLE
CNF-24583: thread context through NAR timeout check function

### DIFF
--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -172,7 +172,7 @@ func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 	result := hwmgrutils.DoNotRequeue()
 
 	// Check for hardware timeout at the top level
-	if timeoutExceeded, conditionType, err := r.checkHardwareTimeout(nodeAllocationRequest); err != nil {
+	if timeoutExceeded, conditionType, err := r.checkHardwareTimeout(ctx, nodeAllocationRequest); err != nil {
 		r.Logger.ErrorContext(ctx, "Failed to check hardware timeout",
 			slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
 			slog.String("error", err.Error()))
@@ -513,7 +513,7 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestProcessing(
 // It times out Day 0 (Provisioned) and Day 2 (Configured) operations using HardwareOperationStartTime.
 // The active operation is determined from the conditions.
 func (r *NodeAllocationRequestReconciler) checkHardwareTimeout(
-	nar *hwmgmtv1alpha1.NodeAllocationRequest,
+	ctx context.Context, nar *hwmgmtv1alpha1.NodeAllocationRequest,
 ) (bool, hwmgmtv1alpha1.ConditionType, error) {
 
 	// 1) Resolve timeout
@@ -547,16 +547,14 @@ func (r *NodeAllocationRequestReconciler) checkHardwareTimeout(
 	if inProgress(prov) {
 		if nar.Status.HardwareOperationStartTime == nil || nar.Status.HardwareOperationStartTime.Time.IsZero() {
 			// Inconsistent state: provisioning says in-progress but no start time.
-			r.Logger.WarnContext(context.Background(), "Provisioning in progress but no start time set",
-				slog.String("nar", nar.Name),
+			r.Logger.WarnContext(ctx, "Provisioning in progress but no start time set",
 				slog.String("provisionedStatus", string(prov.Status)),
 				slog.String("provisionedReason", prov.Reason))
 			return false, hwmgmtv1alpha1.ConditionType(""), nil
 		}
 		deadline := nar.Status.HardwareOperationStartTime.Time.Add(timeout)
 		elapsed := now.Sub(nar.Status.HardwareOperationStartTime.Time)
-		r.Logger.InfoContext(context.Background(), "Checking provisioning timeout",
-			slog.String("nar", nar.Name),
+		r.Logger.InfoContext(ctx, "Checking provisioning timeout",
 			slog.Time("now", now),
 			slog.Time("startTime", nar.Status.HardwareOperationStartTime.Time),
 			slog.Time("deadline", deadline),
@@ -577,8 +575,7 @@ func (r *NodeAllocationRequestReconciler) checkHardwareTimeout(
 		if nar.Spec.ConfigTransactionId != 0 &&
 			(nar.Status.ObservedConfigTransactionId == 0 ||
 				nar.Status.ObservedConfigTransactionId != nar.Spec.ConfigTransactionId) {
-			r.Logger.InfoContext(context.Background(), "Configuration spec change detected, skipping timeout check for retry",
-				slog.String("nar", nar.Name),
+			r.Logger.InfoContext(ctx, "Configuration spec change detected, skipping timeout check for retry",
 				slog.Int64("specConfigTransactionId", nar.Spec.ConfigTransactionId),
 				slog.Int64("observedConfigTransactionId", nar.Status.ObservedConfigTransactionId))
 			return false, hwmgmtv1alpha1.ConditionType(""), nil
@@ -586,16 +583,14 @@ func (r *NodeAllocationRequestReconciler) checkHardwareTimeout(
 
 		if nar.Status.HardwareOperationStartTime == nil || nar.Status.HardwareOperationStartTime.Time.IsZero() {
 			// Inconsistent state: configuring says in-progress but no start time.
-			r.Logger.WarnContext(context.Background(), "Configuration in progress but no start time set",
-				slog.String("nar", nar.Name),
+			r.Logger.WarnContext(ctx, "Configuration in progress but no start time set",
 				slog.String("configuredStatus", string(cfg.Status)),
 				slog.String("configuredReason", cfg.Reason))
 			return false, hwmgmtv1alpha1.ConditionType(""), nil
 		}
 		deadline := nar.Status.HardwareOperationStartTime.Time.Add(timeout)
 		elapsed := now.Sub(nar.Status.HardwareOperationStartTime.Time)
-		r.Logger.InfoContext(context.Background(), "Checking configuration timeout",
-			slog.String("nar", nar.Name),
+		r.Logger.InfoContext(ctx, "Checking configuration timeout",
 			slog.Time("now", now),
 			slog.Time("startTime", nar.Status.HardwareOperationStartTime.Time),
 			slog.Time("deadline", deadline),

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
@@ -21,6 +21,7 @@ Key Test Areas:
 package controller
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"time"
@@ -79,7 +80,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 		Context("when HardwareProvisioningTimeout is specified", func() {
 			It("should use the specified timeout value", func() {
 				nar.Spec.HardwareProvisioningTimeout = "10m"
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeFalse())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.ConditionType("")))
@@ -89,7 +90,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 		Context("when HardwareProvisioningTimeout is empty", func() {
 			It("should use default timeout", func() {
 				nar.Spec.HardwareProvisioningTimeout = ""
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeFalse())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.ConditionType("")))
@@ -99,7 +100,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 		Context("when HardwareProvisioningTimeout is invalid", func() {
 			It("should return error for invalid duration", func() {
 				nar.Spec.HardwareProvisioningTimeout = "invalid"
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid hardware provisioning timeout"))
 				Expect(timeoutExceeded).To(BeFalse())
@@ -108,7 +109,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 
 			It("should return error for zero timeout", func() {
 				nar.Spec.HardwareProvisioningTimeout = "0s"
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("hardware provisioning timeout must be > 0"))
 				Expect(timeoutExceeded).To(BeFalse())
@@ -131,7 +132,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 			})
 
 			It("should detect provisioning timeout", func() {
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeTrue())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.Provisioned))
@@ -153,7 +154,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 			})
 
 			It("should not detect timeout", func() {
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeFalse())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.ConditionType("")))
@@ -182,7 +183,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 			})
 
 			It("should detect configuration timeout", func() {
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeTrue())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.Configured))
@@ -211,7 +212,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 			})
 
 			It("should not detect timeout", func() {
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeFalse())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.ConditionType("")))
@@ -235,7 +236,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 			})
 
 			It("should not detect any timeout", func() {
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeFalse())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.ConditionType("")))
@@ -253,7 +254,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 			})
 
 			It("should not detect timeout without start time", func() {
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeFalse())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.ConditionType("")))
@@ -278,7 +279,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 			})
 
 			It("should not detect timeout without start time", func() {
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeFalse())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.ConditionType("")))
@@ -332,7 +333,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 			It("should allow retry when spec changes", func() {
 				// The hardware manager controller should detect the spec change and skip timeout checking
 				// This allows retry even when the previous configuration failed/timed out
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeFalse())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.ConditionType("")))
@@ -366,7 +367,7 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 			It("should allow retry when spec changes", func() {
 				// Similar to failed case, should allow retry with spec change
 				// Timeout check should be skipped when spec changes
-				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(nar)
+				timeoutExceeded, conditionType, err := reconciler.checkHardwareTimeout(context.Background(), nar)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(timeoutExceeded).To(BeFalse())
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.ConditionType("")))


### PR DESCRIPTION
Add ctx parameter to checkHardwareTimeout so it receives the reconciler's enriched context instead of using context.Background(). This allows the NAR name, cluster ID, and other context fields to appear in timeout-related log entries.

Remove redundant explicit "nar" attributes from log calls within the function — the NAR name is already in the caller's context.

Also remove redundant "now" field from timeout check logs since the log entry timestamp serves the same purpose.