### PR TITLE
CNF-23716: Add scope-to-groups-to-RBAC observability and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,19 @@ issues during code review.
   `NamespacedName`. `ProvisioningRequest` is cluster-scoped (`scope: Cluster`
   in the CRD) and has no namespace.
 
+- **DD-003: OAuth scope verification via groups-to-RBAC mapping.**
+  The O-RAN O2 IMS specification requires token scope verification. This
+  project does not verify the OAuth `scope` claim directly. Instead, the
+  OAuth server translates granted scopes into group memberships, which
+  appear in the token's `groups` claim. The OIDC authenticator
+  (`auth_oauth.go`) extracts these groups, and the `Authorizer`
+  (`auth.go`) maps them to Kubernetes RBAC permissions via
+  `SubjectAccessReview`. This provides functionally equivalent
+  authorization: a token can only access resources permitted by the
+  groups derived from its scopes. The `Authorizer` logs the user's
+  groups at DEBUG level on every successful authorization to make this
+  chain observable for compliance auditing.
+
 ## Logging Conventions
 
 - Use context-aware slog calls (`slog.InfoContext(ctx, ...)`,

--- a/internal/service/alarms/api/openapi.yaml
+++ b/internal/service/alarms/api/openapi.yaml
@@ -23,6 +23,10 @@ tags:
 - name: subscriptions
   description: Alarm subscription management
 
+# Scope enforcement: OAuth scopes are not verified directly from the token's
+# scope claim. The OAuth server translates scopes into group memberships
+# (via the groups claim), and the Authorizer maps those groups to Kubernetes
+# RBAC permissions via SubjectAccessReview. See DD-003 in AGENTS.md.
 security:
 - oauth2:
   - role:o2ims-admin

--- a/internal/service/artifacts/api/openapi.yaml
+++ b/internal/service/artifacts/api/openapi.yaml
@@ -37,6 +37,10 @@ tags:
   description: |
     Information about infrastructure templates.
 
+# Scope enforcement: OAuth scopes are not verified directly from the token's
+# scope claim. The OAuth server translates scopes into group memberships
+# (via the groups claim), and the Authorizer maps those groups to Kubernetes
+# RBAC permissions via SubjectAccessReview. See DD-003 in AGENTS.md.
 security:
 - oauth2:
   - role:o2ims-admin

--- a/internal/service/cluster/api/openapi.yaml
+++ b/internal/service/cluster/api/openapi.yaml
@@ -47,6 +47,10 @@ tags:
   description: |
     Information about cluster subscriptions.
 
+# Scope enforcement: OAuth scopes are not verified directly from the token's
+# scope claim. The OAuth server translates scopes into group memberships
+# (via the groups claim), and the Authorizer maps those groups to Kubernetes
+# RBAC permissions via SubjectAccessReview. See DD-003 in AGENTS.md.
 security:
 - oauth2:
   - role:o2ims-admin

--- a/internal/service/common/auth/auth.go
+++ b/internal/service/common/auth/auth.go
@@ -98,14 +98,20 @@ func Authorizer(kubernetesAuthorizer authorizer.Authorizer) middleware.Middlewar
 			decision, reason, err := kubernetesAuthorizer.Authorize(req.Context(), attributes)
 			if err != nil {
 				msg := fmt.Sprintf("Authorization for user '%s' failed", attributes.User.GetName())
-				slog.ErrorContext(req.Context(), msg, slog.Any("user", user), slog.String("verb", attributes.Verb), slog.String("path", attributes.Path), slog.Any("error", err))
+				slog.ErrorContext(req.Context(), msg,
+					slog.String("user", user.GetName()), slog.Any("groups", user.GetGroups()),
+					slog.String("verb", attributes.Verb), slog.String("path", attributes.Path),
+					slog.Any("error", err))
 				middleware.ProblemDetails(w, msg, http.StatusInternalServerError)
 				return
 			}
 
 			if decision != authorizer.DecisionAllow {
 				msg := fmt.Sprintf("Authorization not allowed for user '%s'", attributes.User.GetName())
-				slog.DebugContext(req.Context(), msg, slog.Any("user", user), slog.String("verb", attributes.Verb), slog.String("path", attributes.Path), slog.Any("decision", decision), slog.String("reason", reason))
+				slog.DebugContext(req.Context(), msg,
+					slog.String("user", user.GetName()), slog.Any("groups", user.GetGroups()),
+					slog.String("verb", attributes.Verb), slog.String("path", attributes.Path),
+					slog.Any("decision", decision), slog.String("reason", reason))
 				middleware.ProblemDetails(w, msg, http.StatusForbidden)
 				return
 			}

--- a/internal/service/common/auth/auth.go
+++ b/internal/service/common/auth/auth.go
@@ -110,6 +110,10 @@ func Authorizer(kubernetesAuthorizer authorizer.Authorizer) middleware.Middlewar
 				return
 			}
 
