### PR TITLE
CNF-24959: redact secret values in must-gather collection

### DIFF
--- a/must-gather/gather
+++ b/must-gather/gather
@@ -78,7 +78,11 @@ gather_bmh_preprovisioning_secrets() {
         fi
 
         mkdir -p "${output_dir}/${ns}"
-        oc get secret "${secret_name}" -n "${ns}" -o yaml > "${output_dir}/${ns}/${secret_name}.yaml" 2>/dev/null || true
+        # Collect metadata and data key names only — redact values to
+        # avoid leaking network credentials into support-case archives.
+        oc get secret "${secret_name}" -n "${ns}" -o yaml 2>/dev/null \
+            | sed '/^data:/,/^[^ ]/{/^data:/!{/^[^ ]/!s/:.*$/: REDACTED/}}' \
+            > "${output_dir}/${ns}/${secret_name}.yaml" 2>/dev/null || true
         count=$((count + 1))
     done <<< "${bmhs}"
 


### PR DESCRIPTION
The must-gather script collected preprovisioningNetworkData Secrets in full, including base64-encoded values that may contain network credentials. These archives are routinely attached to support cases. Redact the data values while preserving key names and metadata for debugging.