### PR TITLE
CNF-24707: use slog.String for UUID log attributes

### DIFF
--- a/internal/service/alarms/internal/alertmanager/converter.go
+++ b/internal/service/alarms/internal/alertmanager/converter.go
@@ -90,7 +90,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 		if record.ObjectID != nil {
 			objectTypeID, err := infrastructureClient.GetObjectTypeID(ctx, *record.ObjectID)
 			if err != nil {
-				slog.WarnContext(ctx, "Could not get object type ID", slog.Any("objectID", record.ObjectID), slog.String("err", err.Error()))
+				slog.WarnContext(ctx, "Could not get object type ID", slog.String("objectID", record.ObjectID.String()), slog.String("err", err.Error()))
 			} else {
 				record.ObjectTypeID = &objectTypeID
 			}
@@ -102,7 +102,7 @@ func ConvertAmToAlarmEventRecordModels(ctx context.Context, alerts *[]api.Alert,
 			_, severity := getPerceivedSeverity(labels)
 			alarmDefinitionID, err := infrastructureClient.GetAlarmDefinitionID(ctx, *record.ObjectTypeID, getAlertName(labels), severity)
 			if err != nil {
-				slog.WarnContext(ctx, "Could not get alarm definition ID", slog.Any("objectTypeID", *record.ObjectTypeID), slog.String("name", getAlertName(labels)), slog.String("severity", severity), slog.String("err", err.Error()))
+				slog.WarnContext(ctx, "Could not get alarm definition ID", slog.String("objectTypeID", record.ObjectTypeID.String()), slog.String("name", getAlertName(labels)), slog.String("severity", severity), slog.String("err", err.Error()))
 			} else {
 				record.AlarmDefinitionID = &alarmDefinitionID
 			}

--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -141,13 +141,13 @@ func (c *Collector) initDataSource(ctx context.Context, dataSource DataSource) e
 		}
 
 		dataSource.Init(*result.DataSourceID, 0, c.asyncChangeEvents)
-		slog.InfoContext(ctx, "created new data source", slog.String("name", name), slog.Any("uuid", *result.DataSourceID))
+		slog.InfoContext(ctx, "created new data source", slog.String("name", name), slog.String("uuid", result.DataSourceID.String()))
 	case err != nil:
 		return fmt.Errorf("failed to get data source %q: %w", name, err)
 	default:
 		dataSource.Init(*record.DataSourceID, record.GenerationID, c.asyncChangeEvents)
 		slog.InfoContext(ctx, "restored data source",
-			slog.String("name", name), slog.Any("uuid", record.DataSourceID), slog.Int("generation", record.GenerationID))
+			slog.String("name", name), slog.String("uuid", record.DataSourceID.String()), slog.Int("generation", record.GenerationID))
 	}
 
 	return nil
@@ -479,7 +479,7 @@ func (c *Collector) deleteRelatedClusterResources(ctx context.Context, nodeClust
 		return fmt.Errorf("failed to get cluster resources for node_cluster_id %s: %w", nodeCluster.NodeClusterID, err)
 	}
 
