### PR TITLE
CNF-24707: use typed slog attributes in collector packages

### DIFF
--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -99,7 +99,7 @@ func (c *Collector) Run(ctx context.Context) error {
 		select {
 		case event := <-c.asyncChangeEvents:
 			if err := c.handleAsyncEvent(ctx, event); err != nil {
-				slog.ErrorContext(ctx, "failed to handle async change", "handleWatchEvent", event, "error", err)
+				slog.ErrorContext(ctx, "failed to handle async change", slog.Any("handleWatchEvent", event), slog.Any("error", err))
 			}
 		case <-time.After(pollingDelay):
 			c.execute(ctx)
@@ -141,13 +141,13 @@ func (c *Collector) initDataSource(ctx context.Context, dataSource DataSource) e
 		}
 
 		dataSource.Init(*result.DataSourceID, 0, c.asyncChangeEvents)
-		slog.InfoContext(ctx, "created new data source", "name", name, "uuid", *result.DataSourceID)
+		slog.InfoContext(ctx, "created new data source", slog.String("name", name), slog.Any("uuid", *result.DataSourceID))
 	case err != nil:
 		return fmt.Errorf("failed to get data source %q: %w", name, err)
 	default:
 		dataSource.Init(*record.DataSourceID, record.GenerationID, c.asyncChangeEvents)
 		slog.InfoContext(ctx, "restored data source",
-			"name", name, "uuid", record.DataSourceID, "generation", record.GenerationID)
+			slog.String("name", name), slog.Any("uuid", record.DataSourceID), slog.Int("generation", record.GenerationID))
 	}
 
 	return nil
@@ -162,7 +162,7 @@ func (c *Collector) watchForChanges(ctx context.Context) error {
 		}
 
 		if err := d.(WatchableDataSource).Watch(ctx); err != nil {
-			slog.ErrorContext(ctx, "failed to watch for changes", "source", d.Name(), "error", err)
+			slog.ErrorContext(ctx, "failed to watch for changes", slog.String("source", d.Name()), slog.Any("error", err))
 			return fmt.Errorf("failed to watch for changes: %w", err)
 		}
 	}
