### PR TITLE
CNF-25110: move TemplateParam constants to shared constants package

### DIFF
--- a/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -17,18 +17,13 @@ import (
 	"os"
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/r3labs/diff/v3"
 	"github.com/xeipuuv/gojsonschema"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	TemplateParamClusterInstance = "clusterInstanceParameters"
-	TemplateParamPolicyConfig    = "policyTemplateParameters"
-	TemplateParamHwMgmt          = "hwMgmtParameters"
 )
 
 var (
@@ -180,17 +175,17 @@ func (r *ProvisioningRequest) ValidateTemplateInputMatchesSchema(
 		return fmt.Errorf(
 			"missing keyword 'properties' in the schema from ClusterTemplate (%s)", clusterTemplate.Name)
 	}
-	clusterInstanceSubSchema, ok := schemaProperties.(map[string]any)[TemplateParamClusterInstance]
+	clusterInstanceSubSchema, ok := schemaProperties.(map[string]any)[constants.TemplateParamClusterInstance]
 	if !ok {
 		return fmt.Errorf(
 			"missing required property '%s' in the schema from ClusterTemplate (%s)",
-			TemplateParamClusterInstance, clusterTemplate.Name)
+			constants.TemplateParamClusterInstance, clusterTemplate.Name)
 	}
-	policyTemplateSubSchema, ok := schemaProperties.(map[string]any)[TemplateParamPolicyConfig]
+	policyTemplateSubSchema, ok := schemaProperties.(map[string]any)[constants.TemplateParamPolicyConfig]
 	if !ok {
 		return fmt.Errorf(
 			"missing required property '%s' in the schema from ClusterTemplate (%s)",
-			TemplateParamPolicyConfig, clusterTemplate.Name)
+			constants.TemplateParamPolicyConfig, clusterTemplate.Name)
 	}
 
 	// The ClusterInstance, PolicyTemplate, and HwMgmt parameters have their own specific
@@ -202,7 +197,7 @@ func (r *ProvisioningRequest) ValidateTemplateInputMatchesSchema(
 	// hwMgmtParameters is validated after merging with hwMgmtDefaults from the ClusterTemplate,
 	// so strip its detailed schema here to avoid rejecting partial overrides (e.g. nodeGroupData
 	// entries that omit fields like "role" because they come from the defaults).
-	if hwMgmtSubSchema, ok := schemaProperties.(map[string]any)[TemplateParamHwMgmt]; ok {
+	if hwMgmtSubSchema, ok := schemaProperties.(map[string]any)[constants.TemplateParamHwMgmt]; ok {
 		if hwMgmtMap, ok := hwMgmtSubSchema.(map[string]any); ok {
 			delete(hwMgmtMap, "properties")
 		}
@@ -226,20 +221,20 @@ func (r *ProvisioningRequest) ValidateClusterInstanceInputMatchesSchema(
 
 	// Get the subschema for ClusterInstanceParameters
 	clusterInstanceSubSchema, err := ExtractSubSchema(
-		clusterTemplate.Spec.TemplateParameterSchema.Raw, TemplateParamClusterInstance)
+		clusterTemplate.Spec.TemplateParameterSchema.Raw, constants.TemplateParamClusterInstance)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to extract %s subschema: %s", TemplateParamClusterInstance, err.Error())
+			"failed to extract %s subschema: %s", constants.TemplateParamClusterInstance, err.Error())
 	}
 	// Any unknown fields not defined in the schema will be disallowed
 	DisallowUnknownFieldsInSchema(clusterInstanceSubSchema)
 
 	// Get the matching input for ClusterInstanceParameters
 	clusterInstanceMatchingInput, err := ExtractMatchingInput(
-		r.Spec.TemplateParameters.Raw, TemplateParamClusterInstance)
+		r.Spec.TemplateParameters.Raw, constants.TemplateParamClusterInstance)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to extract matching input for subSchema %s: %w", TemplateParamClusterInstance, err)
+			"failed to extract matching input for subSchema %s: %w", constants.TemplateParamClusterInstance, err)
 	}
 
 	// The schema defined in ClusterTemplate's spec.templateParameterSchema for
@@ -253,7 +248,7 @@ func (r *ProvisioningRequest) ValidateClusterInstanceInputMatchesSchema(
 	if err != nil {
 		return nil, fmt.Errorf(
 			"spec.templateParameters.%s does not match the schema defined in ClusterTemplate (%s) spec.templateParameterSchema.%s: %w",
-			TemplateParamClusterInstance, clusterTemplate.Name, TemplateParamClusterInstance, err)
+			constants.TemplateParamClusterInstance, clusterTemplate.Name, constants.TemplateParamClusterInstance, err)
 	}
 
 	return clusterInstanceMatchingInput, nil
