### PR TITLE
chore: add missing ocloud CRDs to must-gather and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,10 @@ This project has not reached GA, so there are no production databases to migrate
 ### API Groups and Key CRDs
 
 - `clcm.openshift.io` - ClusterTemplate, ProvisioningRequest, HardwareProfile, NodeAllocationRequest, AllocatedNode
-- `ocloud.openshift.io` - Inventory
+- `ocloud.openshift.io` - Inventory, Location, OCloudSite, ResourcePool
+
+When adding a new CRD, also add a corresponding `gather_resource` call in
+`must-gather/gather` so the resource is collected in support archives.
 
 ### Design Decisions
 

--- a/must-gather/gather
+++ b/must-gather/gather
@@ -159,6 +159,9 @@ gather_resource "allocatednodes.clcm.openshift.io" "clcm/allocatednodes"
 
 # O-Cloud Manager CRDs - ocloud.openshift.io
 gather_resource "inventories.ocloud.openshift.io" "ocloud/inventories"
+gather_resource "locations.ocloud.openshift.io" "ocloud/locations"
+gather_resource "ocloudsites.ocloud.openshift.io" "ocloud/ocloudsites"
+gather_resource "resourcepools.ocloud.openshift.io" "ocloud/resourcepools"
 
 # Metal3 resources
 gather_resource "baremetalhosts.metal3.io" "metal3/baremetalhosts"


### PR DESCRIPTION
The must-gather script was not updated when Location, OCloudSite, and ResourcePool CRDs were introduced. Add gather_resource calls for all three. Update the CRD list in AGENTS.md and add a directive to update must-gather when new CRDs are added.