### PR TITLE
CNF-24945: Add NetworkPolicy to restrict pod ingress traffic

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1764,7 +1764,6 @@ spec:
           - networking.k8s.io
           resources:
           - ingresses
-          - networkpolicies
           verbs:
           - create
           - delete
@@ -2245,6 +2244,18 @@ spec:
           verbs:
           - create
           - patch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: oran-o2ims-controller-manager
     strategy: deployment
   installModes:

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1764,6 +1764,7 @@ spec:
           - networking.k8s.io
           resources:
           - ingresses
+          - networkpolicies
           verbs:
           - create
           - delete

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -23,6 +23,8 @@ resources:
 - clusterrolebindings_services.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- networkpolicy_role.yaml
+- networkpolicy_role_binding.yaml
 - metrics_service.yaml
 - metrics_service_clusterrole.yaml
 # Pre-canned roles to allow binding to users that require specific access to our API endpoints

--- a/config/rbac/networkpolicy_role.yaml
+++ b/config/rbac/networkpolicy_role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: networkpolicy-manager-role
+  namespace: system
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/networkpolicy_role_binding.yaml
+++ b/config/rbac/networkpolicy_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: networkpolicy-manager-rolebinding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: networkpolicy-manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -275,7 +275,6 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
-  - networkpolicies
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -275,6 +275,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - create
   - delete

--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -24,10 +24,13 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/klog/v2"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -197,8 +200,19 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		})
 	}
 
