### PR TITLE
CNF-24956: add clusterName validation and reserved namespace checks

### DIFF
--- a/.coverage-thresholds.yaml
+++ b/.coverage-thresholds.yaml
@@ -14,6 +14,7 @@ packages:
   internal: 16
   internal/controllers: 60
   internal/controllers/utils: 19
+  internal/validation: 80
   internal/logging: 39
   internal/search: 38
   internal/service/alarms/api: 2

--- a/api/provisioning/v1alpha1/provisioningrequest_webhook.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_webhook.go
@@ -20,6 +20,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clustervalidation "github.com/openshift-kni/oran-o2ims/internal/validation"
 )
 
 const HardwareConfigInProgress = "Hardware configuring is in progress"
@@ -142,6 +144,20 @@ func (v *provisioningRequestValidator) validateCreateOrUpdate(ctx context.Contex
 	newPrClusterInstanceInput, err := newPr.ValidateClusterInstanceInputMatchesSchema(clusterTemplate)
 	if err != nil {
 		return err
+	}
+
+	// Best-effort clusterName validation on the raw PR input. The controller
+	// performs the authoritative check on the merged value after defaults are
+	// applied; this catches obvious issues at admission time.
+	if inputMap, ok := newPrClusterInstanceInput.(map[string]any); ok {
+		if clusterName, ok := inputMap["clusterName"].(string); ok && clusterName != "" {
+			if err := clustervalidation.ValidateClusterNameFormat(clusterName); err != nil {
+				return fmt.Errorf("clusterInstanceParameters.clusterName: %w", err)
+			}
+			if err := clustervalidation.ValidateClusterNameNotReserved(clusterName); err != nil {
+				return fmt.Errorf("clusterInstanceParameters.clusterName: %w", err)
+			}
+		}
 	}
 
 	if oldPr == nil {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,7 @@ the failed phase. Common failure conditions:
 
 | Condition | Phase | Common Causes |
 |---|---|---|
-| `ProvisioningRequestValidated` | Validation | Invalid template parameters, missing ConfigMaps |
+| `ProvisioningRequestValidated` | Validation | Invalid template parameters, missing ConfigMaps, reserved or in-use `clusterName` |
 | `NodeAllocationRequestRendered` | NodeAllocationRequest rendering | Invalid hwMgmtDefaults or HardwareProfile CR |
 | `HardwareProvisioned` | BMH allocation | No available BMHs matching resource selector |
 | `HardwareConfigured` | Firmware/BIOS | Firmware URL unreachable, BMC errors |

--- a/docs/user-guide/cluster-provisioning.md
+++ b/docs/user-guide/cluster-provisioning.md
@@ -95,6 +95,9 @@ Pending (Validating and preparing resources)
 1. O-Cloud Manager first validates the ProvisioningRequest CR, including but not limited to:
     - Verify timeout values for hardware provisioning, cluster installation, or configuration as specified in the respective ConfigMaps if provided.
     - Validate the `clusterInstanceParameters` against the subschema defined in the ClusterTemplate. Any fields not present in the subschema but provided in the `clusterInstanceParameters` are disallowed and will cause validation failure.
+    - Validate that `clusterName` is a valid DNS-1123 label and does not conflict with reserved
+      system namespaces (e.g., `kube-*`, `openshift-*`, `default`) or namespaces already
+      in use by another ProvisioningRequest.
     - Validate the merged policy template input data (`policyTemplateParameters` combined with default values in the `policyTemplateDefaults` ConfigMap) against the PolicyTemplate subschema.
 2. Render the ClusterInstance CR with the merged ClusterInstance input (data from `clusterInstanceParameters` combined with the default values in the `clusterInstanceDefaults` ConfigMap) and validate it via client dry-run.
 3. Prepare the neccessary resources for provisioning.

--- a/internal/controllers/provisioningrequest_resourcecreation.go
+++ b/internal/controllers/provisioningrequest_resourcecreation.go
@@ -142,6 +142,9 @@ func (t *provisioningRequestReconcilerTask) createClusterInstanceNamespace(
 	// Validate the clusterName before creating the namespace. The early
 	// validation in validateProvisioningRequestCR performs these same checks;
 	// this guard ensures consistency regardless of the code path taken.
+	if err := clustervalidation.ValidateClusterNameFormat(clusterName); err != nil {
+		return fmt.Errorf("invalid clusterName format: %w", err)
+	}
 	if err := clustervalidation.ValidateClusterNameNotReserved(clusterName); err != nil {
 		return fmt.Errorf("clusterName rejected: %w", err)
 	}

--- a/internal/controllers/provisioningrequest_resourcecreation.go
+++ b/internal/controllers/provisioningrequest_resourcecreation.go
@@ -16,6 +16,7 @@ import (
 
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	clustervalidation "github.com/openshift-kni/oran-o2ims/internal/validation"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 )
 
@@ -136,6 +137,17 @@ func (t *provisioningRequestReconcilerTask) createClusterInstanceNamespace(
 
 	if clusterName == "" {
 		return fmt.Errorf("spec.clusterName cannot be empty")
+	}
+
+	// Validate the clusterName before creating the namespace. The early
+	// validation in validateProvisioningRequestCR performs these same checks;
+	// this guard ensures consistency regardless of the code path taken.
+	if err := clustervalidation.ValidateClusterNameNotReserved(clusterName); err != nil {
+		return fmt.Errorf("clusterName rejected: %w", err)
+	}
+	if err := clustervalidation.ValidateClusterNameOwnership(ctx, t.client, clusterName, t.object.Name,
+		provisioningv1alpha1.ProvisioningRequestNameLabel); err != nil {
+		return fmt.Errorf("clusterName ownership check failed: %w", err)
 	}
 
 	// Create the namespace.

--- a/internal/controllers/provisioningrequest_resourcecreation_test.go
+++ b/internal/controllers/provisioningrequest_resourcecreation_test.go
@@ -437,3 +437,159 @@ var _ = Describe("createOrUpdateClusterResources", func() {
 		Expect(errors.IsNotFound(err)).To(BeTrue())
 	})
 })
+
+var _ = Describe("createClusterInstanceNamespace", func() {
+	var (
+		ctx  context.Context
+		c    client.Client
+		task *provisioningRequestReconcilerTask
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		pr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pr",
+			},
+		}
+
+		c = fakeclient.GetFakeClientFromObjects(pr)
+		task = &provisioningRequestReconcilerTask{
+			client: c,
+			object: pr,
+		}
+	})
+
+	It("rejects reserved namespace names", func() {
+		err := task.createClusterInstanceNamespace(ctx, "kube-system")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("reserved namespace"))
+	})
+
+	It("rejects namespace owned by a different PR", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "other-cluster",
+				Labels: map[string]string{
+					provisioningv1alpha1.ProvisioningRequestNameLabel: "other-pr",
+				},
+			},
+		}
+		Expect(c.Create(ctx, ns)).To(Succeed())
+
+		err := task.createClusterInstanceNamespace(ctx, "other-cluster")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not owned by"))
+	})
+
+	It("creates namespace for a valid cluster name", func() {
+		err := task.createClusterInstanceNamespace(ctx, "my-new-cluster")
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: "my-new-cluster"}, ns)).To(Succeed())
+		Expect(ns.Labels[provisioningv1alpha1.ProvisioningRequestNameLabel]).To(Equal("test-pr"))
+	})
+
+	It("allows namespace already owned by this PR", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-cluster",
+				Labels: map[string]string{
+					provisioningv1alpha1.ProvisioningRequestNameLabel: "test-pr",
+				},
+			},
+		}
+		Expect(c.Create(ctx, ns)).To(Succeed())
+
+		err := task.createClusterInstanceNamespace(ctx, "my-cluster")
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("validateClusterName", func() {
+	var (
+		ctx  context.Context
+		c    client.Client
+		task *provisioningRequestReconcilerTask
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		pr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pr",
+			},
+		}
+
+		c = fakeclient.GetFakeClientFromObjects(pr)
+		task = &provisioningRequestReconcilerTask{
+			client: c,
+			object: pr,
+			clusterInput: &clusterInput{
+				clusterInstanceData: map[string]any{},
+			},
+		}
+	})
+
+	It("rejects missing clusterName", func() {
+		err := task.validateClusterName(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("clusterName is required"))
+	})
+
+	It("rejects invalid DNS-1123 label", func() {
+		task.clusterInput.clusterInstanceData["clusterName"] = "My_Invalid_Name"
+		err := task.validateClusterName(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not a valid DNS-1123 label"))
+	})
+
+	It("rejects reserved namespace", func() {
+		task.clusterInput.clusterInstanceData["clusterName"] = "openshift-monitoring"
+		err := task.validateClusterName(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("reserved namespace"))
+	})
+
+	It("rejects namespace owned by another PR", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "taken-cluster",
+				Labels: map[string]string{
+					provisioningv1alpha1.ProvisioningRequestNameLabel: "other-pr",
+				},
+			},
+		}
+		Expect(c.Create(ctx, ns)).To(Succeed())
+
+		task.clusterInput.clusterInstanceData["clusterName"] = "taken-cluster"
+		err := task.validateClusterName(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not owned by"))
+	})
+
+	It("accepts a valid cluster name", func() {
+		task.clusterInput.clusterInstanceData["clusterName"] = "my-cluster-01"
+		err := task.validateClusterName(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("accepts a name when namespace is owned by this PR", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-cluster",
+				Labels: map[string]string{
+					provisioningv1alpha1.ProvisioningRequestNameLabel: "test-pr",
+				},
+			},
+		}
+		Expect(c.Create(ctx, ns)).To(Succeed())
+
+		task.clusterInput.clusterInstanceData["clusterName"] = "my-cluster"
+		err := task.validateClusterName(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/internal/controllers/provisioningrequest_validation.go
+++ b/internal/controllers/provisioningrequest_validation.go
@@ -18,6 +18,7 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	clustervalidation "github.com/openshift-kni/oran-o2ims/internal/validation"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -44,6 +45,10 @@ func (t *provisioningRequestReconcilerTask) validateProvisioningRequestCR(ctx co
 
 	if err = t.validateClusterInstanceInputMatchesSchema(ctx, clusterTemplate); err != nil {
 		return fmt.Errorf("failed to validate ClusterInstance input: %w", err)
+	}
+
+	if err = t.validateClusterName(ctx); err != nil {
+		return fmt.Errorf("failed to validate clusterName: %w", err)
 	}
 
 	if err = t.validatePolicyTemplateInputMatchesSchema(ctx, clusterTemplate); err != nil {
@@ -129,6 +134,31 @@ func (t *provisioningRequestReconcilerTask) validateClusterInstanceInputMatchesS
 	}
 
 	t.clusterInput.clusterInstanceData = mergedClusterInstanceData
+	return nil
+}
+
+// validateClusterName validates that the merged clusterName value is a valid
+// DNS-1123 label, does not conflict with reserved system namespaces, and is
+// not already in use by another ProvisioningRequest.
+func (t *provisioningRequestReconcilerTask) validateClusterName(ctx context.Context) error {
+	clusterName, ok := t.clusterInput.clusterInstanceData["clusterName"].(string)
+	if !ok || clusterName == "" {
+		return ctlrutils.NewInputError("clusterName is required and must be a non-empty string")
+	}
+
+	if err := clustervalidation.ValidateClusterNameFormat(clusterName); err != nil {
+		return fmt.Errorf("invalid clusterName format: %w", err)
+	}
+
+	if err := clustervalidation.ValidateClusterNameNotReserved(clusterName); err != nil {
+		return fmt.Errorf("reserved clusterName: %w", err)
+	}
+
+	if err := clustervalidation.ValidateClusterNameOwnership(ctx, t.client, clusterName, t.object.Name,
+		provisioningv1alpha1.ProvisioningRequestNameLabel); err != nil {
+		return fmt.Errorf("clusterName ownership check failed: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/validation/cluster_name.go
+++ b/internal/validation/cluster_name.go
@@ -20,14 +20,18 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 )
 
-// ReservedNamespacePrefixes lists namespace name patterns that cannot be
-// used as clusterName values. Entries are matched by exact equality or by
-// prefix (e.g., "default" matches exactly, "openshift-" matches any name
-// starting with "openshift-").
-var ReservedNamespacePrefixes = []string{
+// reservedNamespaceExact lists exact namespace names that cannot be used
+// as clusterName values.
+var reservedNamespaceExact = []string{
 	"default",
-	"kube-",
 	"openshift",
+}
+
+// reservedNamespacePrefixes lists namespace name prefixes that cannot be
+// used as clusterName values. Any name starting with one of these prefixes
+// is rejected.
+var reservedNamespacePrefixes = []string{
+	"kube-",
 	"openshift-",
 	"open-cluster-management",
 	"multicluster-",
@@ -37,9 +41,14 @@ var ReservedNamespacePrefixes = []string{
 // IsReservedNamespace checks if a name matches reserved namespace patterns.
 // Returns true and the matched pattern if reserved, false otherwise.
 func IsReservedNamespace(name string) (bool, string) {
-	for _, p := range ReservedNamespacePrefixes {
-		if name == p || strings.HasPrefix(name, p) {
-			return true, p
+	for _, exact := range reservedNamespaceExact {
+		if name == exact {
+			return true, exact
+		}
+	}
+	for _, prefix := range reservedNamespacePrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true, prefix
 		}
 	}
 

--- a/internal/validation/cluster_name.go
+++ b/internal/validation/cluster_name.go
@@ -1,0 +1,105 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validation
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
+)
+
+// ReservedNamespacePrefixes lists namespace name patterns that cannot be
+// used as clusterName values. Entries are matched by exact equality or by
+// prefix (e.g., "default" matches exactly, "openshift-" matches any name
+// starting with "openshift-").
+var ReservedNamespacePrefixes = []string{
+	"default",
+	"kube-",
+	"openshift",
+	"openshift-",
+	"open-cluster-management",
+	"multicluster-",
+	"ztp-",
+}
+
+// IsReservedNamespace checks if a name matches reserved namespace patterns.
+// Returns true and the matched pattern if reserved, false otherwise.
+func IsReservedNamespace(name string) (bool, string) {
+	for _, p := range ReservedNamespacePrefixes {
+		if name == p || strings.HasPrefix(name, p) {
+			return true, p
+		}
+	}
+
+	operatorNs := os.Getenv(constants.DefaultNamespaceEnvName)
+	if operatorNs == "" {
+		operatorNs = constants.DefaultNamespace
+	}
+	if name == operatorNs {
+		return true, operatorNs
+	}
+
+	return false, ""
+}
+
+// ValidateClusterNameFormat checks that the name is a valid DNS-1123 label.
+func ValidateClusterNameFormat(name string) error {
+	if name == "" {
+		return fmt.Errorf("clusterName is required and must be a non-empty string")
+	}
+
+	if errs := validation.IsDNS1123Label(name); len(errs) > 0 {
+		return fmt.Errorf(
+			"clusterName %q is not a valid DNS-1123 label: %s",
+			name, strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+// ValidateClusterNameNotReserved checks that the name does not target a
+// reserved namespace.
+func ValidateClusterNameNotReserved(name string) error {
+	if reserved, pattern := IsReservedNamespace(name); reserved {
+		return fmt.Errorf(
+			"clusterName %q targets a reserved namespace (prefix %q)", name, pattern)
+	}
+	return nil
+}
+
+// ValidateClusterNameOwnership checks if a namespace with the given name
+// already exists and, if so, verifies it is owned by the specified
+// ProvisioningRequest. The ownerLabel parameter is the label key used to
+// identify the owning PR. Returns nil if the namespace does not exist or
+// is owned by the expected PR.
+func ValidateClusterNameOwnership(
+	ctx context.Context, c client.Client, clusterName, prName, ownerLabel string) error {
+
+	existing := &corev1.Namespace{}
+	if err := c.Get(ctx, client.ObjectKey{Name: clusterName}, existing); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to check for existing namespace %s: %w", clusterName, err)
+	}
+
+	if existing.Labels[ownerLabel] != prName {
+		return fmt.Errorf(
+			"namespace %q already exists and is not owned by ProvisioningRequest %q",
+			clusterName, prName)
+	}
+
+	return nil
+}

--- a/internal/validation/cluster_name_test.go
+++ b/internal/validation/cluster_name_test.go
@@ -1,0 +1,194 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validation
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
+)
+
+func TestValidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validation")
+}
+
+var _ = Describe("IsReservedNamespace", func() {
+	It("rejects kube-system", func() {
+		reserved, _ := IsReservedNamespace("kube-system")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects kube-public", func() {
+		reserved, _ := IsReservedNamespace("kube-public")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects default", func() {
+		reserved, _ := IsReservedNamespace("default")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects openshift exactly", func() {
+		reserved, _ := IsReservedNamespace("openshift")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects openshift-monitoring", func() {
+		reserved, _ := IsReservedNamespace("openshift-monitoring")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects open-cluster-management", func() {
+		reserved, _ := IsReservedNamespace("open-cluster-management")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects open-cluster-management-agent", func() {
+		reserved, _ := IsReservedNamespace("open-cluster-management-agent")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects multicluster-engine", func() {
+		reserved, _ := IsReservedNamespace("multicluster-engine")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects ztp-something", func() {
+		reserved, _ := IsReservedNamespace("ztp-my-templates")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects the operator namespace", func() {
+		os.Setenv(constants.DefaultNamespaceEnvName, "custom-operator-ns")
+		defer os.Unsetenv(constants.DefaultNamespaceEnvName)
+		reserved, _ := IsReservedNamespace("custom-operator-ns")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects default operator namespace when env not set", func() {
+		os.Unsetenv(constants.DefaultNamespaceEnvName)
+		reserved, _ := IsReservedNamespace(constants.DefaultNamespace)
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("accepts a valid cluster name", func() {
+		reserved, _ := IsReservedNamespace("my-cluster-01")
+		Expect(reserved).To(BeFalse())
+	})
+
+	It("accepts a name that contains but doesn't start with reserved prefix", func() {
+		reserved, _ := IsReservedNamespace("cluster-openshift-test")
+		Expect(reserved).To(BeFalse())
+	})
+})
+
+var _ = Describe("ValidateClusterNameFormat", func() {
+	It("rejects empty string", func() {
+		Expect(ValidateClusterNameFormat("")).To(HaveOccurred())
+	})
+
+	It("rejects uppercase letters", func() {
+		Expect(ValidateClusterNameFormat("MyCluster")).To(HaveOccurred())
+	})
+
+	It("rejects names starting with hyphen", func() {
+		Expect(ValidateClusterNameFormat("-cluster")).To(HaveOccurred())
+	})
+
+	It("rejects names ending with hyphen", func() {
+		Expect(ValidateClusterNameFormat("cluster-")).To(HaveOccurred())
+	})
+
+	It("rejects names with underscores", func() {
+		Expect(ValidateClusterNameFormat("my_cluster")).To(HaveOccurred())
+	})
+
+	It("rejects names longer than 63 characters", func() {
+		longName := "a234567890123456789012345678901234567890123456789012345678901234"
+		Expect(len(longName)).To(BeNumerically(">", 63))
+		Expect(ValidateClusterNameFormat(longName)).To(HaveOccurred())
+	})
+
+	It("accepts valid lowercase name", func() {
+		Expect(ValidateClusterNameFormat("my-cluster-01")).ToNot(HaveOccurred())
+	})
+
+	It("accepts single character", func() {
+		Expect(ValidateClusterNameFormat("a")).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("ValidateClusterNameOwnership", func() {
+	const ownerLabel = "provisioningrequest.clcm.openshift.io/name"
+
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	It("allows when namespace does not exist", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		err := ValidateClusterNameOwnership(ctx, c, "new-cluster", "my-pr", ownerLabel)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("allows when namespace is owned by this PR", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-cluster",
+				Labels: map[string]string{
+					ownerLabel: "my-pr",
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+		err := ValidateClusterNameOwnership(ctx, c, "my-cluster", "my-pr", ownerLabel)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("rejects when namespace is owned by a different PR", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-cluster",
+				Labels: map[string]string{
+					ownerLabel: "other-pr",
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+		err := ValidateClusterNameOwnership(ctx, c, "my-cluster", "my-pr", ownerLabel)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not owned by ProvisioningRequest"))
+	})
+
+	It("rejects when namespace exists without PR label", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "existing-ns",
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+		err := ValidateClusterNameOwnership(ctx, c, "existing-ns", "my-pr", ownerLabel)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/validation/cluster_name_test.go
+++ b/internal/validation/cluster_name_test.go
@@ -90,6 +90,31 @@ var _ = Describe("IsReservedNamespace", func() {
 		Expect(reserved).To(BeFalse())
 	})
 
+	It("accepts default-team (not an exact match for default)", func() {
+		reserved, _ := IsReservedNamespace("default-team")
+		Expect(reserved).To(BeFalse())
+	})
+
+	It("accepts openshift-like names that don't start with the prefix", func() {
+		reserved, _ := IsReservedNamespace("my-openshift-cluster")
+		Expect(reserved).To(BeFalse())
+	})
+
+	It("rejects openshift-anything (prefix match)", func() {
+		reserved, _ := IsReservedNamespace("openshift-custom")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("rejects kube-anything (prefix match)", func() {
+		reserved, _ := IsReservedNamespace("kube-custom")
+		Expect(reserved).To(BeTrue())
+	})
+
+	It("accepts defaulting (not exact match for default)", func() {
+		reserved, _ := IsReservedNamespace("defaulting")
+		Expect(reserved).To(BeFalse())
+	})
+
 	It("accepts a name that contains but doesn't start with reserved prefix", func() {
 		reserved, _ := IsReservedNamespace("cluster-openshift-test")
 		Expect(reserved).To(BeFalse())


### PR DESCRIPTION
Validate the clusterName value from ProvisioningRequest templateParameters to ensure it is a valid DNS-1123 label, does not conflict with reserved system namespaces, and is not already in use by another ProvisioningRequest.

- Add shared validation utilities (ValidateClusterNameFormat, ValidateClusterNameNotReserved, ValidateClusterNameOwnership) in controllers/utils with a reserved namespace denylist
- Add early validation in validateProvisioningRequestCR after clusterInstanceData is populated
- Add validation guard in createClusterInstanceNamespace using the same shared utilities for consistency
- Add best-effort webhook validation for immediate rejection of invalid or reserved clusterName values at admission time
- Add unit tests for all validation utilities and integration tests for both the validation and namespace creation paths