@@ -172,7 +172,7 @@ func (c *Collector) watchForChanges(ctx context.Context) error {
 // execute runs a single iteration of the main loop.  It does not return an error because all errors should be handled
 // gracefully.  If a truly unrecoverable error happens then a panic should be used to restart the process.
 func (c *Collector) execute(ctx context.Context) {
-	slog.DebugContext(ctx, "collector loop running", "sources", len(c.dataSources))
+	slog.DebugContext(ctx, "collector loop running", slog.Int("sources", len(c.dataSources)))
 	for _, d := range c.dataSources {
 		// Skip K8S data source since it is handled by the reflector
 		if _, ok := d.(*K8SDataSource); ok {
@@ -180,14 +180,14 @@ func (c *Collector) execute(ctx context.Context) {
 		}
 
 		d.IncrGenerationID()
-		slog.DebugContext(ctx, "collecting data from data source", "source", d.Name(), "generationID", d.GetGenerationID())
+		slog.DebugContext(ctx, "collecting data from data source", slog.String("source", d.Name()), slog.Int("generationID", d.GetGenerationID()))
 		if err := c.executeOneDataSource(ctx, d); err != nil {
-			slog.WarnContext(ctx, "failed to collect data from data source", "source", d.Name(), "error", err)
+			slog.WarnContext(ctx, "failed to collect data from data source", slog.String("source", d.Name()), slog.Any("error", err))
 		} else {
-			slog.DebugContext(ctx, "collected data from data source", "source", d.Name())
+			slog.DebugContext(ctx, "collected data from data source", slog.String("source", d.Name()))
 		}
 	}
-	slog.DebugContext(ctx, "collector loop complete", "sources", len(c.dataSources))
+	slog.DebugContext(ctx, "collector loop complete", slog.Int("sources", len(c.dataSources)))
 }
 
 // executeOneDataSource runs a single iteration of the main loop for a specific data source instance.
@@ -245,7 +245,7 @@ func (c *Collector) executeOneDataSource(ctx context.Context, dataSource DataSou
 		return fmt.Errorf("failed to purge stale alarm dictionaries: %w", err)
 	}
 
-	slog.InfoContext(ctx, "Alarm dictionaries synced", "generationID", ds.GetGenerationID())
+	slog.InfoContext(ctx, "Alarm dictionaries synced", slog.Int("generationID", ds.GetGenerationID()))
 	return nil
 }
 
@@ -292,7 +292,7 @@ func (c *Collector) linkClusterResources(ctx context.Context, nodeCluster *model
 	if err != nil {
 		return fmt.Errorf("failed to set node cluster ID: %w", err)
 	}
-	slog.InfoContext(ctx, "set node cluster id value on cluster resources", "name", nodeCluster.Name, "count", count)
+	slog.InfoContext(ctx, "set node cluster id value on cluster resources", slog.String("name", nodeCluster.Name), slog.Int("count", count))
 	return nil
 }
 
@@ -354,7 +354,7 @@ func (c *Collector) findDataSource(dataSourceID uuid.UUID) DataSource {
 // handleNodeClusterSyncCompletion handles the end of sync for NodeCluster objects.  It deletes any NodeCluster objects
 // not included in the set of keys received during the sync operation.
 func (c *Collector) handleNodeClusterSyncCompletion(ctx context.Context, ids []any) error {
-	slog.DebugContext(ctx, "Handling end of sync for NodeCluster instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for NodeCluster instances", slog.Int("count", len(ids)))
 	records, err := c.repository.GetNodeClustersNotIn(ctx, ids)
 	if err != nil {
 		return fmt.Errorf("failed to get stale node clusters: %w", err)
@@ -383,7 +383,7 @@ func (c *Collector) handleNodeClusterSyncCompletion(ctx context.Context, ids []a
 	}
 
 	if count > 0 {
-		slog.InfoContext(ctx, "Deleted stale node cluster records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale node cluster records", slog.Int("count", count))
 	}
 
 	return nil
@@ -392,7 +392,7 @@ func (c *Collector) handleNodeClusterSyncCompletion(ctx context.Context, ids []a
 // handleClusterResourceSyncCompletion handles the end of sync for ClusterResource objects.  It deletes any
 // ClusterResource objects not included in the set of keys received during the sync operation.
 func (c *Collector) handleClusterResourceSyncCompletion(ctx context.Context, ids []any) error {
-	slog.DebugContext(ctx, "Handling end of sync for ClusterResource instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for ClusterResource instances", slog.Int("count", len(ids)))
 	records, err := c.repository.GetClusterResourcesNotIn(ctx, ids)
 	if err != nil {
 		return fmt.Errorf("failed to get stale cluster resources: %w", err)
@@ -416,7 +416,7 @@ func (c *Collector) handleClusterResourceSyncCompletion(ctx context.Context, ids
 	}
 
 	if count > 0 {
-		slog.InfoContext(ctx, "Deleted stale cluster resource records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale cluster resource records", slog.Int("count", count))
 	}
 
 	return nil
@@ -479,7 +479,7 @@ func (c *Collector) deleteRelatedClusterResources(ctx context.Context, nodeClust
 		return fmt.Errorf("failed to get cluster resources for node_cluster_id %s: %w", nodeCluster.NodeClusterID, err)
 	}
 
-	slog.DebugContext(ctx, "deleting related cluster resources", "node_cluster_id", nodeCluster.NodeClusterID, "count", len(resources))
+	slog.DebugContext(ctx, "deleting related cluster resources", slog.Any("node_cluster_id", nodeCluster.NodeClusterID), slog.Int("count", len(resources)))
 
 	for _, resource := range resources {
 		dataChangeEvent, err := svcutils.DeleteObjectWithChangeEvent(
@@ -567,7 +567,7 @@ func (c *Collector) handleAsyncClusterResourceEvent(ctx context.Context, dataSou
 	if errors.Is(err, svcutils.ErrNotFound) {
 		// Agents will finish being installed before the Managed Cluster is completely provisioned, therefore, we have to
 		// link them after the fact, so here we just skip them.
-		slog.WarnContext(ctx, "no node cluster found", "name", clusterResource.NodeClusterName, "resource", clusterResource.Name)
+		slog.WarnContext(ctx, "no node cluster found", slog.String("name", clusterResource.NodeClusterName), slog.String("resource", clusterResource.Name))
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("failed to get node cluster '%s': %w", clusterResource.NodeClusterName, err)
@@ -600,7 +600,7 @@ func (c *Collector) syncThanosAlarmDefinitions(ctx context.Context, ds *AlarmsDa
 		}
 
 		if count != 0 {
-			slog.InfoContext(ctx, "Deleted Thanos alarm definitions", "count", count)
+			slog.InfoContext(ctx, "Deleted Thanos alarm definitions", slog.Int64("count", count))
 		}
 
 		return nil
@@ -625,17 +625,17 @@ func (c *Collector) syncThanosAlarmDefinitions(ctx context.Context, ds *AlarmsDa
 
 	count, err := c.repository.DeleteThanosAlarmDefinitionsNotIn(ctx, alarmDefinitionIDs)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to delete outdated thanos alarm definitions", "error", err)
+		slog.ErrorContext(ctx, "failed to delete outdated thanos alarm definitions", slog.Any("error", err))
 		return nil
 	}
 
-	slog.InfoContext(ctx, "Thanos alarm definitions synced", "upserted count", len(alarmDefinitionRecords), "deleted count", count)
+	slog.InfoContext(ctx, "Thanos alarm definitions synced", slog.Int("upserted count", len(alarmDefinitionRecords)), slog.Int64("deleted count", count))
 	return nil
 }
 
 // syncManagedClusterAlarmDefinitions fetches Prometheus rules and syncs alarm definitions to the database
 func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *AlarmsDataSource, nodeClusterTypes []models.NodeClusterType) error {
-	slog.InfoContext(ctx, "Syncing managed cluster alarm definitions", "nodeClusterTypes", len(nodeClusterTypes))
+	slog.InfoContext(ctx, "Syncing managed cluster alarm definitions", slog.Int("nodeClusterTypes", len(nodeClusterTypes)))
 
 	// Fetch prometheus rules and build a map of alarm definitions
 	alarmDictionaryIDToAlarmDefinitions, err := ds.makeAlarmDictionaryIDToAlarmDefinitions(ctx, nodeClusterTypes)
@@ -654,7 +654,7 @@ func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *
 		g.Go(func() error {
 			alarmDefinitionRecords, err := c.repository.UpsertAlarmDefinitions(ctx, alarmDictionaryIDToAlarmDefinitions[alarmDictionaryID])
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to upsert alarm definitions", "alarmDictionaryID", alarmDictionaryID, "error", err)
+				slog.ErrorContext(ctx, "failed to upsert alarm definitions", slog.Any("alarmDictionaryID", alarmDictionaryID), slog.Any("error", err))
 				return nil
 			}
 
@@ -666,11 +666,11 @@ func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *
 
 			count, err := c.repository.DeleteAlarmDefinitionsNotIn(ctx, alarmDefinitionIDs, alarmDictionaryID)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to delete non-valid alarm definitions", "alarmDictionaryID", alarmDictionaryID, "error", err)
+				slog.ErrorContext(ctx, "failed to delete non-valid alarm definitions", slog.Any("alarmDictionaryID", alarmDictionaryID), slog.Any("error", err))
 				return nil
 			}
 
-			slog.InfoContext(ctx, "Alarm definitions synced", "alarmDictionaryID", alarmDictionaryID, "upserted count", len(alarmDefinitionRecords), "deleted count", count)
+			slog.InfoContext(ctx, "Alarm definitions synced", slog.Any("alarmDictionaryID", alarmDictionaryID), slog.Int("upserted count", len(alarmDefinitionRecords)), slog.Int64("deleted count", count))
 			return nil
 		})
 	}
@@ -684,7 +684,7 @@ func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *
 
 // syncAlarmDictionaries syncs alarm dictionaries to the database
 func (c *Collector) syncAlarmDictionaries(ctx context.Context, ds *AlarmsDataSource, nodeClusterTypes []models.NodeClusterType) error {
-	slog.InfoContext(ctx, "Syncing alarm dictionaries", "nodeClusterTypes", len(nodeClusterTypes))
+	slog.InfoContext(ctx, "Syncing alarm dictionaries", slog.Int("nodeClusterTypes", len(nodeClusterTypes)))
 
 	alarmDictionaries := ds.makeAlarmDictionaries(nodeClusterTypes)
 
@@ -705,7 +705,7 @@ func (c *Collector) syncAlarmDictionaries(ctx context.Context, ds *AlarmsDataSou
 		g.Go(func() error {
 			alarmDefinitions, err := c.repository.GetAlarmDefinitionsByAlarmDictionaryID(ctx, alarmDictionary.AlarmDictionaryID)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to get alarm definitions", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID, "error", err)
+				slog.ErrorContext(ctx, "failed to get alarm definitions", slog.Any("alarmDictionaryID", alarmDictionary.AlarmDictionaryID), slog.Any("error", err))
 				return nil
 			}
 
@@ -719,7 +719,7 @@ func (c *Collector) syncAlarmDictionaries(ctx context.Context, ds *AlarmsDataSou
 					return models.AlarmDictionaryToModel(&record, alarmDefinitions)
 				})
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to persist node cluster type'", "error", err)
+				slog.ErrorContext(ctx, "failed to persist node cluster type'", slog.Any("error", err))
 				return nil
 			}
 
@@ -769,7 +769,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 		g.Go(func() error {
 			alarmDefinitions, err := c.repository.GetAlarmDefinitionsByAlarmDictionaryID(ctx, alarmDictionary.AlarmDictionaryID)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to get alarm definitions", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID, "error", err)
+				slog.ErrorContext(ctx, "failed to get alarm definitions", slog.Any("alarmDictionaryID", alarmDictionary.AlarmDictionaryID), slog.Any("error", err))
 				return nil
 			}
 
@@ -778,7 +778,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 				return models.AlarmDictionaryToModel(&record, alarmDefinitions)
 			})
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to delete stale alarm dictionary", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID, "error", err)
+				slog.ErrorContext(ctx, "failed to delete stale alarm dictionary", slog.Any("alarmDictionaryID", alarmDictionary.AlarmDictionaryID), slog.Any("error", err))
 				return nil
 			}
 
@@ -786,7 +786,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 				c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 			}
 
-			slog.InfoContext(ctx, "Stale alarm dictionary purged", "alarmDictionaryID", alarmDictionary.AlarmDictionaryID)
+			slog.InfoContext(ctx, "Stale alarm dictionary purged", slog.Any("alarmDictionaryID", alarmDictionary.AlarmDictionaryID))
 			return nil
 		})
 	}
@@ -800,7 +800,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 
 // handleAsyncAlarmDictionaryAndDefinitionsCreation handles the creation of alarm dictionary and definitions triggered by a new node cluster type
 func (c *Collector) handleAsyncAlarmDictionaryAndDefinitionsCreation(ctx context.Context, nodeClusterType *models.NodeClusterType) {
-	slog.InfoContext(ctx, "Creating alarm dictionary and definitions", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
+	slog.InfoContext(ctx, "Creating alarm dictionary and definitions", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
 
 	var alarmsDataSource *AlarmsDataSource
 	for i := range c.dataSources {
@@ -813,23 +813,23 @@ func (c *Collector) handleAsyncAlarmDictionaryAndDefinitionsCreation(ctx context
 	// Create and persist Alarm Dictionary without Alarm Definitions
 	err := c.syncAlarmDictionaries(ctx, alarmsDataSource, []models.NodeClusterType{*nodeClusterType})
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to create alarm dictionary", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
+		slog.ErrorContext(ctx, "failed to create alarm dictionary", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
 		return
 	}
 
 	// Collect and persist Alarm Definitions
 	err = c.syncManagedClusterAlarmDefinitions(ctx, alarmsDataSource, []models.NodeClusterType{*nodeClusterType})
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to create alarm definitions", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
+		slog.ErrorContext(ctx, "failed to create alarm definitions", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
 		return
 	}
 
 	// Sync Alarm Dictionary to include Alarm Definitions
 	err = c.syncAlarmDictionaries(ctx, alarmsDataSource, []models.NodeClusterType{*nodeClusterType})
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to update alarm dictionary", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
+		slog.ErrorContext(ctx, "failed to update alarm dictionary", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
 		return
 	}
 
-	slog.InfoContext(ctx, "Alarm dictionary and definitions created", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
+	slog.InfoContext(ctx, "Alarm dictionary and definitions created", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
 }

--- a/internal/service/cluster/collector/collector_alarms.go
+++ b/internal/service/cluster/collector/collector_alarms.go
@@ -88,7 +88,7 @@ func (d *AlarmsDataSource) IncrGenerationID() int {
 
 // makeAlarmDictionaryIDToAlarmDefinitions fetches monitoring rules for each node cluster type and builds a map of alarm dictionary ID to alarm definitions
 func (d *AlarmsDataSource) makeAlarmDictionaryIDToAlarmDefinitions(ctx context.Context, nodeClusterTypes []models.NodeClusterType) (map[uuid.UUID][]models.AlarmDefinition, error) {
-	slog.InfoContext(ctx, "making alarm dictionary ID to alarm definitions map", "nodeClusterTypes count", len(nodeClusterTypes))
+	slog.InfoContext(ctx, "making alarm dictionary ID to alarm definitions map", slog.Int("nodeClusterTypes count", len(nodeClusterTypes)))
 
 	// Fetch prometheus rules from managed clusters and hub
 	nodeClusterTypeIDToMonitoringRules := d.makeNodeClusterTypeIDToMonitoringRules(ctx, nodeClusterTypes)
@@ -106,7 +106,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 	var filteredNodeClusterTypes []models.NodeClusterType
 	for _, nodeClusterType := range nodeClusterTypes {
 		if nodeClusterType.Extensions == nil {
-			slog.Error("no extensions found for node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
+			slog.Error("no extensions found for node cluster type", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
 			continue
 		}
 
@@ -114,7 +114,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 		if alarmDictionaryIDString != nil {
 			id, err := uuid.Parse(alarmDictionaryIDString.(string))
 			if err != nil {
-				slog.Error("error parsing alarm dictionary ID", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
+				slog.Error("error parsing alarm dictionary ID", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
 				continue
 			}
 			(*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension] = id
@@ -127,7 +127,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 
 // makeNodeClusterTypeIDToMonitoringRules fetches monitoring rules for each node cluster type
 func (d *AlarmsDataSource) makeNodeClusterTypeIDToMonitoringRules(ctx context.Context, nodeClusterTypes []models.NodeClusterType) map[uuid.UUID][]monitoringv1.Rule {
-	slog.InfoContext(ctx, "making node cluster type ID to monitoring rules map", "nodeClusterTypes count", len(nodeClusterTypes))
+	slog.InfoContext(ctx, "making node cluster type ID to monitoring rules map", slog.Int("nodeClusterTypes count", len(nodeClusterTypes)))
 
 	nodeClusterTypeIDToMonitoringRules := make(map[uuid.UUID][]monitoringv1.Rule)
 
@@ -180,12 +180,12 @@ func (d *AlarmsDataSource) makeNodeClusterTypeIDToMonitoringRules(ctx context.Co
 	// Collect results
 	for res := range resultChannel {
 		if res.err != nil {
-			slog.ErrorContext(ctx, "error fetching rules for node cluster type", "nodeClusterTypeID", res.nodeClusterTypeID, "error", res.err)
+			slog.ErrorContext(ctx, "error fetching rules for node cluster type", slog.Any("nodeClusterTypeID", res.nodeClusterTypeID), slog.Any("error", res.err))
 			continue
 		}
 
 		nodeClusterTypeIDToMonitoringRules[res.nodeClusterTypeID] = res.rules
-		slog.InfoContext(ctx, "loaded rules for node cluster type", "nodeClusterTypeID", res.nodeClusterTypeID, "rules count", len(res.rules))
+		slog.InfoContext(ctx, "loaded rules for node cluster type", slog.Any("nodeClusterTypeID", res.nodeClusterTypeID), slog.Int("rules count", len(res.rules)))
 	}
 
 	return nodeClusterTypeIDToMonitoringRules
@@ -198,7 +198,7 @@ func (d *AlarmsDataSource) processHub(ctx context.Context) ([]monitoringv1.Rule,
 		return nil, err
 	}
 
-	slog.DebugContext(ctx, "fetched rules for Hub cluster", "rules count", len(rules))
+	slog.DebugContext(ctx, "fetched rules for Hub cluster", slog.Int("rules count", len(rules)))
 	return rules, nil
 }
 
@@ -222,7 +222,7 @@ func (d *AlarmsDataSource) processManagedCluster(ctx context.Context, version st
 		return nil, err
 	}
 
-	slog.DebugContext(ctx, "fetched rules for managed cluster", "cluster", cluster.Name, "version", version, "rules count", len(rules))
+	slog.DebugContext(ctx, "fetched rules for managed cluster", slog.Any("cluster", cluster.Name), slog.Any("version", version), slog.Int("rules count", len(rules)))
 	return rules, nil
 }
 
@@ -286,12 +286,12 @@ func (d *AlarmsDataSource) getRules(ctx context.Context, cl crclient.Client) ([]
 
 // buildAlarmDictionaryIDToAlarmDefinitionsMap builds a map of alarm dictionary ID to alarm definitions
 func (d *AlarmsDataSource) buildAlarmDictionaryIDToAlarmDefinitions(nodeClusterTypes []models.NodeClusterType, nodeClusterTypeIDToMonitoringRules map[uuid.UUID][]monitoringv1.Rule) map[uuid.UUID][]models.AlarmDefinition {
-	slog.Info("building alarm dictionary ID to alarm definitions map", "nodeClusterTypes count", len(nodeClusterTypes))
+	slog.Info("building alarm dictionary ID to alarm definitions map", slog.Int("nodeClusterTypes count", len(nodeClusterTypes)))
 
 	alarmDictionaryIDToAlarmDefinitions := make(map[uuid.UUID][]models.AlarmDefinition)
 	for _, nodeClusterType := range nodeClusterTypes {
 		if _, ok := nodeClusterTypeIDToMonitoringRules[nodeClusterType.NodeClusterTypeID]; !ok {
-			slog.Warn("no monitoring rules found for node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
+			slog.Warn("no monitoring rules found for node cluster type", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
 			continue
 		}
 
@@ -299,18 +299,18 @@ func (d *AlarmsDataSource) buildAlarmDictionaryIDToAlarmDefinitions(nodeClusterT
 		extensions, err := getVendorExtensions(nodeClusterType)
 		if err != nil {
 			// Should never happen
-			slog.Error("error getting vendor extensions", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
+			slog.Error("error getting vendor extensions", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
 			continue
 		}
 
 		// Only process node cluster types with an alarm dictionary ID
 		alarmDictionaryID, ok := (*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension].(uuid.UUID)
 		if !ok || alarmDictionaryID == uuid.Nil {
-			slog.Error("no alarm dictionary ID found for node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
+			slog.Error("no alarm dictionary ID found for node cluster type", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
 			continue
 		}
 
-		slog.Debug("filtering rules for node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
+		slog.Debug("filtering rules for node cluster type", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
 		// Remove conflicting rules before creating alarm definitions
 		filteredRules := d.getFilteredRules(nodeClusterTypeIDToMonitoringRules[nodeClusterType.NodeClusterTypeID])
 
@@ -348,7 +348,7 @@ func (d *AlarmsDataSource) getFilteredRules(monitoringRules []monitoringv1.Rule)
 	for _, rule := range monitoringRules {
 		severity, ok := rule.Labels["severity"]
 		if !ok {
-			slog.Warn("rule missing severity label", "alert", rule.Alert)
+			slog.Warn("rule missing severity label", slog.Any("alert", rule.Alert))
 		}
 
 		key := uniqueAlarm{
@@ -360,7 +360,7 @@ func (d *AlarmsDataSource) getFilteredRules(monitoringRules []monitoringv1.Rule)
 			exist[key] = true
 			filteredRules = append(filteredRules, rule)
 		} else {
-			slog.Warn("Duplicate rules found", "rule", rule)
+			slog.Warn("Duplicate rules found", slog.Any("rule", rule))
 		}
 	}
 	return filteredRules
@@ -408,13 +408,13 @@ func (d *AlarmsDataSource) createAlarmDefinitions(rules []monitoringv1.Rule, ala
 		records = append(records, record)
 	}
 
-	slog.Info("AlarmDefinitions from prometheus rules prepared", "count", len(records), "alarmDictionaryID", alarmDictionaryID)
+	slog.Info("AlarmDefinitions from prometheus rules prepared", slog.Int("count", len(records)), slog.Any("alarmDictionaryID", alarmDictionaryID))
 	return records
 }
 
 // makeAlarmDictionaries creates alarm dictionaries from node cluster types
 func (d *AlarmsDataSource) makeAlarmDictionaries(nodeClusterTypes []models.NodeClusterType) []models.AlarmDictionary {
-	slog.Info("making alarm dictionaries", "nodeClusterTypes count", len(nodeClusterTypes))
+	slog.Info("making alarm dictionaries", slog.Int("nodeClusterTypes count", len(nodeClusterTypes)))
 
 	var alarmDictionaries []models.AlarmDictionary
 	for _, nodeClusterType := range nodeClusterTypes {
@@ -422,13 +422,13 @@ func (d *AlarmsDataSource) makeAlarmDictionaries(nodeClusterTypes []models.NodeC
 		extensions, err := getVendorExtensions(nodeClusterType)
 		if err != nil {
 			// Should never happen
-			slog.Error("error getting vendor extensions", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID, "error", err)
+			slog.Error("error getting vendor extensions", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
 			continue
 		}
 
 		alarmDictionaryID, ok := (*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension].(uuid.UUID)
 		if !ok || alarmDictionaryID == uuid.Nil {
-			slog.Error("no alarm dictionary ID found for node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeID)
+			slog.Error("no alarm dictionary ID found for node cluster type", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
 			continue
 		}
 
@@ -497,7 +497,7 @@ func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoring
 		}, configMap)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				slog.WarnContext(ctx, "Config map not found", "configMap", configMapName)
+				slog.WarnContext(ctx, "Config map not found", slog.Any("configMap", configMapName))
 				continue
 			}
 
@@ -513,7 +513,7 @@ func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoring
 			var spec RuleSpec
 			err = yaml.Unmarshal([]byte(rulSpec), &spec)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to unmarshal thanos prometheus rules spec", "configMap", configMapName, "error", err)
+				slog.ErrorContext(ctx, "failed to unmarshal thanos prometheus rules spec", slog.Any("configMap", configMapName), slog.Any("error", err))
 				continue
 			}
 
@@ -533,11 +533,11 @@ func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoring
 				}
 			}
 		} else {
-			slog.WarnContext(ctx, "No data found in thanos config map", "configMap", configMapName)
+			slog.WarnContext(ctx, "No data found in thanos config map", slog.Any("configMap", configMapName))
 		}
 	}
 
-	slog.DebugContext(ctx, "Collected thanos rules", "rules count", len(rules))
+	slog.DebugContext(ctx, "Collected thanos rules", slog.Int("rules count", len(rules)))
 
 	// Expand rules with templated severity into multiple static rules
 	expandedRules := d.expandTemplatedSeverity(rules)
@@ -569,7 +569,7 @@ func (d *AlarmsDataSource) expandTemplatedSeverity(rules []monitoringv1.Rule) []
 			continue
 		}
 
-		slog.Info("Expanding templated severity rule", "alert", rule.Alert, "severity", severity)
+		slog.Info("Expanding templated severity rule", slog.Any("alert", rule.Alert), slog.Any("severity", severity))
 
 		// Create one rule for each static severity value
 		for _, staticSeverity := range severities {
@@ -597,11 +597,11 @@ func (d *AlarmsDataSource) expandTemplatedSeverity(rules []monitoringv1.Rule) []
 			}
 
 			expandedRules = append(expandedRules, expandedRule)
-			slog.Debug("Created expanded rule", "alert", expandedRule.Alert, "severity", staticSeverity)
+			slog.Debug("Created expanded rule", slog.Any("alert", expandedRule.Alert), slog.Any("severity", staticSeverity))
 		}
 	}
 
-	slog.Info("Severity expansion complete", "original count", len(rules), "expanded count", len(expandedRules))
+	slog.Info("Severity expansion complete", slog.Int("original count", len(rules)), slog.Int("expanded count", len(expandedRules)))
 	return expandedRules
 }
 
@@ -612,7 +612,7 @@ func IsTemplated(s string) bool {
 
 // makeThanosAlarmDefinitions creates alarm definitions from thanos rules
 func (d *AlarmsDataSource) makeThanosAlarmDefinitions(rules []monitoringv1.Rule) ([]models.AlarmDefinition, error) {
-	slog.Debug("Making Thanos alarm definitions", "rules count", len(rules))
+	slog.Debug("Making Thanos alarm definitions", slog.Int("rules count", len(rules)))
 
 	filteredRules := d.getFilteredRules(rules)
 

--- a/internal/service/cluster/collector/collector_k8s.go
+++ b/internal/service/cluster/collector/collector_k8s.go
@@ -360,20 +360,20 @@ func isLocalCluster(cluster *v1.ManagedCluster) bool {
 		if err == nil {
 			return localCluster
 		}
-		slog.Warn("failed to parse local-cluster label as boolean", "cluster", cluster.Name, "value", value, "error", err)
+		slog.Warn("failed to parse local-cluster label as boolean", slog.Any("cluster", cluster.Name), slog.Any("value", value), slog.Any("error", err))
 	}
 	return false
 }
 
 // handleClusterWatchEvent handles an async event received from the managed cluster watcher
 func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1.ManagedCluster, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", "agent", cluster.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", slog.Any("agent", cluster.Name), slog.Any("type", eventType))
 
 	if eventType != async.Deleted {
 		condition := meta.FindStatusCondition(cluster.Status.Conditions, "ManagedClusterConditionAvailable")
 		if condition == nil || condition.Status == metav1.ConditionFalse {
 			// This cluster is not yet available, so filter it out.
-			slog.DebugContext(ctx, "Managed cluster is not available; skipping", "cluster", cluster.Name, "condition", condition)
+			slog.DebugContext(ctx, "Managed cluster is not available; skipping", slog.Any("cluster", cluster.Name), slog.Any("condition", condition))
 			return uuid.Nil, nil
 		}
 
@@ -382,7 +382,7 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 			// provisioning request has completed, but the local-cluster will never have this, so we continue without it.
 			if _, found := cluster.Labels[ctlrutils.ClusterTemplateArtifactsLabel]; !found {
 				// The provisioning request which is managing the installation of this cluster is not yet fulfilled
-				slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", "cluster", cluster.Name)
+				slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", slog.Any("cluster", cluster.Name))
 				return uuid.Nil, nil
 			}
 		}
@@ -407,19 +407,19 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 
 // handleAgentWatchEvent handles an async event received from the agent watcher
 func (d *K8SDataSource) handleAgentWatchEvent(ctx context.Context, agent *v1beta1.Agent, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for agent", "agent", agent.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleWatchEvent received for agent", slog.Any("agent", agent.Name), slog.Any("type", eventType))
 
 	if eventType != async.Deleted {
 		condition := conditionsv1.FindStatusCondition(agent.Status.Conditions, "Installed")
 		if condition == nil || condition.Status == corev1.ConditionFalse {
 			// This cluster is not yet available, so filter it out.
-			slog.DebugContext(ctx, "Agent installation is not yet completed; skipping", "agent", agent.Name, "condition", condition)
+			slog.DebugContext(ctx, "Agent installation is not yet completed; skipping", slog.Any("agent", agent.Name), slog.Any("condition", condition))
 			return uuid.Nil, nil
 		}
 
 		if _, found := agent.Labels[ctlrutils.ClusterTemplateArtifactsLabel]; !found {
 			// The provisioning request which is managing the installation of this agent is not yet fulfilled
-			slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", "agent", agent.Name)
+			slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", slog.Any("agent", agent.Name))
 			return uuid.Nil, nil
 		}
 	}
@@ -443,7 +443,7 @@ func (d *K8SDataSource) handleAgentWatchEvent(ctx context.Context, agent *v1beta
 
 // HandleAsyncEvent handles an add/update/delete to an object received by from the Reflector.
 func (d *K8SDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for store adapter", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	slog.DebugContext(ctx, "handleWatchEvent received for store adapter", slog.Any("type", eventType), slog.String("object", fmt.Sprintf("%T", obj)))
 	switch value := obj.(type) {
 	case *v1.ManagedCluster:
 		return d.handleClusterWatchEvent(ctx, value, eventType)
@@ -451,7 +451,7 @@ func (d *K8SDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, e
 		return d.handleAgentWatchEvent(ctx, value, eventType)
 	default:
 		// We are only watching for specific event types so this should happen.
-		slog.WarnContext(ctx, "Unknown object type", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type", slog.String("type", fmt.Sprintf("%T", obj)))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -466,7 +466,7 @@ func (d *K8SDataSource) HandleSyncComplete(ctx context.Context, objectType runti
 		object = models.ClusterResource{}
 	default:
 		// This should never happen since we watch for specific types
-		slog.WarnContext(ctx, "Unknown object type", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type", slog.String("type", fmt.Sprintf("%T", objectType)))
 		return nil
 	}
 

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -101,7 +101,7 @@ func (c *Collector) Run(ctx context.Context) error {
 		select {
 		case event := <-c.AsyncChangeEvents:
 			if err := c.handleAsyncEvent(ctx, event); err != nil {
-				slog.ErrorContext(ctx, "failed to handle async change", "event", event, "error", err)
+				slog.ErrorContext(ctx, "failed to handle async change", slog.Any("event", event), slog.Any("error", err))
 			}
 		case <-ctx.Done():
 			slog.InfoContext(ctx, "Context terminated; collector exiting")
@@ -141,13 +141,13 @@ func (c *Collector) initDataSource(ctx context.Context, dataSource DataSource) e
 		}
 
 		dataSource.Init(*result.DataSourceID, 0, c.AsyncChangeEvents)
-		slog.InfoContext(ctx, "created new data source", "name", name, "uuid", *result.DataSourceID)
+		slog.InfoContext(ctx, "created new data source", slog.String("name", name), slog.Any("uuid", *result.DataSourceID))
 	case err != nil:
 		return fmt.Errorf("failed to get data source %q: %w", name, err)
 	default:
 		dataSource.Init(*record.DataSourceID, record.GenerationID, c.AsyncChangeEvents)
 		slog.InfoContext(ctx, "restored data source",
-			"name", name, "uuid", record.DataSourceID, "generation", record.GenerationID)
+			slog.String("name", name), slog.Any("uuid", record.DataSourceID), slog.Int("generation", record.GenerationID))
 	}
 	return nil
 }
@@ -241,7 +241,7 @@ func (c *Collector) handleAsyncResourceEvent(ctx context.Context, resource model
 // handleResourceSyncCompletion handles the sync completion for Resource objects
 // by purging resources and resource types not in the key set.
 func (c *Collector) handleResourceSyncCompletion(ctx context.Context, ids []any) error {
-	slog.DebugContext(ctx, "Handling end of sync for Resource instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for Resource instances", slog.Int("count", len(ids)))
 	c.invalidateAlarmDictCache()
 
 	// Purge stale resources
@@ -267,7 +267,7 @@ func (c *Collector) handleResourceSyncCompletion(ctx context.Context, ids []any)
 	}
 
 	if resourceCount > 0 {
-		slog.InfoContext(ctx, "Deleted stale resources", "count", resourceCount)
+		slog.InfoContext(ctx, "Deleted stale resources", slog.Int("count", resourceCount))
 	}
 
 	return nil
@@ -279,7 +279,7 @@ func (c *Collector) getAlarmDictionaryID(ctx context.Context, resourceTypeID uui
 	if c.alarmDictCache == nil {
 		alarmDictionaries, err := c.repository.GetAlarmDictionaries(ctx)
 		if err != nil {
-			slog.WarnContext(ctx, "failed to fetch alarm dictionaries", "error", err)
+			slog.WarnContext(ctx, "failed to fetch alarm dictionaries", slog.Any("error", err))
 			return nil
 		}
 		c.alarmDictCache = make(map[string]*uuid.UUID)
@@ -302,7 +302,7 @@ func (c *Collector) invalidateAlarmDictCache() {
 // handleDeploymentManagerSyncCompletion handles the end of sync for DeploymentManager objects.  It deletes any
 // DeploymentManager objects not included in the set of keys received during the sync operation.
 func (c *Collector) handleDeploymentManagerSyncCompletion(ctx context.Context, ids []any) error {
-	slog.DebugContext(ctx, "Handling end of sync for DeploymentManager instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for DeploymentManager instances", slog.Int("count", len(ids)))
 	records, err := c.repository.GetDeploymentManagersNotIn(ctx, ids)
 	if err != nil {
 		return fmt.Errorf("failed to get stale deployment managers: %w", err)
@@ -326,7 +326,7 @@ func (c *Collector) handleDeploymentManagerSyncCompletion(ctx context.Context, i
 	}
 
 	if count > 0 {
-		slog.InfoContext(ctx, "Deleted stale deployment manager records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale deployment manager records", slog.Int("count", count))
 	}
 
 	return nil
@@ -425,8 +425,8 @@ func (c *Collector) locationAPIForChangeEvent(ctx context.Context, record *model
 	siteIDs, err := c.repository.GetOCloudSiteIDsForLocation(ctx, record.GlobalLocationID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to load O-Cloud site IDs for location change event",
-			"globalLocationId", record.GlobalLocationID,
-			"error", err)
+			slog.Any("globalLocationId", record.GlobalLocationID),
+			slog.Any("error", err))
 		return models.LocationToModel(record, nil)
 	}
 	return models.LocationToModel(record, siteIDs)
@@ -438,8 +438,8 @@ func (c *Collector) oCloudSiteAPIForChangeEvent(ctx context.Context, record *mod
 	poolIDs, err := c.repository.GetResourcePoolIDsForSite(ctx, record.OCloudSiteID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to load resource pool IDs for O-Cloud site change event",
-			"oCloudSiteId", record.OCloudSiteID,
-			"error", err)
+			slog.Any("oCloudSiteId", record.OCloudSiteID),
+			slog.Any("error", err))
 		return models.OCloudSiteToModel(record, nil)
 	}
 	return models.OCloudSiteToModel(record, poolIDs)
@@ -515,7 +515,7 @@ func (c *Collector) handleAsyncOCloudSiteEvent(ctx context.Context, site models.
 
 // handleLocationSyncCompletion handles the sync completion for Location objects.
 func (c *Collector) handleLocationSyncCompletion(ctx context.Context, keys []uuid.UUID) error {
-	slog.DebugContext(ctx, "Handling end of sync for Location instances", "count", len(keys))
+	slog.DebugContext(ctx, "Handling end of sync for Location instances", slog.Int("count", len(keys)))
 
 	// Create a set of tracking UUIDs for fast lookup
 	keySet := make(map[uuid.UUID]struct{}, len(keys))
@@ -554,7 +554,7 @@ func (c *Collector) handleLocationSyncCompletion(ctx context.Context, keys []uui
 	}
 
 	if count > 0 {
-		slog.InfoContext(ctx, "Deleted stale location records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale location records", slog.Int("count", count))
 	}
 
 	return nil
@@ -562,7 +562,7 @@ func (c *Collector) handleLocationSyncCompletion(ctx context.Context, keys []uui
 
 // handleOCloudSiteSyncCompletion handles the sync completion for OCloudSite objects.
 func (c *Collector) handleOCloudSiteSyncCompletion(ctx context.Context, ids []any) error {
-	slog.DebugContext(ctx, "Handling end of sync for OCloudSite instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for OCloudSite instances", slog.Int("count", len(ids)))
 
 	records, err := c.repository.GetOCloudSitesNotIn(ctx, ids)
 	if err != nil {
@@ -587,7 +587,7 @@ func (c *Collector) handleOCloudSiteSyncCompletion(ctx context.Context, ids []an
 	}
 
 	if count > 0 {
-		slog.InfoContext(ctx, "Deleted stale OCloudSite records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale OCloudSite records", slog.Int("count", count))
 	}
 
 	return nil
@@ -639,30 +639,30 @@ func (c *Collector) rebuildResourcesForPool(ctx context.Context, poolName string
 
 		results, err := handler.BuildResourcesForPool(ctx, poolName)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to rebuild resources for pool", "pool", poolName, "error", err)
+			slog.ErrorContext(ctx, "failed to rebuild resources for pool", slog.Any("pool", poolName), slog.Any("error", err))
 			continue
 		}
 
 		for i := range results {
 			if err := c.handleAsyncResourceTypeEvent(ctx, results[i].ResourceType, false); err != nil {
 				slog.ErrorContext(ctx, "failed to persist resource type during pool rebuild",
-					"pool", poolName, "error", err)
+					slog.String("pool", poolName), slog.Any("error", err))
 			}
 			if err := c.handleAsyncResourceEvent(ctx, results[i].Resource, false); err != nil {
 				slog.ErrorContext(ctx, "failed to persist resource during pool rebuild",
-					"pool", poolName, "error", err)
+					slog.String("pool", poolName), slog.Any("error", err))
 			}
 		}
 
 		if len(results) > 0 {
-			slog.InfoContext(ctx, "Rebuilt resources for pool", "pool", poolName, "count", len(results))
+			slog.InfoContext(ctx, "Rebuilt resources for pool", slog.Any("pool", poolName), slog.Int("count", len(results)))
 		}
 	}
 }
 
 // handleResourcePoolSyncCompletion handles the sync completion for ResourcePool objects.
 func (c *Collector) handleResourcePoolSyncCompletion(ctx context.Context, ids []any) error {
-	slog.DebugContext(ctx, "Handling end of sync for ResourcePool instances", "count", len(ids))
+	slog.DebugContext(ctx, "Handling end of sync for ResourcePool instances", slog.Int("count", len(ids)))
 
 	records, err := c.repository.GetResourcePoolsNotIn(ctx, ids)
 	if err != nil {
@@ -687,7 +687,7 @@ func (c *Collector) handleResourcePoolSyncCompletion(ctx context.Context, ids []
 	}
 
 	if count > 0 {
-		slog.InfoContext(ctx, "Deleted stale ResourcePool records", "count", count)
+		slog.InfoContext(ctx, "Deleted stale ResourcePool records", slog.Int("count", count))
 	}
 
 	return nil

--- a/internal/service/resources/collector/collector_hwmgr.go
+++ b/internal/service/resources/collector/collector_hwmgr.go
@@ -232,7 +232,7 @@ func (d *HardwareDataSource) HandleAsyncEvent(ctx context.Context, obj interface
 	case *hwmgmtv1alpha1.AllocatedNode:
 		return d.handleAllocatedNodeEvent(ctx, value, eventType)
 	default:
-		slog.WarnContext(ctx, "Unknown object type in HardwareDataSource", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type in HardwareDataSource", slog.String("type", fmt.Sprintf("%T", obj)))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -244,7 +244,7 @@ func (d *HardwareDataSource) HandleAsyncEvent(ctx context.Context, obj interface
 func (d *HardwareDataSource) HandleSyncComplete(ctx context.Context, objectType runtime.Object, keys []uuid.UUID) error {
 	switch objectType.(type) {
 	case *metal3v1alpha1.BareMetalHost:
-		slog.InfoContext(ctx, "BMH sync complete", "resourceCount", len(keys))
+		slog.InfoContext(ctx, "BMH sync complete", slog.Int("resourceCount", len(keys)))
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("context cancelled; aborting")
@@ -262,7 +262,7 @@ func (d *HardwareDataSource) HandleSyncComplete(ctx context.Context, objectType 
 		slog.InfoContext(ctx, "AllocatedNode sync complete")
 		return nil
 	default:
-		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", slog.String("type", fmt.Sprintf("%T", objectType)))
 		return nil
 	}
 }
@@ -272,7 +272,7 @@ func (d *HardwareDataSource) HandleSyncComplete(ctx context.Context, objectType 
 func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1alpha1.BareMetalHost, eventType async.AsyncEventType) (uuid.UUID, error) {
 	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	ctx = logging.AppendCtx(ctx, slog.String("bmhNamespace", bmh.Namespace))
-	slog.DebugContext(ctx, "handleBMHEvent", "type", eventType)
+	slog.DebugContext(ctx, "handleBMHEvent", slog.Any("type", eventType))
 
 	resourceID := uuid.MustParse(string(bmh.UID))
 
@@ -293,7 +293,7 @@ func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1al
 func (d *HardwareDataSource) handleHardwareDataEvent(ctx context.Context, hwdata *metal3v1alpha1.HardwareData, eventType async.AsyncEventType) (uuid.UUID, error) {
 	ctx = logging.AppendCtx(ctx, slog.String("bmh", hwdata.Name))
 	ctx = logging.AppendCtx(ctx, slog.String("bmhNamespace", hwdata.Namespace))
-	slog.DebugContext(ctx, "handleHardwareDataEvent", "type", eventType)
+	slog.DebugContext(ctx, "handleHardwareDataEvent", slog.Any("type", eventType))
 
 	var bmh metal3v1alpha1.BareMetalHost
 	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: hwdata.Name, Namespace: hwdata.Namespace}, &bmh); err != nil {
@@ -315,7 +315,7 @@ func (d *HardwareDataSource) handleHardwareDataEvent(ctx context.Context, hwdata
 // the corresponding BMH and rebuilding the resource.
 func (d *HardwareDataSource) handleAllocatedNodeEvent(ctx context.Context, node *hwmgmtv1alpha1.AllocatedNode, eventType async.AsyncEventType) (uuid.UUID, error) {
 	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
-	slog.DebugContext(ctx, "handleAllocatedNodeEvent", "type", eventType)
+	slog.DebugContext(ctx, "handleAllocatedNodeEvent", slog.Any("type", eventType))
 
 	bmhName := node.Spec.HwMgrNodeId
 	bmhNamespace := node.Spec.HwMgrNodeNs
@@ -371,7 +371,7 @@ func (d *HardwareDataSource) buildAndSendResource(ctx context.Context, bmh *meta
 	if poolUID == "" {
 		poolName := bmh.Labels[constants.LabelResourcePoolName]
 		slog.WarnContext(ctx, "skipping BMH: unresolved resourcePoolId (will retry on pool creation)",
-			"bmh", bmh.Namespace+"/"+bmh.Name, "poolName", poolName)
+			slog.String("bmh", bmh.Namespace+"/"+bmh.Name), slog.Any("poolName", poolName))
 		return uuid.Nil, nil
 	}
 
@@ -436,7 +436,7 @@ func (d *HardwareDataSource) findAllocatedNodeForBMH(ctx context.Context, bmh *m
 	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: bmh.Namespace}, &node); err != nil {
 		if !errors.IsNotFound(err) {
 			slog.WarnContext(ctx, "failed to get AllocatedNode for BMH",
-				"bmh", bmh.Namespace+"/"+bmh.Name, "node", nodeName, "error", err)
+				slog.String("bmh", bmh.Namespace+"/"+bmh.Name), slog.Any("node", nodeName), slog.Any("error", err))
 		}
 		return nil
 	}
@@ -492,7 +492,7 @@ func (d *HardwareDataSource) BuildResourcesForPool(ctx context.Context, poolName
 		if err := d.hubClient.Get(ctx, types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}, &hwdata); err != nil {
 			if !errors.IsNotFound(err) {
 				slog.WarnContext(ctx, "failed to get HardwareData during pool rebuild",
-					"bmh", bmh.Namespace+"/"+bmh.Name, "error", err)
+					slog.String("bmh", bmh.Namespace+"/"+bmh.Name), slog.Any("error", err))
 			}
 			hwdata = metal3v1alpha1.HardwareData{}
 		}
@@ -503,7 +503,7 @@ func (d *HardwareDataSource) BuildResourcesForPool(ctx context.Context, poolName
 		resourceType, err := d.MakeResourceType(resource)
 		if err != nil {
 			slog.WarnContext(ctx, "failed to make resource type during pool rebuild",
-				"bmh", bmh.Namespace+"/"+bmh.Name, "error", err)
+				slog.String("bmh", bmh.Namespace+"/"+bmh.Name), slog.Any("error", err))
 			continue
 		}
 

--- a/internal/service/resources/collector/collector_k8s.go
+++ b/internal/service/resources/collector/collector_k8s.go
@@ -206,7 +206,7 @@ func (d *K8SDataSource) convertManagedClusterToDeploymentManager(ctx context.Con
 	err := d.getKubeconfig(ctx, cluster.Name, extensions)
 	if err != nil {
 		// TODO: turn this back into an error once we fix getting the Kubeconfig for the local-cluster
-		slog.WarnContext(ctx, "failed to get deployment manager extensions", "cluster", cluster.Name, "error", err)
+		slog.WarnContext(ctx, "failed to get deployment manager extensions", slog.Any("cluster", cluster.Name), slog.Any("error", err))
 	}
 
 	// Generate a unique UUID scoped to a different namespace so that it does not collide with the NodeCluster which
@@ -232,19 +232,19 @@ func (d *K8SDataSource) convertManagedClusterToDeploymentManager(ctx context.Con
 
 // handleClusterWatchEvent handles an async event received from the managed cluster watcher
 func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1.ManagedCluster, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", "agent", cluster.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", slog.Any("agent", cluster.Name), slog.Any("type", eventType))
 
 	if eventType != async.Deleted {
 		condition := meta.FindStatusCondition(cluster.Status.Conditions, "ManagedClusterConditionAvailable")
 		if condition == nil || condition.Status == metav1.ConditionFalse {
 			// This cluster is not yet available, so filter it out.
-			slog.DebugContext(ctx, "Managed cluster is not available; skipping", "cluster", cluster.Name, "condition", condition)
+			slog.DebugContext(ctx, "Managed cluster is not available; skipping", slog.Any("cluster", cluster.Name), slog.Any("condition", condition))
 			return uuid.Nil, nil
 		}
 
 		if _, found := cluster.Labels[ctlrutils.ClusterTemplateArtifactsLabel]; !found {
 			// The provisioning request which is managing the installation of this cluster is not yet fulfilled
-			slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", "cluster", cluster.Name)
+			slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", slog.Any("cluster", cluster.Name))
 			return uuid.Nil, nil
 		}
 	}
@@ -268,13 +268,13 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 
 // HandleAsyncEvent handles an add/update/delete to an object received by from the Reflector.
 func (d *K8SDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for store adapter", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	slog.DebugContext(ctx, "handleWatchEvent received for store adapter", slog.Any("type", eventType), slog.String("object", fmt.Sprintf("%T", obj)))
 	switch value := obj.(type) {
 	case *v1.ManagedCluster:
 		return d.handleClusterWatchEvent(ctx, value, eventType)
 	default:
 		// We are only watching for specific event types so this should happen.
-		slog.WarnContext(ctx, "Unknown object type", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type", slog.String("type", fmt.Sprintf("%T", obj)))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -287,7 +287,7 @@ func (d *K8SDataSource) HandleSyncComplete(ctx context.Context, objectType runti
 		object = models.DeploymentManager{}
 	default:
 		// This should never happen since we watch for specific types
-		slog.WarnContext(ctx, "Unknown object type", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type", slog.String("type", fmt.Sprintf("%T", objectType)))
 		return nil
 	}
 

--- a/internal/service/resources/collector/collector_location.go
+++ b/internal/service/resources/collector/collector_location.go
@@ -130,13 +130,13 @@ func (d *LocationDataSource) Watch(ctx context.Context) error {
 
 // HandleAsyncEvent handles an add/update/delete event received from the Reflector.
 func (d *LocationDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleAsyncEvent received for location", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	slog.DebugContext(ctx, "handleAsyncEvent received for location", slog.Any("type", eventType), slog.String("object", fmt.Sprintf("%T", obj)))
 
 	switch value := obj.(type) {
 	case *inventoryv1alpha1.Location:
 		return d.handleLocationWatchEvent(ctx, value, eventType)
 	default:
-		slog.WarnContext(ctx, "Unknown object type in LocationDataSource", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type in LocationDataSource", slog.String("type", fmt.Sprintf("%T", obj)))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -148,7 +148,7 @@ func (d *LocationDataSource) HandleSyncComplete(ctx context.Context, objectType 
 	case *inventoryv1alpha1.Location:
 		object = models.Location{}
 	default:
-		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", slog.String("type", fmt.Sprintf("%T", objectType)))
 		return nil
 	}
 
@@ -167,14 +167,14 @@ func (d *LocationDataSource) HandleSyncComplete(ctx context.Context, objectType 
 
 // handleLocationWatchEvent handles an async event received for a Location CR
 func (d *LocationDataSource) handleLocationWatchEvent(ctx context.Context, location *inventoryv1alpha1.Location, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleLocationWatchEvent received", "name", location.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleLocationWatchEvent received", slog.Any("name", location.Name), slog.Any("type", eventType))
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.
 	if eventType != async.Deleted && !inventoryv1alpha1.IsResourceReady(location.Status.Conditions) {
 		slog.DebugContext(ctx, "Location not ready, treating as deletion",
-			"name", location.Name,
-			"reason", inventoryv1alpha1.GetReadyReason(location.Status.Conditions))
+			slog.String("name", location.Name),
+			slog.String("reason", inventoryv1alpha1.GetReadyReason(location.Status.Conditions)))
 		eventType = async.Deleted
 	}
 

--- a/internal/service/resources/collector/collector_ocloudsite.go
+++ b/internal/service/resources/collector/collector_ocloudsite.go
@@ -129,13 +129,13 @@ func (d *OCloudSiteDataSource) Watch(ctx context.Context) error {
 
 // HandleAsyncEvent handles an add/update/delete event received from the Reflector.
 func (d *OCloudSiteDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleAsyncEvent received for ocloudsite", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	slog.DebugContext(ctx, "handleAsyncEvent received for ocloudsite", slog.Any("type", eventType), slog.String("object", fmt.Sprintf("%T", obj)))
 
 	switch value := obj.(type) {
 	case *inventoryv1alpha1.OCloudSite:
 		return d.handleOCloudSiteWatchEvent(ctx, value, eventType)
 	default:
-		slog.WarnContext(ctx, "Unknown object type in OCloudSiteDataSource", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type in OCloudSiteDataSource", slog.String("type", fmt.Sprintf("%T", obj)))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -147,7 +147,7 @@ func (d *OCloudSiteDataSource) HandleSyncComplete(ctx context.Context, objectTyp
 	case *inventoryv1alpha1.OCloudSite:
 		object = models.OCloudSite{}
 	default:
-		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", slog.String("type", fmt.Sprintf("%T", objectType)))
 		return nil
 	}
 
@@ -166,14 +166,14 @@ func (d *OCloudSiteDataSource) HandleSyncComplete(ctx context.Context, objectTyp
 
 // handleOCloudSiteWatchEvent handles an async event received for an OCloudSite CR
 func (d *OCloudSiteDataSource) handleOCloudSiteWatchEvent(ctx context.Context, site *inventoryv1alpha1.OCloudSite, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleOCloudSiteWatchEvent received", "name", site.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleOCloudSiteWatchEvent received", slog.Any("name", site.Name), slog.Any("type", eventType))
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.
 	if eventType != async.Deleted && !inventoryv1alpha1.IsResourceReady(site.Status.Conditions) {
 		slog.DebugContext(ctx, "OCloudSite not ready, treating as deletion",
-			"name", site.Name,
-			"reason", inventoryv1alpha1.GetReadyReason(site.Status.Conditions))
+			slog.String("name", site.Name),
+			slog.String("reason", inventoryv1alpha1.GetReadyReason(site.Status.Conditions)))
 		eventType = async.Deleted
 	}
 

--- a/internal/service/resources/collector/collector_resourcepool.go
+++ b/internal/service/resources/collector/collector_resourcepool.go
@@ -129,13 +129,13 @@ func (d *ResourcePoolDataSource) Watch(ctx context.Context) error {
 
 // HandleAsyncEvent handles an add/update/delete event received from the Reflector.
 func (d *ResourcePoolDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleAsyncEvent received for resourcepool", "type", eventType, "object", fmt.Sprintf("%T", obj))
+	slog.DebugContext(ctx, "handleAsyncEvent received for resourcepool", slog.Any("type", eventType), slog.String("object", fmt.Sprintf("%T", obj)))
 
 	switch value := obj.(type) {
 	case *inventoryv1alpha1.ResourcePool:
 		return d.handleResourcePoolWatchEvent(ctx, value, eventType)
 	default:
-		slog.WarnContext(ctx, "Unknown object type in ResourcePoolDataSource", "type", fmt.Sprintf("%T", obj))
+		slog.WarnContext(ctx, "Unknown object type in ResourcePoolDataSource", slog.String("type", fmt.Sprintf("%T", obj)))
 		return uuid.Nil, fmt.Errorf("unknown type: %T", obj)
 	}
 }
@@ -147,7 +147,7 @@ func (d *ResourcePoolDataSource) HandleSyncComplete(ctx context.Context, objectT
 	case *inventoryv1alpha1.ResourcePool:
 		object = models.ResourcePool{}
 	default:
-		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", "type", fmt.Sprintf("%T", objectType))
+		slog.WarnContext(ctx, "Unknown object type in HandleSyncComplete", slog.String("type", fmt.Sprintf("%T", objectType)))
 		return nil
 	}
 
@@ -166,14 +166,14 @@ func (d *ResourcePoolDataSource) HandleSyncComplete(ctx context.Context, objectT
 
 // handleResourcePoolWatchEvent handles an async event received for a ResourcePool CR
 func (d *ResourcePoolDataSource) handleResourcePoolWatchEvent(ctx context.Context, pool *inventoryv1alpha1.ResourcePool, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleResourcePoolWatchEvent received", "name", pool.Name, "type", eventType)
+	slog.DebugContext(ctx, "handleResourcePoolWatchEvent received", slog.Any("name", pool.Name), slog.Any("type", eventType))
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.
 	if eventType != async.Deleted && !inventoryv1alpha1.IsResourceReady(pool.Status.Conditions) {
 		slog.DebugContext(ctx, "ResourcePool not ready, treating as deletion",
-			"name", pool.Name,
-			"reason", inventoryv1alpha1.GetReadyReason(pool.Status.Conditions))
+			slog.String("name", pool.Name),
+			slog.String("reason", inventoryv1alpha1.GetReadyReason(pool.Status.Conditions)))
 		eventType = async.Deleted
 	}
 


### PR DESCRIPTION
Replace untyped alternating key-value pairs with typed slog attribute constructors (slog.String, slog.Int, slog.Any, etc.) in the cluster and resources collector packages. Typed attributes provide compile-time type safety and consistent log field types.