@@ -426,7 +421,7 @@ func SchemaDefinesHwMgmtParameters(clusterTemplate *ClusterTemplate) bool {
 	if !ok {
 		return false
 	}
-	_, defined := properties[TemplateParamHwMgmt]
+	_, defined := properties[constants.TemplateParamHwMgmt]
 	return defined
 }
 
@@ -450,7 +445,7 @@ func (r *ProvisioningRequest) ValidateHwMgmtHwProfiles(
 		return nil
 	}
 
-	hwMgmtParams, ok := params[TemplateParamHwMgmt]
+	hwMgmtParams, ok := params[constants.TemplateParamHwMgmt]
 	if !ok {
 		return nil
 	}

--- a/api/provisioning/v1alpha1/provisioningrequest_webhook.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_webhook.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -193,10 +194,10 @@ func (v *provisioningRequestValidator) validateCreateOrUpdate(ctx context.Contex
 	// updates are disallowed. After cluster installation is completed, only permissible
 	// fields can be updated.
 	oldPrClusterInstanceInput, err := ExtractMatchingInput(
-		oldPr.Spec.TemplateParameters.Raw, TemplateParamClusterInstance)
+		oldPr.Spec.TemplateParameters.Raw, constants.TemplateParamClusterInstance)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to extract matching input for subSchema %s: %w", TemplateParamClusterInstance, err)
+			"failed to extract matching input for subSchema %s: %w", constants.TemplateParamClusterInstance, err)
 	}
 
 	var disallowedFields, scalingNodes []string

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -170,3 +170,13 @@ const (
 	BootInterfaceLabel        = "boot-interface"
 	BootInterfaceLabelFullKey = LabelPrefixInterfaces + BootInterfaceLabel
 )
+
+// Required template schema parameters
+const (
+	TemplateParamNodeClusterName = "nodeClusterName"
+	TemplateParamOCloudSiteId    = "oCloudSiteId"
+	TemplateParamClusterInstance = "clusterInstanceParameters"
+	TemplateParamPolicyConfig    = "policyTemplateParameters"
+	TemplateParamHwMgmt          = "hwMgmtParameters"
+	TemplateParamUpgrade         = "upgradeParameters"
+)

--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -486,10 +486,10 @@ func validateTemplateParameterSchema(object *provisioningv1alpha1.ClusterTemplat
 		stringString = "string"
 		objectString = "object"
 	)
-	mandatoryParams := [][]string{{ctlrutils.TemplateParamNodeClusterName, stringString},
-		{ctlrutils.TemplateParamOCloudSiteId, stringString},
-		{ctlrutils.TemplateParamPolicyConfig, objectString},
-		{ctlrutils.TemplateParamClusterInstance, objectString}}
+	mandatoryParams := [][]string{{constants.TemplateParamNodeClusterName, stringString},
+		{constants.TemplateParamOCloudSiteId, stringString},
+		{constants.TemplateParamPolicyConfig, objectString},
+		{constants.TemplateParamClusterInstance, objectString}}
 	if object.Spec.TemplateParameterSchema.Size() == 0 {
 		return ctlrutils.NewInputError("templateParameterSchema is present but empty:")
 	}
@@ -542,11 +542,11 @@ func validateTemplateParameterSchema(object *provisioningv1alpha1.ClusterTemplat
 		return ctlrutils.NewInputError("%s", validationFailureReason)
 	}
 
-	policyTemplateParamsSchema := subSchemas[ctlrutils.TemplateParamPolicyConfig].(map[string]any)
+	policyTemplateParamsSchema := subSchemas[constants.TemplateParamPolicyConfig].(map[string]any)
 	if err := validatePolicyTemplateParamsSchema(policyTemplateParamsSchema); err != nil {
 		return ctlrutils.NewInputError("Error validating the policyTemplateParameters schema: %s", err.Error())
 	}
-	clusterInstanceParamsSchema := subSchemas[ctlrutils.TemplateParamClusterInstance].(map[string]any)
+	clusterInstanceParamsSchema := subSchemas[constants.TemplateParamClusterInstance].(map[string]any)
 	// Hardware provisioning is active if the CT has hwMgmtDefaults.nodeGroupData OR
 	// if the templateParameterSchema exposes hwMgmtParameters (allowing the PR to supply it).
 	hasHwMgmt := len(object.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData) > 0 ||
