### PR TITLE
CNF-24707: use slog.String for known string-typed log attributes

### DIFF
--- a/internal/service/cluster/collector/collector_alarms.go
+++ b/internal/service/cluster/collector/collector_alarms.go
@@ -222,7 +222,7 @@ func (d *AlarmsDataSource) processManagedCluster(ctx context.Context, version st
 		return nil, err
 	}
 
-	slog.DebugContext(ctx, "fetched rules for managed cluster", slog.Any("cluster", cluster.Name), slog.Any("version", version), slog.Int("rules count", len(rules)))
+	slog.DebugContext(ctx, "fetched rules for managed cluster", slog.String("cluster", cluster.Name), slog.String("version", version), slog.Int("rules count", len(rules)))
 	return rules, nil
 }
 
@@ -349,7 +349,7 @@ func (d *AlarmsDataSource) getFilteredRules(monitoringRules []monitoringv1.Rule)
 	for _, rule := range monitoringRules {
 		severity, ok := rule.Labels["severity"]
 		if !ok {
-			slog.Warn("rule missing severity label", slog.Any("alert", rule.Alert))
+			slog.Warn("rule missing severity label", slog.String("alert", rule.Alert))
 		}
 
 		key := uniqueAlarm{
@@ -503,7 +503,7 @@ func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoring
 		}, configMap)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				slog.WarnContext(ctx, "Config map not found", slog.Any("configMap", configMapName))
+				slog.WarnContext(ctx, "Config map not found", slog.String("configMap", configMapName))
 				continue
 			}
 
@@ -519,7 +519,7 @@ func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoring
 			var spec RuleSpec
 			err = yaml.Unmarshal([]byte(rulSpec), &spec)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to unmarshal thanos prometheus rules spec", slog.Any("configMap", configMapName), slog.Any("error", err))
+				slog.ErrorContext(ctx, "failed to unmarshal thanos prometheus rules spec", slog.String("configMap", configMapName), slog.Any("error", err))
 				continue
 			}
 
@@ -539,7 +539,7 @@ func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoring
 				}
 			}
 		} else {
-			slog.WarnContext(ctx, "No data found in thanos config map", slog.Any("configMap", configMapName))
+			slog.WarnContext(ctx, "No data found in thanos config map", slog.String("configMap", configMapName))
 		}
 	}
 
@@ -575,7 +575,7 @@ func (d *AlarmsDataSource) expandTemplatedSeverity(rules []monitoringv1.Rule) []
 			continue
 		}
 
-		slog.Info("Expanding templated severity rule", slog.Any("alert", rule.Alert), slog.Any("severity", severity))
+		slog.Info("Expanding templated severity rule", slog.String("alert", rule.Alert), slog.String("severity", severity))
 
 		// Create one rule for each static severity value
 		for _, staticSeverity := range severities {
@@ -603,7 +603,7 @@ func (d *AlarmsDataSource) expandTemplatedSeverity(rules []monitoringv1.Rule) []
 			}
 
 			expandedRules = append(expandedRules, expandedRule)
-			slog.Debug("Created expanded rule", slog.Any("alert", expandedRule.Alert), slog.Any("severity", staticSeverity))
+			slog.Debug("Created expanded rule", slog.String("alert", expandedRule.Alert), slog.String("severity", staticSeverity))
 		}
 	}
 

--- a/internal/service/cluster/collector/collector_k8s.go
+++ b/internal/service/cluster/collector/collector_k8s.go
@@ -360,20 +360,20 @@ func isLocalCluster(cluster *v1.ManagedCluster) bool {
 		if err == nil {
 			return localCluster
 		}
-		slog.Warn("failed to parse local-cluster label as boolean", slog.Any("cluster", cluster.Name), slog.Any("value", value), slog.Any("error", err))
+		slog.Warn("failed to parse local-cluster label as boolean", slog.String("cluster", cluster.Name), slog.String("value", value), slog.Any("error", err))
 	}
 	return false
 }
 
 // handleClusterWatchEvent handles an async event received from the managed cluster watcher
 func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1.ManagedCluster, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", slog.Any("agent", cluster.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", slog.String("agent", cluster.Name), slog.Any("type", eventType))
 
 	if eventType != async.Deleted {
 		condition := meta.FindStatusCondition(cluster.Status.Conditions, "ManagedClusterConditionAvailable")
 		if condition == nil || condition.Status == metav1.ConditionFalse {
 			// This cluster is not yet available, so filter it out.
-			slog.DebugContext(ctx, "Managed cluster is not available; skipping", slog.Any("cluster", cluster.Name), slog.Any("condition", condition))
+			slog.DebugContext(ctx, "Managed cluster is not available; skipping", slog.String("cluster", cluster.Name), slog.Any("condition", condition))
 			return uuid.Nil, nil
 		}
 
@@ -382,7 +382,7 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 			// provisioning request has completed, but the local-cluster will never have this, so we continue without it.
 			if _, found := cluster.Labels[ctlrutils.ClusterTemplateArtifactsLabel]; !found {
 				// The provisioning request which is managing the installation of this cluster is not yet fulfilled
-				slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", slog.Any("cluster", cluster.Name))
+				slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", slog.String("cluster", cluster.Name))
 				return uuid.Nil, nil
 			}
 		}
