### PR TITLE
chore: disable CodeRabbit auto-pause after 5 commits

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 inheritance: true
 reviews:
+  auto_review:
+    auto_pause_after_reviewed_commits: 0
   path_filters:
   - "!vendor/**"
   path_instructions:


### PR DESCRIPTION
The default auto_pause_after_reviewed_commits threshold of 5 causes CodeRabbit to silently stop reviewing PRs that go through many review iterations, requiring manual `@coderabbitai review` to resume. Set to 0 so reviews run on every push.