@@ -557,7 +557,7 @@ func validateTemplateParameterSchema(object *provisioningv1alpha1.ClusterTemplat
 
 	hasUpgradeDefaults := object.Spec.TemplateDefaults.UpgradeDefaults.Size() > 0
 	if err := validateUpgradeParametersSchema(object.Spec.TemplateParameterSchema.Raw, hasUpgradeDefaults); err != nil {
-		return ctlrutils.NewInputError("Error validating the %s schema: %s", ctlrutils.TemplateParamUpgrade, err.Error())
+		return ctlrutils.NewInputError("Error validating the %s schema: %s", constants.TemplateParamUpgrade, err.Error())
 	}
 
 	return nil
@@ -567,30 +567,30 @@ func validateTemplateParameterSchema(object *provisioningv1alpha1.ClusterTemplat
 // When the sub-schema is present it must define imageBasedGroupUpgrade as an object.
 // When upgradeDefaults is set the sub-schema is required.
 func validateUpgradeParametersSchema(schemaRaw []byte, hasUpgradeDefaults bool) error {
-	upgradeSchema, err := provisioningv1alpha1.ExtractSubSchema(schemaRaw, ctlrutils.TemplateParamUpgrade)
+	upgradeSchema, err := provisioningv1alpha1.ExtractSubSchema(schemaRaw, constants.TemplateParamUpgrade)
 	if err != nil {
 		if !provisioningv1alpha1.IsErrSubSchemaNotFound(err) {
-			return fmt.Errorf("failed to extract %q schema: %w", ctlrutils.TemplateParamUpgrade, err)
+			return fmt.Errorf("failed to extract %q schema: %w", constants.TemplateParamUpgrade, err)
 		}
 		if hasUpgradeDefaults {
-			return fmt.Errorf("templateParameterSchema must define %q when upgradeDefaults is set", ctlrutils.TemplateParamUpgrade)
+			return fmt.Errorf("templateParameterSchema must define %q when upgradeDefaults is set", constants.TemplateParamUpgrade)
 		}
 		return nil
 	}
 
-	ibguKeyPath := ctlrutils.TemplateParamUpgrade + "." + ctlrutils.UpgradeDefaultsIBGUKey
+	ibguKeyPath := constants.TemplateParamUpgrade + "." + ctlrutils.UpgradeDefaultsIBGUKey
 
 	if t, _ := upgradeSchema["type"].(string); t != "object" {
-		return fmt.Errorf("%q must have type \"object\"", ctlrutils.TemplateParamUpgrade)
+		return fmt.Errorf("%q must have type \"object\"", constants.TemplateParamUpgrade)
 	}
 	props, ok := upgradeSchema["properties"].(map[string]any)
 	if !ok {
-		return fmt.Errorf("%q schema must have a properties section", ctlrutils.TemplateParamUpgrade)
+		return fmt.Errorf("%q schema must have a properties section", constants.TemplateParamUpgrade)
 	}
 	ibguProp, ok := props[ctlrutils.UpgradeDefaultsIBGUKey]
 	if !ok {
 		return fmt.Errorf("%q schema must define the %q property",
-			ctlrutils.TemplateParamUpgrade, ctlrutils.UpgradeDefaultsIBGUKey)
+			constants.TemplateParamUpgrade, ctlrutils.UpgradeDefaultsIBGUKey)
 	}
 	ibguPropMap, ok := ibguProp.(map[string]any)
 	if !ok {
@@ -618,28 +618,28 @@ func validateUpgradeParametersSchema(schemaRaw []byte, hasUpgradeDefaults bool) 
 func validatePolicyTemplateParamsSchema(schema map[string]any) error {
 	propertiesInterface, hasProperties := schema["properties"]
 	if !hasProperties {
-		return fmt.Errorf("unexpected %s structure, no properties present", ctlrutils.TemplateParamPolicyConfig)
+		return fmt.Errorf("unexpected %s structure, no properties present", constants.TemplateParamPolicyConfig)
 	}
 
 	properties, isMap := propertiesInterface.(map[string]any)
 	if !isMap {
-		return fmt.Errorf("unexpected %s properties structure", ctlrutils.TemplateParamPolicyConfig)
+		return fmt.Errorf("unexpected %s properties structure", constants.TemplateParamPolicyConfig)
 	}
 
 	for propertyKey, propertyValue := range properties {
 		propertyValueMap, ok := propertyValue.(map[string]any)
 		if !ok {
-			return fmt.Errorf("unexpected %s structure for the %s property", ctlrutils.TemplateParamPolicyConfig, propertyKey)
+			return fmt.Errorf("unexpected %s structure for the %s property", constants.TemplateParamPolicyConfig, propertyKey)
 		}
 
 		valueTypeInterface, ok := propertyValueMap["type"]
 		if !ok {
-			return fmt.Errorf("unexpected %s structure: expected subproperty \"type\" missing", ctlrutils.TemplateParamPolicyConfig)
+			return fmt.Errorf("unexpected %s structure: expected subproperty \"type\" missing", constants.TemplateParamPolicyConfig)
 		}
 
 		valueType, ok := valueTypeInterface.(string)
 		if !ok {
-			return fmt.Errorf("unexpected %s structure: expected the subproperty \"type\" to be string", ctlrutils.TemplateParamPolicyConfig)
+			return fmt.Errorf("unexpected %s structure: expected the subproperty \"type\" to be string", constants.TemplateParamPolicyConfig)
 		}
 
 		if valueType != "string" {
@@ -667,8 +667,8 @@ func validateSchemaWithoutHwMgmt(schema map[string]any) error {
 		return fmt.Errorf("failed to parse expected clusterInstanceParams subschema for no hwMgmtDefaults: %w", err)
 	}
 
-	if err := checkSchemaContains(schema, expectedSubSchema, ctlrutils.TemplateParamClusterInstance); err != nil {
-		return fmt.Errorf("unexpected %s structure: %w", ctlrutils.TemplateParamClusterInstance, err)
+	if err := checkSchemaContains(schema, expectedSubSchema, constants.TemplateParamClusterInstance); err != nil {
+		return fmt.Errorf("unexpected %s structure: %w", constants.TemplateParamClusterInstance, err)
 	}
 
 	return nil

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -63,6 +63,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/test/fakeclient"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
@@ -164,10 +165,10 @@ var _ = Describe("handleRenderClusterInstance", func() {
 		}
 
 		clusterInstanceInputParams, err := provisioningv1alpha1.ExtractMatchingInput(
-			cr.Spec.TemplateParameters.Raw, utils.TemplateParamClusterInstance)
+			cr.Spec.TemplateParameters.Raw, constants.TemplateParamClusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 		mergedClusterInstanceData, err := task.getMergedClusterInputData(
-			ctx, ciDefaultsCm, clusterInstanceInputParams.(map[string]any), utils.TemplateParamClusterInstance)
+			ctx, ciDefaultsCm, clusterInstanceInputParams.(map[string]any), constants.TemplateParamClusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 		task.clusterInput.clusterInstanceData = mergedClusterInstanceData
 	})
@@ -336,10 +337,10 @@ var _ = Describe("handleClusterInstallation", func() {
 		}
 
 		clusterInstanceInputParams, err := provisioningv1alpha1.ExtractMatchingInput(
-			cr.Spec.TemplateParameters.Raw, utils.TemplateParamClusterInstance)
+			cr.Spec.TemplateParameters.Raw, constants.TemplateParamClusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 		mergedClusterInstanceData, err := task.getMergedClusterInputData(
-			ctx, ciDefaultsCm, clusterInstanceInputParams.(map[string]any), utils.TemplateParamClusterInstance)
+			ctx, ciDefaultsCm, clusterInstanceInputParams.(map[string]any), constants.TemplateParamClusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 		task.clusterInput.clusterInstanceData = mergedClusterInstanceData
 	})

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -2419,7 +2419,7 @@ nodes:
 
 			// Extract and merge cluster instance parameters
 			clusterInstanceInputParams, err := provisioningv1alpha1.ExtractMatchingInput(
-				cr.Spec.TemplateParameters.Raw, utils.TemplateParamClusterInstance)
+				cr.Spec.TemplateParameters.Raw, constants.TemplateParamClusterInstance)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(clusterInstanceInputParams).ToNot(BeNil())
 
@@ -2432,7 +2432,7 @@ nodes:
 
 			mergedData, err := task.getMergedClusterInputData(
 				ctx, "no-hw-defaults-cm", clusterInstanceInputParams.(map[string]any),
-				utils.TemplateParamClusterInstance)
+				constants.TemplateParamClusterInstance)
 			Expect(err).ToNot(HaveOccurred())
 			task.clusterInput.clusterInstanceData = mergedData
 

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -792,23 +792,23 @@ func (t *provisioningRequestReconcilerTask) buildNodeAllocationRequestSpec(
 	}
 
 	siteIDRaw, err := provisioningv1alpha1.ExtractMatchingInput(
-		t.object.Spec.TemplateParameters.Raw, ctlrutils.TemplateParamOCloudSiteId)
+		t.object.Spec.TemplateParameters.Raw, constants.TemplateParamOCloudSiteId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get %s from templateParameters: %w", ctlrutils.TemplateParamOCloudSiteId, err)
+		return nil, fmt.Errorf("failed to get %s from templateParameters: %w", constants.TemplateParamOCloudSiteId, err)
 	}
 	siteID, ok := siteIDRaw.(string)
 	if !ok {
-		return nil, fmt.Errorf("%s is not a string", ctlrutils.TemplateParamOCloudSiteId)
+		return nil, fmt.Errorf("%s is not a string", constants.TemplateParamOCloudSiteId)
 	}
 
 	clusterIdRaw, err := provisioningv1alpha1.ExtractMatchingInput(
-		t.object.Spec.TemplateParameters.Raw, ctlrutils.TemplateParamNodeClusterName)
+		t.object.Spec.TemplateParameters.Raw, constants.TemplateParamNodeClusterName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get %s from templateParameters: %w", ctlrutils.TemplateParamNodeClusterName, err)
+		return nil, fmt.Errorf("failed to get %s from templateParameters: %w", constants.TemplateParamNodeClusterName, err)
 	}
 	clusterId, ok := clusterIdRaw.(string)
 	if !ok {
-		return nil, fmt.Errorf("%s is not a string", ctlrutils.TemplateParamNodeClusterName)
+		return nil, fmt.Errorf("%s is not a string", constants.TemplateParamNodeClusterName)
 	}
 
 	narNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)

