### PR TITLE
CNF-24707: standardize error log key to "error"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ issues during code review.
 - Log errors with `slog.Any("error", err)`, not
   `slog.String("error", err.Error())`. This preserves the error type
   for structured logging handlers and avoids eager `.Error()` calls.
+  Always use `"error"` as the key — not `"err"` or `"Error"`.
+- Log messages should not end with punctuation or trailing spaces.
 
 ## Test Conventions
 

--- a/internal/controllers/provisioningrequest_setup.go
+++ b/internal/controllers/provisioningrequest_setup.go
@@ -251,7 +251,7 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForManagedClus
 			// Return as this ManagedCluster is not deployed/managed by ClusterInstance.
 			return nil
 		}
-		r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForManagedCluster] Error getting ClusterInstance. ", slog.Any("Error", err))
+		r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForManagedCluster] Error getting ClusterInstance", slog.Any("error", err))
 		return nil
 	}
 
@@ -301,13 +301,13 @@ func (r *ProvisioningRequestReconciler) enqueueProvisioningRequestForPolicy(
 				// The provisioning request could have been deleted
 				return nil
 			}
-			r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForPolicy] Error getting ProvisioningRequest. ", slog.Any("Error", err))
+			r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForPolicy] Error getting ProvisioningRequest", slog.Any("error", err))
 			return nil
 		}
 
 		clusterTemplates := &provisioningv1alpha1.ClusterTemplateList{}
 		if err := r.List(ctx, clusterTemplates); err != nil {
-			r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForPolicy] Error listing ClusterTemplates. ", slog.Any("Error", err))
+			r.Logger.ErrorContext(ctx, "[enqueueProvisioningRequestForPolicy] Error listing ClusterTemplates", slog.Any("error", err))
 			return nil
 		}
 

