### PR TITLE
Add SMO URL propagation and callback target validation

### DIFF
--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -414,6 +414,10 @@ func addArgsForOAuth(inventory *inventoryv1alpha1.Inventory, args []string) []st
 	if inventory.Spec.SmoConfig != nil {
 		smo := inventory.Spec.SmoConfig
 
+		if smo.URL != "" {
+			args = append(args, fmt.Sprintf("--smo-url=%s", smo.URL))
+		}
+
 		if smo.OAuthConfig != nil {
 			args = append(args,
 				fmt.Sprintf("--oauth-scopes=%s", strings.Join(smo.OAuthConfig.Scopes, ",")),

--- a/internal/service/alarms/api/server.go
+++ b/internal/service/alarms/api/server.go
@@ -46,6 +46,8 @@ type AlarmsServerConfig struct {
 }
 
 type AlarmsServer struct {
+	// Config is the alarms server configuration
+	Config *AlarmsServerConfig
 	// GlobalCloudID is the global O-Cloud identifier. Create subscription requests are blocked if the global O-Cloud identifier is not set
 	GlobalCloudID uuid.UUID
 	// AlarmsRepository is the repository for the alarms
@@ -135,7 +137,7 @@ func (a *AlarmsServer) CreateSubscription(ctx context.Context, request api.Creat
 	}
 
 	// Validate the subscription
-	if err := commonapi.ValidateCallbackURL(ctx, a.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback); err != nil {
+	if err := commonapi.ValidateCallbackURL(ctx, a.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback, a.Config.SmoURL); err != nil {
 		slog.ErrorContext(ctx, "callback URL validation failed", slog.Any("error", err))
 		return api.CreateSubscription400ApplicationProblemPlusJSONResponse{
 			Detail: "callback URL validation failed",

--- a/internal/service/alarms/api/server_test.go
+++ b/internal/service/alarms/api/server_test.go
@@ -23,6 +23,7 @@ import (
 	alarmapi "github.com/openshift-kni/oran-o2ims/internal/service/alarms/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/db/repo/generated"
+	svcapi "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 )
@@ -58,7 +59,7 @@ var _ = Describe("AlarmsServer", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockRepo = generated.NewMockAlarmRepositoryInterface(ctrl)
-		server = &api.AlarmsServer{AlarmsRepository: mockRepo}
+		server = &api.AlarmsServer{Config: &api.AlarmsServerConfig{}, AlarmsRepository: mockRepo}
 		ctx = context.Background()
 		testUUID = uuid.New()
 	})
@@ -149,6 +150,7 @@ var _ = Describe("AlarmsServer", func() {
 		When("validation fails due to unreachable callback URL", func() {
 			It("returns 400 without reflecting the callback URL in Detail", func() {
 				server.GlobalCloudID = uuid.New()
+				server.Config.SmoURL = "https://192.0.2.1"
 				callbackURL := "https://192.0.2.1/callback?secret=token123"
 				shortTimeoutClient := &http.Client{Timeout: 1}
 
@@ -178,6 +180,13 @@ var _ = Describe("AlarmsServer", func() {
 					w.WriteHeader(http.StatusNoContent)
 				}))
 				defer ts.Close()
+
+				server.Config.SmoURL = ts.URL
+				savedResolver := svcapi.DefaultResolver
+				svcapi.DefaultResolver = &svcapi.TestResolver{Addrs: map[string][]string{
+					"127.0.0.1": {"203.0.113.1"},
+				}}
+				DeferCleanup(func() { svcapi.DefaultResolver = savedResolver })
 
 				server.SubscriptionEventHandler = &mockSubscriptionEventHandler{
 					provider: &mockClientProvider{client: ts.Client()},

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -138,6 +138,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 	// Init server
 	// Create the handler
 	alarmServer := api.AlarmsServer{
+		Config:           config,
 		GlobalCloudID:    globalCloudID,
 		AlarmsRepository: alarmRepository,
 		Infrastructure:   infrastructureClients,

--- a/internal/service/cluster/api/server.go
+++ b/internal/service/cluster/api/server.go
@@ -415,7 +415,7 @@ func (r *ClusterServer) GetSubscriptions(ctx context.Context, request api.GetSub
 
 // validateSubscription validates a subscription before accepting the request
 func (r *ClusterServer) validateSubscription(ctx context.Context, request api.CreateSubscriptionRequestObject) error {
-	if err := commonapi.ValidateCallbackURL(ctx, r.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback); err != nil {
+	if err := commonapi.ValidateCallbackURL(ctx, r.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback, r.Config.SmoURL); err != nil {
 		slog.ErrorContext(ctx, "callback URL validation failed", slog.Any("error", err))
 		return fmt.Errorf("callback URL validation failed")
 	}

--- a/internal/service/cluster/api/server_test.go
+++ b/internal/service/cluster/api/server_test.go
@@ -21,6 +21,7 @@ import (
 	apigenerated "github.com/openshift-kni/oran-o2ims/internal/service/cluster/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/cluster/db/repo/generated"
+	svcapi "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 )
 
@@ -56,7 +57,8 @@ var _ = Describe("Cluster Server", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockRepo = generated.NewMockRepositoryInterface(ctrl)
 		server = &ClusterServer{
-			Repo: mockRepo,
+			Config: &ClusterServerConfig{},
+			Repo:   mockRepo,
 		}
 		server.InitAlarmDictCache()
 		ctx = context.Background()
@@ -345,6 +347,7 @@ var _ = Describe("Cluster Server", func() {
 
 		When("validation fails due to unreachable callback URL", func() {
 			It("returns 400 without reflecting the callback URL in Detail", func() {
+				server.Config.SmoURL = "https://192.0.2.1"
 				callbackURL := "https://192.0.2.1/callback?secret=token123"
 				shortTimeoutClient := &http.Client{Timeout: 1}
 
@@ -373,6 +376,13 @@ var _ = Describe("Cluster Server", func() {
 					w.WriteHeader(http.StatusNoContent)
 				}))
 				defer ts.Close()
+
+				server.Config.SmoURL = ts.URL
+				savedResolver := svcapi.DefaultResolver
+				svcapi.DefaultResolver = &svcapi.TestResolver{Addrs: map[string][]string{
+					"127.0.0.1": {"203.0.113.1"},
+				}}
+				DeferCleanup(func() { svcapi.DefaultResolver = savedResolver })
 
 				server.SubscriptionEventHandler = &mockSubscriptionEventHandler{
 					provider: &mockClientProvider{client: ts.Client()},

--- a/internal/service/common/api/utils.go
+++ b/internal/service/common/api/utils.go
@@ -11,18 +11,82 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 )
 
-// ValidateCallbackURL ensures that the URL used in subscription callback meets our requirements
-func ValidateCallbackURL(ctx context.Context, c notifier.ClientProvider, callback string) error {
-	// Validate URL
-	u, err := url.Parse(callback)
+// Resolver abstracts DNS resolution for testability.
+type Resolver interface {
+	LookupHost(ctx context.Context, host string) ([]string, error)
+}
+
+// DefaultResolver is the DNS resolver used by ValidateCallbackURL. Tests may replace it.
+var DefaultResolver Resolver = net.DefaultResolver
+
+// TestResolver is a Resolver stub for use in tests. Known hosts return their
+// configured addresses; unknown hosts return the hostname itself as the address
+// so that test-server URLs (e.g., 127.0.0.1) pass through without setup.
+type TestResolver struct {
+	Addrs map[string][]string
+}
+
+func (r *TestResolver) LookupHost(_ context.Context, host string) ([]string, error) {
+	if addrs, ok := r.Addrs[host]; ok {
+		return addrs, nil
+	}
+	return []string{host}, nil
+}
+
+// DeniedCIDRStrings lists the CIDR ranges that must never be used as callback targets.
+// Exported so tests can verify every entry parses correctly.
+var DeniedCIDRStrings = []string{
+	"127.0.0.0/8",    // loopback
+	"::1/128",        // IPv6 loopback
+	"169.254.0.0/16", // link-local (cloud metadata)
+	"fe80::/10",      // IPv6 link-local
+	"0.0.0.0/8",      // "this network"
+}
+
+var deniedCIDRs []*net.IPNet
+
+func init() {
+	for _, cidr := range DeniedCIDRStrings {
+		_, network, _ := net.ParseCIDR(cidr)
+		deniedCIDRs = append(deniedCIDRs, network)
+	}
+}
+
+// ValidateCallbackURL ensures that the URL used in subscription callback meets our requirements.
+func ValidateCallbackURL(ctx context.Context, c notifier.ClientProvider, callback, smoURL string) error {
+	if err := ValidateCallbackTarget(ctx, callback, smoURL, DefaultResolver); err != nil {
+		return err
+	}
+
+	authType := ctlrutils.DetermineAuthType(callback)
+	client, err := c.NewClient(ctx, authType)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	if err := CheckCallbackReachabilityGET(ctx, client, callback); err != nil {
+		return fmt.Errorf("reachability check failed: %w", err)
+	}
+
+	return nil
+}
+
+// ValidateCallbackTarget checks that a callback URL targets a safe and permitted host.
+// Cluster-local callbacks (.svc.cluster.local) are always allowed.
+// External callbacks must target the configured SMO host.
+// All callbacks are checked against a blocklist of dangerous IP ranges.
+func ValidateCallbackTarget(ctx context.Context, callbackURL, smoURL string, resolver Resolver) error {
+	u, err := url.Parse(callbackURL)
 	if err != nil {
 		return fmt.Errorf("invalid callback URL: %w", err)
 	}
@@ -31,16 +95,41 @@ func ValidateCallbackURL(ctx context.Context, c notifier.ClientProvider, callbac
 		return fmt.Errorf("invalid callback scheme %q, only https is supported", u.Scheme)
 	}
 
-	// A new client is created every time since the user may request a baseclient or oauthclient which we figure out at runtime
-	authType := ctlrutils.DetermineAuthType(callback)
-	client, err := c.NewClient(ctx, authType)
-	if err != nil {
-		return fmt.Errorf("failed to create client: %w", err)
+	hostname := u.Hostname()
+	if hostname == "" {
+		return fmt.Errorf("callback URL has no hostname")
 	}
 
-	// Call the url without retry for quick feedback
-	if err := CheckCallbackReachabilityGET(ctx, client, callback); err != nil {
-		return fmt.Errorf("reachability check failed: %w", err)
+	isClusterLocal := ctlrutils.IsClusterLocalHostname(hostname)
+
+	if !isClusterLocal {
+		if smoURL == "" {
+			return fmt.Errorf("external callback URLs are not allowed when SMO URL is not configured")
+		}
+		smoU, err := url.Parse(smoURL)
+		if err != nil {
+			return fmt.Errorf("invalid SMO URL: %w", err)
+		}
+		if !strings.EqualFold(hostname, smoU.Hostname()) {
+			return fmt.Errorf("callback host %q does not match SMO host %q", hostname, smoU.Hostname())
+		}
+	}
+
+	addrs, err := resolver.LookupHost(ctx, hostname)
+	if err != nil {
+		return fmt.Errorf("failed to resolve callback hostname %q: %w", hostname, err)
+	}
+
+	for _, addr := range addrs {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			continue
+		}
+		for _, denied := range deniedCIDRs {
+			if denied.Contains(ip) {
+				return fmt.Errorf("callback hostname %q resolves to blocked address %s (%s)", hostname, addr, denied)
+			}
+		}
 	}
 
 	return nil

--- a/internal/service/common/api/utils_test.go
+++ b/internal/service/common/api/utils_test.go
@@ -5,6 +5,8 @@ package api_test
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 
@@ -17,10 +19,11 @@ import (
 
 var _ = Describe("ValidateCallbackURL", func() {
 	var (
-		ctx      context.Context
-		callback string
-		client   *http.Client
-		server   *httptest.Server
+		ctx           context.Context
+		callback      string
+		client        *http.Client
+		server        *httptest.Server
+		savedResolver api.Resolver
 	)
 
 	BeforeEach(func() {
@@ -35,16 +38,23 @@ var _ = Describe("ValidateCallbackURL", func() {
 		}))
 		callback = server.URL // This URL uses "https"
 		client = server.Client()
+
+		// Replace the default resolver so the loopback test server address passes target validation
+		savedResolver = api.DefaultResolver
+		api.DefaultResolver = &mockResolver{addrs: map[string][]string{
+			"127.0.0.1": {"203.0.113.1"},
+		}}
 	})
 
 	AfterEach(func() {
 		server.Close()
+		api.DefaultResolver = savedResolver
 	})
 
 	Context("when the callback URL is valid and reachable", func() {
 		It("should not return an error", func() {
 			stub := &stubClientProvider{client: client}
-			err := api.ValidateCallbackURL(ctx, stub, callback)
+			err := api.ValidateCallbackURL(ctx, stub, callback, callback)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -53,7 +63,7 @@ var _ = Describe("ValidateCallbackURL", func() {
 		It("should return an error", func() {
 			invalidURL := "http://example.com"
 			stub := &stubClientProvider{client: client}
-			err := api.ValidateCallbackURL(ctx, stub, invalidURL)
+			err := api.ValidateCallbackURL(ctx, stub, invalidURL, "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid callback scheme \"http\", only https is supported"))
 		})
@@ -73,7 +83,7 @@ var _ = Describe("ValidateCallbackURL", func() {
 
 		It("should return an error on reachability check", func() {
 			stub := &stubClientProvider{client: client}
-			err := api.ValidateCallbackURL(ctx, stub, callback)
+			err := api.ValidateCallbackURL(ctx, stub, callback, callback)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("unexpected status code"))
 		})
@@ -118,11 +128,178 @@ var _ = Describe("CheckCallbackReachabilityGET", func() {
 	})
 })
 
+var _ = Describe("ValidateCallbackTarget", func() {
+	var (
+		ctx      context.Context
+		resolver *mockResolver
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		resolver = &mockResolver{addrs: map[string][]string{}}
+	})
+
+	Context("cluster-local callbacks", func() {
+		It("should allow cluster-local URLs regardless of SMO URL", func() {
+			resolver.addrs["my-svc.my-ns.svc.cluster.local"] = []string{"10.0.0.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://my-svc.my-ns.svc.cluster.local/cb", "", resolver)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should allow cluster-local URLs when SMO is configured", func() {
+			resolver.addrs["my-svc.my-ns.svc.cluster.local"] = []string{"10.0.0.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://my-svc.my-ns.svc.cluster.local/cb", "https://smo.example.com", resolver)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("external callbacks", func() {
+		It("should allow callback matching SMO host", func() {
+			resolver.addrs["smo.example.com"] = []string{"203.0.113.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://smo.example.com/callback", "https://smo.example.com", resolver)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should allow callback matching SMO host with different path", func() {
+			resolver.addrs["smo.example.com"] = []string{"203.0.113.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://smo.example.com/other/path", "https://smo.example.com/api", resolver)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should allow callback matching SMO host with different case (RFC 4343)", func() {
+			resolver.addrs["SMO.Example.COM"] = []string{"203.0.113.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://SMO.Example.COM/callback", "https://smo.example.com", resolver)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject callback to a different host than SMO", func() {
+			resolver.addrs["attacker.com"] = []string{"198.51.100.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://attacker.com/cb", "https://smo.example.com", resolver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("does not match SMO host"))
+		})
+
+		It("should reject external callbacks when SMO URL is not configured", func() {
+			err := api.ValidateCallbackTarget(ctx, "https://external.example.com/cb", "", resolver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not allowed when SMO URL is not configured"))
+		})
+	})
+
+	Context("blocked IP ranges", func() {
+		It("should reject loopback addresses", func() {
+			resolver.addrs["smo.example.com"] = []string{"127.0.0.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://smo.example.com/cb", "https://smo.example.com", resolver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("blocked address"))
+		})
+
+		It("should reject IPv6 loopback", func() {
+			resolver.addrs["smo.example.com"] = []string{"::1"}
+			err := api.ValidateCallbackTarget(ctx, "https://smo.example.com/cb", "https://smo.example.com", resolver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("blocked address"))
+		})
+
+		It("should reject link-local addresses (cloud metadata)", func() {
+			resolver.addrs["smo.example.com"] = []string{"169.254.169.254"}
+			err := api.ValidateCallbackTarget(ctx, "https://smo.example.com/cb", "https://smo.example.com", resolver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("blocked address"))
+		})
+
+		It("should reject 0.0.0.0/8 addresses", func() {
+			resolver.addrs["smo.example.com"] = []string{"0.0.0.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://smo.example.com/cb", "https://smo.example.com", resolver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("blocked address"))
+		})
+
+		It("should allow public IP addresses", func() {
+			resolver.addrs["smo.example.com"] = []string{"203.0.113.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://smo.example.com/cb", "https://smo.example.com", resolver)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should allow private IPs for cluster-local callbacks", func() {
+			resolver.addrs["svc.ns.svc.cluster.local"] = []string{"10.96.0.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://svc.ns.svc.cluster.local/cb", "", resolver)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("edge cases", func() {
+		It("should reject callback with no hostname", func() {
+			err := api.ValidateCallbackTarget(ctx, "https:///path", "https://smo.example.com", resolver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no hostname"))
+		})
+
+		It("should reject unresolvable hostname", func() {
+			resolver.err = fmt.Errorf("no such host")
+			err := api.ValidateCallbackTarget(ctx, "https://smo.example.com/cb", "https://smo.example.com", resolver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to resolve"))
+		})
+
+		It("should reject non-https scheme", func() {
+			err := api.ValidateCallbackTarget(ctx, "http://smo.example.com/cb", "https://smo.example.com", resolver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("only https is supported"))
+		})
+
+		It("should handle IPv6 bracket notation in callback URL", func() {
+			resolver.addrs["::1"] = []string{"::1"}
+			err := api.ValidateCallbackTarget(ctx, "https://[::1]/cb", "https://[::1]", resolver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("blocked address"))
+		})
+
+		It("should allow callback with different port than SMO", func() {
+			resolver.addrs["smo.example.com"] = []string{"203.0.113.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://smo.example.com:8443/cb", "https://smo.example.com:443", resolver)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should strip userinfo before comparing hostnames", func() {
+			resolver.addrs["smo.example.com"] = []string{"203.0.113.1"}
+			err := api.ValidateCallbackTarget(ctx, "https://user:pass@smo.example.com/cb", "https://smo.example.com", resolver)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("DeniedCIDRStrings", func() {
+	It("should all be valid CIDR notation", func() {
+		for _, cidr := range api.DeniedCIDRStrings {
+			_, _, err := net.ParseCIDR(cidr)
+			Expect(err).ToNot(HaveOccurred(), "invalid denied CIDR: %s", cidr)
+		}
+	})
+})
+
 // stubClientProvider is a simple stub that implements the notifier.ClientProvider interface.
 type stubClientProvider struct {
 	client *http.Client
 }
 
-func (s *stubClientProvider) NewClient(ctx context.Context, authType commonapi.AuthType) (*http.Client, error) {
+func (s *stubClientProvider) NewClient(_ context.Context, _ commonapi.AuthType) (*http.Client, error) {
 	return s.client, nil
+}
+
+// mockResolver implements api.Resolver for testing.
+type mockResolver struct {
+	addrs map[string][]string
+	err   error
+}
+
+func (m *mockResolver) LookupHost(_ context.Context, host string) ([]string, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	addrs, ok := m.addrs[host]
+	if !ok {
+		return nil, fmt.Errorf("no such host: %s", host)
+	}
+	return addrs, nil
 }

--- a/internal/service/common/utils/config.go
+++ b/internal/service/common/utils/config.go
@@ -54,10 +54,13 @@ type CommonServerConfig struct {
 	OAuth OAuthConfig
 	// TLS defines the attributes used to start mTLS sessions to the SMO/OAuth servers
 	TLS TLSConfig
+	// SmoURL is the base URL of the SMO instance used to restrict callback URLs
+	SmoURL string
 }
 
 const (
 	ListenerFlagName                = "api-listener-address"
+	SmoURLFlagName                  = "smo-url"
 	OAuthIssuerURLFlagName          = "oauth-issuer-url"     // nolint: gosec
 	OAuthTokenEndpointFlagName      = "oauth-token-endpoint" // nolint: gosec
 	OAuthScopesFlagName             = "oauth-scopes"
@@ -79,6 +82,12 @@ func SetCommonServerFlags(cmd *cobra.Command, config *CommonServerConfig) error 
 		ListenerFlagName,
 		fmt.Sprintf("%s:%d", constants.Localhost, constants.DefaultContainerPort),
 		"API listener address",
+	)
+	flags.StringVar(
+		&config.SmoURL,
+		SmoURLFlagName,
+		"",
+		"SMO base URL used to restrict callback URLs to the SMO host",
 	)
 	flags.StringVar(
 		&config.OAuth.TokenEndpoint,

--- a/internal/service/resources/api/server.go
+++ b/internal/service/resources/api/server.go
@@ -296,7 +296,7 @@ func (r *ResourceServer) GetSubscriptions(ctx context.Context, request api.GetSu
 
 // validateSubscription validates a subscription before accepting the request
 func (r *ResourceServer) validateSubscription(ctx context.Context, request api.CreateSubscriptionRequestObject) error {
-	if err := commonapi.ValidateCallbackURL(ctx, r.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback); err != nil {
+	if err := commonapi.ValidateCallbackURL(ctx, r.SubscriptionEventHandler.GetClientFactory(), request.Body.Callback, r.Config.SmoURL); err != nil {
 		slog.ErrorContext(ctx, "callback URL validation failed", slog.Any("error", err))
 		return fmt.Errorf("callback URL validation failed")
 	}

--- a/internal/service/resources/api/server_test.go
+++ b/internal/service/resources/api/server_test.go
@@ -18,14 +18,14 @@ import (
 	"go.uber.org/mock/gomock"
 
 	commonapi "github.com/openshift-kni/oran-o2ims/api/common"
+	svcapi "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	commonmodels "github.com/openshift-kni/oran-o2ims/internal/service/common/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
+	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/api"
 	apiGenerated "github.com/openshift-kni/oran-o2ims/internal/service/resources/api/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/models"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/repo/generated"
-
-	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
 )
 
 const (
@@ -75,6 +75,7 @@ var _ = Describe("ResourceServer", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockRepo = generated.NewMockResourcesRepositoryInterface(ctrl)
 		server = &api.ResourceServer{
+			Config:                   &api.ResourceServerConfig{},
 			Repo:                     mockRepo,
 			SubscriptionEventHandler: &mockSubscriptionEventHandler{},
 		}
@@ -299,11 +300,13 @@ var _ = Describe("ResourceServer", func() {
 				shortTimeoutClient := &http.Client{Timeout: 1}
 
 				serverWithProvider := &api.ResourceServer{
-					Repo: mockRepo,
+					Config: &api.ResourceServerConfig{},
+					Repo:   mockRepo,
 					SubscriptionEventHandler: &mockSubscriptionEventHandlerWithProvider{
 						provider: &mockClientProvider{client: shortTimeoutClient},
 					},
 				}
+				serverWithProvider.Config.SmoURL = "https://192.0.2.1"
 
 				resp, err := serverWithProvider.CreateSubscription(ctx, apiGenerated.CreateSubscriptionRequestObject{
 					Body: &apiGenerated.Subscription{
@@ -327,12 +330,20 @@ var _ = Describe("ResourceServer", func() {
 				}))
 				defer ts.Close()
 
+				savedResolver := svcapi.DefaultResolver
+				svcapi.DefaultResolver = &svcapi.TestResolver{Addrs: map[string][]string{
+					"127.0.0.1": {"203.0.113.1"},
+				}}
+				DeferCleanup(func() { svcapi.DefaultResolver = savedResolver })
+
 				serverWithProvider := &api.ResourceServer{
-					Repo: mockRepo,
+					Config: &api.ResourceServerConfig{},
+					Repo:   mockRepo,
 					SubscriptionEventHandler: &mockSubscriptionEventHandlerWithProvider{
 						provider: &mockClientProvider{client: ts.Client()},
 					},
 				}
+				serverWithProvider.Config.SmoURL = ts.URL
 
 				mockRepo.EXPECT().
 					CreateSubscription(gomock.Any(), gomock.Any()).


### PR DESCRIPTION
Add ValidateCallbackTarget() which enforces two policies:
    - External callbacks must target the configured SMO host
    - All callback hostnames are checked against a blocklist
    
Cluster-local callbacks (.svc.cluster.local) are allowed regardless of SMO URL configuration and may resolve to private IPs since they point back to internal services.
