### PR TITLE
CNF-24707: enable sloglint attr-only rule and document convention

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,6 +122,7 @@ linters:
           disabled: false
     sloglint:
       context: scope
+      attr-only: true
     wrapcheck:
       ignore-sigs:
         - .Errorf(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,10 @@ issues during code review.
   `slog.ErrorContext(ctx, ...)`, etc.) whenever a `ctx` variable is in
   scope. The `sloglint` linter enforces this. Use `logging.AppendCtx()`
   to add structured attributes to the context at entry points.
+- Use typed slog attribute constructors (`slog.String("key", value)`,
+  `slog.Int(...)`, `slog.Any(...)`, etc.) instead of untyped
+  alternating key-value pairs (`"key", value`). The `sloglint`
+  `attr-only` rule enforces this at lint time.
 
 ## Test Conventions
 


### PR DESCRIPTION
Enable attr-only: true in sloglint config to enforce typed slog attribute constructors at lint time. Add guidance to AGENTS.md Logging Conventions.

This requires PRs #2786, #2787, and #2788 to be merged first, as these PRs address the untyped logs.