### PR TITLE
CNF-24707: standardize log attribute keys to camelCase

### DIFF
--- a/internal/hardwaremanager/controller/allocatednode_controller.go
+++ b/internal/hardwaremanager/controller/allocatednode_controller.go
@@ -62,7 +62,7 @@ func (r *AllocatedNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}()
 
 	// Add logging context with the resource name
-	ctx = logging.AppendCtx(ctx, slog.String("ReconcileRequest", req.Name))
+	ctx = logging.AppendCtx(ctx, slog.String("reconcileRequest", req.Name))
 
 	allocatedNode, err := hwmgrutils.GetNode(ctx, r.Logger, r.NoncachedClient, req.Namespace, req.Name)
 	if err != nil {

--- a/internal/hardwaremanager/controller/hostfirmwarecomponents_controller.go
+++ b/internal/hardwaremanager/controller/hostfirmwarecomponents_controller.go
@@ -70,7 +70,7 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 	}()
 
 	// Add logging context with the resource name
-	ctx = logging.AppendCtx(ctx, slog.String("ReconcileRequest", req.Name))
+	ctx = logging.AppendCtx(ctx, slog.String("reconcileRequest", req.Name))
 
 	// Fetch the HostFirmwareComponents
 	hfc := &metal3v1alpha1.HostFirmwareComponents{}

--- a/internal/hardwaremanager/controller/hostfirmwaresettings_manager.go
+++ b/internal/hardwaremanager/controller/hostfirmwaresettings_manager.go
@@ -45,7 +45,7 @@ func createHostFirmwareSettings(ctx context.Context, c client.Client, logger *sl
 			// Metal3 may have created the HFS concurrently; treat as success.
 			return nil
 		}
-		logger.InfoContext(ctx, "Failed to create HostFirmwareSettings", slog.String("HFS", hfs.Name))
+		logger.InfoContext(ctx, "Failed to create HostFirmwareSettings", slog.String("hfs", hfs.Name))
 		return fmt.Errorf("failed to create HostFirmwareSettings: %w", err)
 	}
 	return nil
@@ -92,7 +92,7 @@ func IsBiosUpdateRequired(ctx context.Context,
 		if err := createHostFirmwareSettings(ctx, c, logger, &hfs); err != nil {
 			return false, fmt.Errorf("failed to create HostFirmwareSettings: %w", err)
 		}
-		logger.InfoContext(ctx, "Successfully created HostFirmwareSettings", slog.String("HFS", hfs.Name))
+		logger.InfoContext(ctx, "Successfully created HostFirmwareSettings", slog.String("hfs", hfs.Name))
 		return true, nil
 	}
 
@@ -106,7 +106,7 @@ func IsBiosUpdateRequired(ctx context.Context,
 
 	// Compare desired settings with current status
 	if !isChangeDetected(ctx, logger, hfs.Spec.Settings, existingHFS.Status.Settings) {
-		logger.InfoContext(ctx, "No changes detected in HostFirmwareSettings", slog.String("HFS", hfs.Name))
+		logger.InfoContext(ctx, "No changes detected in HostFirmwareSettings", slog.String("hfs", hfs.Name))
 		return false, nil
 	}
 
@@ -115,13 +115,13 @@ func IsBiosUpdateRequired(ctx context.Context,
 		return true, nil
 	}
 
-	logger.InfoContext(ctx, "Updating existing HostFirmwareSettings", slog.String("HFS", hfs.Name))
+	logger.InfoContext(ctx, "Updating existing HostFirmwareSettings", slog.String("hfs", hfs.Name))
 	if err := updateHostFirmwareSettings(ctx, c, types.NamespacedName{Name: hfs.Name, Namespace: hfs.Namespace}, hfs); err != nil {
-		logger.InfoContext(ctx, "Failed to update HostFirmwareSettings", slog.String("HFS", hfs.Name))
+		logger.InfoContext(ctx, "Failed to update HostFirmwareSettings", slog.String("hfs", hfs.Name))
 		return false, fmt.Errorf("failed to update HostFirmwareSettings: %w", err)
 	}
 
-	logger.InfoContext(ctx, "Successfully updated HostFirmwareSetting", slog.String("HFS", hfs.Name))
+	logger.InfoContext(ctx, "Successfully updated HostFirmwareSetting", slog.String("hfs", hfs.Name))
 	return true, nil
 }
 

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -90,7 +90,7 @@ func (r *NodeAllocationRequestReconciler) Reconcile(ctx context.Context, req ctr
 	}()
 
 	// Add logging context with the NodeAllocationRequest name
