### PR TITLE
CNF-24954: add govulncheck periodic scan and Makefile target

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -103,8 +104,8 @@ jobs:
               });
             }
 
-            // Get existing open govulncheck issues
-            const existing = await github.rest.issues.listForRepo({
+            // Get all existing open govulncheck issues
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               labels: label,
@@ -113,7 +114,7 @@ jobs:
             });
 
             const existingByVulnId = new Map();
-            for (const issue of existing.data) {
+            for (const issue of existing) {
               const match = issue.title.match(/^govulncheck: (GO-\d{4}-\d+)/);
               if (match) existingByVulnId.set(match[1], issue);
             }

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,169 @@
+---
+name: Govulncheck Vulnerability Scan
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '17 8 * * 1'  # Weekly on Monday at 08:17 UTC
+  workflow_dispatch: {}
+
+# Pinned tool version — also read by the Makefile govulncheck target.
+env:
+  GOVULNCHECK_VERSION: v1.3.0
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  govulncheck:
+    name: Scan for vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install govulncheck
+        run: go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+
+      - name: Run govulncheck
+        id: scan
+        run: |
+          govulncheck -format json ./... > govulncheck-results.json 2>&1 || true
+
+      - name: Process results and manage issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const raw = fs.readFileSync('govulncheck-results.json', 'utf8');
+            const label = 'govulncheck';
+
+            // Parse NDJSON output — extract vulnerability findings
+            const vulns = new Map();
+            for (const line of raw.split('\n').filter(l => l.trim())) {
+              try {
+                const entry = JSON.parse(line);
+                if (entry.finding) {
+                  const f = entry.finding;
+                  const id = f.osv;
+                  if (!vulns.has(id)) {
+                    vulns.set(id, {
+                      id,
+                      fixedVersion: f.fixed_version || 'unknown',
+                      modules: new Set(),
+                      traces: [],
+                    });
+                  }
+                  const v = vulns.get(id);
+                  if (f.trace && f.trace.length > 0) {
+                    const mod = f.trace[f.trace.length - 1];
+                    if (mod.module) v.modules.add(`${mod.module}@${mod.version || '?'}`);
+                  }
+                  v.traces.push(f);
+                }
+              } catch (e) { /* skip non-JSON lines */ }
+            }
+
+            // Also extract OSV details for descriptions
+            const osvDetails = new Map();
+            for (const line of raw.split('\n').filter(l => l.trim())) {
+              try {
+                const entry = JSON.parse(line);
+                if (entry.osv && entry.osv.id) {
+                  osvDetails.set(entry.osv.id, {
+                    summary: entry.osv.summary || '',
+                    details: entry.osv.details || '',
+                    aliases: (entry.osv.aliases || []).join(', '),
+                  });
+                }
+              } catch (e) { /* skip */ }
+            }
+
+            // Ensure label exists
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'd93f0b',
+                description: 'Vulnerability detected by govulncheck',
+              });
+            }
+
+            // Get existing open govulncheck issues
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const existingByVulnId = new Map();
+            for (const issue of existing.data) {
+              const match = issue.title.match(/^govulncheck: (GO-\d{4}-\d+)/);
+              if (match) existingByVulnId.set(match[1], issue);
+            }
+
+            // Open new issues for new findings
+            for (const [id, vuln] of vulns) {
+              if (existingByVulnId.has(id)) {
+                existingByVulnId.delete(id);  // Still active, don't close
+                continue;
+              }
+              const osv = osvDetails.get(id) || {};
+              const modules = [...vuln.modules].join(', ');
+              const body = [
+                `## ${osv.summary || id}`,
+                '',
+                `**Vulnerability:** [${id}](https://pkg.go.dev/vuln/${id})`,
+                osv.aliases ? `**CVE:** ${osv.aliases}` : '',
+                `**Affected modules:** ${modules}`,
+                `**Fixed in:** ${vuln.fixedVersion}`,
+                '',
+                osv.details ? `### Details\n\n${osv.details}` : '',
+                '',
+                `_Detected by govulncheck ${process.env.GOVULNCHECK_VERSION} on ${new Date().toISOString().split('T')[0]}_`,
+              ].filter(Boolean).join('\n');
+
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `govulncheck: ${id} — ${modules.split(',')[0] || 'unknown'}`,
+                body,
+                labels: [label],
+              });
+              console.log(`Created issue for ${id}`);
+            }
+
+            // Close issues for resolved vulnerabilities
+            for (const [id, issue] of existingByVulnId) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `This vulnerability is no longer detected by govulncheck ${process.env.GOVULNCHECK_VERSION}. Closing.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+              console.log(`Closed issue #${issue.number} for ${id}`);
+            }
+
+            console.log(`Scan complete: ${vulns.size} active vulnerabilities`);

--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 MOCK_GEN ?= $(LOCALBIN)/mockgen
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 OPM ?= $(LOCALBIN)/opm
+GOVULNCHECK ?= $(LOCALBIN)/govulncheck
 SHELLCHECK ?= $(LOCALBIN)/shellcheck
 YAMLLINT ?= $(LOCALBIN)/yamllint
 YQ ?= $(LOCALBIN)/yq
@@ -598,6 +599,21 @@ yq-sort-and-format: yq ## Sort keys/reformat all yaml files
 		$(YQ) -i '.. |= sort_keys(.)' "$$file"; \
 	done
 	@echo "YAML sorting and formatting completed successfully."
+
+# GOVULNCHECK_VERSION is parsed from the GitHub Actions workflow to maintain a single source of truth.
+GOVULNCHECK_VERSION := $(shell grep 'GOVULNCHECK_VERSION:' $(PROJECT_DIR)/.github/workflows/govulncheck.yml | head -1 | awk '{print $$2}')
+
+.PHONY: govulncheck-download
+govulncheck-download: $(GOVULNCHECK) ## Download govulncheck locally if necessary.
+
+$(GOVULNCHECK): $(LOCALBIN)
+	@echo "Downloading govulncheck $(GOVULNCHECK_VERSION)..."
+	GOBIN=$(LOCALBIN) go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+	@echo "Govulncheck downloaded successfully."
+
+.PHONY: govulncheck
+govulncheck: govulncheck-download ## Run govulncheck vulnerability scanner against code.
+	$(GOVULNCHECK) ./...
 
 ##@ Binary
 .PHONY: binary


### PR DESCRIPTION
Add a weekly GitHub Actions workflow that runs govulncheck, opens issues for new vulnerability findings, and closes issues when vulnerabilities are resolved. The workflow uses the govulncheck label to track findings as GitHub issues, avoiding duplicates.

Add Makefile targets (govulncheck-download, govulncheck) for local use. The tool version (v1.3.0) is defined in the workflow YAML and parsed by the Makefile to maintain a single source of truth.