### PR TITLE
CNF-24707: use typed slog attributes in alarms internal packages

### DIFF
--- a/internal/service/alarms/internal/alertmanager/api.go
+++ b/internal/service/alarms/internal/alertmanager/api.go
@@ -71,7 +71,7 @@ func (c *AMClient) RunAlertSyncScheduler(ctx context.Context, interval time.Dura
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	slog.InfoContext(ctx, "Alert sync scheduler started", "interval", interval.String())
+	slog.InfoContext(ctx, "Alert sync scheduler started", slog.String("interval", interval.String()))
 
 	// Continue syncing at regular intervals until context is canceled
 	for {
@@ -79,7 +79,7 @@ func (c *AMClient) RunAlertSyncScheduler(ctx context.Context, interval time.Dura
 		case <-ticker.C:
 			slog.InfoContext(ctx, "Running scheduled alert sync")
 			if err := c.SyncAlerts(ctx); err != nil {
-				slog.ErrorContext(ctx, "failed to sync alerts", "error", err)
+				slog.ErrorContext(ctx, "failed to sync alerts", slog.Any("error", err))
 				// Continue running even if a sync fails
 			}
 		case <-ctx.Done():
@@ -160,7 +160,7 @@ func (c *AMClient) getAlerts(ctx context.Context) ([]APIAlert, error) {
 	}
 	defer func(Body io.ReadCloser) {
 		if err := Body.Close(); err != nil {
-			slog.ErrorContext(ctx, "failed to close response body during AM get call", "error", err.Error())
+			slog.ErrorContext(ctx, "failed to close response body during AM get call", slog.String("error", err.Error()))
 		}
 	}(resp.Body)
 
@@ -181,7 +181,7 @@ func (c *AMClient) getAlerts(ctx context.Context) ([]APIAlert, error) {
 		return nil, fmt.Errorf("error parsing response: %w, body: %s", err, string(body))
 	}
 
-	slog.InfoContext(ctx, "Got alerts with AM API", "alerts", len(alerts))
+	slog.InfoContext(ctx, "Got alerts with AM API", slog.Int("alerts", len(alerts)))
 	return alerts, nil
 }
 

--- a/internal/service/alarms/internal/alertmanager/config.go
+++ b/internal/service/alarms/internal/alertmanager/config.go
@@ -98,7 +98,7 @@ func MergeWithExisting(existingYAML []byte) (map[string]interface{}, error) {
 	updateReceivers(config)
 	updateRoutes(config)
 
-	slog.Debug("Alertmanager config update complete", "receiver_name", OranReceiverName)
+	slog.Debug("Alertmanager config update complete", slog.String("receiver_name", OranReceiverName))
 	return config, nil
 }
 

--- a/internal/service/alarms/internal/alertmanager/converter.go
+++ b/internal/service/alarms/internal/alertmanager/converter.go
@@ -29,7 +29,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 		if alert.StartsAt != nil && !alert.StartsAt.IsZero() {
 			record.AlarmRaisedTime = *alert.StartsAt
 		} else {
-			slog.ErrorContext(ctx, "Alert StartsAt is required, skipping.", "alert", alert)
+			slog.ErrorContext(ctx, "Alert StartsAt is required, skipping.", slog.Any("alert", alert))
 			continue
 		}
 
@@ -48,7 +48,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 				record.PerceivedSeverity = ps
 			}
 		} else {
-			slog.ErrorContext(ctx, "Alert Status is required, skipping.", "alert", alert)
+			slog.ErrorContext(ctx, "Alert Status is required, skipping.", slog.Any("alert", alert))
 			continue
 		}
 
@@ -56,7 +56,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 		if alert.Fingerprint != nil {
 			record.Fingerprint = *alert.Fingerprint
 		} else {
-			slog.ErrorContext(ctx, "Alert Fingerprint is required, skipping.", "alert", alert)
+			slog.ErrorContext(ctx, "Alert Fingerprint is required, skipping.", slog.Any("alert", alert))
 			continue
 		}
 
@@ -90,7 +90,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 		if record.ObjectID != nil {
 			objectTypeID, err := infrastructureClient.GetObjectTypeID(ctx, *record.ObjectID)
 			if err != nil {
-				slog.WarnContext(ctx, "Could not get object type ID", "objectID", record.ObjectID, "err", err.Error())
+				slog.WarnContext(ctx, "Could not get object type ID", slog.Any("objectID", record.ObjectID), slog.String("err", err.Error()))
 			} else {
 				record.ObjectTypeID = &objectTypeID
 			}
@@ -102,7 +102,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 			_, severity := getPerceivedSeverity(labels)
 			alarmDefinitionID, err := infrastructureClient.GetAlarmDefinitionID(ctx, *record.ObjectTypeID, getAlertName(labels), severity)
 			if err != nil {
-				slog.WarnContext(ctx, "Could not get alarm definition ID", "objectTypeID", *record.ObjectTypeID, "name", getAlertName(labels), "severity", severity, "err", err.Error())
+				slog.WarnContext(ctx, "Could not get alarm definition ID", slog.Any("objectTypeID", *record.ObjectTypeID), slog.String("name", getAlertName(labels)), slog.String("severity", severity), slog.String("err", err.Error()))
 			} else {
 				record.AlarmDefinitionID = &alarmDefinitionID
 			}
@@ -112,7 +112,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 		records = append(records, record)
 	}
 
