### PR TITLE
CNF-24707: fix remaining non-camelCase log attribute keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,8 +126,9 @@ issues during code review.
   for `uuid.UUID` values — `slog.Any` renders UUIDs as base64-encoded
   byte arrays. Reserve `slog.Any` for errors, complex structs, maps,
   and interfaces.
-- Use camelCase for log attribute keys (e.g., `"clusterId"`, not
-  `"ClusterID"` or `"cluster_id"`).
+- Use camelCase for log attribute keys with no spaces (e.g.,
+  `"clusterId"`, not `"ClusterID"`, `"cluster_id"`, or
+  `"cluster id"`).
 - Log messages should not end with punctuation or trailing spaces.
 - Choose the appropriate log level: use DEBUG for verbose/polling
   output that would clutter normal operation, INFO for significant

--- a/internal/controllers/utils/integration_test.go
+++ b/internal/controllers/utils/integration_test.go
@@ -101,7 +101,7 @@ func TestControllerLoggingIntegration(t *testing.T) {
 		// From AddObjectContext
 		LogAttrResourceVersion: "12345",
 		LogAttrGeneration:      float64(3), // JSON numbers are float64
-		"clusterID":            "test-cluster",
+		"clusterId":            "test-cluster",
 
 		// From LogPhaseStart
 		LogAttrPhase: "validation",

--- a/internal/controllers/utils/logging.go
+++ b/internal/controllers/utils/logging.go
@@ -52,7 +52,7 @@ func AddObjectContext(ctx context.Context, obj client.Object) context.Context {
 		// Add any relevant labels or annotations as context
 		if labels := obj.GetLabels(); len(labels) > 0 {
 			if clusterID, exists := labels["cluster-id"]; exists {
-				ctx = logging.AppendCtx(ctx, slog.String("clusterID", clusterID))
+				ctx = logging.AppendCtx(ctx, slog.String("clusterId", clusterID))
 			}
 		}
 	}

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -454,7 +454,7 @@ func createNode(ctx context.Context,
 	nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest,
 	nodename, nodeId, nodeNs, groupname, hwprofile string) (*hwmgmtv1alpha1.AllocatedNode, error) {
 	logger.InfoContext(ctx, "Ensuring AllocatedNode exists",
-		slog.String("nodegroup name", groupname),
+		slog.String("nodegroupName", groupname),
 		slog.String("nodename", nodename),
 		slog.String("nodeId", nodeId))
 
@@ -1415,7 +1415,7 @@ func releaseNodeAllocationRequest(ctx context.Context,
 	clusterID := nodeAllocationRequest.Spec.ClusterId
 
 	logger.InfoContext(ctx, "Processing releaseNodeAllocationRequest request:",
-		slog.String("clusterID", clusterID),
+		slog.String("clusterId", clusterID),
 	)
 
 	// Wait for all child nodes to be deleted

--- a/internal/service/cluster/collector/collector.go
+++ b/internal/service/cluster/collector/collector.go
@@ -629,7 +629,7 @@ func (c *Collector) syncThanosAlarmDefinitions(ctx context.Context, ds *AlarmsDa
 		return nil
 	}
 
-	slog.InfoContext(ctx, "Thanos alarm definitions synced", slog.Int("upserted count", len(alarmDefinitionRecords)), slog.Int64("deleted count", count))
+	slog.InfoContext(ctx, "Thanos alarm definitions synced", slog.Int("upsertedCount", len(alarmDefinitionRecords)), slog.Int64("deletedCount", count))
 	return nil
 }
 
@@ -670,7 +670,7 @@ func (c *Collector) syncManagedClusterAlarmDefinitions(ctx context.Context, ds *
 				return nil
 			}
 
-			slog.InfoContext(ctx, "Alarm definitions synced", slog.String("alarmDictionaryID", alarmDictionaryID.String()), slog.Int("upserted count", len(alarmDefinitionRecords)), slog.Int64("deleted count", count))
+			slog.InfoContext(ctx, "Alarm definitions synced", slog.String("alarmDictionaryID", alarmDictionaryID.String()), slog.Int("upsertedCount", len(alarmDefinitionRecords)), slog.Int64("deletedCount", count))
 			return nil
 		})
 	}