+	operatorNamespace := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&networkingv1.NetworkPolicy{}: {
+					Namespaces: map[string]cache.Config{
+						operatorNamespace: {},
+					},
+				},
+			},
+		},
 		Metrics: metricsserver.Options{
 			SecureServing:  c.metricsCertDir != "",
 			CertDir:        c.metricsCertDir,

--- a/internal/controllers/hardwaremanager_setup.go
+++ b/internal/controllers/hardwaremanager_setup.go
@@ -28,6 +28,12 @@ func (t *reconcilerTask) setupHardwareManager(ctx context.Context, defaultResult
 		return
 	}
 
+	if err = t.createNetworkPolicy(ctx, ctlrutils.HardwareManagerServerName, constants.DefaultServicePort, ExternalIngress); err != nil {
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for hardware manager server.",
+			slog.String("error", err.Error()))
+		return
+	}
+
 	errorReason, err := t.deployServer(ctx, ctlrutils.HardwareManagerServerName)
 	if err != nil {
 		t.logger.ErrorContext(ctx, "Failed to deploy the hardware manager server.",

--- a/internal/controllers/hardwaremanager_setup.go
+++ b/internal/controllers/hardwaremanager_setup.go
@@ -30,7 +30,7 @@ func (t *reconcilerTask) setupHardwareManager(ctx context.Context, defaultResult
 
 	if err = t.createNetworkPolicy(ctx, ctlrutils.HardwareManagerServerName, constants.DefaultServicePort, ExternalIngress); err != nil {
 		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for hardware manager server.",
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		return
 	}
 

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -198,7 +198,7 @@ func (t *reconcilerTask) setupResourceServerConfig(ctx context.Context, defaultR
 
 	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryResourceServerName, constants.DefaultServicePort, ExternalIngress)
 	if err != nil {
-		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for Resource server.", slog.String("error", err.Error()))
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for Resource server.", slog.Any("error", err))
 		return
 	}
 
@@ -236,7 +236,7 @@ func (t *reconcilerTask) setupClusterServerConfig(ctx context.Context, defaultRe
 
 	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryClusterServerName, constants.DefaultServicePort, ExternalIngress)
 	if err != nil {
-		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for cluster server.", slog.String("error", err.Error()))
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for cluster server.", slog.Any("error", err))
 		return
 	}
 
@@ -274,7 +274,7 @@ func (t *reconcilerTask) setupArtifactsServerConfig(ctx context.Context, default
 
 	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryArtifactsServerName, constants.DefaultServicePort, ExternalIngress)
 	if err != nil {
-		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for Artifacts server.", slog.String("error", err.Error()))
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for Artifacts server.", slog.Any("error", err))
 		return
 	}
 
@@ -334,7 +334,7 @@ func (t *reconcilerTask) setupAlarmServerConfig(ctx context.Context, defaultResu
 	}
 	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryAlarmServerName, constants.DefaultServicePort, ExternalIngress, alertmanagerIngress)
 	if err != nil {
-		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for alarm server.", slog.String("error", err.Error()))
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for alarm server.", slog.Any("error", err))
 		return
 	}
 
@@ -371,7 +371,7 @@ func (t *reconcilerTask) setupProvisioningServerConfig(ctx context.Context, defa
 
 	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryProvisioningServerName, constants.DefaultServicePort, ExternalIngress)
 	if err != nil {
-		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for provisioning server.", slog.String("error", err.Error()))
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for provisioning server.", slog.Any("error", err))
 		return
 	}
 

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -51,7 +51,6 @@ import (
 //+kubebuilder:rbac:groups=ocloud.openshift.io,resources=inventories/finalizers,verbs=update
 //+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -51,6 +51,7 @@ import (
 //+kubebuilder:rbac:groups=ocloud.openshift.io,resources=inventories/finalizers,verbs=update
 //+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
@@ -196,6 +197,12 @@ func (t *reconcilerTask) setupResourceServerConfig(ctx context.Context, defaultR
 		return
 	}
 
+	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryResourceServerName, constants.DefaultServicePort, ExternalIngress)
+	if err != nil {
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for Resource server.", slog.String("error", err.Error()))
+		return
+	}
+
 	// Create the resource-server deployment.
 	errorReason, err := t.deployServer(ctx, ctlrutils.InventoryResourceServerName)
 	if err != nil {
@@ -225,6 +232,12 @@ func (t *reconcilerTask) setupClusterServerConfig(ctx context.Context, defaultRe
 			"Failed to deploy Service for cluster server.",
 			slog.Any("error", err),
 		)
+		return
+	}
+
+	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryClusterServerName, constants.DefaultServicePort, ExternalIngress)
+	if err != nil {
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for cluster server.", slog.String("error", err.Error()))
 		return
 	}
 
@@ -260,6 +273,12 @@ func (t *reconcilerTask) setupArtifactsServerConfig(ctx context.Context, default
 		return
 	}
 
+	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryArtifactsServerName, constants.DefaultServicePort, ExternalIngress)
+	if err != nil {
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for Artifacts server.", slog.String("error", err.Error()))
+		return
+	}
+
 	// Create the artifacts-server deployment.
 	errorReason, err := t.deployServer(ctx, ctlrutils.InventoryArtifactsServerName)
 	if err != nil {
@@ -292,6 +311,34 @@ func (t *reconcilerTask) setupAlarmServerConfig(ctx context.Context, defaultResu
 		return
 	}
 
+	// The alarm server additionally accepts webhook POSTs from alertmanager.
+	alertmanagerPort := intstr.FromInt32(constants.DefaultServicePort)
+	alertmanagerProtocol := corev1.ProtocolTCP
+	alertmanagerIngress := networkingv1.NetworkPolicyIngressRule{
+		From: []networkingv1.NetworkPolicyPeer{
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"kubernetes.io/metadata.name": ctlrutils.OpenClusterManagementObservabilityNamespace,
+					},
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						ctlrutils.AlertmanagerObjectName: "observability",
+					},
+				},
+			},
+		},
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &alertmanagerProtocol, Port: &alertmanagerPort},
+		},
+	}
+	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryAlarmServerName, constants.DefaultServicePort, ExternalIngress, alertmanagerIngress)
+	if err != nil {
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for alarm server.", slog.String("error", err.Error()))
+		return
+	}
+
 	// Create the alarm-server deployment.
 	errorReason, err := t.deployServer(ctx, ctlrutils.InventoryAlarmServerName)
 	if err != nil {
@@ -320,6 +367,12 @@ func (t *reconcilerTask) setupProvisioningServerConfig(ctx context.Context, defa
 			"Failed to deploy Service for the provisioning server.",
 			slog.Any("error", err),
 		)
+		return
+	}
+
+	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryProvisioningServerName, constants.DefaultServicePort, ExternalIngress)
+	if err != nil {
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for provisioning server.", slog.String("error", err.Error()))
 		return
 	}
 
@@ -923,6 +976,83 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (c
 	}
 
 	return "", nil