-	slog.DebugContext(ctx, "deleting related cluster resources", slog.Any("node_cluster_id", nodeCluster.NodeClusterID), slog.Int("count", len(resources)))
+	slog.DebugContext(ctx, "deleting related cluster resources", slog.String("node_cluster_id", nodeCluster.NodeClusterID.String()), slog.Int("count", len(resources)))
 
 	for _, resource := range resources {
 		dataChangeEvent, err := svcutils.DeleteObjectWithChangeEvent(
@@ -654,7 +654,7 @@ func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *
 		g.Go(func() error {
 			alarmDefinitionRecords, err := c.repository.UpsertAlarmDefinitions(ctx, alarmDictionaryIDToAlarmDefinitions[alarmDictionaryID])
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to upsert alarm definitions", slog.Any("alarmDictionaryID", alarmDictionaryID), slog.Any("error", err))
+				slog.ErrorContext(ctx, "failed to upsert alarm definitions", slog.String("alarmDictionaryID", alarmDictionaryID.String()), slog.Any("error", err))
 				return nil
 			}
 
@@ -666,11 +666,11 @@ func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *
 
 			count, err := c.repository.DeleteAlarmDefinitionsNotIn(ctx, alarmDefinitionIDs, alarmDictionaryID)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to delete non-valid alarm definitions", slog.Any("alarmDictionaryID", alarmDictionaryID), slog.Any("error", err))
+				slog.ErrorContext(ctx, "failed to delete non-valid alarm definitions", slog.String("alarmDictionaryID", alarmDictionaryID.String()), slog.Any("error", err))
 				return nil
 			}
 
-			slog.InfoContext(ctx, "Alarm definitions synced", slog.Any("alarmDictionaryID", alarmDictionaryID), slog.Int("upserted count", len(alarmDefinitionRecords)), slog.Int64("deleted count", count))
+			slog.InfoContext(ctx, "Alarm definitions synced", slog.String("alarmDictionaryID", alarmDictionaryID.String()), slog.Int("upserted count", len(alarmDefinitionRecords)), slog.Int64("deleted count", count))
 			return nil
 		})
 	}
@@ -705,7 +705,7 @@ func (c *Collector) syncAlarmDictionaries(ctx context.Context, ds *AlarmsDataSou
 		g.Go(func() error {
 			alarmDefinitions, err := c.repository.GetAlarmDefinitionsByAlarmDictionaryID(ctx, alarmDictionary.AlarmDictionaryID)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to get alarm definitions", slog.Any("alarmDictionaryID", alarmDictionary.AlarmDictionaryID), slog.Any("error", err))
+				slog.ErrorContext(ctx, "failed to get alarm definitions", slog.String("alarmDictionaryID", alarmDictionary.AlarmDictionaryID.String()), slog.Any("error", err))
 				return nil
 			}
 
@@ -769,7 +769,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 		g.Go(func() error {
 			alarmDefinitions, err := c.repository.GetAlarmDefinitionsByAlarmDictionaryID(ctx, alarmDictionary.AlarmDictionaryID)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to get alarm definitions", slog.Any("alarmDictionaryID", alarmDictionary.AlarmDictionaryID), slog.Any("error", err))
+				slog.ErrorContext(ctx, "failed to get alarm definitions", slog.String("alarmDictionaryID", alarmDictionary.AlarmDictionaryID.String()), slog.Any("error", err))
 				return nil
 			}
 
@@ -778,7 +778,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 				return models.AlarmDictionaryToModel(&record, alarmDefinitions)
 			})
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to delete stale alarm dictionary", slog.Any("alarmDictionaryID", alarmDictionary.AlarmDictionaryID), slog.Any("error", err))
+				slog.ErrorContext(ctx, "failed to delete stale alarm dictionary", slog.String("alarmDictionaryID", alarmDictionary.AlarmDictionaryID.String()), slog.Any("error", err))
 				return nil
 			}
 
@@ -786,7 +786,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 				c.notificationHandler.Notify(ctx, models.DataChangeEventToNotification(dataChangeEvent))
 			}
 
-			slog.InfoContext(ctx, "Stale alarm dictionary purged", slog.Any("alarmDictionaryID", alarmDictionary.AlarmDictionaryID))
+			slog.InfoContext(ctx, "Stale alarm dictionary purged", slog.String("alarmDictionaryID", alarmDictionary.AlarmDictionaryID.String()))
 			return nil
 		})
 	}
