### PR TITLE
CNF-24640: Upstream release-config version bump — O-Cloud 4.22.0

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -5,6 +5,6 @@ variables:
   description: |
       O-cloud manager operator
   display_name: "o-cloud manager"
-  manager_version: "o-cloud-manager.v4.22.0"
+  manager_version: "o-cloud-manager.v4.22.1"
   min_kube_version: "1.32.0"
-  version: "4.22.0"
+  version: "4.22.1"


### PR DESCRIPTION
Automated post-release update for O-Cloud 4.22.0 → 4.22.1.

Generated by release-automator-konflux.