@@ -407,19 +407,19 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 
 // handleAgentWatchEvent handles an async event received from the agent watcher
 func (d *K8SDataSource) handleAgentWatchEvent(ctx context.Context, agent *v1beta1.Agent, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for agent", slog.Any("agent", agent.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleWatchEvent received for agent", slog.String("agent", agent.Name), slog.Any("type", eventType))
 
 	if eventType != async.Deleted {
 		condition := conditionsv1.FindStatusCondition(agent.Status.Conditions, "Installed")
 		if condition == nil || condition.Status == corev1.ConditionFalse {
 			// This cluster is not yet available, so filter it out.
-			slog.DebugContext(ctx, "Agent installation is not yet completed; skipping", slog.Any("agent", agent.Name), slog.Any("condition", condition))
+			slog.DebugContext(ctx, "Agent installation is not yet completed; skipping", slog.String("agent", agent.Name), slog.Any("condition", condition))
 			return uuid.Nil, nil
 		}
 
 		if _, found := agent.Labels[ctlrutils.ClusterTemplateArtifactsLabel]; !found {
 			// The provisioning request which is managing the installation of this agent is not yet fulfilled
-			slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", slog.Any("agent", agent.Name))
+			slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", slog.String("agent", agent.Name))
 			return uuid.Nil, nil
 		}
 	}

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -425,7 +425,7 @@ func (c *Collector) locationAPIForChangeEvent(ctx context.Context, record *model
 	siteIDs, err := c.repository.GetOCloudSiteIDsForLocation(ctx, record.GlobalLocationID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to load O-Cloud site IDs for location change event",
-			slog.Any("globalLocationId", record.GlobalLocationID),
+			slog.String("globalLocationId", record.GlobalLocationID),
 			slog.Any("error", err))
 		return models.LocationToModel(record, nil)
 	}
@@ -639,7 +639,7 @@ func (c *Collector) rebuildResourcesForPool(ctx context.Context, poolName string
 
 		results, err := handler.BuildResourcesForPool(ctx, poolName)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to rebuild resources for pool", slog.Any("pool", poolName), slog.Any("error", err))
+			slog.ErrorContext(ctx, "failed to rebuild resources for pool", slog.String("pool", poolName), slog.Any("error", err))
 			continue
 		}
 
@@ -655,7 +655,7 @@ func (c *Collector) rebuildResourcesForPool(ctx context.Context, poolName string
 		}
 
 		if len(results) > 0 {
-			slog.InfoContext(ctx, "Rebuilt resources for pool", slog.Any("pool", poolName), slog.Int("count", len(results)))
+			slog.InfoContext(ctx, "Rebuilt resources for pool", slog.String("pool", poolName), slog.Int("count", len(results)))
 		}
 	}
 }

--- a/internal/service/resources/collector/collector_hwmgr.go
+++ b/internal/service/resources/collector/collector_hwmgr.go
@@ -371,7 +371,7 @@ func (d *HardwareDataSource) buildAndSendResource(ctx context.Context, bmh *meta
 	if poolUID == "" {
 		poolName := bmh.Labels[constants.LabelResourcePoolName]
 		slog.WarnContext(ctx, "skipping BMH: unresolved resourcePoolId (will retry on pool creation)",
-			slog.String("bmh", bmh.Namespace+"/"+bmh.Name), slog.Any("poolName", poolName))
+			slog.String("bmh", bmh.Namespace+"/"+bmh.Name), slog.String("poolName", poolName))
 		return uuid.Nil, nil
 	}
 
@@ -436,7 +436,7 @@ func (d *HardwareDataSource) findAllocatedNodeForBMH(ctx context.Context, bmh *m
 	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: bmh.Namespace}, &node); err != nil {
 		if !errors.IsNotFound(err) {
 			slog.WarnContext(ctx, "failed to get AllocatedNode for BMH",
-				slog.String("bmh", bmh.Namespace+"/"+bmh.Name), slog.Any("node", nodeName), slog.Any("error", err))
+				slog.String("bmh", bmh.Namespace+"/"+bmh.Name), slog.String("node", nodeName), slog.Any("error", err))
 		}
 		return nil
 	}

