### PR TITLE
fix: prevent postgres crash-loop during rollout restart

### DIFF
--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -130,6 +130,9 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 
 	// Build the deployment's spec.
 	deploymentSpec := appsv1.DeploymentSpec{
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		},
 		Replicas: k8sptr.To(int32(1)),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{

--- a/internal/service/postgres/files/init.sh
+++ b/internal/service/postgres/files/init.sh
@@ -32,7 +32,7 @@ for service_name in "${!services[@]}"; do
     psql -U postgres -c "CREATE DATABASE ${service_name} OWNER ${service_name};" || true
 
     # Grant privileges (safe to run multiple times)
-    psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE ${service_name} TO ${service_name};"
+    psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE ${service_name} TO ${service_name};" || true
 
     echo "Completed setup for service: ${service_name}"
 done


### PR DESCRIPTION
## Summary
- Use `Recreate` deployment strategy for the postgres server. The default `RollingUpdate` creates the new pod before terminating the old one, causing two postgres instances to run concurrently against the same data directory. This corrupts pg_catalog tuples and crash-loops the container.
- Add `|| true` to the `GRANT ALL PRIVILEGES` statement in the postgres init script for consistency with the existing `CREATE USER` and `CREATE DATABASE` guards.

## Verification
Deployed on vcl03 and performed three consecutive `rollout restart` cycles across all deployments. Postgres survived every rollout with 0 restarts and clean startup logs.

## Test plan
- [x] `make ci-job` passes
- [x] Deployed to lab cluster (vcl03), confirmed postgres starts cleanly on rollout restart
- [x] Repeated rollout restart 3x to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)