### PR TITLE
fix: retry database connection at startup instead of crashing

### DIFF
--- a/internal/service/common/db/migration.go
+++ b/internal/service/common/db/migration.go
@@ -19,6 +19,8 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/database/pgx/v5"
 	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 )
 
 // MigrationsTable table created by migration lib to track state of migration
@@ -37,10 +39,30 @@ type MigrationConfig struct {
 
 // StartMigration starts migration for alarms server from a k8s job.
 func StartMigration(pgc PgConfig, source source.Driver) error {
-	// Init
-	h, err := NewHandler(PGtoMigrateConfig(pgc, source))
+	// Retry the initial connection. The migration init container starts
+	// simultaneously with postgres, so it may need to wait for the database
+	// to become ready. Note: do not use Cap with Factor > 1.0 — the wait
+	// library zeros Steps when Duration exceeds Cap, ending retries
+	// prematurely.
+	connectBackoff := wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   1.0,
+		Jitter:   0.1,
+		Steps:    40, // ~3.3 minutes total
+	}
+
+	var h *MigrationHandler
+	err := retry.OnError(connectBackoff, func(_ error) bool { return true }, func() error {
+		var handlerErr error
+		h, handlerErr = NewHandler(PGtoMigrateConfig(pgc, source))
+		if handlerErr != nil {
+			slog.Warn("Database not ready for migration, retrying", slog.Any("error", handlerErr))
+			return fmt.Errorf("failed to create migrations handler: %w", handlerErr)
+		}
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("failed to create migrations handler: %w", err)
+		return fmt.Errorf("failed to connect to database for migration after retries: %w", err)
 	}
 
 	// Setup signal handling

--- a/internal/service/common/db/postgres.go
+++ b/internal/service/common/db/postgres.go
@@ -16,6 +16,8 @@ import (
 	"github.com/jackc/pgx/v5/tracelog"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 )
 
 type PgConfig struct {
@@ -56,9 +58,30 @@ func NewPgxPool(ctx context.Context, cfg PgConfig) (*pgxpool.Pool, error) {
 		return nil, fmt.Errorf("failed to create connection pool: %w", err)
 	}
 
-	if err := pool.Ping(ctx); err != nil {
+	// Retry the initial connection. This handles the common startup race
+	// where the service pod starts before postgres is accepting connections.
+	// Note: do not use Cap with Factor > 1.0 — the wait library zeros Steps
+	// when Duration exceeds Cap, ending retries prematurely.
+	connectBackoff := wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   1.0,
+		Jitter:   0.1,
+		Steps:    40, // ~3.3 minutes total
+	}
+	err = retry.OnError(connectBackoff, func(err error) bool {
+		return ctx.Err() == nil
+	}, func() error {
+		pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		if pingErr := pool.Ping(pingCtx); pingErr != nil {
+			slog.WarnContext(ctx, "Database not ready, retrying", slog.Any("error", pingErr))
+			return fmt.Errorf("failed to ping database: %w", pingErr)
+		}
+		return nil
+	})
+	if err != nil {
 		pool.Close()
-		return nil, fmt.Errorf("failed to ping database: %w", err)
+		return nil, fmt.Errorf("failed to connect to database after retries: %w", err)
 	}
 
 	slog.InfoContext(ctx, "Database connection pool established")


### PR DESCRIPTION
## Summary

Service pods and their migration init containers crash when postgres isn't ready
at startup, entering CrashLoopBackOff. Add retry logic so they poll every
5 seconds until postgres is accepting connections (~3.3 minutes max).

## Changes

- **NewPgxPool** (`internal/service/common/db/postgres.go`): Retry Ping with
  10-second context timeout per attempt, stop retrying on context cancellation
- **StartMigration** (`internal/service/common/db/migration.go`): Retry
  NewHandler creation with same interval
- Both use fixed 5-second interval (`Factor: 1.0`) to avoid the `wait.Backoff`
  `Cap` behavior that zeros `Steps` prematurely when using `Factor > 1.0`

## Test plan

- [x] Deploy operator, delete all pods + postgres — service pods wait and
  connect after postgres restarts (zero pod restarts)
- [x] Verify WARN retry logs appear during wait period
- [x] Verify normal startup (postgres ready) shows no retries
- [x] Verify context cancellation stops retries (pod shutdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)