--- a/internal/controllers/provisioningrequest_resourcecreation.go
+++ b/internal/controllers/provisioningrequest_resourcecreation.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	clustervalidation "github.com/openshift-kni/oran-o2ims/internal/validation"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
@@ -265,10 +266,10 @@ func (t *provisioningRequestReconcilerTask) createClusterInstanceBMCSecrets(
 
 	// The BMC credential details are obtained from the ProvisioningRequest.
 	clusterInstanceMatchingInput, err := provisioningv1alpha1.ExtractMatchingInput(
-		t.object.Spec.TemplateParameters.Raw, ctlrutils.TemplateParamClusterInstance)
+		t.object.Spec.TemplateParameters.Raw, constants.TemplateParamClusterInstance)
 	if err != nil {
 		return ctlrutils.NewInputError(
-			"failed to extract matching input for subSchema %s: %w", ctlrutils.TemplateParamClusterInstance, err)
+			"failed to extract matching input for subSchema %s: %w", constants.TemplateParamClusterInstance, err)
 	}
 	clusterInstanceMatchingInputMap := clusterInstanceMatchingInput.(map[string]any)
 

--- a/internal/controllers/provisioningrequest_upgrade.go
+++ b/internal/controllers/provisioningrequest_upgrade.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	ibgu "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -276,7 +277,7 @@ func (t *provisioningRequestReconcilerTask) mergeAndValidateUpgradeData(
 	if err := json.Unmarshal(t.object.Spec.TemplateParameters.Raw, &templateParams); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal templateParameters: %w", err)
 	}
