### PR TITLE
CNF-24948: remove INSECURE_SKIP_VERIFY environment variable

### DIFF
--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -212,9 +212,6 @@ const (
 
 // Environment variable names
 const (
-	TLSSkipVerifyEnvName      = "INSECURE_SKIP_VERIFY"
-	TLSSkipVerifyDefaultValue = false
-
 	TLSProfileMinVersionEnvName = "TLS_PROFILE_MIN_VERSION"
 	TLSProfileCiphersEnvName    = "TLS_PROFILE_CIPHERS"
 )

--- a/internal/controllers/utils/tls_profile.go
+++ b/internal/controllers/utils/tls_profile.go
@@ -110,8 +110,8 @@ func NewOutboundMTLSConfig(ctx context.Context, profile configv1.TLSProfileSpec,
 }
 
 // NewOutboundTLSConfig creates a tls.Config for general outbound connections applying only the
-// TLS profile (MinVersion, CipherSuites). It does not load CA bundles or check INSECURE_SKIP_VERIFY;
-// those cluster-runtime concerns are handled by the GetDefaultTLSConfig wrapper in utils.go.
+// TLS profile (MinVersion, CipherSuites). It does not load CA bundles; that is handled by the
+// GetDefaultTLSConfig wrapper in utils.go.
 func NewOutboundTLSConfig(profile configv1.TLSProfileSpec, config *tls.Config) (*tls.Config, error) {
 	if config == nil {
 		config = &tls.Config{} //nolint:gosec

--- a/internal/controllers/utils/tls_profile_test.go
+++ b/internal/controllers/utils/tls_profile_test.go
@@ -108,12 +108,10 @@ var _ = Describe("TLS Profile", func() {
 			configurator := NewTLSConfiguratorFromProfile(profile)
 
 			cfg := &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec // test-only config to verify profile doesn't override unrelated fields
-				ServerName:         "test.example.com",
+				ServerName: "test.example.com",
 			}
 			configurator(cfg)
 
-			Expect(cfg.InsecureSkipVerify).To(BeTrue())
 			Expect(cfg.ServerName).To(Equal("test.example.com"))
 			Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 		})
@@ -154,11 +152,10 @@ var _ = Describe("TLS Profile", func() {
 			Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
 		})
 
-		It("should not set InsecureSkipVerify or RootCAs", func() {
+		It("should not set RootCAs", func() {
 			profile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 			cfg, err := NewOutboundTLSConfig(profile, nil)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cfg.InsecureSkipVerify).To(BeFalse())
 			Expect(cfg.RootCAs).To(BeNil())
 		})
 	})

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -18,7 +18,6 @@ import (
 	"reflect"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -837,27 +836,7 @@ func GetDefaultsFromSlices[K comparable, V any](
 	return editable, immutable, nil
 }
 
-// GetTLSSkipVerify returns the current requested value of the TLS Skip Verify setting
-func GetTLSSkipVerify() bool {
-	value, ok := os.LookupEnv(TLSSkipVerifyEnvName)
-	if !ok {
-		return TLSSkipVerifyDefaultValue
-	}
-
-	result, err := strconv.ParseBool(value)
-	if err != nil {
-		oranUtilsLog.Error(err, fmt.Sprintf("Error parsing '%s' variable value '%s'",
-			TLSSkipVerifyEnvName, value))
-		return TLSSkipVerifyDefaultValue
-	}
-
-	return result
-}
-
-// loadDefaultCABundles loads the default service account and ingress CA bundles.  This should only be invoked if TLS
-// verification has not been disabled since the expectation is that it will only need to be disabled when testing as a
-// standalone binary in which case the paths to the bundles won't be present.  Otherwise, we always expect the bundles
-// to be present when running in-cluster.
+// loadDefaultCABundles loads the default service account and ingress CA bundles.
 func loadDefaultCABundles(config *tls.Config) error {
 	config.RootCAs = x509.NewCertPool()
 	if data, err := os.ReadFile(defaultBackendCABundle); err != nil {
@@ -883,8 +862,7 @@ func loadDefaultCABundles(config *tls.Config) error {
 // GetDefaultTLSConfig sets the TLS configuration attributes appropriately to enable communication between internal
 // services and accessing the public facing API endpoints. TLS version and cipher suites are inherited from the
 // cluster TLS security profile (via operator-injected environment variables).
-// InsecureSkipVerify is always read from the INSECURE_SKIP_VERIFY env var regardless of loadCAs.
-// When loadCAs is true and verification is enabled, default in-cluster CA bundles are loaded.
+// When loadCAs is true, default in-cluster CA bundles are loaded.
 // Pass loadCAs=false when the caller provides its own trust anchors (e.g., a pinned service CA).
 func GetDefaultTLSConfig(config *tls.Config, loadCAs bool) (*tls.Config, error) {
 	profile := newTLSProfileFromEnv()
@@ -893,8 +871,7 @@ func GetDefaultTLSConfig(config *tls.Config, loadCAs bool) (*tls.Config, error) 
 		return nil, err
 	}
 
-	tlsConfig.InsecureSkipVerify = GetTLSSkipVerify()
-	if loadCAs && !tlsConfig.InsecureSkipVerify {
+	if loadCAs {
 		if err := loadDefaultCABundles(tlsConfig); err != nil {
 			return nil, fmt.Errorf("error loading default CABundles: %w", err)
 		}

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -1675,11 +1675,9 @@ var _ = Describe("TLS profile-based configuration", func() {
 	BeforeEach(func() {
 		os.Setenv(TLSProfileMinVersionEnvName, testMinVersion)
 		os.Setenv(TLSProfileCiphersEnvName, testCipher1+","+testCipher2)
-		os.Setenv("INSECURE_SKIP_VERIFY", "true")
 		DeferCleanup(func() {
 			os.Unsetenv(TLSProfileMinVersionEnvName)
 			os.Unsetenv(TLSProfileCiphersEnvName)
-			os.Unsetenv("INSECURE_SKIP_VERIFY")
 		})
 	})
 
@@ -1699,7 +1697,7 @@ var _ = Describe("TLS profile-based configuration", func() {
 	})
 
 	It("should apply profile cipher suites on GetDefaultTLSConfig", func() {
-		cfg, err := GetDefaultTLSConfig(nil, true)
+		cfg, err := GetDefaultTLSConfig(nil, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 		Expect(cfg.CipherSuites).To(Equal(expectedCiphers))
@@ -1710,7 +1708,7 @@ var _ = Describe("TLS profile-based configuration", func() {
 			MinVersion:   tls.VersionTLS10,                           //nolint:gosec
 			CipherSuites: []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA}, //nolint:gosec
 		}
-		cfg, err := GetDefaultTLSConfig(custom, true)
+		cfg, err := GetDefaultTLSConfig(custom, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 		Expect(cfg.CipherSuites).To(Equal(expectedCiphers))
@@ -1749,7 +1747,7 @@ var _ = Describe("TLS profile-based configuration", func() {
 		os.Unsetenv(TLSProfileMinVersionEnvName)
 		os.Unsetenv(TLSProfileCiphersEnvName)
 
-		cfg, err := GetDefaultTLSConfig(nil, true)
+		cfg, err := GetDefaultTLSConfig(nil, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 		Expect(cfg.CipherSuites).ToNot(BeEmpty())

--- a/internal/service/common/db/migration.go
+++ b/internal/service/common/db/migration.go
@@ -19,7 +19,6 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/database/pgx/v5"
 	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
 // MigrationsTable table created by migration lib to track state of migration
@@ -92,13 +91,9 @@ func (h *MigrationHandler) Verbose() bool {
 
 // NewHandler configure the migration data
 func NewHandler(cfg MigrationConfig) (*MigrationHandler, error) {
-	sslMode := "verify-full"
-	if ctlrutils.GetTLSSkipVerify() {
-		sslMode = "require"
-	}
 	// https://github.com/golang-migrate/migrate/tree/c378583d782e026f472dff657bfd088bf2510038/database/pgx/v5
-	connStr := fmt.Sprintf("pgx5://%s:%s@%s:%s/%s?sslmode=%s&connect_timeout=10",
-		cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Database, sslMode)
+	connStr := fmt.Sprintf("pgx5://%s:%s@%s:%s/%s?sslmode=verify-full&connect_timeout=10",
+		cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Database)
 	if cfg.MigrationsTable != "" {
 		connStr += fmt.Sprintf("&x-migrations-table=%s", cfg.MigrationsTable)
 	}

--- a/internal/tool.go
+++ b/internal/tool.go
@@ -16,7 +16,6 @@ import (
 	"runtime/debug"
 	"slices"
 
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
 
 	"github.com/spf13/cobra"
@@ -178,9 +177,6 @@ func (t *Tool) run(cmd *cobra.Command, args []string) error {
 	// Write build information:
 	t.writeBuildInfo(ctx)
 
-	// Security validation checks
-	t.validateSecurityParameters(ctx)
-
 	return nil
 }
 
@@ -252,15 +248,6 @@ func (t *Tool) writeBuildInfo(ctx context.Context) {
 
 	// Write the information:
 	t.logger.InfoContext(ctx, "Build", logFields...)
-}
-
-// validateSecurityParameters validates
-func (t *Tool) validateSecurityParameters(ctx context.Context) {
-	value := ctlrutils.GetTLSSkipVerify()
-	if value {
-		t.logger.WarnContext(ctx, fmt.Sprintf("TLS certificate verification skipped by environment variable '%s'; this configuration is not recommended for production systems",
-			ctlrutils.TLSSkipVerifyEnvName))
-	}
 }
 
 // In returns the input stream of the tool.


### PR DESCRIPTION
Remove the global toggle that allowed disabling TLS certificate verification on all outbound connections. All outbound HTTPS and database migration connections now always verify server certificates. The crd-watcher dev tool retains its independent --tls-skip-verify CLI flag.