### PR TITLE
fix: format slog.Duration as human-readable strings in JSON logs

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -211,8 +211,8 @@ func (b *LoggerBuilder) Build() (result *slog.Logger, err error) {
 	}
 
 	// Create the handler:
-	replacers := make([]func([]string, slog.Attr) slog.Attr, 0, 2)
-	replacers = append(replacers, replaceTime)
+	replacers := make([]func([]string, slog.Attr) slog.Attr, 0, 3)
+	replacers = append(replacers, replaceTime, replaceDuration)
 	if b.redact {
 		replacers = append(replacers, replaceRedacted)
 	} else {
@@ -311,6 +311,13 @@ func replaceTime(groups []string, a slog.Attr) slog.Attr {
 	if a.Value.Kind() == slog.KindTime {
 		value := a.Value.Time().UTC()
 		a = slog.String(a.Key, value.Format(time.RFC3339))
+	}
+	return a
+}
+
+func replaceDuration(_ []string, a slog.Attr) slog.Attr {
+	if a.Value.Kind() == slog.KindDuration {
+		a = slog.String(a.Key, a.Value.Duration().String())
 	}
 	return a
 }

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -8,8 +8,10 @@ package logging
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -651,6 +653,46 @@ var _ = Describe("Logger", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(msg.MyField).To(Equal("***"))
 		Expect(msg.YourField).To(Equal("***"))
+	})
+
+	It("Writes duration as human-readable string", func() {
+		buffer := &bytes.Buffer{}
+		logger, err := NewLogger().
+			SetWriter(io.MultiWriter(buffer, GinkgoWriter)).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		logger.Info("timeout check",
+			slog.Duration("timeout", 2*time.Hour),
+			slog.Duration("elapsed", 506*time.Millisecond+423*time.Microsecond+654*time.Nanosecond),
+		)
+
+		var msg struct {
+			Timeout string `json:"timeout"`
+			Elapsed string `json:"elapsed"`
+		}
+		err = json.Unmarshal(buffer.Bytes(), &msg)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(msg.Timeout).To(Equal("2h0m0s"))
+		Expect(msg.Elapsed).To(Equal("506.423654ms"))
+	})
+
+	It("Writes context-injected duration as human-readable string", func() {
+		buffer := &bytes.Buffer{}
+		logger, err := NewLogger().
+			SetWriter(io.MultiWriter(buffer, GinkgoWriter)).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx := AppendCtx(context.Background(), slog.Duration("timeout", 90*time.Minute))
+		logger.InfoContext(ctx, "context duration check")
+
+		var msg struct {
+			Timeout string `json:"timeout"`
+		}
+		err = json.Unmarshal(buffer.Bytes(), &msg)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(msg.Timeout).To(Equal("1h30m0s"))
 	})
 
 	It("Logger with group redacts sensitive fields like parent", func() {


### PR DESCRIPTION
slog.Duration renders time.Duration as raw nanosecond integers in JSON output (e.g., "timeout":7200000000000). Add a replaceDuration function to the log handler's ReplaceAttr chain so durations display as readable strings (e.g., "timeout":"2h0m0s").