### PR TITLE
ci: add 0.5% tolerance to coverage threshold checks

### DIFF
--- a/hack/check-coverage.sh
+++ b/hack/check-coverage.sh
@@ -153,8 +153,8 @@ while IFS= read -r line; do
             continue
         fi
 
-        # Compare using awk for float comparison
-        if (( $(awk "BEGIN {print (${actual} < ${threshold})}") )); then
+        # Compare with 0.5% tolerance to account for non-deterministic coverage variance
+        if (( $(awk "BEGIN {print (${actual} < ${threshold} - 0.5)}") )); then
             printf "%-65s %7s%% %7s%% %s\n" "${pkg}" "${actual}" "${threshold}" "✗ FAIL"
             FAILURES=$((FAILURES + 1))
         else
@@ -173,7 +173,7 @@ done
 
 echo ""
 printf "%-65s %7s%% %7s%% " "OVERALL" "${OVERALL_COVERAGE}" "${OVERALL_THRESHOLD}"
-if (( $(awk "BEGIN {print (${OVERALL_COVERAGE} < ${OVERALL_THRESHOLD})}") )); then
+if (( $(awk "BEGIN {print (${OVERALL_COVERAGE} < ${OVERALL_THRESHOLD} - 0.5)}") )); then
     echo "✗ FAIL"
     FAILURES=$((FAILURES + 1))
 else


### PR DESCRIPTION
Coverage for a given package can vary slightly between CI runs due to non-deterministic test ordering and timing, even when the code under test is unchanged. A threshold set to exactly the measured value (e.g., 71% when coverage fluctuates between 70.6% and 71.0%) causes spurious CI failures on unrelated PRs. Add 0.5% tolerance so a threshold of 71 passes anything >= 70.5%.