-	if upgradeParamsRaw, ok := templateParams[ctlrutils.TemplateParamUpgrade]; ok {
+	if upgradeParamsRaw, ok := templateParams[constants.TemplateParamUpgrade]; ok {
 		upgradeParamsMap, ok = upgradeParamsRaw.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("upgradeParameters is not a map")
@@ -296,14 +297,14 @@ func (t *provisioningRequestReconcilerTask) mergeAndValidateUpgradeData(
 
 	// Validate the merged data against the upgradeParameters schema
 	upgradeSchema, err := provisioningv1alpha1.ExtractSubSchema(
-		clusterTemplate.Spec.TemplateParameterSchema.Raw, ctlrutils.TemplateParamUpgrade)
+		clusterTemplate.Spec.TemplateParameterSchema.Raw, constants.TemplateParamUpgrade)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract %s schema: %w", ctlrutils.TemplateParamUpgrade, err)
+		return nil, fmt.Errorf("failed to extract %s schema: %w", constants.TemplateParamUpgrade, err)
 	}
 	if err := provisioningv1alpha1.ValidateJsonAgainstJsonSchema(upgradeSchema, mergedUpgradeData); err != nil {
 		return nil, fmt.Errorf(
 			"merged upgrade parameters do not match the schema defined in ClusterTemplate (%s) spec.templateParameterSchema.%s: %s",
-			clusterTemplate.Name, ctlrutils.TemplateParamUpgrade, err.Error())
+			clusterTemplate.Name, constants.TemplateParamUpgrade, err.Error())
 	}
 
 	return mergedUpgradeData, nil