+			slog.DebugContext(req.Context(), "authorization allowed",
+				slog.String("user", user.GetName()), slog.Any("groups", user.GetGroups()),
+				slog.String("verb", attributes.Verb), slog.String("path", attributes.Path))
+
 			// Proceed to the next layer of handler
 			next.ServeHTTP(w, req)
 		})

--- a/internal/service/common/auth/auth_test.go
+++ b/internal/service/common/auth/auth_test.go
@@ -186,6 +186,8 @@ var _ = Describe("Authorizer", func() {
 	var k8sAuthorizer NoopAuthorizer
 	var recorder *httptest.ResponseRecorder
 	var handler http.Handler
+	var logBuffer bytes.Buffer
+	var origLogger *slog.Logger
 
 	BeforeEach(func() {
 		k8sAuthorizer = NoopAuthorizer{
@@ -194,16 +196,40 @@ var _ = Describe("Authorizer", func() {
 			Error:    nil,
 		}
 		req = &http.Request{Header: http.Header{}, Method: http.MethodGet, URL: &url.URL{Path: "/some/path"}}
-		req = req.WithContext(request.WithUser(req.Context(), &user.DefaultInfo{Name: "test"}))
+		req = req.WithContext(request.WithUser(req.Context(), &user.DefaultInfo{
+			Name:   "test",
+			Groups: []string{"o2ims-admin", "o2ims-reader"},
+		}))
 		next = &NoopHandler{}
 		recorder = httptest.NewRecorder()
 		handler = Authorizer(&k8sAuthorizer)(next)
+
+		logBuffer.Reset()
+		origLogger = slog.Default()
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	})
+
+	AfterEach(func() {
+		slog.SetDefault(origLogger)
 	})
 
 	It("Authorizes the request", func() {
 		handler.ServeHTTP(recorder, req)
 		Expect(k8sAuthorizer.called).To(BeTrue())
 		Expect(next.(*NoopHandler).called).To(BeTrue())
+	})
+
+	It("Logs groups on successful authorization", func() {
+		handler.ServeHTTP(recorder, req)
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+
+		logOutput := logBuffer.String()
+		Expect(logOutput).To(ContainSubstring("authorization allowed"))
+		Expect(logOutput).To(ContainSubstring(`"level":"DEBUG"`))
+		Expect(logOutput).To(ContainSubstring("test"))
+		Expect(logOutput).To(ContainSubstring("o2ims-admin"))
+		Expect(logOutput).To(ContainSubstring("o2ims-reader"))
+		Expect(logOutput).To(ContainSubstring("/some/path"))
 	})
 
 	It("Fails the request if User not in context", func() {

--- a/internal/service/provisioning/api/openapi.yaml
+++ b/internal/service/provisioning/api/openapi.yaml
@@ -37,6 +37,10 @@ tags:
   description: |
     Information about provisioning requests.
 
+# Scope enforcement: OAuth scopes are not verified directly from the token's
+# scope claim. The OAuth server translates scopes into group memberships
+# (via the groups claim), and the Authorizer maps those groups to Kubernetes
+# RBAC permissions via SubjectAccessReview. See DD-003 in AGENTS.md.
 security:
 - oauth2:
   - role:o2ims-admin

--- a/internal/service/resources/api/openapi.yaml
+++ b/internal/service/resources/api/openapi.yaml
@@ -59,6 +59,10 @@ tags:
   description: |
     Information about O-Cloud Sites.
 
+# Scope enforcement: OAuth scopes are not verified directly from the token's
+# scope claim. The OAuth server translates scopes into group memberships
+# (via the groups claim), and the Authorizer maps those groups to Kubernetes
+# RBAC permissions via SubjectAccessReview. See DD-003 in AGENTS.md.
 security:
 - oauth2:
   - role:o2ims-admin


### PR DESCRIPTION
## Summary
- Log user groups at DEBUG level in the Authorizer on successful authorization, making the OAuth scope → groups → RBAC chain observable for compliance auditing ([CNF-23717](https://redhat.atlassian.net/browse/CNF-23717))
- Document DD-003 in AGENTS.md explaining the indirect scope verification pattern, and add clarifying comments above the `security:` section in all five service OpenAPI specs ([CNF-23718](https://redhat.atlassian.net/browse/CNF-23718))

## Test plan
- [x] New test verifies groups appear in log output on successful authorization
- [x] Auth package tests pass (`go test ./internal/service/common/auth/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)