### PR TITLE
ci: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -23,7 +23,7 @@ jobs:
         uses: raven-actions/actionlint@v2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 


### PR DESCRIPTION
Update actions/checkout v4 → v6 and actions/setup-go v5 → v6 to resolve Node.js 20 deprecation warnings. Node.js 20 runners are deprecated as of June 2026 and will be removed September 2026.