### PR TITLE
CNF-24953: harden container security contexts across all deployments

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -2328,6 +2328,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert
@@ -2336,6 +2337,8 @@ spec:
                   name: metrics-tls
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: oran-o2ims-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,13 +60,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: manager
         image: controller:latest
@@ -96,6 +91,7 @@ spec:
           - --metrics-tls-cert-dir=/secrets/tls/metrics
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - "ALL"

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -940,6 +940,12 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (c
 			Spec: corev1.PodSpec{
 				ServiceAccountName: fmt.Sprintf("%s-%s", constants.DefaultNamespace, serverName),
 				Volumes:            deploymentVolumes,
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: k8sptr.To(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Containers: []corev1.Container{
 					{
 						Name:            constants.ServerContainerName,
@@ -949,6 +955,13 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (c
 						Command:         []string{constants.ManagerExec},
 						Args:            deploymentContainerArgs,
 						Env:             envVars,
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: k8sptr.To(false),
+							ReadOnlyRootFilesystem:   k8sptr.To(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          ctlrutils.DefaultServiceTargetPort,
@@ -976,6 +989,13 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (c
 				Command: []string{constants.ManagerExec},
 				Args:    []string{serverName, "migrate"},
 				Env:     envVars,
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: k8sptr.To(false),
+					ReadOnlyRootFilesystem:   k8sptr.To(true),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"ALL"},
+					},
+				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("100m"),

--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -64,6 +64,23 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 				},
 			},
 		},
+		// Writable emptyDir volumes for readOnlyRootFilesystem support.
+		// The RHEL postgres image writes NSS passwd to $HOME (/var/lib/pgsql),
+		// temp files to /tmp, and socket/PID files to /var/run/postgresql.
+		// The data PVC at /var/lib/pgsql/data is a nested mount that
+		// Kubernetes handles correctly alongside the parent emptyDir.
+		corev1.Volume{
+			Name:         "home",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		corev1.Volume{
+			Name:         "tmp",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		corev1.Volume{
+			Name:         "run",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
 	)
 
 	deploymentVolumeMounts = append(deploymentVolumeMounts,
@@ -78,6 +95,18 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 		corev1.VolumeMount{
 			Name:      "data",
 			MountPath: "/var/lib/pgsql/data",
+		},
+		corev1.VolumeMount{
+			Name:      "home",
+			MountPath: "/var/lib/pgsql",
+		},
+		corev1.VolumeMount{
+			Name:      "tmp",
+			MountPath: "/tmp",
+		},
+		corev1.VolumeMount{
+			Name:      "run",
+			MountPath: "/var/run/postgresql",
 		})
 
 	// Create PersistentVolumeClaim for data storage
@@ -125,9 +154,6 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 		return fmt.Errorf("missing %s environment variable value", constants.PostgresImageName)
 	}
 
-	// Disable privilege escalation
-	privilegeEscalation := false
-
 	// Build the deployment's spec.
 	deploymentSpec := appsv1.DeploymentSpec{
 		Replicas: k8sptr.To(int32(1)),
@@ -148,6 +174,12 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 			Spec: corev1.PodSpec{
 				ServiceAccountName: serverName,
 				Volumes:            deploymentVolumes,
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: k8sptr.To(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Containers: []corev1.Container{
 					{
 						Name: constants.ServerContainerName,
@@ -161,7 +193,8 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
-							AllowPrivilegeEscalation: &privilegeEscalation,
+							AllowPrivilegeEscalation: k8sptr.To(false),
+							ReadOnlyRootFilesystem:   k8sptr.To(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},


### PR DESCRIPTION
Add readOnlyRootFilesystem, seccompProfile (RuntimeDefault), and runAsNonRoot to all container and pod security contexts:

- Service server containers: add full SecurityContext (was missing)
- Migration init containers: add full SecurityContext (was missing)
- Postgres: add readOnlyRootFilesystem with emptyDir mounts for /tmp and /var/run/postgresql, add pod-level seccompProfile and runAsNonRoot
- Controller-manager (CSV): add readOnlyRootFilesystem and seccompProfile