--- a/internal/controllers/provisioningrequest_validation.go
+++ b/internal/controllers/provisioningrequest_validation.go
@@ -120,7 +120,7 @@ func (t *provisioningRequestReconcilerTask) validateClusterInstanceInputMatchesS
 	if err != nil {
 		return ctlrutils.NewInputError(
 			"the provided %s does not match the schema from ClusterTemplate (%s): %w",
-			ctlrutils.TemplateParamClusterInstance, clusterTemplate.Name, err)
+			constants.TemplateParamClusterInstance, clusterTemplate.Name, err)
 	}
 	clusterInstanceMatchingInputMap := clusterInstanceMatchingInput.(map[string]any)
 
@@ -128,7 +128,7 @@ func (t *provisioningRequestReconcilerTask) validateClusterInstanceInputMatchesS
 	mergedClusterInstanceData, err := t.getMergedClusterInputData(
 		ctx, clusterTemplate.Spec.TemplateDefaults.ClusterInstanceDefaults,
 		clusterInstanceMatchingInputMap,
-		ctlrutils.TemplateParamClusterInstance)
+		constants.TemplateParamClusterInstance)
 	if err != nil {
 		return fmt.Errorf("failed to get merged cluster input data: %w", err)
 	}
@@ -170,17 +170,17 @@ func (t *provisioningRequestReconcilerTask) validatePolicyTemplateInputMatchesSc
 
 	// Get the subschema for PolicyTemplateParameters
 	policyTemplateSubSchema, err := provisioningv1alpha1.ExtractSubSchema(
-		clusterTemplate.Spec.TemplateParameterSchema.Raw, ctlrutils.TemplateParamPolicyConfig)
+		clusterTemplate.Spec.TemplateParameterSchema.Raw, constants.TemplateParamPolicyConfig)
 	if err != nil {
 		return ctlrutils.NewInputError(
-			"failed to extract %s subschema: %s", ctlrutils.TemplateParamPolicyConfig, err.Error())
+			"failed to extract %s subschema: %s", constants.TemplateParamPolicyConfig, err.Error())
 	}
 	// Get the matching input for PolicyTemplateParameters
 	policyTemplateMatchingInput, err := provisioningv1alpha1.ExtractMatchingInput(
-		t.object.Spec.TemplateParameters.Raw, ctlrutils.TemplateParamPolicyConfig)
+		t.object.Spec.TemplateParameters.Raw, constants.TemplateParamPolicyConfig)
 	if err != nil {
 		return ctlrutils.NewInputError(
-			"failed to extract matching input for subschema %s: %w", ctlrutils.TemplateParamPolicyConfig, err)
+			"failed to extract matching input for subschema %s: %w", constants.TemplateParamPolicyConfig, err)
 	}
 	policyTemplateMatchingInputMap := policyTemplateMatchingInput.(map[string]any)
 
@@ -188,7 +188,7 @@ func (t *provisioningRequestReconcilerTask) validatePolicyTemplateInputMatchesSc
 	mergedPolicyTemplateData, err := t.getMergedClusterInputData(
 		ctx, clusterTemplate.Spec.TemplateDefaults.PolicyTemplateDefaults,
 		policyTemplateMatchingInputMap,
-		ctlrutils.TemplateParamPolicyConfig)
+		constants.TemplateParamPolicyConfig)
 	if err != nil {
 		return fmt.Errorf("failed to get merged cluster input data: %w", err)
 	}
@@ -199,7 +199,7 @@ func (t *provisioningRequestReconcilerTask) validatePolicyTemplateInputMatchesSc
 	if err != nil {
 		return ctlrutils.NewInputError(
 			"spec.templateParameters.%s does not match the schema defined in ClusterTemplate (%s) spec.templateParameterSchema.%s: %w",
-			ctlrutils.TemplateParamPolicyConfig, clusterTemplate.Name, ctlrutils.TemplateParamPolicyConfig, err)
+			constants.TemplateParamPolicyConfig, clusterTemplate.Name, constants.TemplateParamPolicyConfig, err)
 	}
 
 	t.clusterInput.policyTemplateData = mergedPolicyTemplateData
