### PR TITLE
CNF-24759: standardize error logging to use slog.Any

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,9 @@ issues during code review.
   `slog.Int(...)`, `slog.Any(...)`, etc.) instead of untyped
   alternating key-value pairs (`"key", value`). The `sloglint`
   `attr-only` rule enforces this at lint time.
+- Log errors with `slog.Any("error", err)`, not
+  `slog.String("error", err.Error())`. This preserves the error type
+  for structured logging handlers and avoids eager `.Error()` calls.
 
 ## Test Conventions
 

--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -231,7 +231,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		logger.ErrorContext(
 			ctx,
 			"Unable to start manager",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return exit.Error(1)
 	}
@@ -242,7 +242,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		logger.ErrorContext(
 			ctx,
 			"Failed to create default inventory CR",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return exit.Error(1)
 	}
@@ -257,7 +257,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 			ctx,
 			"Unable to create controller",
 			slog.String("controller", "O-Cloud Manager"),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return exit.Error(1)
 	}
@@ -278,7 +278,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 			ctx,
 			"Unable to create controller",
 			slog.String("controller", "ClusterTemplate"),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return exit.Error(1)
 	}
@@ -292,7 +292,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 			ctx,
 			"Unable to create controller",
 			slog.String("controller", "Location"),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return exit.Error(1)
 	}
@@ -306,7 +306,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 			ctx,
 			"Unable to create controller",
 			slog.String("controller", "OCloudSite"),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return exit.Error(1)
 	}
@@ -320,7 +320,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 			ctx,
 			"Unable to create controller",
 			slog.String("controller", "ResourcePool"),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return exit.Error(1)
 	}
@@ -339,7 +339,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 			ctx,
 			"Unable to create controller",
 			slog.String("controller", "ProvisioningRequest"),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return exit.Error(1)
 	}
@@ -350,7 +350,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 				ctx,
 				"Unable to create webhook",
 				slog.String("webhook", "ProvisioningRequest"),
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 			return exit.Error(1)
 		}
@@ -360,7 +360,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		logger.ErrorContext(
 			ctx,
 			"Unable to set up health check",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return exit.Error(1)
 	}
@@ -368,7 +368,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		logger.ErrorContext(
 			ctx,
 			"Unable to set up ready check",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return exit.Error(1)
 	}
@@ -380,7 +380,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 			slog.String("image", c.image),
 		)
 		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-			logger.ErrorContext(ctx, "Problem running manager", slog.String("error", err.Error()))
+			logger.ErrorContext(ctx, "Problem running manager", slog.Any("error", err))
 			serverErrors <- err
 			return
 		}