--- a/internal/service/cluster/collector/collector_alarms.go
+++ b/internal/service/cluster/collector/collector_alarms.go
@@ -88,7 +88,7 @@ func (d *AlarmsDataSource) IncrGenerationID() int {
 
 // makeAlarmDictionaryIDToAlarmDefinitions fetches monitoring rules for each node cluster type and builds a map of alarm dictionary ID to alarm definitions
 func (d *AlarmsDataSource) makeAlarmDictionaryIDToAlarmDefinitions(ctx context.Context, nodeClusterTypes []models.NodeClusterType) (map[uuid.UUID][]models.AlarmDefinition, error) {
-	slog.InfoContext(ctx, "making alarm dictionary ID to alarm definitions map", slog.Int("nodeClusterTypes count", len(nodeClusterTypes)))
+	slog.InfoContext(ctx, "making alarm dictionary ID to alarm definitions map", slog.Int("nodeClusterTypesCount", len(nodeClusterTypes)))
 
 	// Fetch prometheus rules from managed clusters and hub
 	nodeClusterTypeIDToMonitoringRules := d.makeNodeClusterTypeIDToMonitoringRules(ctx, nodeClusterTypes)
@@ -127,7 +127,7 @@ func nodeClusterTypesWithAlarmDictionaryID(nodeClusterTypes []models.NodeCluster
 
 // makeNodeClusterTypeIDToMonitoringRules fetches monitoring rules for each node cluster type
 func (d *AlarmsDataSource) makeNodeClusterTypeIDToMonitoringRules(ctx context.Context, nodeClusterTypes []models.NodeClusterType) map[uuid.UUID][]monitoringv1.Rule {
-	slog.InfoContext(ctx, "making node cluster type ID to monitoring rules map", slog.Int("nodeClusterTypes count", len(nodeClusterTypes)))
+	slog.InfoContext(ctx, "making node cluster type ID to monitoring rules map", slog.Int("nodeClusterTypesCount", len(nodeClusterTypes)))
 
 	nodeClusterTypeIDToMonitoringRules := make(map[uuid.UUID][]monitoringv1.Rule)
 
@@ -185,7 +185,7 @@ func (d *AlarmsDataSource) makeNodeClusterTypeIDToMonitoringRules(ctx context.Co
 		}
 
 		nodeClusterTypeIDToMonitoringRules[res.nodeClusterTypeID] = res.rules
-		slog.InfoContext(ctx, "loaded rules for node cluster type", slog.String("nodeClusterTypeID", res.nodeClusterTypeID.String()), slog.Int("rules count", len(res.rules)))
+		slog.InfoContext(ctx, "loaded rules for node cluster type", slog.String("nodeClusterTypeID", res.nodeClusterTypeID.String()), slog.Int("rulesCount", len(res.rules)))
 	}
 
 	return nodeClusterTypeIDToMonitoringRules
@@ -198,7 +198,7 @@ func (d *AlarmsDataSource) processHub(ctx context.Context) ([]monitoringv1.Rule,
 		return nil, err
 	}
 
-	slog.DebugContext(ctx, "fetched rules for Hub cluster", slog.Int("rules count", len(rules)))
+	slog.DebugContext(ctx, "fetched rules for Hub cluster", slog.Int("rulesCount", len(rules)))
 	return rules, nil
 }
 
@@ -222,7 +222,7 @@ func (d *AlarmsDataSource) processManagedCluster(ctx context.Context, version st
 		return nil, err
 	}
 
-	slog.DebugContext(ctx, "fetched rules for managed cluster", slog.String("cluster", cluster.Name), slog.String("version", version), slog.Int("rules count", len(rules)))
+	slog.DebugContext(ctx, "fetched rules for managed cluster", slog.String("cluster", cluster.Name), slog.String("version", version), slog.Int("rulesCount", len(rules)))
 	return rules, nil
 }
 
@@ -286,7 +286,7 @@ func (d *AlarmsDataSource) getRules(ctx context.Context, cl crclient.Client) ([]
 
 // buildAlarmDictionaryIDToAlarmDefinitionsMap builds a map of alarm dictionary ID to alarm definitions
 func (d *AlarmsDataSource) buildAlarmDictionaryIDToAlarmDefinitions(nodeClusterTypes []models.NodeClusterType, nodeClusterTypeIDToMonitoringRules map[uuid.UUID][]monitoringv1.Rule) map[uuid.UUID][]models.AlarmDefinition {
-	slog.Info("building alarm dictionary ID to alarm definitions map", slog.Int("nodeClusterTypes count", len(nodeClusterTypes)))
+	slog.Info("building alarm dictionary ID to alarm definitions map", slog.Int("nodeClusterTypesCount", len(nodeClusterTypes)))
 
 	alarmDictionaryIDToAlarmDefinitions := make(map[uuid.UUID][]models.AlarmDefinition)
 	for _, nodeClusterType := range nodeClusterTypes {
@@ -420,7 +420,7 @@ func (d *AlarmsDataSource) createAlarmDefinitions(rules []monitoringv1.Rule, ala
 
 // makeAlarmDictionaries creates alarm dictionaries from node cluster types
 func (d *AlarmsDataSource) makeAlarmDictionaries(nodeClusterTypes []models.NodeClusterType) []models.AlarmDictionary {
-	slog.Info("making alarm dictionaries", slog.Int("nodeClusterTypes count", len(nodeClusterTypes)))
+	slog.Info("making alarm dictionaries", slog.Int("nodeClusterTypesCount", len(nodeClusterTypes)))
 
 	var alarmDictionaries []models.AlarmDictionary
 	for _, nodeClusterType := range nodeClusterTypes {
@@ -543,7 +543,7 @@ func (d *AlarmsDataSource) collectThanosRules(ctx context.Context) ([]monitoring
 		}
 	}
 
-	slog.DebugContext(ctx, "Collected thanos rules", slog.Int("rules count", len(rules)))
+	slog.DebugContext(ctx, "Collected thanos rules", slog.Int("rulesCount", len(rules)))
 
 	// Expand rules with templated severity into multiple static rules
 	expandedRules := d.expandTemplatedSeverity(rules)
@@ -607,7 +607,7 @@ func (d *AlarmsDataSource) expandTemplatedSeverity(rules []monitoringv1.Rule) []
 		}
 	}
 
-	slog.Info("Severity expansion complete", slog.Int("original count", len(rules)), slog.Int("expanded count", len(expandedRules)))
+	slog.Info("Severity expansion complete", slog.Int("originalCount", len(rules)), slog.Int("expandedCount", len(expandedRules)))
 	return expandedRules
 }
 
@@ -618,7 +618,7 @@ func IsTemplated(s string) bool {
 
 // makeThanosAlarmDefinitions creates alarm definitions from thanos rules
 func (d *AlarmsDataSource) makeThanosAlarmDefinitions(rules []monitoringv1.Rule) ([]models.AlarmDefinition, error) {
-	slog.Debug("Making Thanos alarm definitions", slog.Int("rules count", len(rules)))
+	slog.Debug("Making Thanos alarm definitions", slog.Int("rulesCount", len(rules)))
 
 	filteredRules := d.getFilteredRules(rules)
 


### PR DESCRIPTION
Standardize log attribute keys that were missed in the initial camelCase pass (PR #2857):
- "clusterID" → "clusterId" (2 sites)
- "nodegroup name" → "nodegroupName"
- "nodeClusterTypes count" → "nodeClusterTypesCount"
- "rules count" → "rulesCount"
- "original count" → "originalCount"
- "expanded count" → "expandedCount"
- "upserted count" → "upsertedCount"
- "deleted count" → "deletedCount"