### PR TITLE
CNF-24640: Upstream catalog-template update — O-Cloud 4.22.0

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,3 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-4-22@sha256:fef1f183eb8cdc6330ed039fa6bb40432c0496dd4d2e146fd056c03310564da8
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-4-22@sha256:9eacc9c81e5090c580b20ede3c297a8f7e0175c59bb9c3b7901da03efa3e2aa1
 

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -12,6 +12,7 @@ entries:
       # v4.22.1
       - name: o-cloud-manager.v4.22.1
         replaces: o-cloud-manager.v4.22.0
+        skipRange: '>=4.22.0 <4.22.1'
     name: stable
     package: o-cloud-manager
     schema: olm.channel
@@ -21,6 +22,7 @@ entries:
       # v4.22.1
       - name: o-cloud-manager.v4.22.1
         replaces: o-cloud-manager.v4.22.0
+        skipRange: '>=4.22.0 <4.22.1'
     name: "4.22"
     package: o-cloud-manager
     schema: olm.channel

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -9,16 +9,25 @@ entries:
     # Channel entries for 'stable' channel
   - entries:
       - name: o-cloud-manager.v4.22.0
+      # v4.22.1
+      - name: o-cloud-manager.v4.22.1
+        replaces: o-cloud-manager.v4.22.0
     name: stable
     package: o-cloud-manager
     schema: olm.channel
     # Channel entries for '4.22' channel
   - entries:
       - name: o-cloud-manager.v4.22.0
+      # v4.22.1
+      - name: o-cloud-manager.v4.22.1
+        replaces: o-cloud-manager.v4.22.0
     name: "4.22"
     package: o-cloud-manager
     schema: olm.channel
   # v4.22.0 bundle
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:fef1f183eb8cdc6330ed039fa6bb40432c0496dd4d2e146fd056c03310564da8
+    schema: olm.bundle
+    # v4.22.1 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for O-Cloud 4.22.0 → 4.22.1.

Generated by release-automator-konflux.