@@ -223,32 +223,32 @@ func (t *provisioningRequestReconcilerTask) validateAndMergeHwMgmtInput(
 	// ExtractMatchingInput returns an error both for unmarshal failures and missing keys.
 	// Missing key is expected (no overrides); unmarshal failure is a real input error.
 	hwMgmtParams, extractErr := provisioningv1alpha1.ExtractMatchingInput(
-		t.object.Spec.TemplateParameters.Raw, ctlrutils.TemplateParamHwMgmt)
+		t.object.Spec.TemplateParameters.Raw, constants.TemplateParamHwMgmt)
 	if extractErr != nil && strings.Contains(extractErr.Error(), "failed to unmarshal") {
 		return ctlrutils.NewInputError("failed to extract %s from templateParameters: %s",
-			ctlrutils.TemplateParamHwMgmt, extractErr.Error())
+			constants.TemplateParamHwMgmt, extractErr.Error())
 	}
 	if hwMgmtParams != nil {
 		if !provisioningv1alpha1.SchemaDefinesHwMgmtParameters(clusterTemplate) {
 			return ctlrutils.NewInputError(
 				"templateParameters.%s is not defined in ClusterTemplate %q spec.templateParameterSchema",
-				ctlrutils.TemplateParamHwMgmt, clusterTemplate.Name)
+				constants.TemplateParamHwMgmt, clusterTemplate.Name)
 		}
 
 		// Validate the raw hwMgmtParameters input against the CT's hwMgmt subschema
 		hwMgmtSubSchema, err := provisioningv1alpha1.ExtractSubSchema(
-			clusterTemplate.Spec.TemplateParameterSchema.Raw, ctlrutils.TemplateParamHwMgmt)
+			clusterTemplate.Spec.TemplateParameterSchema.Raw, constants.TemplateParamHwMgmt)
 		if err == nil {
 			if err := provisioningv1alpha1.ValidateJsonAgainstJsonSchema(hwMgmtSubSchema, hwMgmtParams); err != nil {
 				return ctlrutils.NewInputError(
 					"templateParameters.%s does not match the schema defined in ClusterTemplate (%s): %s",
-					ctlrutils.TemplateParamHwMgmt, clusterTemplate.Name, err.Error())
+					constants.TemplateParamHwMgmt, clusterTemplate.Name, err.Error())
 			}
 		}
 
 		hwMgmtParamsMap, ok := hwMgmtParams.(map[string]any)
 		if !ok {
-			return ctlrutils.NewInputError("templateParameters.%s must be an object", ctlrutils.TemplateParamHwMgmt)
+			return ctlrutils.NewInputError("templateParameters.%s must be an object", constants.TemplateParamHwMgmt)
 		}
 
 		// Handle nodeGroupData with name-keyed merge
