### PR TITLE
CNF-24707: use typed slog attributes in remaining packages

### DIFF
--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -250,7 +250,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	// Start the O-Cloud Manager controller.
 	if err = (&controllers.Reconciler{
 		Client: mgr.GetClient(),
-		Logger: logger.With("controller", "O-Cloud Manager"),
+		Logger: logger.With(slog.String("controller", "O-Cloud Manager")),
 		Image:  c.image,
 	}).SetupWithManager(mgr); err != nil {
 		logger.ErrorContext(
@@ -272,7 +272,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	// Start the Cluster Template controller.
 	if err = (&controllers.ClusterTemplateReconciler{
 		Client: mgr.GetClient(),
-		Logger: logger.With("controller", "ClusterTemplate"),
+		Logger: logger.With(slog.String("controller", "ClusterTemplate")),
 	}).SetupWithManager(mgr); err != nil {
 		logger.ErrorContext(
 			ctx,
@@ -286,7 +286,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	// Start the Location controller.
 	if err = (&controllers.LocationReconciler{
 		Client: mgr.GetClient(),
-		Logger: logger.With("controller", "Location"),
+		Logger: logger.With(slog.String("controller", "Location")),
 	}).SetupWithManager(mgr); err != nil {
 		logger.ErrorContext(
 			ctx,
@@ -300,7 +300,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	// Start the OCloudSite controller.
 	if err = (&controllers.OCloudSiteReconciler{
 		Client: mgr.GetClient(),
-		Logger: logger.With("controller", "OCloudSite"),
+		Logger: logger.With(slog.String("controller", "OCloudSite")),
 	}).SetupWithManager(mgr); err != nil {
 		logger.ErrorContext(
 			ctx,
@@ -314,7 +314,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	// Start the ResourcePool controller.
 	if err = (&controllers.ResourcePoolReconciler{
 		Client: mgr.GetClient(),
-		Logger: logger.With("controller", "ResourcePool"),
+		Logger: logger.With(slog.String("controller", "ResourcePool")),
 	}).SetupWithManager(mgr); err != nil {
 		logger.ErrorContext(
 			ctx,
@@ -333,7 +333,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	// Start the Provisioning Request controller.
 	if err = (&controllers.ProvisioningRequestReconciler{
 		Client: mgr.GetClient(),
-		Logger: logger.With("controller", "ProvisioningRequest"),
+		Logger: logger.With(slog.String("controller", "ProvisioningRequest")),
 	}).SetupWithManager(mgr); err != nil {
 		logger.ErrorContext(
 			ctx,

--- a/internal/controllers/envtest/suite_test.go
+++ b/internal/controllers/envtest/suite_test.go
@@ -144,10 +144,10 @@ var _ = BeforeSuite(func() {
 
 	// Download BMH CRD from upstream (matching go.mod version)
 	if version, err := downloadBMHCRD(); err != nil {
-		logger.Warn("Failed to download BMH CRD from upstream", "error", err)
+		logger.Warn("Failed to download BMH CRD from upstream", slog.Any("error", err))
 		Fail(fmt.Sprintf("Failed to download BMH CRD: %v", err))
 	} else {
-		logger.Info("Downloaded BMH CRD from upstream", "version", version)
+		logger.Info("Downloaded BMH CRD from upstream", slog.String("version", version))
 	}
 
 	scheme := runtime.NewScheme()
@@ -186,21 +186,21 @@ var _ = BeforeSuite(func() {
 	// Register the Location controller
 	err = (&controllers.LocationReconciler{
 		Client: mgr.GetClient(),
-		Logger: logger.With("controller", "Location"),
+		Logger: logger.With(slog.String("controller", "Location")),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the OCloudSite controller
 	err = (&controllers.OCloudSiteReconciler{
 		Client: mgr.GetClient(),
-		Logger: logger.With("controller", "OCloudSite"),
+		Logger: logger.With(slog.String("controller", "OCloudSite")),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the ResourcePool controller
 	err = (&controllers.ResourcePoolReconciler{
 		Client: mgr.GetClient(),
-		Logger: logger.With("controller", "ResourcePool"),
+		Logger: logger.With(slog.String("controller", "ResourcePool")),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -785,7 +785,7 @@ func (t *reconcilerTask) checkForPodReadyStatus(ctx context.Context) (ctrl.Resul
 	for _, pod := range list.Items {
 		name, ok := pod.Labels["app"]
 		if !ok {
-			t.logger.WarnContext(ctx, "Pod without an 'app' label in our namespace", "name", pod.Name)
+			t.logger.WarnContext(ctx, "Pod without an 'app' label in our namespace", slog.String("name", pod.Name))
 			continue
 		}
 		if !slices.Contains(servers, name) {
@@ -793,7 +793,7 @@ func (t *reconcilerTask) checkForPodReadyStatus(ctx context.Context) (ctrl.Resul
 		}
 		for _, condition := range pod.Status.Conditions {
 			if condition.Type == corev1.PodReady && condition.Status != corev1.ConditionTrue {
-				t.logger.WarnContext(ctx, "Pod is not yet ready", "name", pod.Name, "reason", condition.Reason, "message", condition.Message)
+				t.logger.WarnContext(ctx, "Pod is not yet ready", slog.String("name", pod.Name), slog.String("reason", condition.Reason), slog.String("message", condition.Message))
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 		}
@@ -1557,7 +1557,7 @@ func (t *reconcilerTask) createServerClusterRoleBinding(ctx context.Context, ser
 }
 
 func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (ctlrutils.InventoryConditionReason, error) {
-	t.logger.DebugContext(ctx, "[deploy server]", "Name", serverName)
+	t.logger.DebugContext(ctx, "[deploy server]", slog.String("Name", serverName))
 
 	// Server variables.
 	deploymentVolumes := ctlrutils.GetDeploymentVolumes(serverName, t.object)
@@ -1749,7 +1749,7 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (c
 		Spec:       deploymentSpec,
 	}
 
-	t.logger.DebugContext(ctx, "[deployManagerServer] Create/Update/Patch Server", "Name", serverName)
+	t.logger.DebugContext(ctx, "[deployManagerServer] Create/Update/Patch Server", slog.String("Name", serverName))
 	if err := ctlrutils.CreateK8sCR(ctx, t.client, newDeployment, t.object, ctlrutils.UPDATE); err != nil {
 		return "", fmt.Errorf("failed to deploy ManagerServer: %w", err)
 	}
@@ -1771,7 +1771,7 @@ func (t *reconcilerTask) createServiceAccount(ctx context.Context, resourceName 
 		ObjectMeta: serviceAccountMeta,
 	}
 
-	t.logger.DebugContext(ctx, "[createServiceAccount] Create/Update/Patch ServiceAccount: ", "name", resourceName)
+	t.logger.DebugContext(ctx, "[createServiceAccount] Create/Update/Patch ServiceAccount: ", slog.String("name", resourceName))
 	if err := ctlrutils.CreateK8sCR(ctx, t.client, newServiceAccount, t.object, ctlrutils.UPDATE); err != nil {
 		return fmt.Errorf("failed to create ServiceAccount for deployment: %w", err)
 	}
@@ -1811,7 +1811,7 @@ func (t *reconcilerTask) createService(ctx context.Context, resourceName string,
 		Spec:       serviceSpec,
 	}
 
-	t.logger.DebugContext(ctx, "[createService] Create/Update/Patch Service: ", "name", resourceName)
+	t.logger.DebugContext(ctx, "[createService] Create/Update/Patch Service: ", slog.String("name", resourceName))
 	if err := ctlrutils.CreateK8sCR(ctx, t.client, newService, t.object, ctlrutils.UPDATE); err != nil {
 		return fmt.Errorf("failed to create Service for deployment: %w", err)
 	}
@@ -1935,7 +1935,7 @@ func (t *reconcilerTask) createIngress(ctx context.Context) error {
 		Spec:       ingressSpec,
 	}
 
-	t.logger.DebugContext(ctx, "[createIngress] Create/Update/Patch Ingress: ", "name", ctlrutils.IngressPortName)
+	t.logger.DebugContext(ctx, "[createIngress] Create/Update/Patch Ingress: ", slog.String("name", ctlrutils.IngressPortName))
 	if err := ctlrutils.CreateK8sCR(ctx, t.client, newIngress, t.object, ctlrutils.UPDATE); err != nil {
 		return fmt.Errorf("failed to create Ingress for deployment: %w", err)
 	}

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -1557,7 +1557,7 @@ func (t *reconcilerTask) createServerClusterRoleBinding(ctx context.Context, ser
 }
 
 func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (ctlrutils.InventoryConditionReason, error) {
-	t.logger.DebugContext(ctx, "[deploy server]", slog.String("Name", serverName))
+	t.logger.DebugContext(ctx, "[deploy server]", slog.String("name", serverName))
 
 	// Server variables.
 	deploymentVolumes := ctlrutils.GetDeploymentVolumes(serverName, t.object)
@@ -1749,7 +1749,7 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (c
 		Spec:       deploymentSpec,
 	}
 
-	t.logger.DebugContext(ctx, "[deployManagerServer] Create/Update/Patch Server", slog.String("Name", serverName))
+	t.logger.DebugContext(ctx, "[deployManagerServer] Create/Update/Patch Server", slog.String("name", serverName))
 	if err := ctlrutils.CreateK8sCR(ctx, t.client, newDeployment, t.object, ctlrutils.UPDATE); err != nil {
 		return "", fmt.Errorf("failed to deploy ManagerServer: %w", err)
 	}

--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -28,7 +28,7 @@ import (
 // deployPostgresServer deploys the actual Postgres database server instance.  Prior to invoking this method the other
 // required resources must have already been created (i.e., configmaps, secrets, service accounts, etc...).
 func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName string) error {
-	t.logger.DebugContext(ctx, "[deploy postgres server]", "Name", serverName)
+	t.logger.DebugContext(ctx, "[deploy postgres server]", slog.String("Name", serverName))
 
 	// Default server volumes.
 	deploymentVolumes := ctlrutils.GetDeploymentVolumes(serverName, t.object)
@@ -105,7 +105,7 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 		},
 	}
 
-	t.logger.DebugContext(ctx, "[deployPostgresServer] Create PVC", "Name", pvcName)
+	t.logger.DebugContext(ctx, "[deployPostgresServer] Create PVC", slog.String("Name", pvcName))
 	if err := ctlrutils.CreateK8sCR(ctx, t.client, pvc, t.object, ""); err != nil {
 		return fmt.Errorf("failed to create PVC: %w", err)
 	}
@@ -194,7 +194,7 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 		Spec:       deploymentSpec,
 	}
 
-	t.logger.DebugContext(ctx, "[deployDatabase] Create/Update/Patch Server", "Name", serverName)
+	t.logger.DebugContext(ctx, "[deployDatabase] Create/Update/Patch Server", slog.String("Name", serverName))
 	if err := ctlrutils.CreateK8sCR(ctx, t.client, newDeployment, t.object, ctlrutils.UPDATE); err != nil {
 		return fmt.Errorf("failed to deploy database: %w", err)
 	}

--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -28,7 +28,7 @@ import (
 // deployPostgresServer deploys the actual Postgres database server instance.  Prior to invoking this method the other
 // required resources must have already been created (i.e., configmaps, secrets, service accounts, etc...).
 func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName string) error {
-	t.logger.DebugContext(ctx, "[deploy postgres server]", slog.String("Name", serverName))
+	t.logger.DebugContext(ctx, "[deploy postgres server]", slog.String("name", serverName))
 
 	// Default server volumes.
 	deploymentVolumes := ctlrutils.GetDeploymentVolumes(serverName, t.object)
@@ -105,7 +105,7 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 		},
 	}
 
-	t.logger.DebugContext(ctx, "[deployPostgresServer] Create PVC", slog.String("Name", pvcName))
+	t.logger.DebugContext(ctx, "[deployPostgresServer] Create PVC", slog.String("name", pvcName))
 	if err := ctlrutils.CreateK8sCR(ctx, t.client, pvc, t.object, ""); err != nil {
 		return fmt.Errorf("failed to create PVC: %w", err)
 	}
@@ -194,7 +194,7 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 		Spec:       deploymentSpec,
 	}
 
-	t.logger.DebugContext(ctx, "[deployDatabase] Create/Update/Patch Server", slog.String("Name", serverName))
+	t.logger.DebugContext(ctx, "[deployDatabase] Create/Update/Patch Server", slog.String("name", serverName))
 	if err := ctlrutils.CreateK8sCR(ctx, t.client, newDeployment, t.object, ctlrutils.UPDATE); err != nil {
 		return fmt.Errorf("failed to deploy database: %w", err)
 	}

--- a/internal/controllers/provisioningrequest_clusterconfig.go
+++ b/internal/controllers/provisioningrequest_clusterconfig.go
@@ -9,6 +9,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -488,8 +489,8 @@ func (t *provisioningRequestReconcilerTask) addPostProvisioningLabels(ctx contex
 			if bmh == nil {
 				t.logger.WarnContext(ctx,
 					"BareMetalHost not found for AllocatedNode",
-					"allocatedNodeId", node.Name,
-					"hostname", hostName,
+					slog.String("allocatedNodeId", node.Name),
+					slog.String("hostname", hostName),
 				)
 				continue
 			}
@@ -506,8 +507,8 @@ func (t *provisioningRequestReconcilerTask) addPostProvisioningLabels(ctx contex
 		if !foundNode {
 			t.logger.WarnContext(
 				ctx,
-				"The corresponding clcm.openshift.io Node not found for the %s/%s Agent",
-				agent.Name, agent.Namespace,
+				fmt.Sprintf("The corresponding clcm.openshift.io Node not found for the %s/%s Agent",
+					agent.Name, agent.Namespace),
 			)
 		}
 	}

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -1069,7 +1069,7 @@ func (r *ProvisioningRequestReconciler) handleFinalizer(
 
 		// Deletion has completed. Remove provisioningRequestFinalizer. Once all finalizers have been
 		// removed, the object will be deleted.
-		r.Logger.InfoContext(ctx, "Dependents have been deleted. Removing provisioningRequest finalizer", "name", provisioningRequest.Name)
+		r.Logger.InfoContext(ctx, "Dependents have been deleted. Removing provisioningRequest finalizer", slog.String("name", provisioningRequest.Name))
 		patch := client.MergeFrom(provisioningRequest.DeepCopy())
 		if controllerutil.RemoveFinalizer(provisioningRequest, provisioningv1alpha1.ProvisioningRequestFinalizer) {
 			if err := r.Patch(ctx, provisioningRequest, patch); err != nil {

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -522,8 +522,8 @@ func (t *provisioningRequestReconcilerTask) updateAllocatedNodeHostMap(ctx conte
 	}
 
 	t.logger.InfoContext(ctx, "Updating AllocatedNodeHostMap status",
-		"allocatedNodeID", allocatedNodeID,
-		"hostName", hostName)
+		slog.String("allocatedNodeID", allocatedNodeID),
+		slog.String("hostName", hostName))
 
 	t.object.Status.Extensions.AllocatedNodeHostMap[allocatedNodeID] = hostName
 

--- a/internal/controllers/provisioningrequest_setup.go
+++ b/internal/controllers/provisioningrequest_setup.go
@@ -9,6 +9,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -193,7 +194,7 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForNAR(
 	ctx context.Context, obj client.Object) []reconcile.Request {
 	r.Logger.InfoContext(ctx,
 		"[enqueueProvisioningRequestForNAR] NAR status changed, triggering PR reconciliation",
-		"name", obj.GetName())
+		slog.String("name", obj.GetName()))
 	return []reconcile.Request{
 		{NamespacedName: types.NamespacedName{Name: obj.GetName()}},
 	}
@@ -220,7 +221,7 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForClusterTemp
 		if clusterTemplateRefName == obj.GetName() {
 			r.Logger.InfoContext(ctx,
 				"[enqueueProvisioningRequestForClusterTemplate] Add new reconcile request for ProvisioningRequest ",
-				"name", provisioningRequest.Name)
+				slog.String("name", provisioningRequest.Name))
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name: provisioningRequest.Name,
@@ -250,7 +251,7 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForManagedClus
 			// Return as this ManagedCluster is not deployed/managed by ClusterInstance.
 			return nil
 		}
-		r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForManagedCluster] Error getting ClusterInstance. ", "Error: ", err)
+		r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForManagedCluster] Error getting ClusterInstance. ", slog.Any("Error", err))
 		return nil
 	}
 
@@ -259,7 +260,7 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForManagedClus
 	if nameExists {
 		r.Logger.InfoContext(ctx,
 			"[enqueueProvisioningRequestForManagedCluster] Add new reconcile request for ProvisioningRequest",
-			"name", crName)
+			slog.String("name", crName))
 		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name: crName,
@@ -300,13 +301,13 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForPolicy(
 				// The provisioning request could have been deleted
 				return nil
 			}
-			r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForPolicy] Error getting ProvisioningRequest. ", "Error: ", err)
+			r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForPolicy] Error getting ProvisioningRequest. ", slog.Any("Error", err))
 			return nil
 		}
 
 		clusterTemplates := &provisioningv1alpha1.ClusterTemplateList{}
 		if err := r.List(ctx, clusterTemplates); err != nil {
-			r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForPolicy] Error listing ClusterTemplates. ", "Error: ", err)
+			r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForPolicy] Error listing ClusterTemplates. ", slog.Any("Error", err))
 			return nil
 		}
 
@@ -325,7 +326,7 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForPolicy(
 		if ctlrutils.IsParentPolicyInZtpClusterTemplateNs(parentPolicyNs, ctRefNamespace) {
 			r.Logger.InfoContext(ctx,
 				"[enqueueProvisioningRequestForPolicy] Add new reconcile request for ProvisioningRequest ",
-				"name", provisioningRequest, "policyName", obj.GetName())
+				slog.String("name", provisioningRequest), slog.String("policyName", obj.GetName()))
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: provisioningRequest},
 			})

--- a/internal/controllers/provisioningrequest_upgrade.go
+++ b/internal/controllers/provisioningrequest_upgrade.go
@@ -9,6 +9,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -55,7 +56,7 @@ func (t *provisioningRequestReconcilerTask) IsUpgradeRequested(
 	openshiftVersion, ok := managedCluster.GetLabels()["openshiftVersion"]
 	if !ok {
 		t.logger.InfoContext(ctx, "openshiftVersion label not found in ManagedCluster, requeueing",
-			"managedCluster", managedClusterName)
+			slog.String("managedCluster", managedClusterName))
 		return false, ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
@@ -68,14 +69,14 @@ func (t *provisioningRequestReconcilerTask) IsUpgradeRequested(
 	switch cmp {
 	case 1:
 		t.logger.InfoContext(ctx, "Upgrade requested: template version is higher than ManagedCluster version",
-			"templateVersion", templateReleaseVersion.String(), "managedClusterVersion", managedClusterVersion.String())
+			slog.String("templateVersion", templateReleaseVersion.String()), slog.String("managedClusterVersion", managedClusterVersion.String()))
 		return true, ctrl.Result{}, nil
 	case -1:
 		t.logger.InfoContext(ctx, "Template version is lower than ManagedCluster version, no upgrade requested",
-			"templateVersion", templateReleaseVersion.String(), "managedClusterVersion", managedClusterVersion.String())
+			slog.String("templateVersion", templateReleaseVersion.String()), slog.String("managedClusterVersion", managedClusterVersion.String()))
 	case 0:
 		t.logger.InfoContext(ctx, "Template version equals ManagedCluster version, no upgrade requested",
-			"version", templateReleaseVersion.String())
+			slog.String("version", templateReleaseVersion.String()))
 	}
 	return false, ctrl.Result{}, nil
 }

--- a/internal/hardwaremanager/controller/resource_selection.go
+++ b/internal/hardwaremanager/controller/resource_selection.go
@@ -283,9 +283,9 @@ func ResourceSelectionSecondaryFilter(ctx context.Context,
 		hwdata := &metal3v1alpha1.HardwareData{}
 		if err := c.Get(ctx, types.NamespacedName{Namespace: bmh.Namespace, Name: bmh.Name}, hwdata); err != nil {
 			if client.IgnoreNotFound(err) != nil {
-				logger.ErrorContext(ctx, "Failed to get HardwareData for BMH, skipping", "bmh", bmh.Name, "error", err)
+				logger.ErrorContext(ctx, "Failed to get HardwareData for BMH, skipping", slog.String("bmh", bmh.Name), slog.Any("error", err))
 			} else {
-				logger.ErrorContext(ctx, "HardwareData not found for BMH, skipping hardware criteria evaluation", "bmh", bmh.Name)
+				logger.ErrorContext(ctx, "HardwareData not found for BMH, skipping hardware criteria evaluation", slog.String("bmh", bmh.Name))
 			}
 			continue
 		}

--- a/internal/hardwaremanager/controller/setup.go
+++ b/internal/hardwaremanager/controller/setup.go
@@ -33,7 +33,7 @@ func SetupControllers(mgr ctrl.Manager, namespace string, baseLogger *slog.Logge
 		Client:          mgr.GetClient(),
 		NoncachedClient: mgr.GetAPIReader(),
 		Scheme:          mgr.GetScheme(),
-		Logger:          baseLogger.With("controller", "hwmgr_nodeallocationrequest_controller"),
+		Logger:          baseLogger.With(slog.String("controller", "hwmgr_nodeallocationrequest_controller")),
 		Namespace:       namespace,
 		Manager:         mgr,
 	}
@@ -46,7 +46,7 @@ func SetupControllers(mgr ctrl.Manager, namespace string, baseLogger *slog.Logge
 		Client:          mgr.GetClient(),
 		NoncachedClient: mgr.GetAPIReader(),
 		Scheme:          mgr.GetScheme(),
-		Logger:          baseLogger.With("controller", "hwmgr_allocatednode_controller"),
+		Logger:          baseLogger.With(slog.String("controller", "hwmgr_allocatednode_controller")),
 		Namespace:       namespace,
 		Manager:         mgr,
 	}
@@ -59,7 +59,7 @@ func SetupControllers(mgr ctrl.Manager, namespace string, baseLogger *slog.Logge
 		Client:          mgr.GetClient(),
 		NoncachedClient: mgr.GetAPIReader(),
 		Scheme:          mgr.GetScheme(),
-		Logger:          baseLogger.With("controller", "hwmgr_hostfirmwarecomponents_controller"),
+		Logger:          baseLogger.With(slog.String("controller", "hwmgr_hostfirmwarecomponents_controller")),
 		Namespace:       namespace,
 		Manager:         mgr,
 	}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -587,7 +587,7 @@ var _ = Describe("Logger", func() {
 		// Write a message:
 		logger.Info(
 			"my message",
-			"!my-field", "my-value",
+			slog.String("!my-field", "my-value"),
 		)
 
 		// Check that the field has been redacted:
@@ -613,7 +613,7 @@ var _ = Describe("Logger", func() {
 		// Write a message:
 		logger.Info(
 			"my message",
-			"!my-field", "my-value",
+			slog.String("!my-field", "my-value"),
 		)
 
 		// Check that the field has been redacted:
@@ -634,12 +634,12 @@ var _ = Describe("Logger", func() {
 			SetWriter(io.MultiWriter(buffer, GinkgoWriter)).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
-		logger = logger.With("!my-field", "my-value")
+		logger = logger.With(slog.String("!my-field", "my-value"))
 
 		// Write a message:
 		logger.Info(
 			"your message",
-			"!your-field", "your-value",
+			slog.String("!your-field", "your-value"),
 		)
 
 		// Check that the field has been redacted:
@@ -707,7 +707,7 @@ var _ = Describe("Logger", func() {
 		// Write a message:
 		logger.Info(
 			"my message",
-			"!my-field", "my-value",
+			slog.String("!my-field", "my-value"),
 		)
 
 		// Check that the field has been redacted:

--- a/internal/search/paths_lexer.go
+++ b/internal/search/paths_lexer.go
@@ -210,7 +210,7 @@ func (l *pathsLexer) readRune() rune {
 	if err != nil {
 		l.logger.Error(
 			"Unexpected error while reading rune",
-			"error", err,
+			slog.Any("error", err),
 		)
 		return 0
 	}
@@ -222,7 +222,7 @@ func (l *pathsLexer) unreadRune() {
 	if err != nil {
 		l.logger.Error(
 			"Unexpected error while unreading rune",
-			"error", err,
+			slog.Any("error", err),
 		)
 	}
 }

--- a/internal/search/paths_parser.go
+++ b/internal/search/paths_parser.go
@@ -67,8 +67,8 @@ func (p *PathsParser) Parse(paths ...string) (result []Path, err error) {
 		if fault != nil {
 			p.logger.Error(
 				"Failed to parse",
-				"text", paths,
-				"error", err,
+				slog.Any("text", paths),
+				slog.Any("error", err),
 			)
 			err = fault.(error)
 		}

--- a/internal/search/selector_evaluator.go
+++ b/internal/search/selector_evaluator.go
@@ -122,9 +122,9 @@ func (e *SelectorEvaluator) Evaluate(ctx context.Context, selector *Selector,
 		e.logger.DebugContext(
 			ctx,
 			"Evaluated selector",
-			"selector", selector.String(),
-			"object", object,
-			"result", result,
+			slog.String("selector", selector.String()),
+			slog.Any("object", object),
+			slog.Bool("result", result),
 		)
 	}
 	return

--- a/internal/search/selector_lexer.go
+++ b/internal/search/selector_lexer.go
@@ -419,7 +419,7 @@ func (l *selectorLexer) readRune() rune {
 	if err != nil {
 		l.logger.Error(
 			"Unexpected error while reading rune",
-			"error", err,
+			slog.Any("error", err),
 		)
 		return 0
 	}
@@ -431,7 +431,7 @@ func (l *selectorLexer) unreadRune() {
 	if err != nil {
 		l.logger.Error(
 			"Unexpected error while unreading rune",
-			"error", err,
+			slog.Any("error", err),
 		)
 	}
 }

--- a/internal/search/selector_parser.go
+++ b/internal/search/selector_parser.go
@@ -71,8 +71,8 @@ func (p *SelectorParser) Parse(text string) (selector *Selector, err error) {
 		if fault != nil {
 			p.logger.Error(
 				"Failed to parse",
-				"text", text,
-				"error", err,
+				slog.String("text", text),
+				slog.Any("error", err),
 			)
 			err = fault.(error)
 		}

--- a/internal/service/alarms/api/server.go
+++ b/internal/service/alarms/api/server.go
@@ -136,7 +136,7 @@ func (a *AlarmsServer) CreateSubscription(ctx context.Context, request api.Creat
 
 	// Validate the subscription
 	if err := commonapi.ValidateCallbackURL(ctx, a.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback); err != nil {
-		slog.ErrorContext(ctx, "callback URL validation failed", "error", err)
+		slog.ErrorContext(ctx, "callback URL validation failed", slog.Any("error", err))
 		return api.CreateSubscription400ApplicationProblemPlusJSONResponse{
 			Detail: "callback URL validation failed",
 			Status: http.StatusBadRequest,
@@ -162,7 +162,7 @@ func (a *AlarmsServer) CreateSubscription(ctx context.Context, request api.Creat
 		Removed:      false,
 		Subscription: models.ConvertAlertSubToNotificationSub(record),
 	})
-	slog.InfoContext(ctx, "Successfully created Alarm Subscription", "record", record)
+	slog.InfoContext(ctx, "Successfully created Alarm Subscription", slog.Any("record", record))
 	return api.CreateSubscription201JSONResponse(models.ConvertSubscriptionModelToApi(*record)), nil
 }
 
@@ -379,8 +379,8 @@ func (a *AlarmsServer) PatchAlarm(ctx context.Context, request api.PatchAlarmReq
 		return nil, fmt.Errorf("failed to patch Alarm Event Record: %w", err)
 	}
 
-	slog.DebugContext(ctx, "Alarm acknowledged/cleared", "alarmAcknowledged", updated.AlarmAcknowledged, "alarmAcknowledgedTime", updated.AlarmAcknowledgedTime,
-		"alarmClearedTime", updated.AlarmClearedTime, "perceivedSeverity", updated.PerceivedSeverity, "alarmChangedTime", updated.AlarmChangedTime)
+	slog.DebugContext(ctx, "Alarm acknowledged/cleared", slog.Bool("alarmAcknowledged", updated.AlarmAcknowledged), slog.Any("alarmAcknowledgedTime", updated.AlarmAcknowledgedTime),
+		slog.Any("alarmClearedTime", updated.AlarmClearedTime), slog.Any("perceivedSeverity", updated.PerceivedSeverity), slog.Any("alarmChangedTime", updated.AlarmChangedTime))
 
 	return api.PatchAlarm200JSONResponse{AlarmAcknowledged: request.Body.AlarmAcknowledged, PerceivedSeverity: request.Body.PerceivedSeverity}, nil
 }
@@ -447,7 +447,7 @@ func (a *AlarmsServer) PatchAlarmServiceConfiguration(ctx context.Context, reque
 		return nil, fmt.Errorf("failed to start cleanup cronjob during AlarmServiceConfiguration patch: %w", err)
 	}
 
-	slog.DebugContext(ctx, "Alarm Service Configuration patched", "retentionPeriod", patched.RetentionPeriod, "extensions", patched.Extensions)
+	slog.DebugContext(ctx, "Alarm Service Configuration patched", slog.Int("retentionPeriod", patched.RetentionPeriod), slog.Any("extensions", patched.Extensions))
 	return api.PatchAlarmServiceConfiguration200JSONResponse(models.ConvertServiceConfigurationToAPI(*patched)), nil
 }
 
@@ -490,7 +490,7 @@ func (a *AlarmsServer) UpdateAlarmServiceConfiguration(ctx context.Context, requ
 		return nil, fmt.Errorf("failed to start cleanup cronjob during AlarmServiceConfiguration update: %w", err)
 	}
 
-	slog.DebugContext(ctx, "Alarm Service Configuration updated", "retentionPeriod", updated.RetentionPeriod, "extensions", updated.Extensions)
+	slog.DebugContext(ctx, "Alarm Service Configuration updated", slog.Int("retentionPeriod", updated.RetentionPeriod), slog.Any("extensions", updated.Extensions))
 	return api.UpdateAlarmServiceConfiguration200JSONResponse(models.ConvertServiceConfigurationToAPI(*updated)), nil
 
 }
@@ -502,7 +502,7 @@ func (a *AlarmsServer) AmNotification(ctx context.Context, request api.AmNotific
 
 	if err := alertmanager.HandleAlerts(ctx, a.Infrastructure.ClusterServer, a.Infrastructure.ResourceServer, a.AlarmsRepository, &request.Body.Alerts, alertmanager.Webhook); err != nil {
 		msg := "failed to handle alerts"
-		slog.ErrorContext(ctx, msg, "error", err)
+		slog.ErrorContext(ctx, msg, slog.Any("error", err))
 		return nil, fmt.Errorf("%s: %w", msg, err)
 	}
 

--- a/internal/service/alarms/cmd/migrate.go
+++ b/internal/service/alarms/cmd/migrate.go
@@ -21,7 +21,7 @@ var alarmsMigrate = &cobra.Command{
 	Long:  `This is will run from k8s job before the server starts.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := alarms.StartAlarmsMigration(); err != nil {
-			slog.Error("failed to do migration", "err", err)
+			slog.Error("failed to do migration", slog.Any("err", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/alarms/cmd/serve.go
+++ b/internal/service/alarms/cmd/serve.go
@@ -39,15 +39,15 @@ var alarmsServe = &cobra.Command{
 		klog.SetSlogLogger(logger)
 
 		if err := config.LoadFromEnv(); err != nil {
-			slog.Error("failed to load environment variables", "err", err)
+			slog.Error("failed to load environment variables", slog.Any("err", err))
 			os.Exit(1)
 		}
 		if err := config.Validate(); err != nil {
-			slog.Error("failed to validate common server configuration", "err", err)
+			slog.Error("failed to validate common server configuration", slog.Any("err", err))
 			os.Exit(1)
 		}
 		if err := alarms.Serve(&config); err != nil {
-			slog.Error("failed to start alarms server", "err", err)
+			slog.Error("failed to start alarms server", slog.Any("err", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -78,13 +78,13 @@ func Serve(config *api.AlarmsServerConfig) error {
 	// Recovery defer to print panic strace
 	defer func() {
 		if r := recover(); r != nil {
-			slog.ErrorContext(ctx, "something went wrong", "stacktrace", string(debug.Stack()))
+			slog.ErrorContext(ctx, "something went wrong", slog.String("stacktrace", string(debug.Stack())))
 		}
 	}()
 
 	go func() {
 		sig := <-shutdown
-		slog.InfoContext(ctx, "Shutdown signal received", "signal", sig)
+		slog.InfoContext(ctx, "Shutdown signal received", slog.Any("signal", sig))
 		cancel()
 	}()
 
@@ -164,7 +164,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 		defer alarmServer.Wg.Done()
 		slog.InfoContext(ctx, "Starting alarms subs notifier")
 		if err := newNotifier.Run(ctx); err != nil {
-			slog.ErrorContext(ctx, "notifier error", "error", err)
+			slog.ErrorContext(ctx, "notifier error", slog.Any("error", err))
 		}
 	}()
 
@@ -308,7 +308,7 @@ func ConfigAlarmServerCleanup(ctx context.Context, alarmServer *api.AlarmsServer
 	if err != nil {
 		return fmt.Errorf("failed to create alarm service configuration: %w", err)
 	}
-	slog.InfoContext(ctx, "Alarm Service configuration created/found", "retentionPeriod", serviceConfig.RetentionPeriod, "extensions", serviceConfig.Extensions)
+	slog.InfoContext(ctx, "Alarm Service configuration created/found", slog.Int("retentionPeriod", serviceConfig.RetentionPeriod), slog.Any("extensions", serviceConfig.Extensions))
 
 	// Init ServiceConfig and start cronjob
 	alarmServer.ServiceConfig, err = serviceconfig.LoadEnvConfig()
@@ -351,7 +351,7 @@ func startAlertmanager(ctx context.Context, alarmServer *api.AlarmsServer) error
 		defer alarmServer.Wg.Done()
 		if err := c.RunAlertSyncScheduler(ctx, 1*time.Hour); err != nil {
 			if !errors.Is(err, context.Canceled) {
-				slog.ErrorContext(ctx, "failed to run alert sync scheduler", "error", err)
+				slog.ErrorContext(ctx, "failed to run alert sync scheduler", slog.Any("error", err))
 			}
 		}
 	}()

--- a/internal/service/artifacts/cmd/serve.go
+++ b/internal/service/artifacts/cmd/serve.go
@@ -36,15 +36,15 @@ var artifactsServer = &cobra.Command{
 		klog.SetSlogLogger(logger)
 
 		if err := config.LoadFromEnv(); err != nil {
-			slog.Error("failed to load environment variables", "err", err)
+			slog.Error("failed to load environment variables", slog.Any("err", err))
 			os.Exit(1)
 		}
 		if err := config.Validate(); err != nil {
-			slog.Error("failed to validate common server configuration", "err", err)
+			slog.Error("failed to validate common server configuration", slog.Any("err", err))
 			os.Exit(1)
 		}
 		if err := artifacts.Serve(&config); err != nil {
-			slog.Error("failed to start artifacts server", "err", err)
+			slog.Error("failed to start artifacts server", slog.Any("err", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -66,7 +66,7 @@ func Serve(config *api.ArtifactsServerConfig) error {
 
 	go func() {
 		sig := <-shutdown
-		slog.InfoContext(ctx, "Shutdown signal received", "signal", sig)
+		slog.InfoContext(ctx, "Shutdown signal received", slog.Any("signal", sig))
 		cancel()
 	}()
 

--- a/internal/service/cluster/api/server.go
+++ b/internal/service/cluster/api/server.go
@@ -416,7 +416,7 @@ func (r *ClusterServer) GetSubscriptions(ctx context.Context, request api.GetSub
 // validateSubscription validates a subscription before accepting the request
 func (r *ClusterServer) validateSubscription(ctx context.Context, request api.CreateSubscriptionRequestObject) error {
 	if err := commonapi.ValidateCallbackURL(ctx, r.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback); err != nil {
-		slog.ErrorContext(ctx, "callback URL validation failed", "error", err)
+		slog.ErrorContext(ctx, "callback URL validation failed", slog.Any("error", err))
 		return fmt.Errorf("callback URL validation failed")
 	}
 	// TODO: add validation of filter and move to common if filter syntax is the same for all servers
@@ -463,7 +463,7 @@ func (r *ClusterServer) CreateSubscription(ctx context.Context, request api.Crea
 				Status: http.StatusBadRequest,
 			}, nil
 		}
-		slog.ErrorContext(ctx, "error writing database record", "target", record, "error", err.Error())
+		slog.ErrorContext(ctx, "error writing database record", slog.Any("target", record), slog.String("error", err.Error()))
 		return api.CreateSubscription500ApplicationProblemPlusJSONResponse{
 			AdditionalAttributes: &map[string]string{
 				"consumerSubscriptionId": consumerSubscriptionId,

--- a/internal/service/cluster/cmd/migrate.go
+++ b/internal/service/cluster/cmd/migrate.go
@@ -22,7 +22,7 @@ var migrate = &cobra.Command{
 	Long:  `This will run from k8s job before the server starts.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := cluster.StartMigration(); err != nil {
-			slog.Error("failed to do migration", "err", err)
+			slog.Error("failed to do migration", slog.Any("err", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/cluster/cmd/serve.go
+++ b/internal/service/cluster/cmd/serve.go
@@ -38,15 +38,15 @@ var clusterServer = &cobra.Command{
 		klog.SetSlogLogger(logger)
 
 		if err := config.LoadFromEnv(); err != nil {
-			slog.Error("failed to load environment variables", "err", err)
+			slog.Error("failed to load environment variables", slog.Any("err", err))
 			os.Exit(1)
 		}
 		if err := config.Validate(); err != nil {
-			slog.Error("failed to validate common server configuration", "err", err)
+			slog.Error("failed to validate common server configuration", slog.Any("err", err))
 			os.Exit(1)
 		}
 		if err := cluster.Serve(&config); err != nil {
-			slog.Error("failed to start cluster server", "err", err)
+			slog.Error("failed to start cluster server", slog.Any("err", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/cluster/db/models/converters.go
+++ b/internal/service/cluster/db/models/converters.go
@@ -167,7 +167,7 @@ func getEventType(before, after map[string]interface{}) int {
 	case before != nil:
 		return 2
 	default:
-		slog.Warn("unsupported event type", "before", before, "after", after)
+		slog.Warn("unsupported event type", slog.Any("before", before), slog.Any("after", after))
 		return -1
 	}
 }

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -74,7 +74,7 @@ func Serve(config *api.ClusterServerConfig) error {
 
 	go func() {
 		sig := <-shutdown
-		slog.InfoContext(ctx, "Shutdown signal received", "signal", sig)
+		slog.InfoContext(ctx, "Shutdown signal received", slog.Any("signal", sig))
 		cancel()
 	}()
 
@@ -242,7 +242,7 @@ func Serve(config *api.ClusterServerConfig) error {
 		// Shutdown the http server
 		slog.InfoContext(ctx, "Shutting down server")
 		if err := common.GracefulShutdown(srv); err != nil {
-			slog.ErrorContext(ctx, "error shutting down server", "error", err)
+			slog.ErrorContext(ctx, "error shutting down server", slog.Any("error", err))
 		}
 	}()
 

--- a/internal/service/common/api/middleware/filtering.go
+++ b/internal/service/common/api/middleware/filtering.go
@@ -238,7 +238,7 @@ func ResponseFilter(adapter *FilterAdapter) Middleware {
 			var err error
 			query, err := url.ParseQuery(r.URL.RawQuery)
 			if err != nil {
-				slog.ErrorContext(r.Context(), "failed to parse query", "RawQuery", r.URL.RawQuery, "err", err)
+				slog.ErrorContext(r.Context(), "failed to parse query", slog.String("RawQuery", r.URL.RawQuery), slog.Any("err", err))
 				_ = adapter.Error(
 					w,
 					"failed to parse query parameters",
@@ -252,7 +252,7 @@ func ResponseFilter(adapter *FilterAdapter) Middleware {
 				for _, value := range values {
 					result, err := adapter.ParseFilter(value)
 					if err != nil {
-						slog.ErrorContext(r.Context(), "failed to parse filter", "value", value, "err", err)
+						slog.ErrorContext(r.Context(), "failed to parse filter", slog.String("value", value), slog.Any("err", err))
 						msg := err.Error()
 						if isParserError(err) {
 							msg = "invalid filter syntax"

--- a/internal/service/common/api/middleware/middleware.go
+++ b/internal/service/common/api/middleware/middleware.go
@@ -60,7 +60,7 @@ func LogDuration() Middleware {
 				ResponseWriter: w,
 			}
 			next.ServeHTTP(&d, r)
-			slog.DebugContext(r.Context(), "Request completed", "status", d.statusCode, "duration", time.Since(startTime).String())
+			slog.DebugContext(r.Context(), "Request completed", slog.Int("status", d.statusCode), slog.String("duration", time.Since(startTime).String()))
 		})
 	}
 }
@@ -126,8 +126,8 @@ func ProblemDetails(w http.ResponseWriter, body string, code int) {
 func getOranErrHandler() oapimiddleware.ErrorHandlerWithOpts {
 	return func(_ context.Context, err error, w http.ResponseWriter, r *http.Request, opts oapimiddleware.ErrorHandlerOpts) {
 		slog.WarnContext(r.Context(), "OpenAPI validation failed",
-			"error", err.Error(),
-			"status", opts.StatusCode,
+			slog.String("error", err.Error()),
+			slog.Int("status", opts.StatusCode),
 		)
 		ProblemDetails(w, err.Error(), opts.StatusCode)
 	}
@@ -137,8 +137,8 @@ func getOranErrHandler() oapimiddleware.ErrorHandlerWithOpts {
 func GetOranReqErrFunc() func(w http.ResponseWriter, r *http.Request, err error) {
 	return func(w http.ResponseWriter, r *http.Request, err error) {
 		slog.WarnContext(r.Context(), "OpenAPI request validation failed",
-			"error", err.Error(),
-			"status", http.StatusBadRequest,
+			slog.String("error", err.Error()),
+			slog.Int("status", http.StatusBadRequest),
 		)
 		msg := err.Error()
 		if strings.HasPrefix(msg, "Invalid format for parameter ") {

--- a/internal/service/common/api/utils.go
+++ b/internal/service/common/api/utils.go
@@ -63,7 +63,7 @@ func CheckCallbackReachabilityGET(ctx context.Context, client *http.Client, call
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()
 		if err != nil {
-			slog.WarnContext(ctx, "failed to close response body", "error", err)
+			slog.WarnContext(ctx, "failed to close response body", slog.Any("error", err))
 		}
 	}(resp.Body)
 
@@ -71,7 +71,7 @@ func CheckCallbackReachabilityGET(ctx context.Context, client *http.Client, call
 		return fmt.Errorf("unexpected status code: got %d, expected %d", resp.StatusCode, http.StatusNoContent)
 	}
 
-	slog.InfoContext(ctx, "Reachability check passed", "status", resp.StatusCode)
+	slog.InfoContext(ctx, "Reachability check passed", slog.Int("status", resp.StatusCode))
 	return nil
 }
 

--- a/internal/service/common/async/store.go
+++ b/internal/service/common/async/store.go
@@ -110,7 +110,7 @@ func (c *ReflectorStore) enqueue(operation operation) {
 	}
 	if count >= c.hwm+10 {
 		// We don't need a log every single time the high watermark is surpassed by 1, so log it when it surpasses by 10
-		slog.Debug("New reflector store queue high watermark", "new", count, "old", c.hwm)
+		slog.Debug("New reflector store queue high watermark", slog.Int("new", count), slog.Int("old", c.hwm))
 		c.hwm = count
 	}
 }
@@ -129,14 +129,14 @@ func (c *ReflectorStore) handleOperations(ctx context.Context, handler AsyncEven
 		case Updated, Deleted:
 			_, err := handler.HandleAsyncEvent(ctx, o.objects[0], o.eventType)
 			if err != nil {
-				slog.WarnContext(ctx, "Failed to handle event", "event", o.eventType, "error", err)
+				slog.WarnContext(ctx, "Failed to handle event", slog.Any("event", o.eventType), slog.Any("error", err))
 			}
 		case SyncComplete:
 			keys := make([]uuid.UUID, 0)
 			for _, obj := range o.objects {
 				key, err := handler.HandleAsyncEvent(ctx, obj, Updated)
 				if err != nil {
-					slog.WarnContext(ctx, "Failed to handle event", "error", err)
+					slog.WarnContext(ctx, "Failed to handle event", slog.Any("error", err))
 					continue
 				}
 				if key != uuid.Nil {
@@ -146,7 +146,7 @@ func (c *ReflectorStore) handleOperations(ctx context.Context, handler AsyncEven
 			}
 			err := handler.HandleSyncComplete(ctx, c.ObjectType, keys)
 			if err != nil {
-				slog.WarnContext(ctx, "Failed to handle sync completion", "error", err)
+				slog.WarnContext(ctx, "Failed to handle sync completion", slog.Any("error", err))
 			}
 		}
 	}
@@ -232,8 +232,8 @@ func (c *ReflectorStore) GetByKey(_ string) (item interface{}, exists bool, err 
 
 // Replace indicates that the underlying Reflector needed to re-list all data from the API server.
 func (c *ReflectorStore) Replace(items []interface{}, resourceVersion string) error {
-	slog.Info("Replace called", "type", fmt.Sprintf("%T", c.ObjectType),
-		"items", len(items), "resourceVersion", resourceVersion)
+	slog.Info("Replace called", slog.String("type", fmt.Sprintf("%T", c.ObjectType)),
+		slog.Int("items", len(items)), slog.String("resourceVersion", resourceVersion))
 	c.enqueue(operation{
 		eventType: SyncComplete,
 		objects:   items,

--- a/internal/service/common/auth/auth.go
+++ b/internal/service/common/auth/auth.go
@@ -98,14 +98,14 @@ func Authorizer(kubernetesAuthorizer authorizer.Authorizer) middleware.Middlewar
 			decision, reason, err := kubernetesAuthorizer.Authorize(req.Context(), attributes)
 			if err != nil {
 				msg := fmt.Sprintf("Authorization for user '%s' failed", attributes.User.GetName())
-				slog.ErrorContext(req.Context(), msg, slog.Any("user", user), slog.Any("verb", attributes.Verb), slog.Any("path", attributes.Path), slog.Any("error", err))
+				slog.ErrorContext(req.Context(), msg, slog.Any("user", user), slog.String("verb", attributes.Verb), slog.String("path", attributes.Path), slog.Any("error", err))
 				middleware.ProblemDetails(w, msg, http.StatusInternalServerError)
 				return
 			}
 
 			if decision != authorizer.DecisionAllow {
 				msg := fmt.Sprintf("Authorization not allowed for user '%s'", attributes.User.GetName())
-				slog.DebugContext(req.Context(), msg, slog.Any("user", user), slog.Any("verb", attributes.Verb), slog.Any("path", attributes.Path), slog.Any("decision", decision), slog.Any("reason", reason))
+				slog.DebugContext(req.Context(), msg, slog.Any("user", user), slog.String("verb", attributes.Verb), slog.String("path", attributes.Path), slog.Any("decision", decision), slog.String("reason", reason))
 				middleware.ProblemDetails(w, msg, http.StatusForbidden)
 				return
 			}

--- a/internal/service/common/auth/auth.go
+++ b/internal/service/common/auth/auth.go
@@ -36,13 +36,13 @@ func Authenticator(oauthHandler, kubernetesHandler authenticator.Request) middle
 
 			response, ok, err := handler.AuthenticateRequest(req)
 			if err != nil {
-				slog.WarnContext(req.Context(), "authentication failed", "error", err, "method", req.Method, "path", req.URL.Path)
+				slog.WarnContext(req.Context(), "authentication failed", slog.Any("error", err), slog.String("method", req.Method), slog.String("path", req.URL.Path))
 				middleware.ProblemDetails(w, fmt.Sprintf("failed to authenticate request: %v", err), http.StatusUnauthorized)
 				return
 			}
 
 			if !ok {
-				slog.WarnContext(req.Context(), "authentication rejected", "method", req.Method, "path", req.URL.Path)
+				slog.WarnContext(req.Context(), "authentication rejected", slog.String("method", req.Method), slog.String("path", req.URL.Path))
 				middleware.ProblemDetails(w, "unable to authenticate request", http.StatusUnauthorized)
 				return
 			}
@@ -98,14 +98,14 @@ func Authorizer(kubernetesAuthorizer authorizer.Authorizer) middleware.Middlewar
 			decision, reason, err := kubernetesAuthorizer.Authorize(req.Context(), attributes)
 			if err != nil {
 				msg := fmt.Sprintf("Authorization for user '%s' failed", attributes.User.GetName())
-				slog.ErrorContext(req.Context(), msg, "user", user, "verb", attributes.Verb, "path", attributes.Path, "error", err)
+				slog.ErrorContext(req.Context(), msg, slog.Any("user", user), slog.Any("verb", attributes.Verb), slog.Any("path", attributes.Path), slog.Any("error", err))
 				middleware.ProblemDetails(w, msg, http.StatusInternalServerError)
 				return
 			}
 
 			if decision != authorizer.DecisionAllow {
 				msg := fmt.Sprintf("Authorization not allowed for user '%s'", attributes.User.GetName())
-				slog.DebugContext(req.Context(), msg, "user", user, "verb", attributes.Verb, "path", attributes.Path, "decision", decision, "reason", reason)
+				slog.DebugContext(req.Context(), msg, slog.Any("user", user), slog.Any("verb", attributes.Verb), slog.Any("path", attributes.Path), slog.Any("decision", decision), slog.Any("reason", reason))
 				middleware.ProblemDetails(w, msg, http.StatusForbidden)
 				return
 			}

--- a/internal/service/common/auth/auth_rfc8705.go
+++ b/internal/service/common/auth/auth_rfc8705.go
@@ -57,7 +57,7 @@ func getClientCertificate(req *http.Request) ([]byte, bool, error) {
 		certString = req.Header.Get(sslClientDERHeaderKey)
 		if certString == "" {
 			// This is unexpected
-			slog.ErrorContext(req.Context(), "No client certificate found, but verification passed", slog.Any("header", sslClientDERHeaderKey))
+			slog.ErrorContext(req.Context(), "No client certificate found, but verification passed", slog.String("header", sslClientDERHeaderKey))
 			return nil, false, nil
 		}
 

--- a/internal/service/common/auth/auth_rfc8705.go
+++ b/internal/service/common/auth/auth_rfc8705.go
@@ -57,7 +57,7 @@ func getClientCertificate(req *http.Request) ([]byte, bool, error) {
 		certString = req.Header.Get(sslClientDERHeaderKey)
 		if certString == "" {
 			// This is unexpected
-			slog.ErrorContext(req.Context(), "No client certificate found, but verification passed", "header", sslClientDERHeaderKey)
+			slog.ErrorContext(req.Context(), "No client certificate found, but verification passed", slog.Any("header", sslClientDERHeaderKey))
 			return nil, false, nil
 		}
 
@@ -149,7 +149,7 @@ func (w *withClientVerification) AuthenticateRequest(req *http.Request) (*authen
 
 	clientFingerprint, present, err := getClientCertificateFingerprint(req)
 	if err != nil {
-		slog.ErrorContext(req.Context(), "error extracting client certificate fingerprint", "error", err)
+		slog.ErrorContext(req.Context(), "error extracting client certificate fingerprint", slog.Any("error", err))
 		return nil, false, err
 	}
 
@@ -158,12 +158,12 @@ func (w *withClientVerification) AuthenticateRequest(req *http.Request) (*authen
 	}
 
 	if len(tokenFingerprintValues) != 1 {
-		slog.ErrorContext(req.Context(), "unexpected number of fingerprint values", "values", tokenFingerprintValues)
+		slog.ErrorContext(req.Context(), "unexpected number of fingerprint values", slog.Any("values", tokenFingerprintValues))
 		return nil, false, fmt.Errorf("unexpected number of fingerprint values")
 	}
 
 	if tokenFingerprintValues[0] != "" && tokenFingerprintValues[0] != clientFingerprint {
-		slog.DebugContext(req.Context(), "fingerprint values do not match", "client", clientFingerprint, "token", tokenFingerprintValues[0])
+		slog.DebugContext(req.Context(), "fingerprint values do not match", slog.String("client", clientFingerprint), slog.String("token", tokenFingerprintValues[0]))
 		return nil, false, fmt.Errorf("client certificate fingerprint mismatch")
 	}
 

--- a/internal/service/common/cache/cache.go
+++ b/internal/service/common/cache/cache.go
@@ -66,7 +66,7 @@ func (c *Entry[T]) Get(ctx context.Context) (T, error) {
 		c.expiresAt = time.Now().Add(c.maxAge)
 	}
 
-	slog.InfoContext(ctx, "Cache populated", "cache", c.name)
+	slog.InfoContext(ctx, "Cache populated", slog.String("cache", c.name))
 	return c.data, nil
 }
 
@@ -75,5 +75,5 @@ func (c *Entry[T]) Invalidate() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.valid = false
-	slog.Info("Cache invalidated", "cache", c.name)
+	slog.Info("Cache invalidated", slog.String("cache", c.name))
 }

--- a/internal/service/common/clients/k8s/k8s.go
+++ b/internal/service/common/clients/k8s/k8s.go
@@ -165,8 +165,8 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object) err
 
 	if err := c.Get(ctx, key, existing); err != nil {
 		if errors.IsNotFound(err) { // Create if not found, otherwise return error
-			slog.InfoContext(ctx, "Creating a new resource", "gvk", obj.GetObjectKind().GroupVersionKind().String(),
-				"namespace", obj.GetNamespace(), "name", obj.GetName())
+			slog.InfoContext(ctx, "Creating a new resource", slog.String("gvk", obj.GetObjectKind().GroupVersionKind().String()),
+				slog.String("namespace", obj.GetNamespace()), slog.String("name", obj.GetName()))
 			return c.Create(ctx, obj) //nolint:wrapcheck
 		}
 		return fmt.Errorf("failed to get existing object: %w", err)
@@ -174,7 +174,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object) err
 
 	// Update existing object
 	obj.SetResourceVersion(existing.GetResourceVersion())
-	slog.InfoContext(ctx, "Updating an existing resource", "gvk", obj.GetObjectKind().GroupVersionKind().String(),
-		"namespace", obj.GetNamespace(), "name", obj.GetName())
+	slog.InfoContext(ctx, "Updating an existing resource", slog.String("gvk", obj.GetObjectKind().GroupVersionKind().String()),
+		slog.String("namespace", obj.GetNamespace()), slog.String("name", obj.GetName()))
 	return c.Update(ctx, obj) //nolint:wrapcheck
 }

--- a/internal/service/common/listener/pg_listener_manager.go
+++ b/internal/service/common/listener/pg_listener_manager.go
@@ -80,10 +80,10 @@ func (lm *Manager) listenChannel(ctx context.Context, channel string, handler No
 			// Wait before retrying to avoid busy-looping.
 			select {
 			case <-ctx.Done():
-				slog.InfoContext(ctx, "Listener is shutting down", "channel", channel)
+				slog.InfoContext(ctx, "Listener is shutting down", slog.String("channel", channel))
 				return
 			case <-time.After(time.Minute):
-				slog.ErrorContext(ctx, "failed to listen to pg channel, retrying", "channel", channel, "error", err)
+				slog.ErrorContext(ctx, "failed to listen to pg channel, retrying", slog.String("channel", channel), slog.Any("error", err))
 			}
 		}
 	}
@@ -101,16 +101,16 @@ func (lm *Manager) listenAndProcess(ctx context.Context, channel string, handler
 		return fmt.Errorf("failed to set up listener on %s: %w", channel, err)
 	}
 
-	slog.InfoContext(ctx, "Listening for notifications", "channel", channel)
+	slog.InfoContext(ctx, "Listening for notifications", slog.String("channel", channel))
 	for {
 		notification, err := conn.Conn().WaitForNotification(ctx)
 		if err != nil {
 			return fmt.Errorf("failed waiting for notification on %s: %w", channel, err)
 		}
-		slog.DebugContext(ctx, "Received notification from PG", "channel", channel, "payload", notification.Payload)
+		slog.DebugContext(ctx, "Received notification from PG", slog.String("channel", channel), slog.String("payload", notification.Payload))
 		// Process the notification payload using the registered handler.
 		if err := handler(ctx, notification); err != nil {
-			slog.ErrorContext(ctx, "Failed to process notification", "channel", channel, "error", err)
+			slog.ErrorContext(ctx, "Failed to process notification", slog.String("channel", channel), slog.Any("error", err))
 		}
 	}
 }
@@ -126,7 +126,7 @@ func (lm *Manager) startChannelCatchUp(ctx context.Context, channel string, inte
 			return
 		case <-ticker.C:
 			if err := catchUp(ctx); err != nil {
-				slog.ErrorContext(ctx, "Catch-up processing failed", "channel", channel, "error", err)
+				slog.ErrorContext(ctx, "Catch-up processing failed", slog.String("channel", channel), slog.Any("error", err))
 			}
 		}
 	}

--- a/internal/service/common/notifier/event.go
+++ b/internal/service/common/notifier/event.go
@@ -42,7 +42,7 @@ func sendNotification(ctx context.Context, client *http.Client, url string, even
 	}
 	defer func(Body io.ReadCloser) {
 		if err := Body.Close(); err != nil {
-			slog.ErrorContext(ctx, "failed to close response body", "error", err)
+			slog.ErrorContext(ctx, "failed to close response body", slog.Any("error", err))
 		}
 	}(response.Body)
 
@@ -59,7 +59,7 @@ func sendNotification(ctx context.Context, client *http.Client, url string, even
 func processEvent(ctx context.Context, logger *slog.Logger, client *http.Client,
 	completionChannel chan *SubscriptionJobComplete, event Notification, subscriptionID uuid.UUID, url string) {
 	logger.InfoContext(ctx, "processing data change event",
-		"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+		slog.String("notificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
 
 	_ = callUrl(ctx, logger, client, url, event)
 
@@ -82,37 +82,37 @@ func callUrl(ctx context.Context, logger *slog.Logger, client *http.Client, url 
 
 		if nonRetryErr := isRetryableError(err); nonRetryErr != nil {
 			msg := "error sending notification; non retryable error"
-			logger.ErrorContext(ctx, msg, "error", nonRetryErr,
-				"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+			logger.ErrorContext(ctx, msg, slog.Any("error", nonRetryErr),
+				slog.String("notificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
 			return fmt.Errorf("%s: %w", msg, err)
 		}
 
-		logger.WarnContext(ctx, "failed to send notification", "error", err,
-			"notificationID", event.NotificationID, "sequenceID", event.SequenceID, "delay", delay.String(), "attemptsRemaining", maxRetries-attempt-1)
+		logger.WarnContext(ctx, "failed to send notification", slog.Any("error", err),
+			slog.String("notificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID), slog.String("delay", delay.String()), slog.Int("attemptsRemaining", maxRetries-attempt-1))
 
 		if attempt < maxRetries-1 { // Skip delay for final attempt since no further retries will occur
 			select {
 			case <-ctx.Done():
 				logger.WarnContext(ctx, "context canceled while sending notification",
-					"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+					slog.String("notificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
 				break
 			case <-time.After(delay):
 				delay *= 2
 				logger.DebugContext(ctx, "retrying notification",
-					"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+					slog.String("notificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
 			}
 		}
 	}
 
 	if err != nil {
-		logger.ErrorContext(ctx, "error sending notification; retries exceeded", "error", err,
-			"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+		logger.ErrorContext(ctx, "error sending notification; retries exceeded", slog.Any("error", err),
+			slog.String("notificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
 		// TODO: If we were able to send this one then we are not likely to be able to send any
 		//  of the others so perhaps we should purge our queue, or enter a longer backoff period.
 		return fmt.Errorf("error sending notification; retries exceeded: %w", err)
 	} else {
 		logger.InfoContext(ctx, "notification sent",
-			"notificationID", event.NotificationID, "sequenceID", event.SequenceID)
+			slog.String("notificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
 	}
 
 	return nil

--- a/internal/service/common/notifier/notifier.go
+++ b/internal/service/common/notifier/notifier.go
@@ -118,16 +118,16 @@ func (n *Notifier) Run(ctx context.Context) error {
 		select {
 		case e := <-n.subscriptionJobCompleteChannel:
 			if err := n.handleSubscriptionJobCompleteEvent(ctx, e); err != nil {
-				slog.ErrorContext(ctx, "failed to handle subscription job complete event", "error", err)
+				slog.ErrorContext(ctx, "failed to handle subscription job complete event", slog.Any("error", err))
 			}
 		case e := <-n.notificationChannel:
 			if err := n.handleNotification(ctx, e); err != nil {
 				slog.ErrorContext(ctx, "failed to handle notification",
-					"NotificationID", e.NotificationID, "sequenceID", e.SequenceID, "error", err)
+					slog.String("NotificationID", e.NotificationID.String()), slog.Int("sequenceID", e.SequenceID), slog.Any("error", err))
 			}
 		case e := <-n.subscriptionChannel:
 			if err := n.handleSubscriptionEvent(ctx, e); err != nil {
-				slog.ErrorContext(ctx, "failed to handle subscription event", "error", err)
+				slog.ErrorContext(ctx, "failed to handle subscription event", slog.Any("error", err))
 			}
 		case <-ctx.Done():
 			n.shutdownWorkers()
@@ -177,7 +177,7 @@ func (n *Notifier) loadEvents(ctx context.Context) error {
 		}
 	}
 
-	slog.InfoContext(ctx, "loaded events", "count", len(notifications))
+	slog.InfoContext(ctx, "loaded events", slog.Int("count", len(notifications)))
 	return nil
 }
 
@@ -200,7 +200,7 @@ func (n *Notifier) loadSubscriptions(ctx context.Context) error {
 		go n.workers[subscriptionID].Run()
 	}
 
-	slog.InfoContext(ctx, "subscriptions loaded", "count", len(n.workers))
+	slog.InfoContext(ctx, "subscriptions loaded", slog.Int("count", len(n.workers)))
 
 	return nil
 }
@@ -216,14 +216,14 @@ func (n *Notifier) Notify(ctx context.Context, event *Notification) {
 
 // handleNotification handles an incoming notification
 func (n *Notifier) handleNotification(ctx context.Context, event *Notification) error {
-	slog.InfoContext(ctx, "handling notification", "NotificationID", event.NotificationID, "sequenceID", event.SequenceID)
+	slog.InfoContext(ctx, "handling notification", slog.String("NotificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
 
 	count := 0
 	for _, worker := range n.workers {
 		if n.subscriptionProvider.Matches(worker.subscription, event) {
 			clone, err := n.subscriptionProvider.Transform(worker.subscription, event)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to transform notification", "subscription", worker.subscription.SubscriptionID, "error", err)
+				slog.ErrorContext(ctx, "failed to transform notification", slog.String("subscription", worker.subscription.SubscriptionID.String()), slog.Any("error", err))
 				continue
 			}
 			worker.NewNotification(clone)
@@ -234,7 +234,7 @@ func (n *Notifier) handleNotification(ctx context.Context, event *Notification) 
 	if count == 0 {
 		// No subscriptions matched just delete the event
 		slog.DebugContext(ctx, "no matching subscriptions; deleting event",
-			"NotificationID", event.NotificationID, "sequenceID", event.SequenceID)
+			slog.String("NotificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
 		if err := n.notificationProvider.DeleteNotification(ctx, event.NotificationID); err != nil {
 			return fmt.Errorf("failed to delete notification: %w", err)
 		}
@@ -242,8 +242,8 @@ func (n *Notifier) handleNotification(ctx context.Context, event *Notification) 
 	}
 
 	slog.InfoContext(ctx, "notification dispatched",
-		"NotificationID", event.NotificationID, "sequenceID", event.SequenceID,
-		"subscribers", count)
+		slog.String("NotificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID),
+		slog.Int("subscribers", count))
 
 	return nil
 }
@@ -286,7 +286,7 @@ func (n *Notifier) releaseNotifications(ctx context.Context, events []*Notificat
 	for _, event := range events {
 		err := n.releaseNotification(ctx, event.NotificationID, event.SequenceID)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to release event", "error", err)
+			slog.ErrorContext(ctx, "failed to release event", slog.Any("error", err))
 		}
 	}
 }
@@ -294,13 +294,13 @@ func (n *Notifier) releaseNotifications(ctx context.Context, events []*Notificat
 // handleSubscriptionEvent handles an incoming subscription change event
 func (n *Notifier) handleSubscriptionEvent(ctx context.Context, event *SubscriptionEvent) error {
 	subscriptionID := event.Subscription.SubscriptionID
-	slog.InfoContext(ctx, "Handling subscription event", "removed", event.Removed, "subscription", event.Subscription)
+	slog.InfoContext(ctx, "Handling subscription event", slog.Bool("removed", event.Removed), slog.Any("subscription", event.Subscription))
 
 	if event.Removed {
 		// The subscription has been removed.  Cleanup any associated data.
 		worker, found := n.workers[subscriptionID]
 		if !found {
-			slog.DebugContext(ctx, "subscription worker not found", "subscriptionID", subscriptionID)
+			slog.DebugContext(ctx, "subscription worker not found", slog.String("subscriptionID", subscriptionID.String()))
 			return nil
 		}
 
@@ -319,14 +319,14 @@ func (n *Notifier) handleSubscriptionEvent(ctx context.Context, event *Subscript
 		go worker.Run()
 	}
 
-	slog.InfoContext(ctx, "subscription event handled", "workers", len(n.workers))
+	slog.InfoContext(ctx, "subscription event handled", slog.Int("workers", len(n.workers)))
 	return nil
 }
 
 // handleSubscriptionJobCompleteEvent handles a job completion event, removes the subscriber from the event job,
 func (n *Notifier) handleSubscriptionJobCompleteEvent(ctx context.Context, event *SubscriptionJobComplete) error {
 	slog.DebugContext(ctx, "handling subscription job complete event",
-		"NotificationID", event.notificationID, "subscriptionID", event.subscriptionID)
+		slog.String("NotificationID", event.notificationID.String()), slog.String("subscriptionID", event.subscriptionID.String()))
 
 	// Lookup the subscription worker for this event
 	if worker, found := n.workers[event.subscriptionID]; found {
@@ -338,7 +338,7 @@ func (n *Notifier) handleSubscriptionJobCompleteEvent(ctx context.Context, event
 		}
 	} else {
 		// Likely has been deleted and this is a race condition.
-		slog.DebugContext(ctx, "subscription worker not found", "subscriptionID", event.subscriptionID)
+		slog.DebugContext(ctx, "subscription worker not found", slog.String("subscriptionID", event.subscriptionID.String()))
 	}
 
 	return n.releaseNotification(ctx, event.notificationID, event.sequenceID)

--- a/internal/service/common/notifier/notifier_worker.go
+++ b/internal/service/common/notifier/notifier_worker.go
@@ -68,7 +68,7 @@ func NewSubscriptionWorker(ctx context.Context, clientProvider ClientProvider, s
 	}
 
 	// Use the default logger with subscription context pre-attached
-	logger := slog.Default().With("subscription", subscription.SubscriptionID)
+	logger := slog.Default().With(slog.String("subscription", subscription.SubscriptionID.String()))
 
 	workerCtx, cancel := context.WithCancel(ctx)
 	return &SubscriptionWorker{
@@ -88,7 +88,7 @@ func (w *SubscriptionWorker) NewNotification(notification *Notification) {
 	w.workMutex.Lock()
 	defer w.workMutex.Unlock()
 	w.workQueue = append(w.workQueue, notification)
-	w.logger.Debug("Notification enqueued to work queue", "size", len(w.workQueue))
+	w.logger.Debug("Notification enqueued to work queue", slog.Int("size", len(w.workQueue)))
 	if len(w.workQueue) == 1 {
 		// If this is the first entry in the queue, then kick the worker to process its queue; otherwise, let it finish
 		// processing the queue before kicking it again.
@@ -109,7 +109,7 @@ func (w *SubscriptionWorker) Shutdown() {
 
 // Run executes that main loop for the worker handling events as they arrive.
 func (w *SubscriptionWorker) Run() {
-	w.logger.Info("Subscription worker started", "callback", w.subscription.Callback)
+	w.logger.Info("Subscription worker started", slog.String("callback", w.subscription.Callback))
 
 	for {
 		select {
@@ -149,7 +149,7 @@ func (w *SubscriptionWorker) handleCurrentEventCompletion(e *SubscriptionJobComp
 		w.logger.Debug("No more events to process")
 		return
 	}
-	w.logger.Debug("Dequeued notification from work queue", "size", len(w.workQueue))
+	w.logger.Debug("Dequeued notification from work queue", slog.Int("size", len(w.workQueue)))
 
 	w.processNextEvent(w.ctx, w.workQueue[0])
 }

--- a/internal/service/common/repo/notifications.go
+++ b/internal/service/common/repo/notifications.go
@@ -53,7 +53,7 @@ func (p *NotificationStorageProvider) GetNotifications(ctx context.Context) ([]n
 func (p *NotificationStorageProvider) DeleteNotification(ctx context.Context, notificationID uuid.UUID) error {
 	// This event has been consumed by all subscriptions
 	slog.DebugContext(ctx, "notification sent to all subscribers; deleting",
-		"NotificationID", notificationID)
+		slog.String("NotificationID", notificationID.String()))
 
 	_, err := p.repository.DeleteDataChangeEvent(ctx, notificationID)
 	if err != nil {

--- a/internal/service/common/repo/repository.go
+++ b/internal/service/common/repo/repository.go
@@ -201,7 +201,7 @@ func updateHighWatermark(ctx context.Context, tx pgx.Tx, dataChangeEvents []comm
 		return fmt.Errorf("failed to execute queryUpdateHighWater: %w", err)
 	}
 
-	slog.DebugContext(ctx, "high-watermark", "from", highWatermark, "to", updateHighWatermark.LastEventID)
+	slog.DebugContext(ctx, "high-watermark", slog.Any("from", highWatermark), slog.Any("to", updateHighWatermark.LastEventID))
 
 	return nil
 }

--- a/internal/service/common/utils/config.go
+++ b/internal/service/common/utils/config.go
@@ -196,7 +196,7 @@ func (c *CommonServerConfig) CreateOAuthConfig(ctx context.Context) (*ctlrutils.
 			return nil, fmt.Errorf("failed to read CA bundle file '%s': %w", c.TLS.CABundleFile, err)
 		}
 		config.TLSConfig = &ctlrutils.TLSConfig{CaBundle: bytes}
-		slog.DebugContext(ctx, "using CA bundle", "path", c.TLS.CABundleFile)
+		slog.DebugContext(ctx, "using CA bundle", slog.String("path", c.TLS.CABundleFile))
 	}
 
 	if c.TLS.ClientCertFile != "" && c.TLS.ClientKeyFile != "" {
@@ -209,7 +209,7 @@ func (c *CommonServerConfig) CreateOAuthConfig(ctx context.Context) (*ctlrutils.
 			config.TLSConfig = &ctlrutils.TLSConfig{}
 		}
 		config.TLSConfig.ClientCert = dynamicClientCert
-		slog.DebugContext(ctx, "using TLS client config", "cert", c.TLS.ClientCertFile, ",key", c.TLS.ClientKeyFile)
+		slog.DebugContext(ctx, "using TLS client config", slog.String("cert", c.TLS.ClientCertFile), slog.String("key", c.TLS.ClientKeyFile))
 
 		// Run the controller so that it monitors for file changes
 		go dynamicClientCert.Run(ctx, 1)

--- a/internal/service/common/utils/persist.go
+++ b/internal/service/common/utils/persist.go
@@ -59,7 +59,7 @@ func PersistObject[T db.Model, K PrimaryKeyType](ctx context.Context, tx pgx.Tx,
 			return nil, nil, fmt.Errorf("failed to create object '%s/%v': %w", object.TableName(), key, err)
 		}
 
-		slog.DebugContext(ctx, "object inserted", "table", object.TableName(), "key", key, "record", after)
+		slog.DebugContext(ctx, "object inserted", slog.String("table", object.TableName()), slog.Any("key", key), slog.Any("record", after))
 		return nil, after, nil
 	}
 
@@ -75,7 +75,7 @@ func PersistObject[T db.Model, K PrimaryKeyType](ctx context.Context, tx pgx.Tx,
 	if len(tags) == 0 {
 		// This shouldn't happen since the generation id always changes
 		after = before
-		slog.WarnContext(ctx, "no change detected on persisted object", "table", object.TableName(), "key", key)
+		slog.WarnContext(ctx, "no change detected on persisted object", slog.String("table", object.TableName()), slog.Any("key", key))
 		return before, after, nil
 	}
 
@@ -85,7 +85,7 @@ func PersistObject[T db.Model, K PrimaryKeyType](ctx context.Context, tx pgx.Tx,
 	}
 
 	slog.DebugContext(ctx, "object updated",
-		"table", object.TableName(), "key", key, "before", before, "after", after, "columns", tags.Fields())
+		slog.String("table", object.TableName()), slog.Any("key", key), slog.Any("before", before), slog.Any("after", after), slog.Any("columns", tags.Fields()))
 
 	return before, after, nil
 }

--- a/internal/service/common/utils/repository.go
+++ b/internal/service/common/utils/repository.go
@@ -233,7 +233,7 @@ func Exists[T db.Model, K PrimaryKeyType](ctx context.Context, db DBQuery, key K
 		return false, fmt.Errorf("failed to build query: %w", err)
 	}
 
-	slog.DebugContext(ctx, "executing query", "sql", sql, "args", args)
+	slog.DebugContext(ctx, "executing query", slog.String("sql", sql), slog.Any("args", args))
 
 	var result bool
 	err = db.QueryRow(ctx, sql, args...).Scan(&result)
@@ -259,7 +259,7 @@ func ExecuteCollectExactlyOneRow[T db.Model](ctx context.Context, db DBQuery, sq
 	record, err = pgx.CollectExactlyOneRow(rows, pgx.RowToStructByNameLax[T])
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			slog.DebugContext(ctx, "no record found", "table", record.TableName())
+			slog.DebugContext(ctx, "no record found", slog.String("table", record.TableName()))
 			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("failed to execute query: %w", err)

--- a/internal/service/provisioning/cmd/serve.go
+++ b/internal/service/provisioning/cmd/serve.go
@@ -36,15 +36,15 @@ var provisioningServe = &cobra.Command{
 		klog.SetSlogLogger(logger)
 
 		if err := config.LoadFromEnv(); err != nil {
-			slog.Error("failed to load environment variables", "err", err)
+			slog.Error("failed to load environment variables", slog.Any("err", err))
 			os.Exit(1)
 		}
 		if err := config.Validate(); err != nil {
-			slog.Error("failed to validate common server configuration", "err", err)
+			slog.Error("failed to validate common server configuration", slog.Any("err", err))
 			os.Exit(1)
 		}
 		if err := provisioning.Serve(&config); err != nil {
-			slog.Error("failed to start provisioning server", "err", err)
+			slog.Error("failed to start provisioning server", slog.Any("err", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -63,7 +63,7 @@ func Serve(config *api.ProvisioningServerConfig) error {
 
 	go func() {
 		sig := <-shutdown
-		slog.InfoContext(ctx, "Shutdown signal received", "signal", sig)
+		slog.InfoContext(ctx, "Shutdown signal received", slog.Any("signal", sig))
 		cancel()
 	}()
 

--- a/internal/service/resources/api/server.go
+++ b/internal/service/resources/api/server.go
@@ -297,7 +297,7 @@ func (r *ResourceServer) GetSubscriptions(ctx context.Context, request api.GetSu
 // validateSubscription validates a subscription before accepting the request
 func (r *ResourceServer) validateSubscription(ctx context.Context, request api.CreateSubscriptionRequestObject) error {
 	if err := commonapi.ValidateCallbackURL(ctx, r.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback); err != nil {
-		slog.ErrorContext(ctx, "callback URL validation failed", "error", err)
+		slog.ErrorContext(ctx, "callback URL validation failed", slog.Any("error", err))
 		return fmt.Errorf("callback URL validation failed")
 	}
 
@@ -345,7 +345,7 @@ func (r *ResourceServer) CreateSubscription(ctx context.Context, request api.Cre
 				Status: http.StatusBadRequest,
 			}, nil
 		}
-		slog.ErrorContext(ctx, "error writing database record", "target", record, "error", err.Error())
+		slog.ErrorContext(ctx, "error writing database record", slog.Any("target", record), slog.String("error", err.Error()))
 		return api.CreateSubscription500ApplicationProblemPlusJSONResponse{
 			AdditionalAttributes: &map[string]string{
 				"consumerSubscriptionId": consumerSubscriptionId,

--- a/internal/service/resources/cmd/migrate.go
+++ b/internal/service/resources/cmd/migrate.go
@@ -22,7 +22,7 @@ var resourcesMigrate = &cobra.Command{
 	Long:  `This will run from k8s job before the server starts.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := resources.StartResourcesMigration(); err != nil {
-			slog.Error("failed to do migration", "err", err)
+			slog.Error("failed to do migration", slog.Any("err", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/resources/cmd/serve.go
+++ b/internal/service/resources/cmd/serve.go
@@ -39,15 +39,15 @@ var resourceServer = &cobra.Command{
 		klog.SetSlogLogger(logger)
 
 		if err := config.LoadFromEnv(); err != nil {
-			slog.Error("failed to load environment variables", "err", err)
+			slog.Error("failed to load environment variables", slog.Any("err", err))
 			os.Exit(1)
 		}
 		if err := config.Validate(); err != nil {
-			slog.Error("failed to validate common server configuration", "err", err)
+			slog.Error("failed to validate common server configuration", slog.Any("err", err))
 			os.Exit(1)
 		}
 		if err := resources.Serve(&config); err != nil {
-			slog.Error("failed to start resource server", "err", err)
+			slog.Error("failed to start resource server", slog.Any("err", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/resources/db/models/converters.go
+++ b/internal/service/resources/db/models/converters.go
@@ -174,7 +174,7 @@ func getEventType(before, after map[string]interface{}) int {
 	case before != nil:
 		return 2
 	default:
-		slog.Warn("unsupported event type", "before", before, "after", after)
+		slog.Warn("unsupported event type", slog.Any("before", before), slog.Any("after", after))
 		return -1
 	}
 }

--- a/internal/service/resources/listener/alarms_sync.go
+++ b/internal/service/resources/listener/alarms_sync.go
@@ -32,7 +32,7 @@ const (
 
 // syncAlarmDictionaryForResourceType syncs the alarm dictionary for a specific resource type
 func syncAlarmDictionaryForResourceType(ctx context.Context, repository *repo.ResourcesRepository, resourceTypeID uuid.UUID) error {
-	slog.InfoContext(ctx, "Syncing alarm dictionary for resource type", "resource_type_id", resourceTypeID)
+	slog.InfoContext(ctx, "Syncing alarm dictionary for resource type", slog.Any("resource_type_id", resourceTypeID))
 
 	// Get the resource type
 	resourceType, err := repository.GetResourceType(ctx, resourceTypeID)
@@ -40,7 +40,7 @@ func syncAlarmDictionaryForResourceType(ctx context.Context, repository *repo.Re
 		if errors.Is(err, svcutils.ErrNotFound) {
 			// Resource type was deleted, alarm dictionary will be cascade deleted
 			slog.InfoContext(ctx, "Resource type not found, skipping alarm dictionary sync",
-				"resource_type_id", resourceTypeID)
+				slog.Any("resource_type_id", resourceTypeID))
 			return nil
 		}
 		return fmt.Errorf("failed to get resource type: %w", err)
@@ -77,8 +77,8 @@ func syncAlarmDictionaryForResourceType(ctx context.Context, repository *repo.Re
 			return fmt.Errorf("failed to upsert alarm definitions: %w", err)
 		}
 
-		slog.InfoContext(ctx, "Successfully synced alarm dictionary", "resource_type_id",
-			resourceTypeID, "alarm_dict_id", result.AlarmDictionaryID, "definitions_count", len(alarmDefs))
+		slog.InfoContext(ctx, "Successfully synced alarm dictionary", slog.Any("resource_type_id",
+			resourceTypeID), slog.Any("alarm_dict_id", result.AlarmDictionaryID), slog.Int("definitions_count", len(alarmDefs)))
 		return nil
 	}); err != nil {
 		return fmt.Errorf("transaction failed: %w", err)
@@ -114,7 +114,7 @@ func getIronicPrometheusRules(ctx context.Context, cl client.Client) ([]monitori
 		}
 	}
 
-	slog.InfoContext(ctx, "Fetched hardware monitoring Prometheus rules", "count", len(rules))
+	slog.InfoContext(ctx, "Fetched hardware monitoring Prometheus rules", slog.Int("count", len(rules)))
 	return rules, nil
 }
 

--- a/internal/service/resources/listener/pg_listener.go
+++ b/internal/service/resources/listener/pg_listener.go
@@ -36,7 +36,7 @@ func ListenForResourcePgChannels(ctx context.Context, pool *pgxpool.Pool, reposi
 	// Sync existing ResourceTypes on startup to handle any that were created before listener started
 	// This prevents race condition where collector creates ResourceTypes before listener is ready
 	if err := syncExistingResourceTypes(ctx, repository); err != nil {
-		slog.ErrorContext(ctx, "Failed to sync existing resource types on startup", "error", err)
+		slog.ErrorContext(ctx, "Failed to sync existing resource types on startup", slog.Any("error", err))
 	}
 
 	// Initialize the generic listener manager
@@ -86,29 +86,29 @@ func processResourceTypeChangeNotification(ctx context.Context, repository *repo
 	}
 
 	slog.InfoContext(ctx, "Processing resource type change",
-		"resource_type_id", notification.ResourceTypeID,
-		"change_type", notification.ChangeType)
+		slog.Any("resource_type_id", notification.ResourceTypeID),
+		slog.Any("change_type", notification.ChangeType))
 
 	// Handle different change types
 	switch notification.ChangeType {
 	case "deleted":
 		// CASCADE delete in the database schema handles alarm dictionary cleanup
 		slog.InfoContext(ctx, "Resource type deleted, alarm dictionary will be cascade deleted",
-			"resource_type_id", notification.ResourceTypeID)
+			slog.Any("resource_type_id", notification.ResourceTypeID))
 		return nil
 
 	case "created", "updated":
 		// Sync alarm dictionary for this resource type
 		if err := syncAlarmDictionaryForResourceType(ctx, repository, notification.ResourceTypeID); err != nil {
 			slog.ErrorContext(ctx, "Failed to sync alarm dictionary for resource type",
-				"resource_type_id", notification.ResourceTypeID,
-				"error", err)
+				slog.Any("resource_type_id", notification.ResourceTypeID),
+				slog.Any("error", err))
 			return fmt.Errorf("failed to sync alarm dictionary: %w", err)
 		}
 		return nil
 
 	default:
-		slog.WarnContext(ctx, "Unknown resource type change type", "change_type", notification.ChangeType)
+		slog.WarnContext(ctx, "Unknown resource type change type", slog.Any("change_type", notification.ChangeType))
 		return nil
 	}
 }
@@ -123,17 +123,17 @@ func syncExistingResourceTypes(ctx context.Context, repository *repo.ResourcesRe
 		return fmt.Errorf("failed to get resource types: %w", err)
 	}
 
-	slog.DebugContext(ctx, "Found existing resource types", "count", len(resourceTypes))
+	slog.DebugContext(ctx, "Found existing resource types", slog.Int("count", len(resourceTypes)))
 
 	for _, rt := range resourceTypes {
 		if err := syncAlarmDictionaryForResourceType(ctx, repository, rt.ResourceTypeID); err != nil {
 			slog.ErrorContext(ctx, "Failed to sync alarm dictionary for existing resource type",
-				"resource_type_id", rt.ResourceTypeID,
-				"error", err)
+				slog.Any("resource_type_id", rt.ResourceTypeID),
+				slog.Any("error", err))
 			// Continue with other resource types even if one fails
 		}
 	}
 
-	slog.DebugContext(ctx, "Completed sync of existing resource types", "count", len(resourceTypes))
+	slog.DebugContext(ctx, "Completed sync of existing resource types", slog.Int("count", len(resourceTypes)))
 	return nil
 }

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -74,7 +74,7 @@ func Serve(config *api.ResourceServerConfig) error {
 
 	go func() {
 		sig := <-shutdown
-		slog.InfoContext(ctx, "Shutdown signal received", "signal", sig)
+		slog.InfoContext(ctx, "Shutdown signal received", slog.Any("signal", sig))
 		cancel()
 	}()
 
@@ -291,7 +291,7 @@ func Serve(config *api.ResourceServerConfig) error {
 		// Shutdown the http server
 		slog.InfoContext(ctx, "Shutting down server")
 		if err := common.GracefulShutdown(srv); err != nil {
-			slog.ErrorContext(ctx, "error shutting down server", "error", err)
+			slog.ErrorContext(ctx, "error shutting down server", slog.Any("error", err))
 		}
 	}()
 

--- a/internal/tool.go
+++ b/internal/tool.go
@@ -147,7 +147,7 @@ func (t *Tool) Run(ctx context.Context) error {
 	t.logger.InfoContext(
 		ctx,
 		"Command",
-		"args", t.args,
+		slog.Any("args", t.args),
 	)
 	t.cmd.SetArgs(t.args[1:])
 	err = t.cmd.ExecuteContext(ctx)


### PR DESCRIPTION
Replace untyped alternating key-value pairs with typed slog attribute constructors in controller manager setup, hardware manager, controllers, search parsers, common service packages, and remaining service files.