@@ -800,7 +800,7 @@ func (c *Collector) purgeStaleAlarmDictionaries(ctx context.Context, ds *AlarmsD
 
 // handleAsyncAlarmDictionaryAndDefinitionsCreation handles the creation of alarm dictionary and definitions triggered by a new node cluster type
 func (c *Collector) handleAsyncAlarmDictionaryAndDefinitionsCreation(ctx context.Context, nodeClusterType *models.NodeClusterType) {
-	slog.InfoContext(ctx, "Creating alarm dictionary and definitions", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
+	slog.InfoContext(ctx, "Creating alarm dictionary and definitions", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()))
 
 	var alarmsDataSource *AlarmsDataSource
 	for i := range c.dataSources {
@@ -813,23 +813,23 @@ func (c *Collector) handleAsyncAlarmDictionaryAndDefinitionsCreation(ctx context
 	// Create and persist Alarm Dictionary without Alarm Definitions
 	err := c.syncAlarmDictionaries(ctx, alarmsDataSource, []models.NodeClusterType{*nodeClusterType})
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to create alarm dictionary", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
+		slog.ErrorContext(ctx, "failed to create alarm dictionary", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()), slog.Any("error", err))
 		return
 	}
 
 	// Collect and persist Alarm Definitions
 	err = c.syncManagedClusterAlarmDefinitions(ctx, alarmsDataSource, []models.NodeClusterType{*nodeClusterType})
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to create alarm definitions", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
+		slog.ErrorContext(ctx, "failed to create alarm definitions", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()), slog.Any("error", err))
 		return
 	}
 
 	// Sync Alarm Dictionary to include Alarm Definitions
 	err = c.syncAlarmDictionaries(ctx, alarmsDataSource, []models.NodeClusterType{*nodeClusterType})
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to update alarm dictionary", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
+		slog.ErrorContext(ctx, "failed to update alarm dictionary", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()), slog.Any("error", err))
 		return
 	}
 
-	slog.InfoContext(ctx, "Alarm dictionary and definitions created", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
+	slog.InfoContext(ctx, "Alarm dictionary and definitions created", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()))
 }