@@ -256,7 +256,7 @@ func (t *provisioningRequestReconcilerTask) validateAndMergeHwMgmtInput(
 		if srcHasNG {
 			srcSlice, ok := srcNodeGroups.([]any)
 			if !ok {
-				return ctlrutils.NewInputError("templateParameters.%s.nodeGroupData must be an array", ctlrutils.TemplateParamHwMgmt)
+				return ctlrutils.NewInputError("templateParameters.%s.nodeGroupData must be an array", constants.TemplateParamHwMgmt)
 			}
 			dstSlice := []any{}
 			if dstNodeGroups, dstHasNG := mergedData["nodeGroupData"]; dstHasNG {
@@ -436,9 +436,9 @@ func (t *provisioningRequestReconcilerTask) getMergedClusterInputData(
 	var templateDefaultsCmKey string
 
 	switch templateParam {
-	case ctlrutils.TemplateParamClusterInstance:
+	case constants.TemplateParamClusterInstance:
 		templateDefaultsCmKey = ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey
-	case ctlrutils.TemplateParamPolicyConfig:
+	case constants.TemplateParamPolicyConfig:
 		templateDefaultsCmKey = ctlrutils.PolicyTemplateDefaultsConfigmapKey
 	default:
 		return nil, ctlrutils.NewInputError("unsupported template parameter")
@@ -455,7 +455,7 @@ func (t *provisioningRequestReconcilerTask) getMergedClusterInputData(
 		return nil, fmt.Errorf("failed to get template defaults from ConfigMap %s: %w", templateDefaultsCm, err)
 	}
 
-	if templateParam == ctlrutils.TemplateParamClusterInstance {
+	if templateParam == constants.TemplateParamClusterInstance {
 		// Special handling for overrides of ClusterInstance's extraLabels and extraAnnotations.
 		// The clusterTemplateInput will be overridden with the values from defaut configmap
 		// if same labels/annotations exist in both.

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -155,16 +155,6 @@ const (
 	ClusterConfigurationTimeoutConfigKey = "clusterConfigurationTimeout"
 )
 
-// Required template schema parameters
-const (
-	TemplateParamNodeClusterName = "nodeClusterName"
-	TemplateParamOCloudSiteId    = "oCloudSiteId"
-	TemplateParamClusterInstance = "clusterInstanceParameters"
-	TemplateParamPolicyConfig    = "policyTemplateParameters"
-	TemplateParamHwMgmt          = "hwMgmtParameters"
-	TemplateParamUpgrade         = "upgradeParameters"
-)
-
 // ClusterInstance template constants
 const (
 	ClusterInstanceTemplateName                 = "ClusterInstance"

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -851,7 +851,7 @@ templateRefs:
 	})
 	It("fails when the ConfigMap is missing", func() {
 		configMapKey = ClusterInstanceTemplateDefaultsConfigmapKey
-		schemaKey = provisioningv1alpha1.TemplateParamClusterInstance
+		schemaKey = constants.TemplateParamClusterInstance
 		result, err := GetDefaultsFromConfigMap(
 			ctx, c, configMapName, configMapNamespace, configMapKey, []byte(schema), schemaKey)
 		Expect(err).To(HaveOccurred())
@@ -860,7 +860,7 @@ templateRefs:
 	})
 	It("fails when it cannot obtain the expected data from the ConfigMap", func() {
 		configMapKey = "other-configmap-key-than-expected"
-		schemaKey = provisioningv1alpha1.TemplateParamClusterInstance
+		schemaKey = constants.TemplateParamClusterInstance
 		// Create the ConfigMap.
 		Expect(c.Create(ctx, clusterInstanceConfigMap)).To(Succeed())
 		result, err := GetDefaultsFromConfigMap(
@@ -883,7 +883,7 @@ templateRefs:
 	})
 	It("return the editable and immutable fields when no errors happen", func() {
 		configMapKey = ClusterInstanceTemplateDefaultsConfigmapKey
-		schemaKey = provisioningv1alpha1.TemplateParamClusterInstance
+		schemaKey = constants.TemplateParamClusterInstance
 		// Create the ConfigMap.
 		Expect(c.Create(ctx, clusterInstanceConfigMap)).To(Succeed())
 		result, err := GetDefaultsFromConfigMap(

--- a/internal/service/artifacts/api/server.go
+++ b/internal/service/artifacts/api/server.go
@@ -167,7 +167,7 @@ func (r *ArtifactsServer) GetManagedInfrastructureTemplateDefaults(
 		oranct.Namespace,
 		ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
 		oranct.Spec.TemplateParameterSchema.Raw,
-		provisioningv1alpha1.TemplateParamClusterInstance,
+		constants.TemplateParamClusterInstance,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not get the clusterInstance default values: %w", err)
@@ -180,7 +180,7 @@ func (r *ArtifactsServer) GetManagedInfrastructureTemplateDefaults(
 		oranct.Namespace,
 		ctlrutils.PolicyTemplateDefaultsConfigmapKey,
 		oranct.Spec.TemplateParameterSchema.Raw,
-		provisioningv1alpha1.TemplateParamPolicyConfig,
+		constants.TemplateParamPolicyConfig,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not get the policy configuration default values: %w", err)

--- a/test/utils/vars.go
+++ b/test/utils/vars.go
@@ -12,7 +12,6 @@ import (
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -346,19 +345,19 @@ const (
 )
 
 var (
-	TestFullTemplateSchema = fmt.Sprintf(TestFullClusterSchemaTemplate, ctlrutils.TemplateParamClusterInstance, TestClusterInstanceSchema,
-		ctlrutils.TemplateParamPolicyConfig, TestPolicyTemplateSchema)
+	TestFullTemplateSchema = fmt.Sprintf(TestFullClusterSchemaTemplate, constants.TemplateParamClusterInstance, TestClusterInstanceSchema,
+		constants.TemplateParamPolicyConfig, TestPolicyTemplateSchema)
 
 	TestFullTemplateParameters = fmt.Sprintf(`{
 		"%s": "exampleCluster",
 		"%s": "local-123",
 		"%s": %s,
 		"%s": %s
-	}`, ctlrutils.TemplateParamNodeClusterName,
-		ctlrutils.TemplateParamOCloudSiteId,
-		ctlrutils.TemplateParamClusterInstance,
+	}`, constants.TemplateParamNodeClusterName,
+		constants.TemplateParamOCloudSiteId,
+		constants.TemplateParamClusterInstance,
 		TestClusterInstanceInput,
-		ctlrutils.TemplateParamPolicyConfig,
+		constants.TemplateParamPolicyConfig,
 		TestPolicyTemplateInput,
 	)
 	ExternalCrdData = []map[string]string{


### PR DESCRIPTION
Consolidate TemplateParam* constants into internal/constants/ to eliminate duplication between controllers/utils and the provisioning API package. This is Phase 1 of the controllers/utils refactoring ([CNF-25068](https://redhat.atlassian.net/browse/CNF-25068)).