### PR TITLE
CNF-24950: Block cross-host redirects on notifier HTTP clients

### DIFF
--- a/.coverage-thresholds.yaml
+++ b/.coverage-thresholds.yaml
@@ -28,6 +28,7 @@ packages:
   internal/service/common/api/middleware: 31
   internal/service/common/async: 48
   internal/service/common/auth: 29
+  internal/service/common/notifier: 70
   internal/service/common/utils: 12
   internal/service/provisioning/api: 66
   internal/service/resources/api: 87

--- a/internal/service/common/notifier/event_test.go
+++ b/internal/service/common/notifier/event_test.go
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Red Hat
+//
+// SPDX-License-Identifier: Apache-2.0
+package notifier
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"syscall"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("sendNotification", func() {
+	var (
+		ctx    context.Context
+		server *httptest.Server
+	)
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	It("sends a JSON POST and succeeds on 204", func() {
+		var receivedBody map[string]interface{}
+		var receivedContentType string
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedContentType = r.Header.Get("Content-Type")
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &receivedBody)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+
+		event := Notification{
+			NotificationID: uuid.New(),
+			SequenceID:     1,
+			Payload:        map[string]string{"key": "value"},
+		}
+		ctx = context.Background()
+		err := sendNotification(ctx, server.Client(), server.URL, event)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(receivedContentType).To(Equal("application/json"))
+		Expect(receivedBody).To(HaveKeyWithValue("key", "value"))
+	})
+
+	It("succeeds on 200", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		ctx = context.Background()
+		err := sendNotification(ctx, server.Client(), server.URL, Notification{Payload: "test"})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("fails on status > 204", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+
+		ctx = context.Background()
+		err := sendNotification(ctx, server.Client(), server.URL, Notification{Payload: "test"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("notification failed"))
+	})
+
+	It("fails on connection error", func() {
+		ctx = context.Background()
+		err := sendNotification(ctx, http.DefaultClient, "http://127.0.0.1:1/bad", Notification{Payload: "test"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to send notification"))
+	})
+})
+
+var _ = Describe("isRetryableError", func() {
+	It("returns nil for retryable errors", func() {
+		err := fmt.Errorf("some transient error")
+		Expect(isRetryableError(err)).To(BeNil())
+	})
+
+	It("returns non-nil for DNS not found", func() {
+		dnsErr := &net.DNSError{
+			Err:        "no such host",
+			Name:       "nonexistent.example.com",
+			IsNotFound: true,
+		}
+		Expect(isRetryableError(dnsErr)).ToNot(BeNil())
+		Expect(isRetryableError(dnsErr).Error()).To(ContainSubstring("host not found"))
+	})
+
+	It("returns non-nil for connection refused", func() {
+		err := fmt.Errorf("dial: %w", syscall.ECONNREFUSED)
+		Expect(isRetryableError(err)).ToNot(BeNil())
+		Expect(isRetryableError(err).Error()).To(ContainSubstring("connection refused"))
+	})
+
+	It("treats DNS temporary errors as retryable", func() {
+		dnsErr := &net.DNSError{
+			Err:         "temporary failure",
+			Name:        "example.com",
+			IsNotFound:  false,
+			IsTemporary: true,
+		}
+		Expect(isRetryableError(dnsErr)).To(BeNil())
+	})
+})
+
+var _ = Describe("processEvent", func() {
+	It("sends notification and reports completion", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		ctx := context.Background()
+		completionCh := make(chan *SubscriptionJobComplete, 1)
+		subID := uuid.New()
+		notifID := uuid.New()
+
+		event := Notification{
+			NotificationID: notifID,
+			SequenceID:     42,
+			Payload:        "test",
+		}
+
+		processEvent(ctx, slog.Default(), server.Client(), completionCh, event, subID, server.URL)
+
+		var result *SubscriptionJobComplete
+		Eventually(completionCh).Should(Receive(&result))
+		Expect(result.subscriptionID).To(Equal(subID))
+		Expect(result.notificationID).To(Equal(notifID))
+		Expect(result.sequenceID).To(Equal(42))
+	})
+})

--- a/internal/service/common/notifier/notifier_test.go
+++ b/internal/service/common/notifier/notifier_test.go
@@ -1,0 +1,346 @@
+// SPDX-FileCopyrightText: Red Hat
+//
+// SPDX-License-Identifier: Apache-2.0
+package notifier
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	commonapi "github.com/openshift-kni/oran-o2ims/api/common"
+)
+
+type stubClientProvider struct {
+	client *http.Client
+}
+
+func (s *stubClientProvider) NewClient(_ context.Context, _ commonapi.AuthType) (*http.Client, error) {
+	return s.client, nil
+}
+
+type stubSubscriptionProvider struct {
+	subscriptions []SubscriptionInfo
+	matchAll      bool
+	updated       []*SubscriptionInfo
+	mu            sync.Mutex
+}
+
+func (s *stubSubscriptionProvider) GetSubscriptions(_ context.Context) ([]SubscriptionInfo, error) {
+	return s.subscriptions, nil
+}
+
+func (s *stubSubscriptionProvider) Matches(_ *SubscriptionInfo, _ *Notification) bool {
+	return s.matchAll
+}
+
+func (s *stubSubscriptionProvider) UpdateSubscription(_ context.Context, sub *SubscriptionInfo) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.updated = append(s.updated, sub)
+	return nil
+}
+
+func (s *stubSubscriptionProvider) Transform(_ *SubscriptionInfo, notification *Notification) (*Notification, error) {
+	return notification, nil
+}
+
+type stubNotificationProvider struct {
+	notifications []Notification
+	deleted       []uuid.UUID
+	mu            sync.Mutex
+}
+
+func (s *stubNotificationProvider) GetNotifications(_ context.Context) ([]Notification, error) {
+	return s.notifications, nil
+}
+
+func (s *stubNotificationProvider) DeleteNotification(_ context.Context, id uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deleted = append(s.deleted, id)
+	return nil
+}
+
+var _ = Describe("NewNotifier", func() {
+	It("creates a notifier with non-nil channels and worker map", func() {
+		n := NewNotifier(&stubSubscriptionProvider{}, &stubNotificationProvider{}, &stubClientProvider{client: http.DefaultClient})
+		Expect(n).ToNot(BeNil())
+		Expect(n.workers).ToNot(BeNil())
+		Expect(n.notificationChannel).ToNot(BeNil())
+		Expect(n.subscriptionChannel).ToNot(BeNil())
+	})
+})
+
+var _ = Describe("GetClientFactory", func() {
+	It("returns the client provider", func() {
+		cp := &stubClientProvider{client: http.DefaultClient}
+		n := NewNotifier(&stubSubscriptionProvider{}, &stubNotificationProvider{}, cp)
+		Expect(n.GetClientFactory()).To(Equal(cp))
+	})
+})
+
+var _ = Describe("handleSubscriptionEvent", func() {
+	It("adds a worker for a new subscription", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		n := NewNotifier(
+			&stubSubscriptionProvider{},
+			&stubNotificationProvider{},
+			&stubClientProvider{client: server.Client()},
+		)
+
+		subID := uuid.New()
+		ctx := context.Background()
+		err := n.handleSubscriptionEvent(ctx, &SubscriptionEvent{
+			Removed: false,
+			Subscription: &SubscriptionInfo{
+				SubscriptionID: subID,
+				Callback:       server.URL + "/cb",
+			},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n.workers).To(HaveKey(subID))
+		n.workers[subID].Shutdown()
+	})
+
+	It("removes a worker for a deleted subscription", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		n := NewNotifier(
+			&stubSubscriptionProvider{},
+			&stubNotificationProvider{},
+			&stubClientProvider{client: server.Client()},
+		)
+
+		subID := uuid.New()
+		ctx := context.Background()
+		_ = n.handleSubscriptionEvent(ctx, &SubscriptionEvent{
+			Removed: false,
+			Subscription: &SubscriptionInfo{
+				SubscriptionID: subID,
+				Callback:       server.URL + "/cb",
+			},
+		})
+		Expect(n.workers).To(HaveKey(subID))
+
+		err := n.handleSubscriptionEvent(ctx, &SubscriptionEvent{
+			Removed: true,
+			Subscription: &SubscriptionInfo{
+				SubscriptionID: subID,
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n.workers).ToNot(HaveKey(subID))
+	})
+
+	It("handles removing a non-existent subscription gracefully", func() {
+		n := NewNotifier(
+			&stubSubscriptionProvider{},
+			&stubNotificationProvider{},
+			&stubClientProvider{client: http.DefaultClient},
+		)
+
+		ctx := context.Background()
+		err := n.handleSubscriptionEvent(ctx, &SubscriptionEvent{
+			Removed: true,
+			Subscription: &SubscriptionInfo{
+				SubscriptionID: uuid.New(),
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("handleNotification", func() {
+	It("deletes notification when no subscriptions match", func() {
+		notifProvider := &stubNotificationProvider{}
+		n := NewNotifier(
+			&stubSubscriptionProvider{matchAll: false},
+			notifProvider,
+			&stubClientProvider{client: http.DefaultClient},
+		)
+
+		ctx := context.Background()
+		notifID := uuid.New()
+		err := n.handleNotification(ctx, &Notification{
+			NotificationID: notifID,
+			SequenceID:     1,
+			Payload:        "test",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(notifProvider.deleted).To(ContainElement(notifID))
+	})
+})
+
+var _ = Describe("NewSubscriptionWorker", func() {
+	It("creates a worker with the correct subscription", func() {
+		ctx := context.Background()
+		completionCh := make(chan *SubscriptionJobComplete, 1)
+		sub := &SubscriptionInfo{
+			SubscriptionID: uuid.New(),
+			Callback:       "https://svc.ns.svc.cluster.local/cb",
+		}
+
+		worker, err := NewSubscriptionWorker(ctx, &stubClientProvider{client: http.DefaultClient}, completionCh, sub)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(worker).ToNot(BeNil())
+		Expect(worker.subscription).To(Equal(sub))
+		worker.Shutdown()
+	})
+})
+
+var _ = Describe("SubscriptionWorker", func() {
+	It("processes notifications and reports completion", func() {
+		var mu sync.Mutex
+		received := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			received++
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		completionCh := make(chan *SubscriptionJobComplete, 10)
+		sub := &SubscriptionInfo{
+			SubscriptionID: uuid.New(),
+			Callback:       server.URL + "/cb",
+		}
+
+		worker, err := NewSubscriptionWorker(ctx, &stubClientProvider{client: server.Client()}, completionCh, sub)
+		Expect(err).ToNot(HaveOccurred())
+
+		go worker.Run()
+
+		notifID := uuid.New()
+		worker.NewNotification(&Notification{
+			NotificationID: notifID,
+			SequenceID:     1,
+			Payload:        map[string]string{"test": "data"},
+		})
+
+		var result *SubscriptionJobComplete
+		Eventually(completionCh, 5*time.Second).Should(Receive(&result))
+		Expect(result.notificationID).To(Equal(notifID))
+		Expect(result.sequenceID).To(Equal(1))
+
+		mu.Lock()
+		Expect(received).To(Equal(1))
+		mu.Unlock()
+
+		worker.Shutdown()
+	})
+
+	It("queues multiple notifications", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		completionCh := make(chan *SubscriptionJobComplete, 10)
+		sub := &SubscriptionInfo{
+			SubscriptionID: uuid.New(),
+			Callback:       server.URL + "/cb",
+		}
+
+		worker, err := NewSubscriptionWorker(ctx, &stubClientProvider{client: server.Client()}, completionCh, sub)
+		Expect(err).ToNot(HaveOccurred())
+
+		go worker.Run()
+
+		for i := 0; i < 3; i++ {
+			worker.NewNotification(&Notification{
+				NotificationID: uuid.New(),
+				SequenceID:     i + 1,
+				Payload:        fmt.Sprintf("event-%d", i),
+			})
+		}
+
+		for i := 0; i < 3; i++ {
+			Eventually(completionCh, 5*time.Second).Should(Receive())
+		}
+
+		worker.Shutdown()
+	})
+})
+
+var _ = Describe("Notifier integration", func() {
+	It("runs, loads subscriptions, dispatches and completes notifications", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		subID := uuid.New()
+		notifID := uuid.New()
+
+		subProvider := &stubSubscriptionProvider{
+			matchAll: true,
+			subscriptions: []SubscriptionInfo{
+				{
+					SubscriptionID: subID,
+					Callback:       server.URL + "/cb",
+					EventCursor:    0,
+				},
+			},
+		}
+		notifProvider := &stubNotificationProvider{
+			notifications: []Notification{
+				{
+					NotificationID: notifID,
+					SequenceID:     1,
+					Payload:        "initial-event",
+				},
+			},
+		}
+
+		n := NewNotifier(subProvider, notifProvider, &stubClientProvider{client: server.Client()})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+
+		go func() {
+			_ = n.Run(ctx)
+			close(done)
+		}()
+
+		Eventually(func() []uuid.UUID {
+			notifProvider.mu.Lock()
+			defer notifProvider.mu.Unlock()
+			return notifProvider.deleted
+		}, 10*time.Second, 100*time.Millisecond).Should(ContainElement(notifID))
+
+		cancel()
+		Eventually(done, 2*time.Second).Should(BeClosed())
+	})
+})
+
+// Verify the internal suite_test.go bootstrap still works alongside internal tests.
+// The suite_test.go is package notifier_test, these are package notifier — Go allows both.
+var _ = Describe("slog default", func() {
+	It("is available for notifier logging", func() {
+		Expect(slog.Default()).ToNot(BeNil())
+	})
+})

--- a/internal/service/common/notifier/provider.go
+++ b/internal/service/common/notifier/provider.go
@@ -9,6 +9,7 @@ package notifier
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -19,6 +20,28 @@ import (
 	commonapi "github.com/openshift-kni/oran-o2ims/api/common"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
+
+// ErrCrossHostRedirect is returned when an HTTP redirect targets a different host.
+var ErrCrossHostRedirect = errors.New("cross-host redirect blocked")
+
+// BlockCrossHostRedirects sets a CheckRedirect policy that prevents the client from following
+// redirects to a different host or port, which would leak credentials to untrusted endpoints.
+func BlockCrossHostRedirects(client *http.Client) {
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) == 0 {
+			return nil
+		}
+		originalHost := via[0].URL.Host
+		redirectHost := req.URL.Host
+		if redirectHost != originalHost {
+			return fmt.Errorf("%w: %s -> %s", ErrCrossHostRedirect, originalHost, redirectHost)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+}
 
 // ClientFactory is a utility used to abstract building an HTTP client based on the type of callback
 // URL supplied.
@@ -50,7 +73,9 @@ func (f *ClientFactory) newClusterClient(ctx context.Context) (*http.Client, err
 		Timeout: 30 * time.Second,
 	}
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, baseClient)
-	return oauth2.NewClient(ctx, transport.NewCachedFileTokenSource(f.serviceTokenFile)), nil
+	client := oauth2.NewClient(ctx, transport.NewCachedFileTokenSource(f.serviceTokenFile))
+	BlockCrossHostRedirects(client)
+	return client, nil
 }
 
 func (f *ClientFactory) newOAuthClient(ctx context.Context) (*http.Client, error) {
@@ -58,6 +83,7 @@ func (f *ClientFactory) newOAuthClient(ctx context.Context) (*http.Client, error
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup oauth client")
 	}
+	BlockCrossHostRedirects(client)
 	return client, nil
 }
 

--- a/internal/service/common/notifier/provider_test.go
+++ b/internal/service/common/notifier/provider_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Red Hat
+//
+// SPDX-License-Identifier: Apache-2.0
+package notifier_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
+)
+
+var _ = Describe("blockCrossHostRedirects", func() {
+	It("should follow same-host redirects", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/redirect" {
+				http.Redirect(w, r, "/target", http.StatusFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client := server.Client()
+		notifier.BlockCrossHostRedirects(client)
+
+		resp, err := client.Get(server.URL + "/redirect")
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	})
+
+	It("should block cross-host redirects", func() {
+		externalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer externalServer.Close()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, externalServer.URL+"/steal", http.StatusFound)
+		}))
+		defer server.Close()
+
+		client := server.Client()
+		notifier.BlockCrossHostRedirects(client)
+
+		_, err := client.Get(server.URL + "/start")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cross-host redirect blocked"))
+	})
+})

--- a/internal/service/common/notifier/suite_test.go
+++ b/internal/service/common/notifier/suite_test.go
@@ -1,0 +1,19 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package notifier_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNotifier(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common/Notifier")
+}


### PR DESCRIPTION
The notifier's HTTP clients (both ServiceAccount and OAuth) did not set CheckRedirect, allowing Go's default 10-redirect chain to potentially pass our request to an unintended recipient. Add BlockCrossHostRedirects which rejects any redirect to a different host:port than the original request.