--- a/internal/service/alarms/cmd/migrate.go
+++ b/internal/service/alarms/cmd/migrate.go
@@ -21,7 +21,7 @@ var alarmsMigrate = &cobra.Command{
 	Long:  `This is will run from k8s job before the server starts.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := alarms.StartAlarmsMigration(); err != nil {
-			slog.Error("failed to do migration", slog.Any("err", err))
+			slog.Error("failed to do migration", slog.Any("error", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/alarms/cmd/serve.go
+++ b/internal/service/alarms/cmd/serve.go
@@ -39,15 +39,15 @@ var alarmsServe = &cobra.Command{
 		klog.SetSlogLogger(logger)
 
 		if err := config.LoadFromEnv(); err != nil {
-			slog.Error("failed to load environment variables", slog.Any("err", err))
+			slog.Error("failed to load environment variables", slog.Any("error", err))
 			os.Exit(1)
 		}
 		if err := config.Validate(); err != nil {
-			slog.Error("failed to validate common server configuration", slog.Any("err", err))
+			slog.Error("failed to validate common server configuration", slog.Any("error", err))
 			os.Exit(1)
 		}
 		if err := alarms.Serve(&config); err != nil {
-			slog.Error("failed to start alarms server", slog.Any("err", err))
+			slog.Error("failed to start alarms server", slog.Any("error", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/alarms/internal/alertmanager/converter.go
+++ b/internal/service/alarms/internal/alertmanager/converter.go
@@ -90,7 +90,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 		if record.ObjectID != nil {
 			objectTypeID, err := infrastructureClient.GetObjectTypeID(ctx, *record.ObjectID)
 			if err != nil {
-				slog.WarnContext(ctx, "Could not get object type ID", slog.String("objectID", record.ObjectID.String()), slog.String("err", err.Error()))
+				slog.WarnContext(ctx, "Could not get object type ID", slog.String("objectID", record.ObjectID.String()), slog.Any("error", err))
 			} else {
 				record.ObjectTypeID = &objectTypeID
 			}
@@ -102,7 +102,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 			_, severity := getPerceivedSeverity(labels)
 			alarmDefinitionID, err := infrastructureClient.GetAlarmDefinitionID(ctx, *record.ObjectTypeID, getAlertName(labels), severity)
 			if err != nil {
-				slog.WarnContext(ctx, "Could not get alarm definition ID", slog.String("objectTypeID", record.ObjectTypeID.String()), slog.String("name", getAlertName(labels)), slog.String("severity", severity), slog.String("err", err.Error()))
+				slog.WarnContext(ctx, "Could not get alarm definition ID", slog.String("objectTypeID", record.ObjectTypeID.String()), slog.String("name", getAlertName(labels)), slog.String("severity", severity), slog.Any("error", err))
 			} else {
 				record.AlarmDefinitionID = &alarmDefinitionID
 			}
@@ -130,7 +130,7 @@ func getClusterID(labels map[string]string) *uuid.UUID {
 
 	id, err := uuid.Parse(val)
 	if err != nil {
-		slog.Warn("Could not convert cluster ID string to uuid", slog.Any("labels", labels), slog.String("err", err.Error()))
+		slog.Warn("Could not convert cluster ID string to uuid", slog.Any("labels", labels), slog.Any("error", err))
 		return nil
 	}
 
@@ -154,7 +154,7 @@ func getResourceID(labels map[string]string) *uuid.UUID {
 
 	id, err := uuid.Parse(val)
 	if err != nil {
-		slog.Warn("Could not convert instance_uuid string to uuid", slog.Any("labels", labels), slog.String("err", err.Error()))
+		slog.Warn("Could not convert instance_uuid string to uuid", slog.Any("labels", labels), slog.Any("error", err))
 		return nil
 	}
 

--- a/internal/service/alarms/internal/notifier_provider/notification.go
+++ b/internal/service/alarms/internal/notifier_provider/notification.go
@@ -48,7 +48,7 @@ func (n *NotificationStorageProvider) GetNotifications(ctx context.Context) ([]n
 	for _, record := range records {
 		notification, err := models.DataChangeEventToNotification(&record, n.globalCloudID)
 		if err != nil {
-			slog.WarnContext(ctx, "failed to convert alarm event to notification", slog.Any("err", err))
+			slog.WarnContext(ctx, "failed to convert alarm event to notification", slog.Any("error", err))
 			continue
 		}
 		if notification != nil {

--- a/internal/service/artifacts/cmd/serve.go
+++ b/internal/service/artifacts/cmd/serve.go
@@ -36,15 +36,15 @@ var artifactsServer = &cobra.Command{
 		klog.SetSlogLogger(logger)
 
 		if err := config.LoadFromEnv(); err != nil {
-			slog.Error("failed to load environment variables", slog.Any("err", err))
+			slog.Error("failed to load environment variables", slog.Any("error", err))
 			os.Exit(1)
 		}
 		if err := config.Validate(); err != nil {
-			slog.Error("failed to validate common server configuration", slog.Any("err", err))
+			slog.Error("failed to validate common server configuration", slog.Any("error", err))
 			os.Exit(1)
 		}
 		if err := artifacts.Serve(&config); err != nil {
-			slog.Error("failed to start artifacts server", slog.Any("err", err))
+			slog.Error("failed to start artifacts server", slog.Any("error", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/cluster/cmd/migrate.go
+++ b/internal/service/cluster/cmd/migrate.go
@@ -22,7 +22,7 @@ var migrate = &cobra.Command{
 	Long:  `This will run from k8s job before the server starts.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := cluster.StartMigration(); err != nil {
-			slog.Error("failed to do migration", slog.Any("err", err))
+			slog.Error("failed to do migration", slog.Any("error", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/cluster/cmd/serve.go
+++ b/internal/service/cluster/cmd/serve.go
@@ -38,15 +38,15 @@ var clusterServer = &cobra.Command{
 		klog.SetSlogLogger(logger)
 
 		if err := config.LoadFromEnv(); err != nil {
-			slog.Error("failed to load environment variables", slog.Any("err", err))
+			slog.Error("failed to load environment variables", slog.Any("error", err))
 			os.Exit(1)
 		}
 		if err := config.Validate(); err != nil {
-			slog.Error("failed to validate common server configuration", slog.Any("err", err))
+			slog.Error("failed to validate common server configuration", slog.Any("error", err))
 			os.Exit(1)
 		}
 		if err := cluster.Serve(&config); err != nil {
-			slog.Error("failed to start cluster server", slog.Any("err", err))
+			slog.Error("failed to start cluster server", slog.Any("error", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/common/api/middleware/filtering.go
+++ b/internal/service/common/api/middleware/filtering.go
@@ -238,7 +238,7 @@ func ResponseFilter(adapter *FilterAdapter) Middleware {
 			var err error
 			query, err := url.ParseQuery(r.URL.RawQuery)
 			if err != nil {
-				slog.ErrorContext(r.Context(), "failed to parse query", slog.String("RawQuery", r.URL.RawQuery), slog.Any("err", err))
+				slog.ErrorContext(r.Context(), "failed to parse query", slog.String("RawQuery", r.URL.RawQuery), slog.Any("error", err))
 				_ = adapter.Error(
 					w,
 					"failed to parse query parameters",
@@ -252,7 +252,7 @@ func ResponseFilter(adapter *FilterAdapter) Middleware {
 				for _, value := range values {
 					result, err := adapter.ParseFilter(value)
 					if err != nil {
-						slog.ErrorContext(r.Context(), "failed to parse filter", slog.String("value", value), slog.Any("err", err))
+						slog.ErrorContext(r.Context(), "failed to parse filter", slog.String("value", value), slog.Any("error", err))
 						msg := err.Error()
 						if isParserError(err) {
 							msg = "invalid filter syntax"

--- a/internal/service/provisioning/cmd/serve.go
+++ b/internal/service/provisioning/cmd/serve.go
@@ -36,15 +36,15 @@ var provisioningServe = &cobra.Command{
 		klog.SetSlogLogger(logger)
 
 		if err := config.LoadFromEnv(); err != nil {
-			slog.Error("failed to load environment variables", slog.Any("err", err))
+			slog.Error("failed to load environment variables", slog.Any("error", err))
 			os.Exit(1)
 		}
 		if err := config.Validate(); err != nil {
-			slog.Error("failed to validate common server configuration", slog.Any("err", err))
+			slog.Error("failed to validate common server configuration", slog.Any("error", err))
 			os.Exit(1)
 		}
 		if err := provisioning.Serve(&config); err != nil {
-			slog.Error("failed to start provisioning server", slog.Any("err", err))
+			slog.Error("failed to start provisioning server", slog.Any("error", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/resources/cmd/migrate.go
+++ b/internal/service/resources/cmd/migrate.go
@@ -22,7 +22,7 @@ var resourcesMigrate = &cobra.Command{
 	Long:  `This will run from k8s job before the server starts.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := resources.StartResourcesMigration(); err != nil {
-			slog.Error("failed to do migration", slog.Any("err", err))
+			slog.Error("failed to do migration", slog.Any("error", err))
 			os.Exit(1)
 		}
 	},

--- a/internal/service/resources/cmd/serve.go
+++ b/internal/service/resources/cmd/serve.go
@@ -39,15 +39,15 @@ var resourceServer = &cobra.Command{
 		klog.SetSlogLogger(logger)
 
 		if err := config.LoadFromEnv(); err != nil {
-			slog.Error("failed to load environment variables", slog.Any("err", err))
+			slog.Error("failed to load environment variables", slog.Any("error", err))
 			os.Exit(1)
 		}
 		if err := config.Validate(); err != nil {
-			slog.Error("failed to validate common server configuration", slog.Any("err", err))
+			slog.Error("failed to validate common server configuration", slog.Any("error", err))
 			os.Exit(1)
 		}
 		if err := resources.Serve(&config); err != nil {
-			slog.Error("failed to start resource server", slog.Any("err", err))
+			slog.Error("failed to start resource server", slog.Any("error", err))
 			os.Exit(1)
 		}
 	},


### PR DESCRIPTION
Rename inconsistent error attribute keys:
- slog.Any("err", err) → slog.Any("error", err) (21 calls)
- slog.Any("Error", err) → slog.Any("error", err) (3 calls)
- slog.String("err", err.Error()) → slog.Any("error", err) (4 calls)