### PR TITLE
OCPBUGS-87974: fix non-hardware PR spec changes causing NAR configTransactionId mismatch

### DIFF
--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -112,9 +112,13 @@ func (t *provisioningRequestReconcilerTask) createOrUpdateNodeAllocationRequest(
 	}
 
 	// NAR exists — compare spec and update if changed.
-	// Carry over fields managed by the hardware manager to avoid false-positive change detection.
+	// Carry over fields not driven by the rendered NAR to avoid false-positive change detection.
 	nodeAllocationRequest.Spec.ClusterProvisioned = existingNAR.Spec.ClusterProvisioned
+	renderedConfigTransactionId := nodeAllocationRequest.Spec.ConfigTransactionId
+	nodeAllocationRequest.Spec.ConfigTransactionId = existingNAR.Spec.ConfigTransactionId
 	if !equality.Semantic.DeepEqual(existingNAR.Spec, nodeAllocationRequest.Spec) {
+		// Real NAR-relevant fields changed, restore the actual new ConfigTransactionId
+		nodeAllocationRequest.Spec.ConfigTransactionId = renderedConfigTransactionId
 		patch := client.MergeFrom(existingNAR.DeepCopy())
 		existingNAR.Spec = nodeAllocationRequest.Spec
 		if err := t.client.Patch(ctx, existingNAR, patch); err != nil {

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -674,7 +674,7 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 		Expect(createdNAR.Spec.ClusterId).To(Equal(crName))
 	})
 
-	It("updates existing NodeAllocationRequest when spec changes", func() {
+	It("updates existing NodeAllocationRequest when hardware-relevant fields change", func() {
 		// Create existing NAR CR
 		existingNAR := &hwmgmtv1alpha1.NodeAllocationRequest{
 			ObjectMeta: metav1.ObjectMeta{
@@ -682,8 +682,9 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 				Namespace: constants.DefaultNamespace,
 			},
 			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
-				ClusterId:    crName,
-				LocationSpec: hwmgmtv1alpha1.LocationSpec{Site: "test-site"},
+				ClusterId:           crName,
+				LocationSpec:        hwmgmtv1alpha1.LocationSpec{Site: "test-site"},
+				ConfigTransactionId: 2,
 				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
 					{
 						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
@@ -698,15 +699,19 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 		}
 		Expect(c.Create(ctx, existingNAR)).To(Succeed())
 
-		// New NAR with changed size
+		// Bump PR generation
+		cr.Generation = 4
+
+		// New NAR with changed size and new ConfigTransactionId
 		nodeAllocationRequest := &hwmgmtv1alpha1.NodeAllocationRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      cr.Name,
 				Namespace: constants.DefaultNamespace,
 			},
 			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
-				ClusterId:    crName,
-				LocationSpec: hwmgmtv1alpha1.LocationSpec{Site: "test-site"},
+				ClusterId:           crName,
+				LocationSpec:        hwmgmtv1alpha1.LocationSpec{Site: "test-site"},
+				ConfigTransactionId: 4,
 				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
 					{
 						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
@@ -722,6 +727,12 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 
 		err := task.createOrUpdateNodeAllocationRequest(ctx, ctNamespace, nodeAllocationRequest)
 		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the NAR was updated with new ConfigTransactionId
+		updatedNAR := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: constants.DefaultNamespace}, updatedNAR)).To(Succeed())
+		Expect(updatedNAR.Spec.ConfigTransactionId).To(Equal(int64(4)))
+		Expect(updatedNAR.Spec.NodeGroup[0].Size).To(Equal(2))
 	})
 
 	It("updates configuring timer when NAR spec changes", func() {
@@ -778,6 +789,67 @@ var _ = Describe("createOrUpdateNodeAllocationRequest", func() {
 		Expect(c.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: constants.DefaultNamespace}, updatedNAR)).To(Succeed())
 		Expect(updatedNAR.Spec.NodeGroup[0].NodeGroupData.HwProfile).To(Equal("profile-spr-single-processor-128G"))
 	})
