### PR TITLE
CNF-24957, CNF-24961: enable TLS and safe DSN construction for PostgreSQL

### DIFF
--- a/.coverage-thresholds.yaml
+++ b/.coverage-thresholds.yaml
@@ -29,6 +29,7 @@ packages:
   internal/service/common/api/middleware: 31
   internal/service/common/async: 48
   internal/service/common/auth: 29
+  internal/service/common/db: 1
   internal/service/common/notifier: 71
   internal/service/common/utils: 12
   internal/service/provisioning/api: 66

--- a/internal/service/common/db/migration.go
+++ b/internal/service/common/db/migration.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -114,19 +116,28 @@ func (h *MigrationHandler) Verbose() bool {
 // NewHandler configure the migration data
 func NewHandler(cfg MigrationConfig) (*MigrationHandler, error) {
 	// https://github.com/golang-migrate/migrate/tree/c378583d782e026f472dff657bfd088bf2510038/database/pgx/v5
-	connStr := fmt.Sprintf("pgx5://%s:%s@%s:%s/%s?sslmode=verify-full&connect_timeout=10",
-		cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Database)
+	query := url.Values{}
+	query.Set("connect_timeout", "10")
 	if cfg.MigrationsTable != "" {
-		connStr += fmt.Sprintf("&x-migrations-table=%s", cfg.MigrationsTable)
+		query.Set("x-migrations-table", cfg.MigrationsTable)
 	}
 
+	query.Set("sslmode", "verify-full")
 	if _, err := os.Stat(constants.DefaultServiceCAFile); err == nil {
-		connStr += fmt.Sprintf("&sslrootcert=%s", constants.DefaultServiceCAFile)
+		query.Set("sslrootcert", constants.DefaultServiceCAFile)
 	} else {
-		slog.Warn("No service CA file found")
+		slog.Warn("Service CA file not found, TLS will use system CA store")
 	}
 
-	m, err := migrate.NewWithSourceInstance("iofs", cfg.Source, connStr)
+	connURL := &url.URL{
+		Scheme:   "pgx5",
+		User:     url.UserPassword(cfg.User, cfg.Password),
+		Host:     net.JoinHostPort(cfg.Host, cfg.Port),
+		Path:     cfg.Database,
+		RawQuery: query.Encode(),
+	}
+
+	m, err := migrate.NewWithSourceInstance("iofs", cfg.Source, connURL.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create migrate instance: %w", err)
 	}

--- a/internal/service/common/db/postgres.go
+++ b/internal/service/common/db/postgres.go
@@ -10,6 +10,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/url"
+	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -28,10 +31,28 @@ type PgConfig struct {
 	Database string
 }
 
+func buildPoolDSN(cfg PgConfig, sslParams url.Values) string {
+	connURL := &url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(cfg.User, cfg.Password),
+		Host:     net.JoinHostPort(cfg.Host, cfg.Port),
+		Path:     cfg.Database,
+		RawQuery: sslParams.Encode(),
+	}
+	return connURL.String()
+}
+
 // NewPgxPool get a concurrency safe pool of connection
 func NewPgxPool(ctx context.Context, cfg PgConfig) (*pgxpool.Pool, error) {
-	poolConfig, err := pgxpool.ParseConfig(fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
-		cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Database))
+	query := url.Values{}
+	query.Set("sslmode", "verify-full")
+	if _, err := os.Stat(constants.DefaultServiceCAFile); err == nil {
+		query.Set("sslrootcert", constants.DefaultServiceCAFile)
+	} else {
+		slog.WarnContext(ctx, "Service CA file not found, TLS will use system CA store")
+	}
+
+	poolConfig, err := pgxpool.ParseConfig(buildPoolDSN(cfg, query))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config: %w", err)
 	}

--- a/internal/service/common/db/postgres_test.go
+++ b/internal/service/common/db/postgres_test.go
@@ -1,0 +1,103 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package db
+
+import (
+	"net/url"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
+)
+
+var _ = Describe("buildPoolDSN", func() {
+	var cfg PgConfig
+
+	BeforeEach(func() {
+		cfg = PgConfig{
+			Host:     "db.example.svc.cluster.local",
+			Port:     "5432",
+			User:     "testuser",
+			Password: "testpass",
+			Database: "testdb",
+		}
+	})
+
+	It("escapes special characters in password", func() {
+		cfg.Password = "p@ss:word?with&special=chars/slash"
+		dsn := buildPoolDSN(cfg, url.Values{"sslmode": {"require"}})
+
+		parsed, err := url.Parse(dsn)
+		Expect(err).ToNot(HaveOccurred())
+
+		password, set := parsed.User.Password()
+		Expect(set).To(BeTrue())
+		Expect(password).To(Equal("p@ss:word?with&special=chars/slash"))
+	})
+
+	It("escapes special characters in username", func() {
+		cfg.User = "user@domain"
+		dsn := buildPoolDSN(cfg, url.Values{"sslmode": {"require"}})
+
+		parsed, err := url.Parse(dsn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parsed.User.Username()).To(Equal("user@domain"))
+	})
+
+	It("uses postgres scheme", func() {
+		dsn := buildPoolDSN(cfg, url.Values{"sslmode": {"require"}})
+
+		parsed, err := url.Parse(dsn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parsed.Scheme).To(Equal("postgres"))
+	})
+
+	It("joins host and port", func() {
+		dsn := buildPoolDSN(cfg, url.Values{"sslmode": {"require"}})
+
+		parsed, err := url.Parse(dsn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parsed.Host).To(Equal("db.example.svc.cluster.local:5432"))
+	})
+
+	It("sets database as path", func() {
+		dsn := buildPoolDSN(cfg, url.Values{"sslmode": {"require"}})
+
+		parsed, err := url.Parse(dsn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parsed.Path).To(Equal("/testdb"))
+	})
+
+	It("passes sslmode=verify-full with sslrootcert", func() {
+		params := url.Values{
+			"sslmode":     {"verify-full"},
+			"sslrootcert": {constants.DefaultServiceCAFile},
+		}
+		dsn := buildPoolDSN(cfg, params)
+
+		parsed, err := url.Parse(dsn)
+		Expect(err).ToNot(HaveOccurred())
+
+		query := parsed.Query()
+		Expect(query.Get("sslmode")).To(Equal("verify-full"))
+		Expect(query.Get("sslrootcert")).To(Equal(constants.DefaultServiceCAFile))
+	})
+
+	It("passes sslmode=verify-full without sslrootcert", func() {
+		params := url.Values{
+			"sslmode": {"verify-full"},
+		}
+		dsn := buildPoolDSN(cfg, params)
+
+		parsed, err := url.Parse(dsn)
+		Expect(err).ToNot(HaveOccurred())
+
+		query := parsed.Query()
+		Expect(query.Get("sslmode")).To(Equal("verify-full"))
+		Expect(query.Get("sslrootcert")).To(BeEmpty())
+	})
+})

--- a/internal/service/common/db/suite_test.go
+++ b/internal/service/common/db/suite_test.go
@@ -1,0 +1,19 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package db
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDB(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DB Suite")
+}


### PR DESCRIPTION
Build DSN using url.URL and url.UserPassword to safely escape credentials and set sslmode=verify-full with service-CA root certificate for both the connection pool and migration handler.

Also fixes: [CNF-24961](https://redhat.atlassian.net/browse/CNF-24961)