### PR TITLE
CNF-24960: use UBI 9 AppStream nodejs in markdownlint image

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,3 +13,4 @@ config:
   no-space-in-emphasis: true
   no-blanks-blockquote: false
   descriptive-link-text: false
+  table-column-style: false

--- a/hack/install-markdownlint.sh
+++ b/hack/install-markdownlint.sh
@@ -6,18 +6,7 @@
 #
 # Following example of: https://github.com/openshift/enhancements/blob/master/hack/install-markdownlint.sh
 
-cat /etc/redhat-release || echo "No /etc/redhat-release"
+dnf -y module enable nodejs:24
+dnf -y install nodejs
 
-if grep -q 'Red Hat Enterprise Linux' /etc/redhat-release; then
-    # https://github.com/nodesource/distributions/blob/master/DEV_README.md#enterprise-linux-based-distributions
-    yum module disable -y nodejs
-    curl -fsSL https://rpm.nodesource.com/setup_23.x -o nodesource_setup.sh
-    bash nodesource_setup.sh
-    yum -y install nodejs
-else
-    # Fedora has a module we can use
-    dnf -y module enable nodejs:16
-    dnf -y install nodejs
-fi
-
-npm install -g markdownlint@v0.38.0 markdownlint-cli2@v0.18.1 --save-dev
+npm install -g markdownlint@v0.41.0 markdownlint-cli2@v0.22.1 --save-dev


### PR DESCRIPTION
## Summary

- Replace unpinned NodeSource `curl | bash` script with `nodejs:24` module from UBI 9 AppStream in the markdownlint container image
- Update markdownlint v0.38.0 → v0.41.0, markdownlint-cli2 v0.18.1 → v0.22.1
- Disable new MD060/table-column-style rule introduced in markdownlint v0.40.0

## Test plan

- [x] `make markdownlint-image` builds successfully with Node.js 24 from AppStream
- [x] `make markdownlint` passes with zero errors
- [x] `make shellcheck bashate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)