--- a/internal/service/resources/collector/collector_k8s.go
+++ b/internal/service/resources/collector/collector_k8s.go
@@ -206,7 +206,7 @@ func (d *K8SDataSource) convertManagedClusterToDeploymentManager(ctx context.Con
 	err := d.getKubeconfig(ctx, cluster.Name, extensions)
 	if err != nil {
 		// TODO: turn this back into an error once we fix getting the Kubeconfig for the local-cluster
-		slog.WarnContext(ctx, "failed to get deployment manager extensions", slog.Any("cluster", cluster.Name), slog.Any("error", err))
+		slog.WarnContext(ctx, "failed to get deployment manager extensions", slog.String("cluster", cluster.Name), slog.Any("error", err))
 	}
 
 	// Generate a unique UUID scoped to a different namespace so that it does not collide with the NodeCluster which
@@ -232,19 +232,19 @@ func (d *K8SDataSource) convertManagedClusterToDeploymentManager(ctx context.Con
 
 // handleClusterWatchEvent handles an async event received from the managed cluster watcher
 func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1.ManagedCluster, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", slog.Any("agent", cluster.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", slog.String("agent", cluster.Name), slog.Any("type", eventType))
 
 	if eventType != async.Deleted {
 		condition := meta.FindStatusCondition(cluster.Status.Conditions, "ManagedClusterConditionAvailable")
 		if condition == nil || condition.Status == metav1.ConditionFalse {
 			// This cluster is not yet available, so filter it out.
-			slog.DebugContext(ctx, "Managed cluster is not available; skipping", slog.Any("cluster", cluster.Name), slog.Any("condition", condition))
+			slog.DebugContext(ctx, "Managed cluster is not available; skipping", slog.String("cluster", cluster.Name), slog.Any("condition", condition))
 			return uuid.Nil, nil
 		}
 
 		if _, found := cluster.Labels[ctlrutils.ClusterTemplateArtifactsLabel]; !found {
 			// The provisioning request which is managing the installation of this cluster is not yet fulfilled
-			slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", slog.Any("cluster", cluster.Name))
+			slog.DebugContext(ctx, "Cluster provisioning request is not yet fulfilled; skipping", slog.String("cluster", cluster.Name))
 			return uuid.Nil, nil
 		}
 	}

--- a/internal/service/resources/collector/collector_location.go
+++ b/internal/service/resources/collector/collector_location.go
@@ -167,7 +167,7 @@ func (d *LocationDataSource) HandleSyncComplete(ctx context.Context, objectType 
 
 // handleLocationWatchEvent handles an async event received for a Location CR
 func (d *LocationDataSource) handleLocationWatchEvent(ctx context.Context, location *inventoryv1alpha1.Location, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleLocationWatchEvent received", slog.Any("name", location.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleLocationWatchEvent received", slog.String("name", location.Name), slog.Any("type", eventType))
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.

--- a/internal/service/resources/collector/collector_ocloudsite.go
+++ b/internal/service/resources/collector/collector_ocloudsite.go
@@ -166,7 +166,7 @@ func (d *OCloudSiteDataSource) HandleSyncComplete(ctx context.Context, objectTyp
 
 // handleOCloudSiteWatchEvent handles an async event received for an OCloudSite CR
 func (d *OCloudSiteDataSource) handleOCloudSiteWatchEvent(ctx context.Context, site *inventoryv1alpha1.OCloudSite, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleOCloudSiteWatchEvent received", slog.Any("name", site.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleOCloudSiteWatchEvent received", slog.String("name", site.Name), slog.Any("type", eventType))
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.

--- a/internal/service/resources/collector/collector_resourcepool.go
+++ b/internal/service/resources/collector/collector_resourcepool.go
@@ -166,7 +166,7 @@ func (d *ResourcePoolDataSource) HandleSyncComplete(ctx context.Context, objectT
 
 // handleResourcePoolWatchEvent handles an async event received for a ResourcePool CR
 func (d *ResourcePoolDataSource) handleResourcePoolWatchEvent(ctx context.Context, pool *inventoryv1alpha1.ResourcePool, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleResourcePoolWatchEvent received", slog.Any("name", pool.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleResourcePoolWatchEvent received", slog.String("name", pool.Name), slog.Any("type", eventType))
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.

--- a/internal/service/resources/listener/pg_listener.go
+++ b/internal/service/resources/listener/pg_listener.go
@@ -87,7 +87,7 @@ func processResourceTypeChangeNotification(ctx context.Context, repository *repo
 
 	slog.InfoContext(ctx, "Processing resource type change",
 		slog.Any("resource_type_id", notification.ResourceTypeID),
-		slog.Any("change_type", notification.ChangeType))
+		slog.String("change_type", notification.ChangeType))
 
 	// Handle different change types
 	switch notification.ChangeType {
@@ -108,7 +108,7 @@ func processResourceTypeChangeNotification(ctx context.Context, repository *repo
 		return nil
 
 	default:
-		slog.WarnContext(ctx, "Unknown resource type change type", slog.Any("change_type", notification.ChangeType))
+		slog.WarnContext(ctx, "Unknown resource type change type", slog.String("change_type", notification.ChangeType))
 		return nil
 	}
 }


### PR DESCRIPTION
Replace slog.Any() with slog.String() where the value is a known string type (resource names, versions, pool names, change types). slog.String avoids reflection overhead and makes the attribute type explicit at the call site.