-	slog.InfoContext(ctx, "Converted alerts", "records", len(records))
+	slog.InfoContext(ctx, "Converted alerts", slog.Int("records", len(records)))
 	return records
 }
 
@@ -123,14 +123,14 @@ func getClusterID(labels map[string]string) *uuid.UUID {
 		// Fall back to clusterID (Thanos/ACM alerts like ViolatedPolicyReport)
 		val, ok = labels["clusterID"]
 		if !ok {
-			slog.Warn("Could not find managed_cluster or clusterID", "labels", labels)
+			slog.Warn("Could not find managed_cluster or clusterID", slog.Any("labels", labels))
 			return nil
 		}
 	}
 
 	id, err := uuid.Parse(val)
 	if err != nil {
-		slog.Warn("Could not convert cluster ID string to uuid", "labels", labels, "err", err.Error())
+		slog.Warn("Could not convert cluster ID string to uuid", slog.Any("labels", labels), slog.String("err", err.Error()))
 		return nil
 	}
 
@@ -148,13 +148,13 @@ func isHardwareAlert(labels map[string]string) bool {
 func getResourceID(labels map[string]string) *uuid.UUID {
 	val, ok := labels["instance_uuid"]
 	if !ok {
-		slog.Warn("Could not find instance_uuid for hardware alert", "labels", labels)
+		slog.Warn("Could not find instance_uuid for hardware alert", slog.Any("labels", labels))
 		return nil
 	}
 
 	id, err := uuid.Parse(val)
 	if err != nil {
-		slog.Warn("Could not convert instance_uuid string to uuid", "labels", labels, "err", err.Error())
+		slog.Warn("Could not convert instance_uuid string to uuid", slog.Any("labels", labels), slog.String("err", err.Error()))
 		return nil
 	}
 
@@ -166,7 +166,7 @@ func getAlertName(labels map[string]string) string {
 	val, ok := labels["alertname"]
 	if !ok {
 		// this may never execute but keeping a check just in case
-		slog.Warn("Could not find alertname", "labels", labels)
+		slog.Warn("Could not find alertname", slog.Any("labels", labels))
 		return "Unknown"
 	}
 
@@ -177,7 +177,7 @@ func getAlertName(labels map[string]string) string {
 func getPerceivedSeverity(labels map[string]string) (api.PerceivedSeverity, string) {
 	severity, ok := labels["severity"]
 	if !ok {
-		slog.Warn("Could not find severity label", "labels", labels)
+		slog.Warn("Could not find severity label", slog.Any("labels", labels))
 		return api.INDETERMINATE, ""
 	}
 
@@ -197,7 +197,7 @@ func severityToPerceivedSeverity(input string) api.PerceivedSeverity {
 	case "warning", "info", "moderate": // "moderate" is used by ACM/PolicyReport (ViolatedPolicyReport)
 		return api.WARNING
 	default:
-		slog.Debug("Unknown severity mapped to INDETERMINATE", "severity", input)
+		slog.Debug("Unknown severity mapped to INDETERMINATE", slog.String("severity", input))
 		return api.INDETERMINATE
 	}
 }
@@ -290,6 +290,6 @@ func ConvertAPIAlertsToWebhook(apiAlerts *[]APIAlert) []api.Alert {
 		webhookAlerts = append(webhookAlerts, webhookAlert)
 	}
 
-	slog.Info("Converted from API to Webhook", "alerts", len(webhookAlerts))
+	slog.Info("Converted from API to Webhook", slog.Int("alerts", len(webhookAlerts)))
 	return webhookAlerts
 }

--- a/internal/service/alarms/internal/alertmanager/handler.go
+++ b/internal/service/alarms/internal/alertmanager/handler.go
@@ -62,6 +62,6 @@ func HandleAlerts(ctx context.Context, clusterServer, resourceServer infrastruct
 		return fmt.Errorf("failed to handle alerts from %s: %w", string(source), err)
 	}
 
-	slog.InfoContext(ctx, "Successfully handled AlarmEventRecords", "source_type", string(source))
+	slog.InfoContext(ctx, "Successfully handled AlarmEventRecords", slog.String("source_type", string(source)))
 	return nil
 }

--- a/internal/service/alarms/internal/db/repo/alarms_repository.go
+++ b/internal/service/alarms/internal/db/repo/alarms_repository.go
@@ -228,7 +228,7 @@ func (ar *AlarmsRepository) ResolveStaleAlarmEventCaaSRecord(ctx context.Context
 	}
 
 	if len(records) > 0 {
-		slog.InfoContext(ctx, "Successfully resolved stale CaaS (alertmanager) alarmeventrecords", "records", len(records))
+		slog.InfoContext(ctx, "Successfully resolved stale CaaS (alertmanager) alarmeventrecords", slog.Int("records", len(records)))
 	}
 	return nil
 }

--- a/internal/service/alarms/internal/infrastructure/clusterserver.go
+++ b/internal/service/alarms/internal/infrastructure/clusterserver.go
@@ -135,7 +135,7 @@ func (r *ClusterServer) GetObjectTypeID(ctx context.Context, nodeClusterID uuid.
 
 	nodeClusterTypeID, ok := r.nodeClusterIDToNodeClusterTypeID[nodeClusterID]
 	if !ok {
-		slog.InfoContext(ctx, "Node cluster ID not found in cache", "nodeClusterID", nodeClusterID)
+		slog.InfoContext(ctx, "Node cluster ID not found in cache", slog.String("nodeClusterID", nodeClusterID.String()))
 
 		// Try to fetch it from the server
 		nodeCluster, err := r.getNodeCluster(ctx, nodeClusterID)
@@ -145,7 +145,7 @@ func (r *ClusterServer) GetObjectTypeID(ctx context.Context, nodeClusterID uuid.
 
 		nodeClusterTypeID = nodeCluster.NodeClusterTypeId
 		r.nodeClusterIDToNodeClusterTypeID[nodeClusterID] = nodeClusterTypeID
-		slog.InfoContext(ctx, "Mapping node cluster ID to node cluster type ID", "nodeClusterID", nodeClusterID, "nodeClusterTypeID", nodeClusterTypeID)
+		slog.InfoContext(ctx, "Mapping node cluster ID to node cluster type ID", slog.String("nodeClusterID", nodeClusterID.String()), slog.String("nodeClusterTypeID", nodeClusterTypeID.String()))
 	}
 
 	return nodeClusterTypeID, nil
@@ -159,7 +159,7 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 
 	alarmDictionaryID, ok := r.nodeClusterTypeIDToAlarmDictionaryID[nodeClusterTypeID]
 	if !ok {
-		slog.InfoContext(ctx, "Node Cluster Type ID not found in cache", "nodeClusterTypeID", nodeClusterTypeID)
+		slog.InfoContext(ctx, "Node Cluster Type ID not found in cache", slog.String("nodeClusterTypeID", nodeClusterTypeID.String()))
 
 		// Try to fetch it from the server
 		nodeClusterType, err := r.getNodeClusterType(ctx, nodeClusterTypeID)
@@ -173,13 +173,13 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 		}
 
 		r.nodeClusterTypeIDToAlarmDictionaryID[nodeClusterTypeID] = alarmDictionaryID
-		slog.InfoContext(ctx, "Mapping node cluster type ID to alarm dictionary ID", "nodeClusterTypeID", nodeClusterTypeID, "alarmDictionaryID", alarmDictionaryID)
+		slog.InfoContext(ctx, "Mapping node cluster type ID to alarm dictionary ID", slog.String("nodeClusterTypeID", nodeClusterTypeID.String()), slog.String("alarmDictionaryID", alarmDictionaryID.String()))
 	}
 
 	definitionsResynced := false
 	alarmDefinitions, ok := r.alarmDictionaryIDToAlarmDefinitions[alarmDictionaryID]
 	if !ok {
-		slog.InfoContext(ctx, "Alarm dictionary ID not found in cache", "alarmDictionaryID", alarmDictionaryID)
+		slog.InfoContext(ctx, "Alarm dictionary ID not found in cache", slog.String("alarmDictionaryID", alarmDictionaryID.String()))
 
 		// Try to fetch it from the server
 		alarmDictionary, err := r.getAlarmDictionary(ctx, alarmDictionaryID)
@@ -190,7 +190,7 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 		definitionsResynced = true
 		alarmDefinitions = getAlarmDefinitionsFromAlarmDictionary(alarmDictionary)
 		r.alarmDictionaryIDToAlarmDefinitions[alarmDictionaryID] = alarmDefinitions
-		slog.InfoContext(ctx, "Mapping alarm dictionary ID to alarm definitions", "alarmDictionaryID", alarmDictionaryID)
+		slog.InfoContext(ctx, "Mapping alarm dictionary ID to alarm definitions", slog.String("alarmDictionaryID", alarmDictionaryID.String()))
 	}
 
 	uniqueAlarmDefinitionIdentifier := AlarmDefinitionUniqueIdentifier{
@@ -202,7 +202,7 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 	if !ok {
 		if !definitionsResynced {
 			// Resync definitions and try again. It is possible that cache is not up to date
-			slog.DebugContext(ctx, "Resynced alarm definitions", "alarmDictionaryID", alarmDictionaryID, "uniqueAlarmDefinitionIdentifier", uniqueAlarmDefinitionIdentifier)
+			slog.DebugContext(ctx, "Resynced alarm definitions", slog.String("alarmDictionaryID", alarmDictionaryID.String()), slog.Any("uniqueAlarmDefinitionIdentifier", uniqueAlarmDefinitionIdentifier))
 
 			alarmDictionary, err := r.getAlarmDictionary(ctx, alarmDictionaryID)
 			if err != nil {
@@ -211,7 +211,7 @@ func (r *ClusterServer) GetAlarmDefinitionID(ctx context.Context, nodeClusterTyp
 
 			alarmDefinitions = getAlarmDefinitionsFromAlarmDictionary(alarmDictionary)
 			r.alarmDictionaryIDToAlarmDefinitions[alarmDictionaryID] = alarmDefinitions
-			slog.InfoContext(ctx, "Mapping alarm dictionary ID to alarm definitions", "alarmDictionaryID", alarmDictionaryID)
+			slog.InfoContext(ctx, "Mapping alarm dictionary ID to alarm definitions", slog.String("alarmDictionaryID", alarmDictionaryID.String()))
 
 			alarmDefinitionID, ok = alarmDefinitions[uniqueAlarmDefinitionIdentifier]
 			if ok {
@@ -235,7 +235,7 @@ func (r *ClusterServer) Sync(ctx context.Context) {
 	// This is edge case and even if the Cluster server cant come up within retry time, we can still continue
 	// But once it does come up, user may get unwanted "CHANGED" alerts
 	if err := r.FetchAllWithRetry(ctx, 3); err != nil {
-		slog.ErrorContext(ctx, "Failed to run initial sync for cluster server objects", "error", err)
+		slog.ErrorContext(ctx, "Failed to run initial sync for cluster server objects", slog.Any("error", err))
 	}
 
 	go func() {
@@ -250,7 +250,7 @@ func (r *ClusterServer) Sync(ctx context.Context) {
 			case <-ticker.C:
 				slog.InfoContext(ctx, "Syncing ClusterServer objects")
 				if err := r.FetchAll(ctx); err != nil {
-					slog.ErrorContext(ctx, "Failed to sync cluster server objects", "error", err)
+					slog.ErrorContext(ctx, "Failed to sync cluster server objects", slog.Any("error", err))
 				}
 			}
 		}
@@ -276,7 +276,7 @@ func (r *ClusterServer) FetchAllWithRetry(ctx context.Context, maxRetries int) e
 		}
 
 		// Wait before retrying with exponential backoff
-		slog.WarnContext(ctx, "Fetch operation failed", "attempt", attempt+1, "maxRetries", maxRetries, "error", err)
+		slog.WarnContext(ctx, "Fetch operation failed", slog.Int("attempt", attempt+1), slog.Int("maxRetries", maxRetries), slog.Any("error", err))
 		select {
 		case <-time.After(backoff):
 			backoff *= 2
@@ -303,7 +303,7 @@ func (r *ClusterServer) getNodeClusters(ctx context.Context) ([]NodeCluster, err
 		return nil, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.InfoContext(ctx, "Got node clusters", "count", len(*resp.JSON200))
+	slog.InfoContext(ctx, "Got node clusters", slog.Int("count", len(*resp.JSON200)))
 	return *resp.JSON200, nil
 }
 
@@ -322,7 +322,7 @@ func (r *ClusterServer) getNodeCluster(ctx context.Context, nodeClusterID uuid.U
 		return NodeCluster{}, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.InfoContext(ctx, "Got node cluster", "nodeClusterID", nodeClusterID)
+	slog.InfoContext(ctx, "Got node cluster", slog.String("nodeClusterID", nodeClusterID.String()))
 	return *resp.JSON200, nil
 }
 
@@ -341,7 +341,7 @@ func (r *ClusterServer) getNodeClusterTypes(ctx context.Context) ([]NodeClusterT
 		return nil, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.InfoContext(ctx, "Got node cluster types", "count", len(*resp.JSON200))
+	slog.InfoContext(ctx, "Got node cluster types", slog.Int("count", len(*resp.JSON200)))
 	return *resp.JSON200, nil
 }
 
@@ -360,7 +360,7 @@ func (r *ClusterServer) getNodeClusterType(ctx context.Context, nodeClusterTypeI
 		return NodeClusterType{}, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.InfoContext(ctx, "Got node cluster type", "nodeClusterTypeID", nodeClusterTypeID)
+	slog.InfoContext(ctx, "Got node cluster type", slog.String("nodeClusterTypeID", nodeClusterTypeID.String()))
 	return *resp.JSON200, nil
 }
 
@@ -379,7 +379,7 @@ func (r *ClusterServer) getAlarmDictionaries(ctx context.Context) ([]AlarmDictio
 		return nil, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.InfoContext(ctx, "Got alarm dictionaries", "count", len(*resp.JSON200))
+	slog.InfoContext(ctx, "Got alarm dictionaries", slog.Int("count", len(*resp.JSON200)))
 	return *resp.JSON200, nil
 }
 
@@ -398,7 +398,7 @@ func (r *ClusterServer) getAlarmDictionary(ctx context.Context, alarmDictionaryI
 		return AlarmDictionary{}, fmt.Errorf("status code different from 200 OK: %s", resp.Status())
 	}
 
-	slog.InfoContext(ctx, "Got alarm dictionary", "alarmDictionaryID", alarmDictionaryID)
+	slog.InfoContext(ctx, "Got alarm dictionary", slog.String("alarmDictionaryID", alarmDictionaryID.String()))
 	return *resp.JSON200, nil
 }
 
@@ -407,7 +407,7 @@ func (r *ClusterServer) buildNodeClusterIDToNodeClusterTypeID(nodeClusters []Nod
 	mapping := make(map[uuid.UUID]uuid.UUID)
 	for _, nodeCluster := range nodeClusters {
 		mapping[nodeCluster.NodeClusterId] = nodeCluster.NodeClusterTypeId
-		slog.Info("Mapping node cluster ID to node cluster type ID", "nodeClusterID", nodeCluster.NodeClusterId, "nodeClusterTypeID", nodeCluster.NodeClusterTypeId)
+		slog.Info("Mapping node cluster ID to node cluster type ID", slog.String("nodeClusterID", nodeCluster.NodeClusterId.String()), slog.String("nodeClusterTypeID", nodeCluster.NodeClusterTypeId.String()))
 	}
 
 	return mapping
@@ -419,12 +419,12 @@ func (r *ClusterServer) buildNodeClusterTypeIDToAlarmDictionaryID(nodeClusterTyp
 	for _, nodeClusterType := range nodeClusterTypes {
 		alarmDictionaryID, err := getAlarmDictionaryIDFromNodeClusterType(nodeClusterType)
 		if err != nil {
-			slog.Error("Failed to get alarm dictionary ID from node cluster type", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeId, "error", err)
+			slog.Error("Failed to get alarm dictionary ID from node cluster type", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeId.String()), slog.Any("error", err))
 			continue
 		}
 
 		mapping[nodeClusterType.NodeClusterTypeId] = alarmDictionaryID
-		slog.Info("Mapping node cluster type ID to alarm dictionary ID", "nodeClusterTypeID", nodeClusterType.NodeClusterTypeId, "alarmDictionaryID", alarmDictionaryID)
+		slog.Info("Mapping node cluster type ID to alarm dictionary ID", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeId.String()), slog.String("alarmDictionaryID", alarmDictionaryID.String()))
 	}
 
 	return mapping
@@ -435,7 +435,7 @@ func (r *ClusterServer) buildAlarmDictionaryIDToAlarmDefinitions(dictionaries []
 	mapping := make(map[uuid.UUID]AlarmDefinition)
 	for _, dictionary := range dictionaries {
 		mapping[dictionary.AlarmDictionaryId] = getAlarmDefinitionsFromAlarmDictionary(dictionary)
-		slog.Info("Mapping alarm dictionary ID to alarm definitions", "alarmDictionaryID", dictionary.AlarmDictionaryId)
+		slog.Info("Mapping alarm dictionary ID to alarm definitions", slog.String("alarmDictionaryID", dictionary.AlarmDictionaryId.String()))
 	}
 
 	return mapping
@@ -465,14 +465,14 @@ func getAlarmDefinitionsFromAlarmDictionary(dictionary AlarmDictionary) AlarmDef
 	alarmDefinitions := make(AlarmDefinition)
 	for _, definition := range dictionary.AlarmDefinition {
 		if definition.AlarmAdditionalFields == nil {
-			slog.Error("Alarm definition has no additional fields", "alarmDefinitionID", definition.AlarmDefinitionId)
+			slog.Error("Alarm definition has no additional fields", slog.String("alarmDefinitionID", definition.AlarmDefinitionId.String()))
 			continue
 		}
 
 		severity, ok := (*definition.AlarmAdditionalFields)[ctlrutils.AlarmDefinitionSeverityField].(string)
 		if !ok {
 			// It should have one, even if it is empty
-			slog.Error("Alarm definition has no severity", "alarmDefinitionID", definition.AlarmDefinitionId)
+			slog.Error("Alarm definition has no severity", slog.String("alarmDefinitionID", definition.AlarmDefinitionId.String()))
 			continue
 		}
 
@@ -484,6 +484,6 @@ func getAlarmDefinitionsFromAlarmDictionary(dictionary AlarmDictionary) AlarmDef
 		alarmDefinitions[uniqueIdentifier] = definition.AlarmDefinitionId
 	}
 
-	slog.Debug("Got alarm definitions", "count", len(alarmDefinitions), "alarmDictionaryID", dictionary.AlarmDictionaryId)
+	slog.Debug("Got alarm definitions", slog.Int("count", len(alarmDefinitions)), slog.String("alarmDictionaryID", dictionary.AlarmDictionaryId.String()))
 	return alarmDefinitions
 }

--- a/internal/service/alarms/internal/infrastructure/resourceserver.go
+++ b/internal/service/alarms/internal/infrastructure/resourceserver.go
@@ -106,24 +106,24 @@ func (r *ResourceServer) FetchAll(ctx context.Context) error {
 		// Fetch the real alarm dictionary for this resource type
 		resp, err := r.client.GetResourceTypeAlarmDictionaryWithResponse(ctx, resourceType.ResourceTypeId)
 		if err != nil {
-			slog.WarnContext(ctx, "Failed to get alarm dictionary for resource type", "resourceTypeID", resourceType.ResourceTypeId, "error", err)
+			slog.WarnContext(ctx, "Failed to get alarm dictionary for resource type", slog.String("resourceTypeID", resourceType.ResourceTypeId.String()), slog.Any("error", err))
 			continue
 		}
 
 		if resp.StatusCode() != http.StatusOK {
-			slog.WarnContext(ctx, "Unexpected status code getting alarm dictionary", "resourceTypeID", resourceType.ResourceTypeId, "statusCode", resp.StatusCode())
+			slog.WarnContext(ctx, "Unexpected status code getting alarm dictionary", slog.String("resourceTypeID", resourceType.ResourceTypeId.String()), slog.Int("statusCode", resp.StatusCode()))
 			continue
 		}
 
 		if resp.JSON200 == nil {
-			slog.DebugContext(ctx, "No alarm dictionary available for resource type", "resourceTypeID", resourceType.ResourceTypeId)
+			slog.DebugContext(ctx, "No alarm dictionary available for resource type", slog.String("resourceTypeID", resourceType.ResourceTypeId.String()))
 			continue
 		}
 
 		// Build alarm definitions from the real alarm dictionary
 		alarmDefinitions := buildAlarmDefinitionsFromDictionary(*resp.JSON200)
 		newResourceTypeIDToAlarmDefinitions[resourceType.ResourceTypeId] = alarmDefinitions
-		slog.InfoContext(ctx, "Mapping resource type ID to alarm definitions", "resourceTypeID", resourceType.ResourceTypeId, "alarmDictionaryID", resp.JSON200.AlarmDictionaryId, "definitionCount", len(alarmDefinitions))
+		slog.InfoContext(ctx, "Mapping resource type ID to alarm definitions", slog.String("resourceTypeID", resourceType.ResourceTypeId.String()), slog.String("alarmDictionaryID", resp.JSON200.AlarmDictionaryId.String()), slog.Int("definitionCount", len(alarmDefinitions)))
 	}
 
 	// Atomically update the maps while holding lock
@@ -149,7 +149,7 @@ func (r *ResourceServer) GetObjectTypeID(ctx context.Context, resourceID uuid.UU
 	}
 
 	// Not in cache, fetch from resource server
-	slog.InfoContext(ctx, "Resource ID not found in cache, fetching from resource server", "resourceID", resourceID)
+	slog.InfoContext(ctx, "Resource ID not found in cache, fetching from resource server", slog.String("resourceID", resourceID.String()))
 	resource, err := r.getResource(ctx, resourceID)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("failed to get resource: %w", err)
@@ -157,7 +157,7 @@ func (r *ResourceServer) GetObjectTypeID(ctx context.Context, resourceID uuid.UU
 
 	// Cache the mapping
 	r.resourceIDToResourceTypeID[resourceID] = resource.ResourceTypeId
-	slog.InfoContext(ctx, "Mapping resource ID to resource type ID", "resourceID", resourceID, "resourceTypeID", resource.ResourceTypeId)
+	slog.InfoContext(ctx, "Mapping resource ID to resource type ID", slog.String("resourceID", resourceID.String()), slog.String("resourceTypeID", resource.ResourceTypeId.String()))
 
 	return resource.ResourceTypeId, nil
 }
@@ -170,7 +170,7 @@ func (r *ResourceServer) GetAlarmDefinitionID(ctx context.Context, resourceTypeI
 
 	alarmDefinitions, ok := r.resourceTypeIDToAlarmDefinitions[resourceTypeID]
 	if !ok {
-		slog.InfoContext(ctx, "Resource type ID not found in cache, fetching from resource server", "resourceTypeID", resourceTypeID)
+		slog.InfoContext(ctx, "Resource type ID not found in cache, fetching from resource server", slog.String("resourceTypeID", resourceTypeID.String()))
 
 		// Try to fetch the alarm dictionary from the server
 		resp, err := r.client.GetResourceTypeAlarmDictionaryWithResponse(ctx, resourceTypeID)
@@ -191,7 +191,7 @@ func (r *ResourceServer) GetAlarmDefinitionID(ctx context.Context, resourceTypeI
 
 		// Cache the alarm definitions
 		r.resourceTypeIDToAlarmDefinitions[resourceTypeID] = alarmDefinitions
-		slog.InfoContext(ctx, "Mapping resource type ID to alarm definitions", "resourceTypeID", resourceTypeID, "alarmDictionaryID", resp.JSON200.AlarmDictionaryId, "definitionCount", len(alarmDefinitions))
+		slog.InfoContext(ctx, "Mapping resource type ID to alarm definitions", slog.String("resourceTypeID", resourceTypeID.String()), slog.String("alarmDictionaryID", resp.JSON200.AlarmDictionaryId.String()), slog.Int("definitionCount", len(alarmDefinitions)))
 	}
 
 	uniqueIdentifier := AlarmDefinitionUniqueIdentifier{
@@ -201,7 +201,7 @@ func (r *ResourceServer) GetAlarmDefinitionID(ctx context.Context, resourceTypeI
 
 	alarmDefinitionID, ok := alarmDefinitions[uniqueIdentifier]
 	if !ok {
-		slog.InfoContext(ctx, "Alarm definition not found in cache", "name", name, "severity", severity, "resourceTypeID", resourceTypeID)
+		slog.InfoContext(ctx, "Alarm definition not found in cache", slog.String("name", name), slog.String("severity", severity), slog.String("resourceTypeID", resourceTypeID.String()))
 		return uuid.Nil, fmt.Errorf("alarm definition not found: name=%s, severity=%s", name, severity)
 	}
 
@@ -216,7 +216,7 @@ func (r *ResourceServer) FetchAllWithRetry(ctx context.Context, retries int) err
 		if err == nil {
 			return nil
 		}
-		slog.ErrorContext(ctx, "Failed to fetch all objects from resource server, retrying", "attempt", i+1, "error", err)
+		slog.ErrorContext(ctx, "Failed to fetch all objects from resource server, retrying", slog.Int("attempt", i+1), slog.Any("error", err))
 		time.Sleep(5 * time.Second)
 	}
 	return fmt.Errorf("failed to fetch all objects after %d retries: %w", retries, err)
@@ -232,7 +232,7 @@ func (r *ResourceServer) Sync(ctx context.Context) {
 	// This is edge case and even if the Resource server cant come up within retry time, we can still continue
 	// But once it does come up, user may get unwanted "CHANGED" alerts
 	if err := r.FetchAllWithRetry(ctx, 3); err != nil {
-		slog.ErrorContext(ctx, "Failed to run initial sync for resource server objects", "error", err)
+		slog.ErrorContext(ctx, "Failed to run initial sync for resource server objects", slog.Any("error", err))
 	}
 
 	go func() {
@@ -247,7 +247,7 @@ func (r *ResourceServer) Sync(ctx context.Context) {
 			case <-ticker.C:
 				slog.InfoContext(ctx, "Syncing resource server objects")
 				if err := r.FetchAll(ctx); err != nil {
-					slog.ErrorContext(ctx, "Failed to sync resource server objects", "error", err)
+					slog.ErrorContext(ctx, "Failed to sync resource server objects", slog.Any("error", err))
 				}
 			}
 		}
@@ -272,7 +272,7 @@ func (r *ResourceServer) getResourceTypes(ctx context.Context) ([]generated.Reso
 		return nil, fmt.Errorf("empty response from resource server")
 	}
 
-	slog.InfoContext(ctx, "Got resource types", "count", len(*resp.JSON200))
+	slog.InfoContext(ctx, "Got resource types", slog.Int("count", len(*resp.JSON200)))
 	return *resp.JSON200, nil
 }
 
@@ -294,7 +294,7 @@ func (r *ResourceServer) getResource(ctx context.Context, resourceID uuid.UUID) 
 		return nil, fmt.Errorf("empty response from resource server")
 	}
 
-	slog.InfoContext(ctx, "Got resource", "resourceID", resourceID)
+	slog.InfoContext(ctx, "Got resource", slog.String("resourceID", resourceID.String()))
 	return resp.JSON200, nil
 }
 
@@ -303,14 +303,14 @@ func buildAlarmDefinitionsFromDictionary(dictionary AlarmDictionary) AlarmDefini
 	alarmDefinitions := make(AlarmDefinition)
 	for _, definition := range dictionary.AlarmDefinition {
 		if definition.AlarmAdditionalFields == nil {
-			slog.Error("Alarm definition has no additional fields", "alarmDefinitionID", definition.AlarmDefinitionId)
+			slog.Error("Alarm definition has no additional fields", slog.String("alarmDefinitionID", definition.AlarmDefinitionId.String()))
 			continue
 		}
 
 		severity, ok := (*definition.AlarmAdditionalFields)[ctlrutils.AlarmDefinitionSeverityField].(string)
 		if !ok {
 			// It should have one, even if it is empty
-			slog.Error("Alarm definition has no severity", "alarmDefinitionID", definition.AlarmDefinitionId)
+			slog.Error("Alarm definition has no severity", slog.String("alarmDefinitionID", definition.AlarmDefinitionId.String()))
 			continue
 		}
 

--- a/internal/service/alarms/internal/listener/pg_listener.go
+++ b/internal/service/alarms/internal/listener/pg_listener.go
@@ -81,6 +81,6 @@ func processOutboxNotification(ctx context.Context, pool *pgxpool.Pool, n *notif
 		n.Notify(ctx, &notification)
 	}
 
-	slog.InfoContext(ctx, "Successfully processed outbox notifications", "caller", caller)
+	slog.InfoContext(ctx, "Successfully processed outbox notifications", slog.String("caller", caller))
 	return nil
 }

--- a/internal/service/alarms/internal/notifier_provider/notification.go
+++ b/internal/service/alarms/internal/notifier_provider/notification.go
@@ -48,7 +48,7 @@ func (n *NotificationStorageProvider) GetNotifications(ctx context.Context) ([]n
 	for _, record := range records {
 		notification, err := models.DataChangeEventToNotification(&record, n.globalCloudID)
 		if err != nil {
-			slog.WarnContext(ctx, "failed to convert alarm event to notification", "err", err)
+			slog.WarnContext(ctx, "failed to convert alarm event to notification", slog.Any("err", err))
 			continue
 		}
 		if notification != nil {

--- a/internal/service/alarms/internal/notifier_provider/subscription.go
+++ b/internal/service/alarms/internal/notifier_provider/subscription.go
@@ -50,14 +50,14 @@ func (s *SubscriptionStorageProvider) GetSubscriptions(ctx context.Context) ([]n
 		subscriptions = append(subscriptions, *models.ConvertAlertSubToNotificationSub(&record))
 	}
 
-	slog.InfoContext(ctx, "Found subscriptions to notify", "count", len(subscriptions))
+	slog.InfoContext(ctx, "Found subscriptions to notify", slog.Int("count", len(subscriptions)))
 	return subscriptions, nil
 }
 
 func (s *SubscriptionStorageProvider) Matches(subscription *notifier.SubscriptionInfo, notification *notifier.Notification) bool {
 	payload, ok := notification.Payload.(generated.AlarmEventNotification)
 	if !ok {
-		slog.Warn("notification payload is not of type generated.AlarmEventNotification", "type", fmt.Sprintf("%T", notification.Payload))
+		slog.Warn("notification payload is not of type generated.AlarmEventNotification", slog.String("type", fmt.Sprintf("%T", notification.Payload)))
 		return false
 	}
 	if subscription.Filter == nil {
@@ -75,7 +75,7 @@ func (s *SubscriptionStorageProvider) UpdateSubscription(ctx context.Context, su
 		return fmt.Errorf("update subscription failed for %s: %w", subscription.SubscriptionID, err)
 	}
 
-	slog.InfoContext(ctx, "Subscription cursor updated", "to", subscription.EventCursor)
+	slog.InfoContext(ctx, "Subscription cursor updated", slog.Int("to", subscription.EventCursor))
 	return nil
 }
 

--- a/internal/service/alarms/internal/serviceconfig/serviceconfig.go
+++ b/internal/service/alarms/internal/serviceconfig/serviceconfig.go
@@ -103,7 +103,7 @@ func (c *Config) EnsureCleanupCronJob(ctx context.Context, sc *models.ServiceCon
 	}
 
 	slog.InfoContext(ctx, "Successfully ensured cleanup cronjob and associated resources",
-		"cronjob", cronJob.Name, "configmap", configMap.Name)
+		slog.String("cronjob", cronJob.Name), slog.String("configmap", configMap.Name))
 	return nil
 }
 
@@ -126,7 +126,7 @@ func (c *Config) generateConfigMapWithSql(ctx context.Context, sc *models.Servic
 
 // getCleanUpPgSQL returns sql string to do alarms events cleanup based on service config
 func getCleanUpPgSQL(ctx context.Context, sc *models.ServiceConfiguration) (string, error) {
-	slog.InfoContext(ctx, "Using service config to generating sql", "serviceConfig", sc)
+	slog.InfoContext(ctx, "Using service config to generating sql", slog.Any("serviceConfig", sc))
 
 	// This should be checked earlier as well but double-checking here since sql is sensitive to it
 	// A "0" basically means delete everything before now()


### PR DESCRIPTION
Replace untyped alternating key-value pairs with typed slog attribute constructors in the alarms infrastructure, alertmanager, listener, db/repo, serviceconfig, and notifier_provider packages.