+
+	It("does not update NAR when only ConfigTransactionId differs", func() {
+		// Existing NAR with ConfigTransactionId from a previous PR generation
+		existingNAR := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cr.Name,
+				Namespace: constants.DefaultNamespace,
+			},
+			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+				ClusterId:           crName,
+				LocationSpec:        hwmgmtv1alpha1.LocationSpec{Site: "test-site"},
+				ConfigTransactionId: 2,
+				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
+					{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+							Name:      "controller",
+							Role:      "master",
+							HwProfile: "profile-spr-single-processor-64G",
+						},
+						Size: 1,
+					},
+				},
+			},
+		}
+		Expect(c.Create(ctx, existingNAR)).To(Succeed())
+
+		// Bump PR generation to simulate a non-hardware spec change
+		cr.Generation = 4
+
+		// New NAR rendered with higher ConfigTransactionId but same hardware fields
+		nodeAllocationRequest := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cr.Name,
+				Namespace: constants.DefaultNamespace,
+			},
+			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+				ClusterId:           crName,
+				LocationSpec:        hwmgmtv1alpha1.LocationSpec{Site: "test-site"},
+				ConfigTransactionId: 4, // Different due to PR generation bump
+				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
+					{
+						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+							Name:      "controller",
+							Role:      "master",
+							HwProfile: "profile-spr-single-processor-64G",
+						},
+						Size: 1,
+					},
+				},
+			},
+		}
+
+		err := task.createOrUpdateNodeAllocationRequest(ctx, ctNamespace, nodeAllocationRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the NAR was NOT updated — ConfigTransactionId should remain at 2
+		updatedNAR := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: constants.DefaultNamespace}, updatedNAR)).To(Succeed())
+		Expect(updatedNAR.Spec.ConfigTransactionId).To(Equal(int64(2)))
+	})
+
 })
 
 var _ = Describe("buildNodeAllocationRequest", func() {

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -338,9 +338,9 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestSpecChanged
 	// skipCleanup or clusterProvisioned was updated), acknowledge the spec change and skip.
 	if !hwProfileChanged && !configInProgress {
 		r.Logger.InfoContext(ctx, "No HW profile changes detected, acknowledging spec change")
-		if err := hwmgrutils.UpdateNodeAllocationRequestObservedGeneration(ctx, r.Client, nodeAllocationRequest); err != nil {
+		if err := hwmgrutils.UpdateNodeAllocationRequestObservedStatus(ctx, r.Client, nodeAllocationRequest); err != nil {
 			return hwmgrutils.RequeueWithShortInterval(),
-				fmt.Errorf("failed to update observedGeneration: %w", err)
+				fmt.Errorf("failed to acknowledge spec change: %w", err)
 		}
 		return hwmgrutils.DoNotRequeue(), nil
 	}

--- a/internal/hardwaremanager/utils/node_allocation_request.go
+++ b/internal/hardwaremanager/utils/node_allocation_request.go
@@ -83,6 +83,34 @@ func UpdateNodeAllocationRequestObservedGeneration(
 	return nil
 }
 
+// UpdateNodeAllocationRequestObservedStatus acknowledges all spec changes by updating
+// both ObservedGeneration and ObservedConfigTransactionId in a single status update.
+func UpdateNodeAllocationRequestObservedStatus(
+	ctx context.Context,
+	c client.Client,
+	nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest) error {
+
+	// nolint: wrapcheck
+	err := ctlrutils.RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
+		newNodeAllocationRequest := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(nodeAllocationRequest), newNodeAllocationRequest); err != nil {
+			return err
+		}
+		newNodeAllocationRequest.Status.ObservedGeneration = newNodeAllocationRequest.ObjectMeta.Generation
+		newNodeAllocationRequest.Status.ObservedConfigTransactionId = newNodeAllocationRequest.Spec.ConfigTransactionId
+		if err := c.Status().Update(ctx, newNodeAllocationRequest); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to update NodeAllocationRequest observed generation and transaction id: %w", err)
+	}
+
+	return nil
+}
+
 func UpdateNodeAllocationRequestStatusCondition(
 	ctx context.Context,
 	c client.Client,

--- a/internal/hardwaremanager/utils/node_allocation_request_test.go
+++ b/internal/hardwaremanager/utils/node_allocation_request_test.go
@@ -1,0 +1,65 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+)
+
+var _ = Describe("UpdateNodeAllocationRequestObservedStatus", func() {
+	var (
+		ctx context.Context
+		c   client.Client
+		nar *hwmgmtv1alpha1.NodeAllocationRequest
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme := runtime.NewScheme()
+		Expect(hwmgmtv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		nar = &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-nar",
+				Namespace:  "default",
+				Generation: 5,
+			},
+			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+				ConfigTransactionId: 4,
+			},
+			Status: hwmgmtv1alpha1.NodeAllocationRequestStatus{
+				ObservedGeneration:          3,
+				ObservedConfigTransactionId: 2,
+			},
+		}
+
+		c = fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(nar).
+			WithStatusSubresource(nar).
+			Build()
+	})
+
+	It("should update both ObservedGeneration and ObservedConfigTransactionId", func() {
+		err := UpdateNodeAllocationRequestObservedStatus(ctx, c, nar)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(nar), updated)).To(Succeed())
+		Expect(updated.Status.ObservedGeneration).To(Equal(updated.ObjectMeta.Generation))
+		Expect(updated.Status.ObservedConfigTransactionId).To(Equal(int64(4)))
+	})
+})


### PR DESCRIPTION
After a day-2 hardware firmware update completes (NAR Configured condition is present), subsequent non-hardware ProvisioningRequest spec changes (e.g., clusterInstance parameters) caused the PR to get stuck in "Hardware provisioning completed: Created". ConfigTransactionId, derived from PR.generation, was bumped on every spec change and included in the NAR spec comparison, triggering a NAR update even with no hardware-relevant changes. The NAR controller acknowledged ObservedGeneration but not ObservedConfigTransactionId when no HW profile changes were detected, causing the PR controller's stale guard to block indefinitely.

Exclude ConfigTransactionId from the NAR spec DeepEqual comparison so only hardware-relevant field changes trigger a NAR update. Add UpdateNodeAllocationRequestObservedStatus helper that acknowledges both ObservedGeneration and ObservedConfigTransactionId, and use it in the no-HW-profile-changes path.