### PR TITLE
CNF-24707: add String() method to AsyncEventType

### DIFF
--- a/internal/service/cluster/collector/collector_k8s.go
+++ b/internal/service/cluster/collector/collector_k8s.go
@@ -367,7 +367,7 @@ func isLocalCluster(cluster *v1.ManagedCluster) bool {
 
 // handleClusterWatchEvent handles an async event received from the managed cluster watcher
 func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1.ManagedCluster, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", slog.String("agent", cluster.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", slog.String("agent", cluster.Name), slog.String("type", eventType.String()))
 
 	if eventType != async.Deleted {
 		condition := meta.FindStatusCondition(cluster.Status.Conditions, "ManagedClusterConditionAvailable")
@@ -407,7 +407,7 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 
 // handleAgentWatchEvent handles an async event received from the agent watcher
 func (d *K8SDataSource) handleAgentWatchEvent(ctx context.Context, agent *v1beta1.Agent, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for agent", slog.String("agent", agent.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleWatchEvent received for agent", slog.String("agent", agent.Name), slog.String("type", eventType.String()))
 
 	if eventType != async.Deleted {
 		condition := conditionsv1.FindStatusCondition(agent.Status.Conditions, "Installed")
@@ -443,7 +443,7 @@ func (d *K8SDataSource) handleAgentWatchEvent(ctx context.Context, agent *v1beta
 
 // HandleAsyncEvent handles an add/update/delete to an object received by from the Reflector.
 func (d *K8SDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for store adapter", slog.Any("type", eventType), slog.String("object", fmt.Sprintf("%T", obj)))
+	slog.DebugContext(ctx, "handleWatchEvent received for store adapter", slog.String("type", eventType.String()), slog.String("object", fmt.Sprintf("%T", obj)))
 	switch value := obj.(type) {
 	case *v1.ManagedCluster:
 		return d.handleClusterWatchEvent(ctx, value, eventType)

--- a/internal/service/common/async/store.go
+++ b/internal/service/common/async/store.go
@@ -143,7 +143,7 @@ func (c *ReflectorStore) handleOperations(ctx context.Context, handler AsyncEven
 		case Updated, Deleted:
 			_, err := handler.HandleAsyncEvent(ctx, o.objects[0], o.eventType)
 			if err != nil {
-				slog.WarnContext(ctx, "Failed to handle event", slog.Any("event", o.eventType), slog.Any("error", err))
+				slog.WarnContext(ctx, "Failed to handle event", slog.String("event", o.eventType.String()), slog.Any("error", err))
 			}
 		case SyncComplete:
 			keys := make([]uuid.UUID, 0)

--- a/internal/service/common/async/store.go
+++ b/internal/service/common/async/store.go
@@ -30,6 +30,20 @@ const (
 	SyncComplete
 )
 
+// String returns the human-readable name of the event type.
+func (t AsyncEventType) String() string {
+	switch t {
+	case Updated:
+		return "Updated"
+	case Deleted:
+		return "Deleted"
+	case SyncComplete:
+		return "SyncComplete"
+	default:
+		return fmt.Sprintf("AsyncEventType(%d)", int(t))
+	}
+}
+
 // AsyncChangeEvent defines the data received by a data source to signal that an async handleWatchEvent has been received for a
 // given object type.
 type AsyncChangeEvent struct {

--- a/internal/service/common/async/store_test.go
+++ b/internal/service/common/async/store_test.go
@@ -7,8 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package async
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -489,5 +491,31 @@ var _ = Describe("ReflectorStore", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}).To(Panic())
 		})
+	})
+})
+
+var _ = Describe("AsyncEventType String", func() {
+	It("renders human-readable event type in JSON log output", func() {
+		buffer := &bytes.Buffer{}
+		logger := slog.New(slog.NewJSONHandler(buffer, nil))
+
+		logger.Info("test", slog.String("type", Updated.String()))
+		Expect(buffer.String()).To(ContainSubstring(`"type":"Updated"`))
+
+		buffer.Reset()
+		logger.Info("test", slog.String("type", Deleted.String()))
+		Expect(buffer.String()).To(ContainSubstring(`"type":"Deleted"`))
+
+		buffer.Reset()
+		logger.Info("test", slog.String("type", SyncComplete.String()))
+		Expect(buffer.String()).To(ContainSubstring(`"type":"SyncComplete"`))
+	})
+
+	It("renders a numeric fallback for unknown values", func() {
+		buffer := &bytes.Buffer{}
+		logger := slog.New(slog.NewJSONHandler(buffer, nil))
+
+		logger.Info("test", slog.String("type", AsyncEventType(99).String()))
+		Expect(buffer.String()).To(ContainSubstring(`"type":"AsyncEventType(99)"`))
 	})
 })