@@ -391,7 +391,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	select {
 	case err = <-serverErrors:
 		// Server failed to start
-		logger.ErrorContext(ctx, "Problem running internal server", slog.String("error", err.Error()))
+		logger.ErrorContext(ctx, "Problem running internal server", slog.Any("error", err))
 		return exit.Error(1)
 	case <-ctx.Done():
 		return exit.Error(0)

--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -115,7 +115,7 @@ func (r *ClusterTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if err != nil {
 			r.Logger.ErrorContext(ctx, "Reconciliation failed",
 				slog.Duration("duration", duration),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		} else {
 			r.Logger.InfoContext(ctx, "Reconciliation completed",
 				slog.Duration("duration", duration),

--- a/internal/controllers/hardwaremanager_setup.go
+++ b/internal/controllers/hardwaremanager_setup.go
@@ -24,14 +24,14 @@ func (t *reconcilerTask) setupHardwareManager(ctx context.Context, defaultResult
 
 	if err = t.createService(ctx, ctlrutils.HardwareManagerServerName, constants.DefaultServicePort, ctlrutils.DefaultServiceTargetPort); err != nil {
 		t.logger.ErrorContext(ctx, "Failed to deploy Service for the hardware manager server.",
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		return
 	}
 
 	errorReason, err := t.deployServer(ctx, ctlrutils.HardwareManagerServerName)
 	if err != nil {
 		t.logger.ErrorContext(ctx, "Failed to deploy the hardware manager server.",
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		if errorReason == "" {
 			nextReconcile = ctrl.Result{RequeueAfter: 60 * time.Second}
 		}

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -146,7 +146,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (resul
 		if err != nil {
 			r.Logger.ErrorContext(ctx, "Reconciliation failed",
 				slog.Duration("duration", duration),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		} else {
 			r.Logger.InfoContext(ctx, "Reconciliation completed",
 				slog.Duration("duration", duration),
@@ -196,7 +196,7 @@ func (t *reconcilerTask) setupResourceServerConfig(ctx context.Context, defaultR
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy Service for Resource server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -207,7 +207,7 @@ func (t *reconcilerTask) setupResourceServerConfig(ctx context.Context, defaultR
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy the Resource server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		if errorReason == "" {
 			nextReconcile = ctrl.Result{RequeueAfter: 60 * time.Second}
@@ -228,7 +228,7 @@ func (t *reconcilerTask) setupClusterServerConfig(ctx context.Context, defaultRe
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy Service for cluster server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -239,7 +239,7 @@ func (t *reconcilerTask) setupClusterServerConfig(ctx context.Context, defaultRe
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy the cluster server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		if errorReason == "" {
 			nextReconcile = ctrl.Result{RequeueAfter: 60 * time.Second}
@@ -260,7 +260,7 @@ func (t *reconcilerTask) setupArtifactsServerConfig(ctx context.Context, default
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy Service for the Artifacts server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -271,7 +271,7 @@ func (t *reconcilerTask) setupArtifactsServerConfig(ctx context.Context, default
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy the Artifacts server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		if errorReason == "" {
 			nextReconcile = ctrl.Result{RequeueAfter: 60 * time.Second}
@@ -292,7 +292,7 @@ func (t *reconcilerTask) setupAlarmServerConfig(ctx context.Context, defaultResu
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy Service for alarm server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -303,7 +303,7 @@ func (t *reconcilerTask) setupAlarmServerConfig(ctx context.Context, defaultResu
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy the alarm server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		if errorReason == "" {
 			nextReconcile = ctrl.Result{RequeueAfter: 60 * time.Second}
@@ -323,7 +323,7 @@ func (t *reconcilerTask) setupProvisioningServerConfig(ctx context.Context, defa
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy Service for the provisioning server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -334,7 +334,7 @@ func (t *reconcilerTask) setupProvisioningServerConfig(ctx context.Context, defa
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy the provisioning server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		if errorReason == "" {
 			nextReconcile = ctrl.Result{RequeueAfter: 60 * time.Second}
@@ -464,7 +464,7 @@ func (t *reconcilerTask) setupSmo(ctx context.Context) (err error) {
 		if err != nil {
 			t.logger.ErrorContext(
 				ctx, "Failed to register with SMO.",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 
 			meta.SetStatusCondition(
@@ -514,7 +514,7 @@ func (t *reconcilerTask) storeIngressDomain(ctx context.Context) error {
 			t.logger.ErrorContext(
 				ctx,
 				"Failed to get ingress domain.",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return fmt.Errorf("failed to get ingress domain: %s", err.Error())
 		}
 		ingressHost = constants.DefaultAppName + "." + ingressHost
@@ -534,7 +534,7 @@ func (t *reconcilerTask) storeClusterID(ctx context.Context) error {
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to get cluster id.",
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		return fmt.Errorf("failed to get cluster id: %s", err.Error())
 	}
 

--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -262,7 +262,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy ServiceAccount for the database server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -272,7 +272,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy Service for database.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -286,7 +286,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to make config configmap for database.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -300,7 +300,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to create startup configmap for database.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -312,7 +312,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to create service passwords for database.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -322,7 +322,7 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 		t.logger.ErrorContext(
 			ctx,
 			"Failed to deploy the database server.",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 	}
 

--- a/internal/controllers/location_controller.go
+++ b/internal/controllers/location_controller.go
@@ -47,7 +47,7 @@ func (r *LocationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		if err != nil {
 			r.Logger.ErrorContext(ctx, "Reconciliation failed",
 				slog.Duration("duration", duration),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		} else {
 			r.Logger.InfoContext(ctx, "Reconciliation completed",
 				slog.Duration("duration", duration),

--- a/internal/controllers/ocloudsite_controller.go
+++ b/internal/controllers/ocloudsite_controller.go
@@ -50,7 +50,7 @@ func (r *OCloudSiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err != nil {
 			r.Logger.ErrorContext(ctx, "Reconciliation failed",
 				slog.Duration("duration", duration),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		} else {
 			r.Logger.InfoContext(ctx, "Reconciliation completed",
 				slog.Duration("duration", duration),
@@ -203,7 +203,7 @@ func (r *OCloudSiteReconciler) enqueueOCloudSitesForLocation(ctx context.Context
 		},
 	); err != nil {
 		r.Logger.ErrorContext(ctx, "Failed to list OCloudSites for Location watch",
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		return nil
 	}
 

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -122,7 +122,7 @@ func (r *ProvisioningRequestReconciler) Reconcile(
 		if err != nil {
 			r.Logger.ErrorContext(ctx, "Reconciliation failed",
 				slog.Duration("duration", duration),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		} else {
 			r.Logger.InfoContext(ctx, "Reconciliation completed",
 				slog.Duration("duration", duration),
@@ -368,7 +368,7 @@ func (t *provisioningRequestReconcilerTask) checkOverallProvisioningTimeout(ctx 
 				fmt.Sprintf("Overall provisioning timed out after %v", overallTimeout))
 
 			if err := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); err != nil {
-				t.logger.WarnContext(ctx, "Failed to update status for overall provisioning timeout", slog.String("error", err.Error()))
+				t.logger.WarnContext(ctx, "Failed to update status for overall provisioning timeout", slog.Any("error", err))
 			}
 			return requeueWithMediumInterval()
 		}
@@ -394,7 +394,7 @@ func (t *provisioningRequestReconcilerTask) checkOverallProvisioningTimeout(ctx 
 					fmt.Sprintf("Cluster installation timed out after %v", t.timeouts.clusterProvisioning))
 
 				if err := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); err != nil {
-					t.logger.WarnContext(ctx, "Failed to update status for cluster installation timeout", slog.String("error", err.Error()))
+					t.logger.WarnContext(ctx, "Failed to update status for cluster installation timeout", slog.Any("error", err))
 				}
 				return requeueWithMediumInterval()
 			}
@@ -416,7 +416,7 @@ func (t *provisioningRequestReconcilerTask) checkOverallProvisioningTimeout(ctx 
 					fmt.Sprintf("Cluster configuration timed out after %v", t.timeouts.clusterConfiguration))
 
 				if err := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); err != nil {
-					t.logger.WarnContext(ctx, "Failed to update status for cluster configuration timeout", slog.String("error", err.Error()))
+					t.logger.WarnContext(ctx, "Failed to update status for cluster configuration timeout", slog.Any("error", err))
 				}
 				return requeueWithMediumInterval()
 			}
@@ -489,7 +489,7 @@ func (t *provisioningRequestReconcilerTask) handlePreProvisioning(ctx context.Co
 	if t.object.Status.ObservedGeneration != t.object.Generation {
 		ctlrutils.SetProvisioningStatePending(t.object, ctlrutils.ValidationMessage)
 		if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
-			t.logger.WarnContext(ctx, "Status update failed, will retry", slog.String("error", updateErr.Error()))
+			t.logger.WarnContext(ctx, "Status update failed, will retry", slog.Any("error", updateErr))
 			return nil, requeueWithShortInterval(), fmt.Errorf(
 				"failed to update status for ProvisioningRequest %s: %w",
 				t.object.Name, updateErr,
@@ -505,7 +505,7 @@ func (t *provisioningRequestReconcilerTask) handlePreProvisioning(ctx context.Co
 			return nil, res, err
 		}
 		// internal error that might recover - requeue to allow recovery
-		t.logger.WarnContext(ctx, "Internal validation error, will retry", slog.String("error", err.Error()))
+		t.logger.WarnContext(ctx, "Internal validation error, will retry", slog.Any("error", err))
 		return nil, requeueWithMediumInterval(), err
 	}
 
@@ -517,7 +517,7 @@ func (t *provisioningRequestReconcilerTask) handlePreProvisioning(ctx context.Co
 			return nil, res, err
 		}
 		// internal error that might recover - requeue to allow recovery
-		t.logger.WarnContext(ctx, "Internal ClusterInstance rendering error, will retry", slog.String("error", err.Error()))
+		t.logger.WarnContext(ctx, "Internal ClusterInstance rendering error, will retry", slog.Any("error", err))
 		return nil, requeueWithMediumInterval(), err
 	}
 
@@ -528,7 +528,7 @@ func (t *provisioningRequestReconcilerTask) handlePreProvisioning(ctx context.Co
 		if ctlrutils.IsInputError(err) {
 			_, err = t.checkClusterDeployConfigState(ctx)
 			if err != nil {
-				t.logger.WarnContext(ctx, "Cluster deploy config state check failed, will retry", slog.String("error", err.Error()))
+				t.logger.WarnContext(ctx, "Cluster deploy config state check failed, will retry", slog.Any("error", err))
 				return nil, requeueWithMediumInterval(), err
 			}
 			// Requeue since we are not watching for updates to required resources
@@ -536,7 +536,7 @@ func (t *provisioningRequestReconcilerTask) handlePreProvisioning(ctx context.Co
 			return nil, requeueWithMediumInterval(), nil
 		}
 		// internal error that might recover - requeue to allow recovery
-		t.logger.WarnContext(ctx, "Internal cluster resources error, will retry", slog.String("error", err.Error()))
+		t.logger.WarnContext(ctx, "Internal cluster resources error, will retry", slog.Any("error", err))
 		return nil, requeueWithMediumInterval(), err
 	}
 
@@ -557,13 +557,13 @@ func (t *provisioningRequestReconcilerTask) handleNodeAllocationRequestProvision
 		if ctlrutils.IsInputError(err) {
 			return doNotRequeue(), false, nil
 		}
-		t.logger.ErrorContext(ctx, "NodeAllocationRequest build error", slog.String("error", err.Error()))
+		t.logger.ErrorContext(ctx, "NodeAllocationRequest build error", slog.Any("error", err))
 		return doNotRequeue(), false, err
 	}
 
 	// Create/Update the NodeAllocationRequest
 	if err := t.createOrUpdateNodeAllocationRequest(ctx, renderedClusterInstance.GetNamespace(), renderedNodeAllocationRequest); err != nil {
-		t.logger.WarnContext(ctx, "NodeAllocationRequest create/update error, will retry", slog.String("error", err.Error()))
+		t.logger.WarnContext(ctx, "NodeAllocationRequest create/update error, will retry", slog.Any("error", err))
 		return requeueWithMediumInterval(), false, err
 	}
 
@@ -575,7 +575,7 @@ func (t *provisioningRequestReconcilerTask) handleNodeAllocationRequestProvision
 
 	nodeAllocationRequestResponse, exists, err := t.getNodeAllocationRequestResponse(ctx)
 	if err != nil {
-		t.logger.WarnContext(ctx, "NodeAllocationRequest response error, will retry", slog.String("error", err.Error()))
+		t.logger.WarnContext(ctx, "NodeAllocationRequest response error, will retry", slog.Any("error", err))
 		return requeueWithMediumInterval(), false, err
 	}
 	if !exists {
@@ -585,7 +585,7 @@ func (t *provisioningRequestReconcilerTask) handleNodeAllocationRequestProvision
 	// Wait for the NodeAllocationRequest to be provisioned and update BMC details if necessary
 	provisioned, configured, timedOutOrFailed, err := t.waitForHardwareData(ctx, renderedClusterInstance, nodeAllocationRequestResponse)
 	if err != nil {
-		t.logger.WarnContext(ctx, "Hardware data wait error, will retry", slog.String("error", err.Error()))
+		t.logger.WarnContext(ctx, "Hardware data wait error, will retry", slog.Any("error", err))
 		return requeueWithMediumInterval(), false, err
 	}
 	if timedOutOrFailed {
@@ -688,7 +688,7 @@ func (t *provisioningRequestReconcilerTask) checkClusterDeployConfigState(ctx co
 		if err != nil {
 			// Don't stop on status check errors - timeout monitoring must continue
 			t.logger.WarnContext(ctx, "Failed to check cluster provision status, continuing monitoring",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 				slog.String("name", t.object.Name))
 			// Continue with timeout monitoring even if status check fails
 		}
@@ -786,7 +786,7 @@ func (t *provisioningRequestReconcilerTask) checkClusterInstallationTimeout(ctx 
 		// The next reconciliation will detect the timeout again if status update fails
 		if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
 			t.logger.WarnContext(ctx, "Failed to update timeout status, will retry next reconciliation",
-				slog.String("error", updateErr.Error()),
+				slog.Any("error", updateErr),
 				slog.String("name", t.object.Name))
 		}
 
@@ -1053,7 +1053,7 @@ func (r *ProvisioningRequestReconciler) handleFinalizer(
 		if !controllerutil.ContainsFinalizer(provisioningRequest, provisioningv1alpha1.ProvisioningRequestFinalizer) {
 			controllerutil.AddFinalizer(provisioningRequest, provisioningv1alpha1.ProvisioningRequestFinalizer)
 			if err := r.Update(ctx, provisioningRequest); err != nil {
-				r.Logger.WarnContext(ctx, "Failed to add finalizer, will retry", slog.String("error", err.Error()))
+				r.Logger.WarnContext(ctx, "Failed to add finalizer, will retry", slog.Any("error", err))
 				return requeueWithShortInterval(), true, fmt.Errorf("failed to update ProvisioningRequest with finalizer: %w", err)
 			}
 			// Requeue since the finalizer has been added.
@@ -1073,7 +1073,7 @@ func (r *ProvisioningRequestReconciler) handleFinalizer(
 		patch := client.MergeFrom(provisioningRequest.DeepCopy())
 		if controllerutil.RemoveFinalizer(provisioningRequest, provisioningv1alpha1.ProvisioningRequestFinalizer) {
 			if err := r.Patch(ctx, provisioningRequest, patch); err != nil {
-				r.Logger.WarnContext(ctx, "Failed to remove finalizer, will retry", slog.String("error", err.Error()))
+				r.Logger.WarnContext(ctx, "Failed to remove finalizer, will retry", slog.Any("error", err))
 				return requeueWithShortInterval(), true, fmt.Errorf("failed to patch ProvisioningRequest: %w", err)
 			}
 			return doNotRequeue(), true, nil
@@ -1119,7 +1119,7 @@ func (r *ProvisioningRequestReconciler) handleProvisioningRequestDeletion(
 			if err := r.Client.Patch(ctx, managedCluster, patch); err != nil {
 				r.Logger.WarnContext(ctx, "Failed to set hubAcceptsClient=false, will retry",
 					slog.String("managedCluster", clusterName),
-					slog.String("error", err.Error()))
+					slog.Any("error", err))
 				return false, nil
 			}
 		}
@@ -1197,7 +1197,7 @@ func (r *ProvisioningRequestReconciler) handleProvisioningRequestDeletion(
 		if err := r.handleObservabilityAddonCleanup(ctx, ns.Name); err != nil {
 			r.Logger.WarnContext(ctx, "Failed to handle ObservabilityAddon cleanup",
 				slog.String("namespace", ns.Name),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			// Continue with deletion attempt even if cleanup fails
 		}
 
@@ -1259,7 +1259,7 @@ func (r *ProvisioningRequestReconciler) handleObservabilityAddonCleanup(ctx cont
 				r.Logger.WarnContext(ctx, "Failed to update ObservabilityAddon after removing finalizers",
 					slog.String("name", addon.Name),
 					slog.String("namespace", addon.Namespace),
-					slog.String("error", err.Error()))
+					slog.Any("error", err))
 				continue
 			}
 

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -143,7 +143,7 @@ func (t *provisioningRequestReconcilerTask) createNodeAllocationRequestResources
 
 	// Create the NodeAllocationRequest CR
 	if err := t.client.Create(ctx, nodeAllocationRequest); err != nil {
-		t.logger.ErrorContext(ctx, "Failed to create the NodeAllocationRequest", slog.String("error", err.Error()))
+		t.logger.ErrorContext(ctx, "Failed to create the NodeAllocationRequest", slog.Any("error", err))
 		return fmt.Errorf("failed to create NodeAllocationRequest %s: %w", t.object.Name, err)
 	}
 
@@ -166,7 +166,7 @@ func (t *provisioningRequestReconcilerTask) waitForHardwareData(
 	// regardless of whether provisioning is complete, in-progress, or failed.
 	if updateErr := t.updateInfrastructureResourceStatuses(ctx); updateErr != nil {
 		t.logger.WarnContext(ctx, "Failed to update infrastructure resource statuses",
-			slog.String("error", updateErr.Error()))
+			slog.Any("error", updateErr))
 	}
 
 	if err != nil {
@@ -270,7 +270,7 @@ func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestStatus(
 			ctx,
 			"Failed to update the NodeAllocationRequest status for ProvisioningRequest",
 			slog.String("name", t.object.Name),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 	}
 

--- a/internal/controllers/resourcepool_controller.go
+++ b/internal/controllers/resourcepool_controller.go
@@ -50,7 +50,7 @@ func (r *ResourcePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if err != nil {
 			r.Logger.ErrorContext(ctx, "Reconciliation failed",
 				slog.Duration("duration", duration),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		} else {
 			r.Logger.InfoContext(ctx, "Reconciliation completed",
 				slog.Duration("duration", duration),
@@ -213,7 +213,7 @@ func (r *ResourcePoolReconciler) enqueueResourcePoolsForOCloudSite(ctx context.C
 		},
 	); err != nil {
 		r.Logger.ErrorContext(ctx, "Failed to list ResourcePools for OCloudSite watch",
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		return nil
 	}
 

--- a/internal/controllers/utils/logging.go
+++ b/internal/controllers/utils/logging.go
@@ -73,13 +73,12 @@ func LogPhaseComplete(ctx context.Context, logger *slog.Logger, phase string, du
 		slog.Duration(LogAttrDuration, duration))
 }
 
-// LogError provides standardized error logging
+// LogError provides standardized error logging. Uses LogAttrs instead of
+// ErrorContext because the variadic parameter is already []slog.Attr,
+// which avoids converting to []any and the runtime type-detection overhead.
 func LogError(ctx context.Context, logger *slog.Logger, msg string, err error, attrs ...slog.Attr) {
-	// Convert slog.Attr to []any for the logger call
-	args := make([]any, 0, len(attrs)*2+2)
-	args = append(args, LogAttrError, err.Error())
-	for _, attr := range attrs {
-		args = append(args, attr.Key, attr.Value)
-	}
-	logger.ErrorContext(ctx, msg, args...)
+	allAttrs := make([]slog.Attr, 0, len(attrs)+1)
+	allAttrs = append(allAttrs, slog.Any(LogAttrError, err))
+	allAttrs = append(allAttrs, attrs...)
+	logger.LogAttrs(ctx, slog.LevelError, msg, allAttrs...)
 }

--- a/internal/hardwaremanager/cmd/start_hardwaremanager.go
+++ b/internal/hardwaremanager/cmd/start_hardwaremanager.go
@@ -141,7 +141,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	}
 
 	if err := hwmgrutils.InitNodeAllocationRequestUtils(scheme); err != nil {
-		logger.ErrorContext(ctx, "failed InitNodeAllocationRequestUtils", slog.String("error", err.Error()))
+		logger.ErrorContext(ctx, "failed InitNodeAllocationRequestUtils", slog.Any("error", err))
 		return exit.Error(1)
 	}
 
@@ -159,7 +159,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		LeaderElectionID:       "a3c1dd20.openshift.io",
 	})
 	if err != nil {
-		logger.ErrorContext(ctx, "Unable to start manager", slog.String("error", err.Error()))
+		logger.ErrorContext(ctx, "Unable to start manager", slog.Any("error", err))
 		return exit.Error(1)
 	}
 
@@ -167,23 +167,23 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 	err = hwmgrctrl.SetupControllers(mgr, namespace, logger)
 	if err != nil {
 		logger.ErrorContext(ctx, "Unable to create hardware manager controller",
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		return exit.Error(1)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		logger.ErrorContext(ctx, "Unable to set up health check", slog.String("error", err.Error()))
+		logger.ErrorContext(ctx, "Unable to set up health check", slog.Any("error", err))
 		return exit.Error(1)
 	}
 
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		logger.ErrorContext(ctx, "Unable to set up ready check", slog.String("error", err.Error()))
+		logger.ErrorContext(ctx, "Unable to set up ready check", slog.Any("error", err))
 		return exit.Error(1)
 	}
 
 	logger.Info("Starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		logger.ErrorContext(ctx, "Problem running manager", slog.String("error", err.Error()))
+		logger.ErrorContext(ctx, "Problem running manager", slog.Any("error", err))
 		return exit.Error(1)
 	}
 

--- a/internal/hardwaremanager/controller/allocatednode_controller.go
+++ b/internal/hardwaremanager/controller/allocatednode_controller.go
@@ -52,7 +52,7 @@ func (r *AllocatedNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err != nil {
 			r.Logger.ErrorContext(ctx, "Reconciliation failed",
 				slog.Duration("duration", duration),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		} else {
 			r.Logger.InfoContext(ctx, "Reconciliation completed",
 				slog.Duration("duration", duration),
@@ -94,7 +94,7 @@ func (r *AllocatedNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 
 			if finalizerErr := hwmgrutils.AllocatedNodeRemoveFinalizer(ctx, r.NoncachedClient, r.Client, allocatedNode); finalizerErr != nil {
-				r.Logger.InfoContext(ctx, "Failed to remove finalizer, requeueing", slog.String("error", finalizerErr.Error()))
+				r.Logger.InfoContext(ctx, "Failed to remove finalizer, requeueing", slog.Any("error", finalizerErr))
 				return hwmgrutils.RequeueWithShortInterval(), nil
 			}
 
@@ -108,7 +108,7 @@ func (r *AllocatedNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if !controllerutil.ContainsFinalizer(allocatedNode, hwmgrutils.AllocatedNodeFinalizer) {
 		if finalizerErr := hwmgrutils.AllocatedNodeAddFinalizer(ctx, r.NoncachedClient, r.Client, allocatedNode); finalizerErr != nil {
-			r.Logger.InfoContext(ctx, "Failed to add node finalizer, requeueing", slog.String("error", finalizerErr.Error()))
+			r.Logger.InfoContext(ctx, "Failed to add node finalizer, requeueing", slog.Any("error", finalizerErr))
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
 	}

--- a/internal/hardwaremanager/controller/baremetalhost_manager.go
+++ b/internal/hardwaremanager/controller/baremetalhost_manager.go
@@ -91,7 +91,7 @@ func updateBMHMetaWithRetry(
 		var latestBMH metal3v1alpha1.BareMetalHost
 		if err := c.Get(ctx, name, &latestBMH); err != nil {
 			logger.ErrorContext(ctx, "Failed to fetch BMH for "+metaType+" update",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return err
 		}
 
@@ -150,7 +150,7 @@ func updateBMHMetaWithRetry(
 		if err := c.Patch(ctx, &latestBMH, patch); err != nil {
 			logger.ErrorContext(ctx, "Failed to update BMH "+metaType,
 				slog.String("operation", operation),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return fmt.Errorf("failed to %s %s on BMH %s: %w", operation, metaType, name.Name, err)
 		}
 
@@ -325,7 +325,7 @@ func setBootMACAddressFromLabel(
 		var latestBMH metal3v1alpha1.BareMetalHost
 		if err := c.Get(ctx, name, &latestBMH); err != nil {
 			logger.ErrorContext(ctx, "Failed to fetch BMH for bootMACAddress update",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return err
 		}
 
@@ -350,7 +350,7 @@ func setBootMACAddressFromLabel(
 		// Apply the patch
 		if err := c.Patch(ctx, &latestBMH, patch); err != nil {
 			logger.ErrorContext(ctx, "Failed to patch BMH bootMACAddress",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return fmt.Errorf("failed to patch BMH bootMACAddress %s: %w", name.Name, err)
 		}
 
@@ -393,7 +393,7 @@ func processHwProfileWithHandledError(
 		}
 		if err := hwmgrutils.SetNodeConditionStatus(ctx, c, noncachedClient, node,
 			contType, metav1.ConditionFalse, string(reason), err.Error()); err != nil {
-			logger.ErrorContext(ctx, "failed to update node status", slog.String("node", node.Name), slog.String("error", err.Error()))
+			logger.ErrorContext(ctx, "failed to update node status", slog.String("node", node.Name), slog.Any("error", err))
 		}
 		return updateRequired, err
 	}
@@ -757,21 +757,21 @@ func processBMHUpdateCase(ctx context.Context,
 		// Clear config-in-progress annotation before setting node to failed
 		if err := clearConfigAnnotationWithPatch(ctx, c, node); err != nil {
 			logger.ErrorContext(ctx, "Failed to clear config annotation",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return ctrl.Result{}, err
 		}
 
 		// Clear BMH update annotations to ensure clean state for retry
 		if err := clearBMHUpdateAnnotations(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "Failed to clear BMH update annotations after error",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
 
 		// Clear BMH error annotation to allow future retry attempts
 		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "failed to clear BMH error annotation for future retries",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
 
@@ -783,7 +783,7 @@ func processBMHUpdateCase(ctx context.Context,
 		}
 		if err := hwmgrutils.SetNodeFailedStatus(ctx, c, logger, node, string(condType), message); err != nil {
 			if k8serrors.IsConflict(err) {
-				logger.WarnContext(ctx, "conflict setting node status; will retry", slog.String("error", err.Error()))
+				logger.WarnContext(ctx, "conflict setting node status; will retry", slog.Any("error", err))
 				return hwmgrutils.RequeueWithShortInterval(), nil
 			}
 			// everything else here is unexpected
@@ -796,7 +796,7 @@ func processBMHUpdateCase(ctx context.Context,
 	// clear transient error annotation if BMH recovered
 	if _, hasAnnotation := bmh.Annotations[BmhErrorTimestampAnnotation]; hasAnnotation {
 		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
-			logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("error", err.Error()))
+			logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.Any("error", err))
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
 	}
@@ -833,7 +833,7 @@ func processBMHUpdateCase(ctx context.Context,
 	bmhName := types.NamespacedName{Name: bmh.Name, Namespace: bmh.Namespace}
 	if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation, uc.AnnotationKey, "", OpRemove); err != nil {
 		logger.WarnContext(ctx, "failed to remove annotation",
-			slog.String("annotation", uc.AnnotationKey), slog.String("error", err.Error()))
+			slog.String("annotation", uc.AnnotationKey), slog.Any("error", err))
 		return hwmgrutils.RequeueWithShortInterval(), nil
 	}
 
@@ -842,7 +842,7 @@ func processBMHUpdateCase(ctx context.Context,
 		if err := annotateNodeConfigInProgress(ctx, c, logger, namespace, node.Name, uc.Reason); err != nil {
 			logger.WarnContext(ctx,
 				fmt.Sprintf("Failed to annotate %s update in progress", uc.LogLabel),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return hwmgrutils.RequeueWithShortInterval(), nil
 		}
 		logger.InfoContext(ctx,
@@ -901,7 +901,7 @@ func handleBMHCompletion(ctx context.Context,
 			}
 			if err != nil {
 				logger.ErrorContext(nodeCtx, "failed to handle single node completion",
-					slog.String("error", err.Error()))
+					slog.Any("error", err))
 				errs = append(errs, fmt.Errorf("node %s, error: %w", node.Name, err))
 			}
 		}(node)
@@ -948,14 +948,14 @@ func handleSingleNodeCompletion(ctx context.Context,
 				string(hwmgmtv1alpha1.Provisioned), metav1.ConditionFalse,
 				string(hwmgmtv1alpha1.Failed), errMessage.Error()); err != nil {
 				logger.ErrorContext(ctx, "failed to set node condition status",
-					slog.String("error", err.Error()))
+					slog.Any("error", err))
 			}
 			return false, errMessage
 		}
 		// if BMH is not in error state, clean up transient annotation if it exists
 		if _, hasAnnotation := bmh.Annotations[BmhErrorTimestampAnnotation]; hasAnnotation {
 			if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
-				logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("error", err.Error()))
+				logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.Any("error", err))
 			}
 		}
 		return true, nil // still waiting for available
@@ -965,7 +965,7 @@ func handleSingleNodeCompletion(ctx context.Context,
 	if _, hasAnnotation := bmh.Annotations[BmhErrorTimestampAnnotation]; hasAnnotation {
 		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "failed to clean up transient error annotation on BMH available transition",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		}
 	}
 
@@ -1035,7 +1035,7 @@ func removeInfraEnvLabelFromPreprovisioningImage(ctx context.Context, c client.C
 		image := &metal3v1alpha1.PreprovisioningImage{}
 		if err := c.Get(ctx, name, image); err != nil {
 			logger.ErrorContext(ctx, "Failed to get PreprovisioningImage",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return err
 		}
 
@@ -1048,7 +1048,7 @@ func removeInfraEnvLabelFromPreprovisioningImage(ctx context.Context, c client.C
 		patch := client.MergeFrom(image)
 		if err := c.Patch(ctx, patched, patch); err != nil {
 			logger.ErrorContext(ctx, "Failed to patch PreprovisioningImage",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return fmt.Errorf("failed to patch PreprovisioningImage %s: %w", name.String(), err)
 		}
 
@@ -1083,7 +1083,7 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 		var current metal3v1alpha1.BareMetalHost
 		if err := c.Get(ctx, name, &current); err != nil {
 			logger.ErrorContext(ctx, "Failed to get BMH",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return err
 		}
 
@@ -1160,7 +1160,7 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 		patch := client.MergeFrom(&current)
 		if err := c.Patch(ctx, patched, patch); err != nil {
 			logger.ErrorContext(ctx, "Failed to patch BMH",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return fmt.Errorf("failed to patch BMH %s: %w", name.String(), err)
 		}
 
@@ -1238,7 +1238,7 @@ func clearBMHAnnotation(ctx context.Context, c client.Client, logger *slog.Logge
 		var latestBMH metal3v1alpha1.BareMetalHost
 		if err := c.Get(ctx, name, &latestBMH); err != nil {
 			logger.ErrorContext(ctx, "Failed to fetch BMH for annotation cleanup",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return err
 		}
 
@@ -1271,7 +1271,7 @@ func clearBMHAnnotation(ctx context.Context, c client.Client, logger *slog.Logge
 		// Apply the patch with both changes in a single API call
 		if err := c.Patch(ctx, &latestBMH, patch); err != nil {
 			logger.ErrorContext(ctx, "Failed to clear BMH annotations",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return fmt.Errorf("failed to clear BMH annotations on BMH %s: %w", name.Name, err)
 		}
 
@@ -1349,7 +1349,7 @@ func tolerateAndAnnotateTransientBMHError(
 	tolerate, err := isTransientBMHError(bmh)
 	if err != nil {
 		message := "error checking transient BMH error"
-		logger.WarnContext(ctx, message, slog.String("error", err.Error()))
+		logger.WarnContext(ctx, message, slog.Any("error", err))
 		return false, fmt.Errorf("%s: %w", message, err)
 	}
 
@@ -1357,7 +1357,7 @@ func tolerateAndAnnotateTransientBMHError(
 		tsStr, hasAnnotation := bmh.Annotations[BmhErrorTimestampAnnotation]
 		if err := markBMHTransitenError(ctx, c, logger, bmh); err != nil {
 			message := "failed to annotate transient BMH error"
-			logger.WarnContext(ctx, message, slog.String("error", err.Error()))
+			logger.WarnContext(ctx, message, slog.Any("error", err))
 			return false, fmt.Errorf("%s: %w", message, err)
 		}
 		logger.InfoContext(ctx, "BMH in transient error — tolerating and skipping failure",
@@ -1384,7 +1384,7 @@ func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slo
 			slog.String("annotation", BiosUpdateNeededAnnotation))
 		if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation, BiosUpdateNeededAnnotation, "", OpRemove); err != nil {
 			logger.WarnContext(ctx, "Failed to remove BIOS update annotation",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			errs = append(errs, fmt.Errorf("bios annotation removal failed: %w", err))
 		} else {
 			logger.DebugContext(ctx, "BIOS update-needed annotation cleared successfully")
@@ -1398,7 +1398,7 @@ func clearBMHUpdateAnnotations(ctx context.Context, c client.Client, logger *slo
 			slog.String("annotation", FirmwareUpdateNeededAnnotation))
 		if err := updateBMHMetaWithRetry(ctx, c, logger, bmhName, MetaTypeAnnotation, FirmwareUpdateNeededAnnotation, "", OpRemove); err != nil {
 			logger.WarnContext(ctx, "Failed to remove firmware update annotation",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			errs = append(errs, fmt.Errorf("firmware annotation removal failed: %w", err))
 		} else {
 			logger.DebugContext(ctx, "Firmware update-needed annotation cleared successfully")

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -116,7 +116,7 @@ func enableBMOManagementForIBINodes(
 		bmh, err := getBMHForNode(nodeCtx, noncachedClient, node)
 		if err != nil {
 			logger.ErrorContext(nodeCtx, "Failed to get BMH for node, skipping IBI management setup",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			continue
 		}
 		nodeCtx = logging.AppendCtx(nodeCtx, slog.String("bmh", bmh.Name))
@@ -312,7 +312,7 @@ func deriveNARStatusFromSingleNode(
 	updatedNode, err := hwmgrutils.GetNode(ctx, logger, noncachedClient, node.Namespace, node.Name)
 	if err != nil {
 		logger.ErrorContext(ctx, "Failed to fetch updated AllocatedNode",
-			slog.String("name", node.Name), slog.String("error", err.Error()))
+			slog.String("name", node.Name), slog.Any("error", err))
 		return metav1.ConditionFalse, string(hwmgmtv1alpha1.InProgress),
 			fmt.Sprintf("AllocatedNode %s could not be fetched: %v", node.Name, err)
 	}
@@ -362,7 +362,7 @@ func deriveNARStatusFromMultipleNodes(
 		updatedNode, err := hwmgrutils.GetNode(ctx, logger, noncachedClient, node.Namespace, node.Name)
 		if err != nil {
 			logger.ErrorContext(ctx, "Failed to fetch updated AllocatedNode",
-				slog.String("name", node.Name), slog.String("error", err.Error()))
+				slog.String("name", node.Name), slog.Any("error", err))
 			return metav1.ConditionFalse, string(hwmgmtv1alpha1.InProgress),
 				fmt.Sprintf("AllocatedNode %s could not be fetched: %v", node.Name, err)
 		}
@@ -677,7 +677,7 @@ func handleNodeInProgressUpdate(ctx context.Context,
 
 		if _, hasAnnotation := bmh.Annotations[BmhErrorTimestampAnnotation]; hasAnnotation {
 			if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
-				logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.String("error", err.Error()))
+				logger.WarnContext(ctx, "failed to clean up transient error annotation", slog.Any("error", err))
 				return ctrl.Result{}, err
 			}
 		}
@@ -688,7 +688,7 @@ func handleNodeInProgressUpdate(ctx context.Context,
 		ready, err := nodeOps.IsNodeReady(ctx, hostname)
 		if err != nil {
 			logger.ErrorContext(ctx, "Failed to check node readiness",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return hwmgrutils.RequeueWithMediumInterval(), nil
 		}
 		if !ready {
@@ -709,13 +709,13 @@ func handleNodeInProgressUpdate(ctx context.Context,
 
 		if err := hwmgrutils.SetNodeConfigApplied(ctx, c, noncachedClient, logger, node, node.Spec.HwProfile); err != nil {
 			logger.ErrorContext(ctx, "Failed to set node config applied",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return ctrl.Result{}, fmt.Errorf("failed to mark node config applied %s: %w", node.Name, err)
 		}
 
 		if err := clearConfigAnnotationWithPatch(ctx, c, node); err != nil {
 			logger.ErrorContext(ctx, "Failed to clear config annotation",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return ctrl.Result{}, err
 		}
 
@@ -745,21 +745,21 @@ func handleNodeInProgressUpdate(ctx context.Context,
 		// Clear BMH update annotations to ensure clean state for retry
 		if err := clearBMHUpdateAnnotations(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "Failed to clear BMH update annotations after error",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return ctrl.Result{}, fmt.Errorf("failed to clear BMH update annotations %s:%w", bmh.Name, err)
 		}
 
 		// Clear BMH error annotation to allow future retry attempts
 		if err := clearTransientBMHErrorAnnotation(ctx, c, logger, bmh); err != nil {
 			logger.WarnContext(ctx, "failed to clear BMH error annotation for future retries",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return ctrl.Result{}, fmt.Errorf("failed to clear BMH error annotation %s:%w", bmh.Name, err)
 		}
 
 		if err := hwmgrutils.SetNodeConditionStatus(ctx, c, noncachedClient, node,
 			string(hwmgmtv1alpha1.Configured), metav1.ConditionFalse,
 			string(hwmgmtv1alpha1.Failed), BmhServicingErr); err != nil {
-			logger.ErrorContext(ctx, "failed to update AllocatedNode status", slog.String("error", err.Error()))
+			logger.ErrorContext(ctx, "failed to update AllocatedNode status", slog.Any("error", err))
 			return ctrl.Result{}, fmt.Errorf("failed to update AllocatedNode status %s:%w", node.Name, err)
 		}
 
@@ -893,7 +893,7 @@ func initiateNodeUpdate(ctx context.Context,
 		if err := nodeOps.DrainNode(ctx, node.Status.Hostname); err != nil {
 			logger.ErrorContext(ctx, "Drain failed, will retry",
 				slog.String("hostname", node.Status.Hostname),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			return hwmgrutils.RequeueWithMediumInterval(), nil
 		}
 	}
@@ -1184,7 +1184,7 @@ func executeNodeUpdates(
 
 			if err != nil {
 				logger.ErrorContext(nodeCtx, "Node processing error",
-					slog.String("error", err.Error()))
+					slog.Any("error", err))
 				errs = append(errs, fmt.Errorf("node %s, error: %w", nodeToProcess.node.Name, err))
 			}
 
@@ -1316,7 +1316,7 @@ func classifyNodes(
 		ready, err := nodeOps.IsNodeReady(ctx, node.Status.Hostname)
 		if err != nil {
 			logger.WarnContext(ctx, "Failed to check node readiness, assuming not ready",
-				slog.String("node", node.Name), slog.String("error", err.Error()))
+				slog.String("node", node.Name), slog.Any("error", err))
 			ready = false
 		}
 		if !ready {
@@ -1601,7 +1601,7 @@ func processNodeAllocationRequestAllocation(
 				}
 				if err != nil {
 					logger.ErrorContext(bmhCtx, "Failed to allocate BMH to NodeAllocationRequest",
-						slog.String("error", err.Error()))
+						slog.Any("error", err))
 					errs = append(errs, fmt.Errorf("bmh %s, error: %w", bmh.Name, err))
 				}
 			}(bmh)
@@ -1859,7 +1859,7 @@ func validateNodeConfiguration(
 	firmwareValid, err := validateFirmwareVersions(ctx, c, noncachedClient, logger, bmh, namespace, hwProfileName)
 	if err != nil {
 		logger.ErrorContext(ctx, "Failed to validate firmware versions",
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		return false, err
 	}
 	if !firmwareValid {
@@ -1871,7 +1871,7 @@ func validateNodeConfiguration(
 	biosValid, err := validateAppliedBiosSettings(ctx, c, noncachedClient, logger, bmh, namespace, hwProfileName)
 	if err != nil {
 		logger.ErrorContext(ctx, "Failed to validate BIOS settings",
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		return false, err
 	}
 	if !biosValid {
@@ -1907,7 +1907,7 @@ func clearBMHUpdateAnnotationsForNAR(
 		bmh, err := getBMHForNode(nodeCtx, c, &node)
 		if err != nil {
 			logger.ErrorContext(nodeCtx, "Failed to get BMH for annotation clear",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			errs = append(errs, fmt.Errorf("failed to get BMH for AllocatedNode %s: %w", node.Name, err))
 			continue
 		}
@@ -1916,7 +1916,7 @@ func clearBMHUpdateAnnotationsForNAR(
 		// Clear update annotations from BMH
 		if err := clearBMHUpdateAnnotations(nodeCtx, c, logger, bmh); err != nil {
 			logger.ErrorContext(nodeCtx, "Failed to clear BMH update annotations",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 			errs = append(errs, fmt.Errorf("failed to clear BMH update annotations for BMH %s: %w", bmh.Name, err))
 		} else {
 			logger.InfoContext(nodeCtx, "Cleared BMH update annotations")
@@ -1955,12 +1955,12 @@ func clearConfigAnnotationForAllocatedNodes(
 		updatedNode := &hwmgmtv1alpha1.AllocatedNode{}
 		if err := noncachedClient.Get(ctx, types.NamespacedName{Name: node.Name, Namespace: node.Namespace}, updatedNode); err != nil {
 			logger.ErrorContext(ctx, "Failed to fetch AllocatedNode for annotation clear",
-				slog.String("allocatedNode", node.Name), slog.String("error", err.Error()))
+				slog.String("allocatedNode", node.Name), slog.Any("error", err))
 			continue
 		}
 		if err := clearConfigAnnotationWithPatch(ctx, c, updatedNode); err != nil {
 			logger.ErrorContext(ctx, "Failed to clear config-in-progress annotation",
-				slog.String("allocatedNode", updatedNode.Name), slog.String("error", err.Error()))
+				slog.String("allocatedNode", updatedNode.Name), slog.Any("error", err))
 			// continue to other nodes
 		} else {
 			logger.InfoContext(ctx, "Cleared config-in-progress annotation",

--- a/internal/hardwaremanager/controller/hostfirmwarecomponents_controller.go
+++ b/internal/hardwaremanager/controller/hostfirmwarecomponents_controller.go
@@ -60,7 +60,7 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 		if err != nil {
 			r.Logger.ErrorContext(ctx, "Reconciliation failed",
 				slog.Duration("duration", duration),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		} else {
 			r.Logger.InfoContext(ctx, "Reconciliation completed",
 				slog.Duration("duration", duration),
@@ -149,7 +149,7 @@ func (r *HostFirmwareComponentsReconciler) isHPEOrDell(ctx context.Context, name
 			r.Logger.InfoContext(ctx, "HardwareData not found for validation check")
 		} else {
 			r.Logger.WarnContext(ctx, "Failed to get HardwareData for vendor check",
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		}
 		return false
 	}

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -80,7 +80,7 @@ func (r *NodeAllocationRequestReconciler) Reconcile(ctx context.Context, req ctr
 		if err != nil {
 			r.Logger.ErrorContext(ctx, "Reconciliation failed",
 				slog.Duration("duration", duration),
-				slog.String("error", err.Error()))
+				slog.Any("error", err))
 		} else {
 			r.Logger.InfoContext(ctx, "Reconciliation completed",
 				slog.Duration("duration", duration),
@@ -134,7 +134,7 @@ func (r *NodeAllocationRequestReconciler) Reconcile(ctx context.Context, req ctr
 			}
 
 			if finalizerErr := hwmgrutils.NodeAllocationRequestRemoveFinalizer(ctx, r.Client, nodeAllocationRequest); finalizerErr != nil {
-				r.Logger.InfoContext(ctx, "Failed to remove finalizer, requeueing", slog.String("error", finalizerErr.Error()))
+				r.Logger.InfoContext(ctx, "Failed to remove finalizer, requeueing", slog.Any("error", finalizerErr))
 				return hwmgrutils.RequeueWithShortInterval(), nil
 			}
 
@@ -175,7 +175,7 @@ func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 	if timeoutExceeded, conditionType, err := r.checkHardwareTimeout(ctx, nodeAllocationRequest); err != nil {
 		r.Logger.ErrorContext(ctx, "Failed to check hardware timeout",
 			slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		return hwmgrutils.RequeueWithMediumInterval(), fmt.Errorf("failed to check hardware timeout: %w", err)
 	} else if timeoutExceeded {
 		var timeoutMessage string
@@ -208,7 +208,7 @@ func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 		); updateErr != nil {
 			r.Logger.ErrorContext(ctx, "Failed to update status for timeout",
 				slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-				slog.String("error", updateErr.Error()))
+				slog.Any("error", updateErr))
 			return hwmgrutils.RequeueWithMediumInterval(),
 				fmt.Errorf("failed to update status for NodeAllocationRequest timeout %s: %w",
 					nodeAllocationRequest.Name, updateErr)
@@ -219,7 +219,7 @@ func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 		if updateErr := hwmgrutils.UpdateNodeAllocationRequestObservedGeneration(ctx, r.Client, nodeAllocationRequest); updateErr != nil {
 			r.Logger.ErrorContext(ctx, "Failed to update ObservedGeneration after timeout",
 				slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-				slog.String("error", updateErr.Error()))
+				slog.Any("error", updateErr))
 			// Don't return error, timeout condition is already set
 		}
 
@@ -227,7 +227,7 @@ func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 			if err := clearConfigAnnotationForAllocatedNodes(ctx, r.Client, r.NoncachedClient, r.Logger, nodeAllocationRequest); err != nil {
 				r.Logger.ErrorContext(ctx, "Failed to clear config in progress annotations after configuration timeout",
 					slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-					slog.String("error", err.Error()))
+					slog.Any("error", err))
 				return hwmgrutils.RequeueWithMediumInterval(),
 					fmt.Errorf("failed to clear config in progress annotations after configuration timeout %s: %w",
 						nodeAllocationRequest.Name, err)
@@ -237,7 +237,7 @@ func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 			if err := clearBMHUpdateAnnotationsForNAR(ctx, r.Client, r.Logger, nodeAllocationRequest); err != nil {
 				r.Logger.ErrorContext(ctx, "Failed to clear BMH update annotations after configuration timeout",
 					slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-					slog.String("error", err.Error()))
+					slog.Any("error", err))
 				return hwmgrutils.RequeueWithMediumInterval(),
 					fmt.Errorf("failed to clear BMH update annotations after configuration timeout %s: %w",
 						nodeAllocationRequest.Name, err)
@@ -279,7 +279,7 @@ func (r *NodeAllocationRequestReconciler) handleNewNodeAllocationRequestCreate(
 	var message string
 
 	if err := processNewNodeAllocationRequest(ctx, r.NoncachedClient, r.Logger, nodeAllocationRequest); err != nil {
-		r.Logger.ErrorContext(ctx, "failed processNewNodeAllocationRequest", slog.String("error", err.Error()))
+		r.Logger.ErrorContext(ctx, "failed processNewNodeAllocationRequest", slog.Any("error", err))
 		conditionReason = hwmgmtv1alpha1.Failed
 		conditionStatus = metav1.ConditionFalse
 		message = "Creation request failed: " + err.Error()
@@ -381,7 +381,7 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestSpecChanged
 			if updateErr := hwmgrutils.UpdateNodeAllocationRequestObservedGeneration(ctx, r.Client, nodeAllocationRequest); updateErr != nil {
 				r.Logger.ErrorContext(ctx, "Failed to update ObservedGeneration status",
 					slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-					slog.String("error", updateErr.Error()))
+					slog.Any("error", updateErr))
 				// Return error to trigger requeue
 				return hwmgrutils.RequeueWithShortInterval(),
 					fmt.Errorf("failed to update ObservedGeneration status: %w", updateErr)
@@ -402,7 +402,7 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestSpecChanged
 			hwmgmtv1alpha1.Configured, hwmgmtv1alpha1.ConditionReason(reason), status, message); updateErr != nil {
 
 			r.Logger.ErrorContext(ctx, "Failed to update aggregated NodeAllocationRequest status",
-				slog.String("error", updateErr.Error()))
+				slog.Any("error", updateErr))
 
 			if err == nil {
 				err = updateErr
@@ -416,7 +416,7 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestSpecChanged
 			if updateErr := hwmgrutils.UpdateNodeAllocationRequestObservedGeneration(ctx, r.Client, nodeAllocationRequest); updateErr != nil {
 				r.Logger.ErrorContext(ctx, "Failed to update ObservedGeneration status",
 					slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-					slog.String("error", updateErr.Error()))
+					slog.Any("error", updateErr))
 				// Return error to trigger requeue
 				return hwmgrutils.RequeueWithShortInterval(),
 					fmt.Errorf("failed to update ObservedGeneration status: %w", updateErr)

--- a/internal/hardwaremanager/utils/allocated_node.go
+++ b/internal/hardwaremanager/utils/allocated_node.go
@@ -131,7 +131,7 @@ func GetChildNodes(
 	if err := ctlrutils.RetryOnConflictOrRetriableOrNotFound(retry.DefaultRetry, func() error {
 		return c.List(ctx, nodelist, opts...)
 	}); err != nil {
-		logger.InfoContext(ctx, "Unable to query node list", slog.String("error", err.Error()))
+		logger.InfoContext(ctx, "Unable to query node list", slog.Any("error", err))
 		return nil, fmt.Errorf("failed to query node list: %w", err)
 	}
 
@@ -203,7 +203,7 @@ func SetNodeFailedStatus(
 		logger.ErrorContext(ctx, "Failed to update node status with failure",
 			slog.String("node", node.Name),
 			slog.String("conditionType", conditionType),
-			slog.String("error", err.Error()))
+			slog.Any("error", err))
 		return fmt.Errorf("failed to set node failed status: %w", err)
 	}
 

--- a/internal/service/alarms/internal/alertmanager/api.go
+++ b/internal/service/alarms/internal/alertmanager/api.go
@@ -160,7 +160,7 @@ func (c *AMClient) getAlerts(ctx context.Context) ([]APIAlert, error) {
 	}
 	defer func(Body io.ReadCloser) {
 		if err := Body.Close(); err != nil {
-			slog.ErrorContext(ctx, "failed to close response body during AM get call", slog.String("error", err.Error()))
+			slog.ErrorContext(ctx, "failed to close response body during AM get call", slog.Any("error", err))
 		}
 	}(resp.Body)
 

--- a/internal/service/cluster/api/server.go
+++ b/internal/service/cluster/api/server.go
@@ -463,7 +463,7 @@ func (r *ClusterServer) CreateSubscription(ctx context.Context, request api.Crea
 				Status: http.StatusBadRequest,
 			}, nil
 		}
-		slog.ErrorContext(ctx, "error writing database record", slog.Any("target", record), slog.String("error", err.Error()))
+		slog.ErrorContext(ctx, "error writing database record", slog.Any("target", record), slog.Any("error", err))
 		return api.CreateSubscription500ApplicationProblemPlusJSONResponse{
 			AdditionalAttributes: &map[string]string{
 				"consumerSubscriptionId": consumerSubscriptionId,

--- a/internal/service/common/api/middleware/middleware.go
+++ b/internal/service/common/api/middleware/middleware.go
@@ -126,7 +126,7 @@ func ProblemDetails(w http.ResponseWriter, body string, code int) {
 func getOranErrHandler() oapimiddleware.ErrorHandlerWithOpts {
 	return func(_ context.Context, err error, w http.ResponseWriter, r *http.Request, opts oapimiddleware.ErrorHandlerOpts) {
 		slog.WarnContext(r.Context(), "OpenAPI validation failed",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 			slog.Int("status", opts.StatusCode),
 		)
 		ProblemDetails(w, err.Error(), opts.StatusCode)
@@ -137,7 +137,7 @@ func getOranErrHandler() oapimiddleware.ErrorHandlerWithOpts {
 func GetOranReqErrFunc() func(w http.ResponseWriter, r *http.Request, err error) {
 	return func(w http.ResponseWriter, r *http.Request, err error) {
 		slog.WarnContext(r.Context(), "OpenAPI request validation failed",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 			slog.Int("status", http.StatusBadRequest),
 		)
 		msg := err.Error()

--- a/internal/service/common/db/postgres.go
+++ b/internal/service/common/db/postgres.go
@@ -151,7 +151,7 @@ var customLogger = tracelog.LoggerFunc(func(ctx context.Context, level tracelog.
 
 	// Handle errors (this takes precedence over performance warnings)
 	if err, ok := data["err"].(error); ok && err != nil {
-		attrs = append(attrs, slog.String("error", err.Error()))
+		attrs = append(attrs, slog.Any("error", err))
 		slog.LogAttrs(ctx, slog.LevelError, fmt.Sprintf("Database %s failed", msg), attrs...)
 		return
 	}

--- a/internal/service/resources/api/server.go
+++ b/internal/service/resources/api/server.go
@@ -345,7 +345,7 @@ func (r *ResourceServer) CreateSubscription(ctx context.Context, request api.Cre
 				Status: http.StatusBadRequest,
 			}, nil
 		}
-		slog.ErrorContext(ctx, "error writing database record", slog.Any("target", record), slog.String("error", err.Error()))
+		slog.ErrorContext(ctx, "error writing database record", slog.Any("target", record), slog.Any("error", err))
 		return api.CreateSubscription500ApplicationProblemPlusJSONResponse{
 			AdditionalAttributes: &map[string]string{
 				"consumerSubscriptionId": consumerSubscriptionId,


### PR DESCRIPTION
- Replace all slog.String("error", err.Error()) calls with slog.Any("error", err) across the codebase — preserves error type, enables lazy evaluation, and is nil-safe
- Fix LogError utility to use slog.Any and LogAttrs instead of untyped key-value pairs
- Add error logging convention to AGENTS.md Logging Conventions