-	ctx = logging.AppendCtx(ctx, slog.String("NodeAllocationRequest", req.Name))
+	ctx = logging.AppendCtx(ctx, slog.String("nodeAllocationRequest", req.Name))
 
 	if !r.indexerEnabled {
 		if err := r.SetupIndexer(ctx); err != nil {

--- a/internal/service/common/api/middleware/filtering.go
+++ b/internal/service/common/api/middleware/filtering.go
@@ -238,7 +238,7 @@ func ResponseFilter(adapter *FilterAdapter) Middleware {
 			var err error
 			query, err := url.ParseQuery(r.URL.RawQuery)
 			if err != nil {
-				slog.ErrorContext(r.Context(), "failed to parse query", slog.String("RawQuery", r.URL.RawQuery), slog.Any("error", err))
+				slog.ErrorContext(r.Context(), "failed to parse query", slog.String("rawQuery", r.URL.RawQuery), slog.Any("error", err))
 				_ = adapter.Error(
 					w,
 					"failed to parse query parameters",

--- a/internal/service/common/notifier/notifier.go
+++ b/internal/service/common/notifier/notifier.go
@@ -123,7 +123,7 @@ func (n *Notifier) Run(ctx context.Context) error {
 		case e := <-n.notificationChannel:
 			if err := n.handleNotification(ctx, e); err != nil {
 				slog.ErrorContext(ctx, "failed to handle notification",
-					slog.String("NotificationID", e.NotificationID.String()), slog.Int("sequenceID", e.SequenceID), slog.Any("error", err))
+					slog.String("notificationID", e.NotificationID.String()), slog.Int("sequenceID", e.SequenceID), slog.Any("error", err))
 			}
 		case e := <-n.subscriptionChannel:
 			if err := n.handleSubscriptionEvent(ctx, e); err != nil {
@@ -216,7 +216,7 @@ func (n *Notifier) Notify(ctx context.Context, event *Notification) {
 
 // handleNotification handles an incoming notification
 func (n *Notifier) handleNotification(ctx context.Context, event *Notification) error {
-	slog.InfoContext(ctx, "handling notification", slog.String("NotificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
+	slog.InfoContext(ctx, "handling notification", slog.String("notificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
 
 	count := 0
 	for _, worker := range n.workers {
@@ -234,7 +234,7 @@ func (n *Notifier) handleNotification(ctx context.Context, event *Notification) 
 	if count == 0 {
 		// No subscriptions matched just delete the event
 		slog.DebugContext(ctx, "no matching subscriptions; deleting event",
-			slog.String("NotificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
+			slog.String("notificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID))
 		if err := n.notificationProvider.DeleteNotification(ctx, event.NotificationID); err != nil {
 			return fmt.Errorf("failed to delete notification: %w", err)
 		}
@@ -242,7 +242,7 @@ func (n *Notifier) handleNotification(ctx context.Context, event *Notification) 
 	}
 
 	slog.InfoContext(ctx, "notification dispatched",
-		slog.String("NotificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID),
+		slog.String("notificationID", event.NotificationID.String()), slog.Int("sequenceID", event.SequenceID),
 		slog.Int("subscribers", count))
 
 	return nil
@@ -326,7 +326,7 @@ func (n *Notifier) handleSubscriptionEvent(ctx context.Context, event *Subscript
 // handleSubscriptionJobCompleteEvent handles a job completion event, removes the subscriber from the event job,
 func (n *Notifier) handleSubscriptionJobCompleteEvent(ctx context.Context, event *SubscriptionJobComplete) error {
 	slog.DebugContext(ctx, "handling subscription job complete event",
-		slog.String("NotificationID", event.notificationID.String()), slog.String("subscriptionID", event.subscriptionID.String()))
+		slog.String("notificationID", event.notificationID.String()), slog.String("subscriptionID", event.subscriptionID.String()))
 
 	// Lookup the subscription worker for this event
 	if worker, found := n.workers[event.subscriptionID]; found {

--- a/internal/service/common/repo/notifications.go
+++ b/internal/service/common/repo/notifications.go
@@ -53,7 +53,7 @@ func (p *NotificationStorageProvider) GetNotifications(ctx context.Context) ([]n
 func (p *NotificationStorageProvider) DeleteNotification(ctx context.Context, notificationID uuid.UUID) error {
 	// This event has been consumed by all subscriptions
 	slog.DebugContext(ctx, "notification sent to all subscribers; deleting",
-		slog.String("NotificationID", notificationID.String()))
+		slog.String("notificationID", notificationID.String()))
 
 	_, err := p.repository.DeleteDataChangeEvent(ctx, notificationID)
 	if err != nil {


### PR DESCRIPTION
Rename PascalCase log attribute keys to camelCase for consistency:
- HFS → hfs
- NodeAllocationRequest → nodeAllocationRequest
- NotificationID → notificationID
- ReconcileRequest → reconcileRequest
- RawQuery → rawQuery