--- a/internal/service/cluster/collector/collector_alarms.go
+++ b/internal/service/cluster/collector/collector_alarms.go
@@ -106,7 +106,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 	var filteredNodeClusterTypes []models.NodeClusterType
 	for _, nodeClusterType := range nodeClusterTypes {
 		if nodeClusterType.Extensions == nil {
-			slog.Error("no extensions found for node cluster type", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
+			slog.Error("no extensions found for node cluster type", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()))
 			continue
 		}
 
@@ -114,7 +114,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 		if alarmDictionaryIDString != nil {
 			id, err := uuid.Parse(alarmDictionaryIDString.(string))
 			if err != nil {
-				slog.Error("error parsing alarm dictionary ID", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
+				slog.Error("error parsing alarm dictionary ID", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()), slog.Any("error", err))
 				continue
 			}
 			(*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension] = id
@@ -180,12 +180,12 @@ func (d *AlarmsDataSource) makeNodeClusterTypeIDToMonitoringRules(ctx context.Co
 	// Collect results
 	for res := range resultChannel {
 		if res.err != nil {
-			slog.ErrorContext(ctx, "error fetching rules for node cluster type", slog.Any("nodeClusterTypeID", res.nodeClusterTypeID), slog.Any("error", res.err))
+			slog.ErrorContext(ctx, "error fetching rules for node cluster type", slog.String("nodeClusterTypeID", res.nodeClusterTypeID.String()), slog.Any("error", res.err))
 			continue
 		}
 
 		nodeClusterTypeIDToMonitoringRules[res.nodeClusterTypeID] = res.rules
-		slog.InfoContext(ctx, "loaded rules for node cluster type", slog.Any("nodeClusterTypeID", res.nodeClusterTypeID), slog.Int("rules count", len(res.rules)))
+		slog.InfoContext(ctx, "loaded rules for node cluster type", slog.String("nodeClusterTypeID", res.nodeClusterTypeID.String()), slog.Int("rules count", len(res.rules)))
 	}
 
 	return nodeClusterTypeIDToMonitoringRules
@@ -291,7 +291,7 @@ func (d *AlarmsDataSource) buildAlarmDictionaryIDToAlarmDefinitions(nodeClusterT
 	alarmDictionaryIDToAlarmDefinitions := make(map[uuid.UUID][]models.AlarmDefinition)
 	for _, nodeClusterType := range nodeClusterTypes {
 		if _, ok := nodeClusterTypeIDToMonitoringRules[nodeClusterType.NodeClusterTypeID]; !ok {
-			slog.Warn("no monitoring rules found for node cluster type", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
+			slog.Warn("no monitoring rules found for node cluster type", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()))
 			continue
 		}
 
@@ -299,18 +299,18 @@ func (d *AlarmsDataSource) buildAlarmDictionaryIDToAlarmDefinitions(nodeClusterT
 		extensions, err := getVendorExtensions(nodeClusterType)
 		if err != nil {
 			// Should never happen
-			slog.Error("error getting vendor extensions", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
+			slog.Error("error getting vendor extensions", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()), slog.Any("error", err))
 			continue
 		}
 
 		// Only process node cluster types with an alarm dictionary ID
 		alarmDictionaryID, ok := (*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension].(uuid.UUID)
 		if !ok || alarmDictionaryID == uuid.Nil {
-			slog.Error("no alarm dictionary ID found for node cluster type", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
+			slog.Error("no alarm dictionary ID found for node cluster type", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()))
 			continue
 		}
 
-		slog.Debug("filtering rules for node cluster type", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
+		slog.Debug("filtering rules for node cluster type", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()))
 		// Remove conflicting rules before creating alarm definitions
 		filteredRules := d.getFilteredRules(nodeClusterTypeIDToMonitoringRules[nodeClusterType.NodeClusterTypeID])
 
@@ -414,7 +414,7 @@ func (d *AlarmsDataSource) createAlarmDefinitions(rules []monitoringv1.Rule, ala
 		records = append(records, record)
 	}
 
-	slog.Info("AlarmDefinitions from prometheus rules prepared", slog.Int("count", len(records)), slog.Any("alarmDictionaryID", alarmDictionaryID))
+	slog.Info("AlarmDefinitions from prometheus rules prepared", slog.Int("count", len(records)), slog.String("alarmDictionaryID", alarmDictionaryID.String()))
 	return records
 }
 
@@ -428,13 +428,13 @@ func (d *AlarmsDataSource) makeAlarmDictionaries(nodeClusterTypes []models.NodeC
 		extensions, err := getVendorExtensions(nodeClusterType)
 		if err != nil {
 			// Should never happen
-			slog.Error("error getting vendor extensions", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID), slog.Any("error", err))
+			slog.Error("error getting vendor extensions", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()), slog.Any("error", err))
 			continue
 		}
 
 		alarmDictionaryID, ok := (*nodeClusterType.Extensions)[ctlrutils.ClusterAlarmDictionaryIDExtension].(uuid.UUID)
 		if !ok || alarmDictionaryID == uuid.Nil {
-			slog.Error("no alarm dictionary ID found for node cluster type", slog.Any("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID))
+			slog.Error("no alarm dictionary ID found for node cluster type", slog.String("nodeClusterTypeID", nodeClusterType.NodeClusterTypeID.String()))
 			continue
 		}
 

--- a/internal/service/resources/collector/collector.go
+++ b/internal/service/resources/collector/collector.go
@@ -141,13 +141,13 @@ func (c *Collector) initDataSource(ctx context.Context, dataSource DataSource) e
 		}
 
 		dataSource.Init(*result.DataSourceID, 0, c.AsyncChangeEvents)
-		slog.InfoContext(ctx, "created new data source", slog.String("name", name), slog.Any("uuid", *result.DataSourceID))
+		slog.InfoContext(ctx, "created new data source", slog.String("name", name), slog.String("uuid", result.DataSourceID.String()))
 	case err != nil:
 		return fmt.Errorf("failed to get data source %q: %w", name, err)
 	default:
 		dataSource.Init(*record.DataSourceID, record.GenerationID, c.AsyncChangeEvents)
 		slog.InfoContext(ctx, "restored data source",
-			slog.String("name", name), slog.Any("uuid", record.DataSourceID), slog.Int("generation", record.GenerationID))
+			slog.String("name", name), slog.String("uuid", record.DataSourceID.String()), slog.Int("generation", record.GenerationID))
 	}
 	return nil
 }
@@ -425,7 +425,7 @@ func (c *Collector) locationAPIForChangeEvent(ctx context.Context, record *model
 	siteIDs, err := c.repository.GetOCloudSiteIDsForLocation(ctx, record.GlobalLocationID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to load O-Cloud site IDs for location change event",
-			slog.Any("globalLocationId", record.GlobalLocationID),
+			slog.String("globalLocationId", record.GlobalLocationID),
 			slog.Any("error", err))
 		return models.LocationToModel(record, nil)
 	}
@@ -438,7 +438,7 @@ func (c *Collector) oCloudSiteAPIForChangeEvent(ctx context.Context, record *mod
 	poolIDs, err := c.repository.GetResourcePoolIDsForSite(ctx, record.OCloudSiteID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to load resource pool IDs for O-Cloud site change event",
-			slog.Any("oCloudSiteId", record.OCloudSiteID),
+			slog.String("oCloudSiteId", record.OCloudSiteID.String()),
 			slog.Any("error", err))
 		return models.OCloudSiteToModel(record, nil)
 	}

--- a/internal/service/resources/listener/alarms_sync.go
+++ b/internal/service/resources/listener/alarms_sync.go
@@ -32,7 +32,7 @@ const (
 
 // syncAlarmDictionaryForResourceType syncs the alarm dictionary for a specific resource type
 func syncAlarmDictionaryForResourceType(ctx context.Context, repository *repo.ResourcesRepository, resourceTypeID uuid.UUID) error {
-	slog.InfoContext(ctx, "Syncing alarm dictionary for resource type", slog.Any("resource_type_id", resourceTypeID))
+	slog.InfoContext(ctx, "Syncing alarm dictionary for resource type", slog.String("resource_type_id", resourceTypeID.String()))
 
 	// Get the resource type
 	resourceType, err := repository.GetResourceType(ctx, resourceTypeID)
@@ -40,7 +40,7 @@ func syncAlarmDictionaryForResourceType(ctx context.Context, repository *repo.Re
 		if errors.Is(err, svcutils.ErrNotFound) {
 			// Resource type was deleted, alarm dictionary will be cascade deleted
 			slog.InfoContext(ctx, "Resource type not found, skipping alarm dictionary sync",
-				slog.Any("resource_type_id", resourceTypeID))
+				slog.String("resource_type_id", resourceTypeID.String()))
 			return nil
 		}
 		return fmt.Errorf("failed to get resource type: %w", err)
@@ -77,8 +77,8 @@ func syncAlarmDictionaryForResourceType(ctx context.Context, repository *repo.Re
 			return fmt.Errorf("failed to upsert alarm definitions: %w", err)
 		}
 
-		slog.InfoContext(ctx, "Successfully synced alarm dictionary", slog.Any("resource_type_id",
-			resourceTypeID), slog.Any("alarm_dict_id", result.AlarmDictionaryID), slog.Int("definitions_count", len(alarmDefs)))
+		slog.InfoContext(ctx, "Successfully synced alarm dictionary", slog.String("resource_type_id",
+			resourceTypeID.String()), slog.String("alarm_dict_id", result.AlarmDictionaryID.String()), slog.Int("definitions_count", len(alarmDefs)))
 		return nil
 	}); err != nil {
 		return fmt.Errorf("transaction failed: %w", err)


### PR DESCRIPTION
Replace slog.Any() with slog.String(key, uuid.String()) for uuid.UUID log attributes. slog.Any renders uuid.UUID as a base64-encoded byte array since UUID is [16]byte, producing unreadable output. Using slog.String renders the standard human-readable format instead.