+}
+
+// NetworkPolicyScope controls whether a NetworkPolicy permits external ingress traffic.
+type NetworkPolicyScope int
+
+const (
+	// InternalOnly restricts ingress to pods in the same namespace.
+	InternalOnly NetworkPolicyScope = iota
+	// ExternalIngress additionally allows traffic from the OpenShift ingress controller.
+	ExternalIngress
+)
+
+func (t *reconcilerTask) createNetworkPolicy(ctx context.Context, serverName string, port int32, scope NetworkPolicyScope, extraIngressRules ...networkingv1.NetworkPolicyIngressRule) error {
+	t.logger.DebugContext(ctx, "[createNetworkPolicy]", slog.String("server", serverName))
+
+	protocol := corev1.ProtocolTCP
+	portVal := intstr.FromInt32(port)
+
+	ingressRules := []networkingv1.NetworkPolicyIngressRule{
+		{
+			// Allow from pods in the same namespace (inter-service communication)
+			From: []networkingv1.NetworkPolicyPeer{
+				{
+					PodSelector: &metav1.LabelSelector{},
+				},
+			},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{Protocol: &protocol, Port: &portVal},
+			},
+		},
+	}
+
+	if scope == ExternalIngress {
+		ingressRules = append([]networkingv1.NetworkPolicyIngressRule{
+			{
+				// Allow from the OpenShift ingress controller (external SMO traffic via Routes)
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"network.openshift.io/policy-group": "ingress",
+							},
+						},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Protocol: &protocol, Port: &portVal},
+				},
+			},
+		}, ingressRules...)
+	}
+
+	ingressRules = append(ingressRules, extraIngressRules...)
+
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serverName,
+			Namespace: t.object.Namespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": serverName,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+			},
+			Ingress: ingressRules,
+		},
+	}
+
+	if err := ctlrutils.CreateK8sCR(ctx, t.client, np, t.object, ctlrutils.UPDATE); err != nil {
+		return fmt.Errorf("failed to create NetworkPolicy for %s: %w", serverName, err)
+	}
+
+	return nil
 }
 
 func (t *reconcilerTask) createServiceAccount(ctx context.Context, resourceName string) error {

--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -280,7 +280,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 	// Database only accepts connections from pods in the same namespace.
 	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryDatabaseServerName, constants.DatabaseServicePort, InternalOnly)
 	if err != nil {
-		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for database.", slog.String("error", err.Error()))
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for database.", slog.Any("error", err))
 		return
 	}
 

--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -277,6 +277,13 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 		return
 	}
 