--- a/internal/service/resources/collector/collector_hwmgr.go
+++ b/internal/service/resources/collector/collector_hwmgr.go
@@ -272,7 +272,7 @@ func (d *HardwareDataSource) HandleSyncComplete(ctx context.Context, objectType 
 func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1alpha1.BareMetalHost, eventType async.AsyncEventType) (uuid.UUID, error) {
 	ctx = logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
 	ctx = logging.AppendCtx(ctx, slog.String("bmhNamespace", bmh.Namespace))
-	slog.DebugContext(ctx, "handleBMHEvent", slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleBMHEvent", slog.String("type", eventType.String()))
 
 	resourceID := uuid.MustParse(string(bmh.UID))
 
@@ -293,7 +293,7 @@ func (d *HardwareDataSource) handleBMHEvent(ctx context.Context, bmh *metal3v1al
 func (d *HardwareDataSource) handleHardwareDataEvent(ctx context.Context, hwdata *metal3v1alpha1.HardwareData, eventType async.AsyncEventType) (uuid.UUID, error) {
 	ctx = logging.AppendCtx(ctx, slog.String("bmh", hwdata.Name))
 	ctx = logging.AppendCtx(ctx, slog.String("bmhNamespace", hwdata.Namespace))
-	slog.DebugContext(ctx, "handleHardwareDataEvent", slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleHardwareDataEvent", slog.String("type", eventType.String()))
 
 	var bmh metal3v1alpha1.BareMetalHost
 	if err := d.hubClient.Get(ctx, types.NamespacedName{Name: hwdata.Name, Namespace: hwdata.Namespace}, &bmh); err != nil {
@@ -315,7 +315,7 @@ func (d *HardwareDataSource) handleHardwareDataEvent(ctx context.Context, hwdata
 // the corresponding BMH and rebuilding the resource.
 func (d *HardwareDataSource) handleAllocatedNodeEvent(ctx context.Context, node *hwmgmtv1alpha1.AllocatedNode, eventType async.AsyncEventType) (uuid.UUID, error) {
 	ctx = logging.AppendCtx(ctx, slog.String("node", node.Name))
-	slog.DebugContext(ctx, "handleAllocatedNodeEvent", slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleAllocatedNodeEvent", slog.String("type", eventType.String()))
 
 	bmhName := node.Spec.HwMgrNodeId
 	bmhNamespace := node.Spec.HwMgrNodeNs

--- a/internal/service/resources/collector/collector_k8s.go
+++ b/internal/service/resources/collector/collector_k8s.go
@@ -232,7 +232,7 @@ func (d *K8SDataSource) convertManagedClusterToDeploymentManager(ctx context.Con
 
 // handleClusterWatchEvent handles an async event received from the managed cluster watcher
 func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1.ManagedCluster, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", slog.String("agent", cluster.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleWatchEvent received for managed cluster", slog.String("agent", cluster.Name), slog.String("type", eventType.String()))
 
 	if eventType != async.Deleted {
 		condition := meta.FindStatusCondition(cluster.Status.Conditions, "ManagedClusterConditionAvailable")
@@ -268,7 +268,7 @@ func (d *K8SDataSource) handleClusterWatchEvent(ctx context.Context, cluster *v1
 
 // HandleAsyncEvent handles an add/update/delete to an object received by from the Reflector.
 func (d *K8SDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleWatchEvent received for store adapter", slog.Any("type", eventType), slog.String("object", fmt.Sprintf("%T", obj)))
+	slog.DebugContext(ctx, "handleWatchEvent received for store adapter", slog.String("type", eventType.String()), slog.String("object", fmt.Sprintf("%T", obj)))
 	switch value := obj.(type) {
 	case *v1.ManagedCluster:
 		return d.handleClusterWatchEvent(ctx, value, eventType)

--- a/internal/service/resources/collector/collector_location.go
+++ b/internal/service/resources/collector/collector_location.go
@@ -130,7 +130,7 @@ func (d *LocationDataSource) Watch(ctx context.Context) error {
 
 // HandleAsyncEvent handles an add/update/delete event received from the Reflector.
 func (d *LocationDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleAsyncEvent received for location", slog.Any("type", eventType), slog.String("object", fmt.Sprintf("%T", obj)))
+	slog.DebugContext(ctx, "handleAsyncEvent received for location", slog.String("type", eventType.String()), slog.String("object", fmt.Sprintf("%T", obj)))
 
 	switch value := obj.(type) {
 	case *inventoryv1alpha1.Location:
@@ -167,7 +167,7 @@ func (d *LocationDataSource) HandleSyncComplete(ctx context.Context, objectType 
 
 // handleLocationWatchEvent handles an async event received for a Location CR
 func (d *LocationDataSource) handleLocationWatchEvent(ctx context.Context, location *inventoryv1alpha1.Location, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleLocationWatchEvent received", slog.String("name", location.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleLocationWatchEvent received", slog.String("name", location.Name), slog.String("type", eventType.String()))
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.

--- a/internal/service/resources/collector/collector_ocloudsite.go
+++ b/internal/service/resources/collector/collector_ocloudsite.go
@@ -129,7 +129,7 @@ func (d *OCloudSiteDataSource) Watch(ctx context.Context) error {
 
 // HandleAsyncEvent handles an add/update/delete event received from the Reflector.
 func (d *OCloudSiteDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleAsyncEvent received for ocloudsite", slog.Any("type", eventType), slog.String("object", fmt.Sprintf("%T", obj)))
+	slog.DebugContext(ctx, "handleAsyncEvent received for ocloudsite", slog.String("type", eventType.String()), slog.String("object", fmt.Sprintf("%T", obj)))
 
 	switch value := obj.(type) {
 	case *inventoryv1alpha1.OCloudSite:
@@ -166,7 +166,7 @@ func (d *OCloudSiteDataSource) HandleSyncComplete(ctx context.Context, objectTyp
 
 // handleOCloudSiteWatchEvent handles an async event received for an OCloudSite CR
 func (d *OCloudSiteDataSource) handleOCloudSiteWatchEvent(ctx context.Context, site *inventoryv1alpha1.OCloudSite, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleOCloudSiteWatchEvent received", slog.String("name", site.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleOCloudSiteWatchEvent received", slog.String("name", site.Name), slog.String("type", eventType.String()))
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.

--- a/internal/service/resources/collector/collector_resourcepool.go
+++ b/internal/service/resources/collector/collector_resourcepool.go
@@ -129,7 +129,7 @@ func (d *ResourcePoolDataSource) Watch(ctx context.Context) error {
 
 // HandleAsyncEvent handles an add/update/delete event received from the Reflector.
 func (d *ResourcePoolDataSource) HandleAsyncEvent(ctx context.Context, obj interface{}, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleAsyncEvent received for resourcepool", slog.Any("type", eventType), slog.String("object", fmt.Sprintf("%T", obj)))
+	slog.DebugContext(ctx, "handleAsyncEvent received for resourcepool", slog.String("type", eventType.String()), slog.String("object", fmt.Sprintf("%T", obj)))
 
 	switch value := obj.(type) {
 	case *inventoryv1alpha1.ResourcePool:
@@ -166,7 +166,7 @@ func (d *ResourcePoolDataSource) HandleSyncComplete(ctx context.Context, objectT
 
 // handleResourcePoolWatchEvent handles an async event received for a ResourcePool CR
 func (d *ResourcePoolDataSource) handleResourcePoolWatchEvent(ctx context.Context, pool *inventoryv1alpha1.ResourcePool, eventType async.AsyncEventType) (uuid.UUID, error) {
-	slog.DebugContext(ctx, "handleResourcePoolWatchEvent received", slog.String("name", pool.Name), slog.Any("type", eventType))
+	slog.DebugContext(ctx, "handleResourcePoolWatchEvent received", slog.String("name", pool.Name), slog.String("type", eventType.String()))
 
 	// If CR is not ready (e.g., validation failed, parent missing), treat as deletion
 	// from API perspective. This ensures stale data is removed when CRs become invalid.


### PR DESCRIPTION
- Add fmt.Stringer implementation so event types render as "Updated", "Deleted", or "SyncComplete" instead of raw integers in log output
- Update call sites from slog.Any("type", eventType) to slog.String("type", eventType.String()) since slog.Any on int-based types uses the numeric value, bypassing Stringer