### PR TITLE
CNF-24640: Upstream catalog-template update — O-Cloud 4.22.0

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,3 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-4-22@sha256:fef1f183eb8cdc6330ed039fa6bb40432c0496dd4d2e146fd056c03310564da8
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-4-22@sha256:9eacc9c81e5090c580b20ede3c297a8f7e0175c59bb9c3b7901da03efa3e2aa1
 


### PR DESCRIPTION
Automated post-release update for O-Cloud 4.22.0 → 4.22.1.

Generated by release-automator-konflux.