+	// Database only accepts connections from pods in the same namespace.
+	err = t.createNetworkPolicy(ctx, ctlrutils.InventoryDatabaseServerName, constants.DatabaseServicePort, InternalOnly)
+	if err != nil {
+		t.logger.ErrorContext(ctx, "Failed to create NetworkPolicy for database.", slog.String("error", err.Error()))
+		return
+	}
+
 	// Create the config volume
 	t.logger.DebugContext(ctx, "[createDatabase] creating database config volume")
 	configVolumeName := fmt.Sprintf("%s-config", ctlrutils.InventoryDatabaseServerName)

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -42,6 +42,7 @@ import (
 	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -293,6 +294,71 @@ var _ = Describe("Inventory Controller", func() {
 					},
 					provisioningDeployment)
 				Expect(err).ToNot(HaveOccurred())
+			},
+		),
+		Entry(
+			"NetworkPolicy scopes: API servers allow ingress-controller, database does not",
+			[]client.Object{
+				&inventoryv1alpha1.Inventory{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "oran-o2ims-sample-1",
+						Namespace:         constants.DefaultNamespace,
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: inventoryv1alpha1.InventorySpec{
+						Image: &ServerTestImage,
+					},
+				},
+			},
+			reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: ctlrutils.InventoryNamespace,
+					Name:      "oran-o2ims-sample-1",
+				},
+			},
+			func(result ctrl.Result, reconciler *Reconciler) {
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Minute}))
+
+				hasIngressControllerRule := func(np *networkingv1.NetworkPolicy) bool {
+					for _, rule := range np.Spec.Ingress {
+						for _, peer := range rule.From {
+							if peer.NamespaceSelector != nil {
+								if peer.NamespaceSelector.MatchLabels["network.openshift.io/policy-group"] == "ingress" {
+									return true
+								}
+							}
+						}
+					}
+					return false
+				}
+
+				// API servers should allow ingress-controller traffic.
+				for _, serverName := range []string{
+					ctlrutils.InventoryResourceServerName,
+					ctlrutils.InventoryClusterServerName,
+					ctlrutils.InventoryAlarmServerName,
+					ctlrutils.InventoryArtifactsServerName,
+					ctlrutils.InventoryProvisioningServerName,
+				} {
+					np := &networkingv1.NetworkPolicy{}
+					err := reconciler.Client.Get(context.TODO(), types.NamespacedName{
+						Name:      serverName,
+						Namespace: ctlrutils.InventoryNamespace,
+					}, np)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(hasIngressControllerRule(np)).To(BeTrue(),
+						"expected ingress-controller rule on %s NetworkPolicy", serverName)
+				}
+
+				// Database should NOT allow ingress-controller traffic.
+				dbNP := &networkingv1.NetworkPolicy{}
+				err := reconciler.Client.Get(context.TODO(), types.NamespacedName{
+					Name:      ctlrutils.InventoryDatabaseServerName,
+					Namespace: ctlrutils.InventoryNamespace,
+				}, dbNP)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hasIngressControllerRule(dbNP)).To(BeFalse(),
+					"database NetworkPolicy should not allow ingress-controller traffic")
 			},
 		),
 	)

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -332,13 +332,43 @@ var _ = Describe("Inventory Controller", func() {
 					return false
 				}
 
-				// API servers should allow ingress-controller traffic.
+				hasSameNamespaceRule := func(np *networkingv1.NetworkPolicy) bool {
+					for _, rule := range np.Spec.Ingress {
+						for _, peer := range rule.From {
+							if peer.PodSelector != nil && peer.NamespaceSelector == nil {
+								if len(peer.PodSelector.MatchLabels) == 0 && len(peer.PodSelector.MatchExpressions) == 0 {
+									return true
+								}
+							}
+						}
+					}
+					return false
+				}
+
+				hasAlertmanagerRule := func(np *networkingv1.NetworkPolicy) bool {
+					for _, rule := range np.Spec.Ingress {
+						for _, peer := range rule.From {
+							if peer.NamespaceSelector != nil && peer.PodSelector != nil {
+								nsMatch := peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] ==
+									ctlrutils.OpenClusterManagementObservabilityNamespace
+								podMatch := peer.PodSelector.MatchLabels[ctlrutils.AlertmanagerObjectName] == "observability"
+								if nsMatch && podMatch {
+									return true
+								}
+							}
+						}
+					}
+					return false
+				}
+
+				// API servers and hardware manager should allow ingress-controller traffic.
 				for _, serverName := range []string{
 					ctlrutils.InventoryResourceServerName,
 					ctlrutils.InventoryClusterServerName,
 					ctlrutils.InventoryAlarmServerName,
 					ctlrutils.InventoryArtifactsServerName,
 					ctlrutils.InventoryProvisioningServerName,
+					ctlrutils.HardwareManagerServerName,
 				} {
 					np := &networkingv1.NetworkPolicy{}
 					err := reconciler.Client.Get(context.TODO(), types.NamespacedName{
@@ -348,17 +378,31 @@ var _ = Describe("Inventory Controller", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(hasIngressControllerRule(np)).To(BeTrue(),
 						"expected ingress-controller rule on %s NetworkPolicy", serverName)
+					Expect(hasSameNamespaceRule(np)).To(BeTrue(),
+						"expected same-namespace rule on %s NetworkPolicy", serverName)
 				}
 
-				// Database should NOT allow ingress-controller traffic.
-				dbNP := &networkingv1.NetworkPolicy{}
+				// Alarm server should additionally allow alertmanager traffic.
+				alarmNP := &networkingv1.NetworkPolicy{}
 				err := reconciler.Client.Get(context.TODO(), types.NamespacedName{
+					Name:      ctlrutils.InventoryAlarmServerName,
+					Namespace: ctlrutils.InventoryNamespace,
+				}, alarmNP)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hasAlertmanagerRule(alarmNP)).To(BeTrue(),
+					"expected alertmanager ingress rule on alarm server NetworkPolicy")
+
+				// Database should NOT allow ingress-controller traffic but SHOULD allow same-namespace traffic.
+				dbNP := &networkingv1.NetworkPolicy{}
+				err = reconciler.Client.Get(context.TODO(), types.NamespacedName{
 					Name:      ctlrutils.InventoryDatabaseServerName,
 					Namespace: ctlrutils.InventoryNamespace,
 				}, dbNP)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hasIngressControllerRule(dbNP)).To(BeFalse(),
 					"database NetworkPolicy should not allow ingress-controller traffic")
+				Expect(hasSameNamespaceRule(dbNP)).To(BeTrue(),
+					"database NetworkPolicy should allow same-namespace traffic")
 			},
 		),
 	)


### PR DESCRIPTION
Create a NetworkPolicy for each server pod that restricts ingress to traffic from the OpenShift ingress controller (external SMO traffic via Routes) and pods in the same namespace (inter-service communication). The alarms server additionally allows ingress from the alertmanager in the open-cluster-management-observability namespace for webhook alert delivery. The postgres pod only allows ingress from the operator namespace.

Egress is left unrestricted.