### PR TITLE
CNF-25112: extract TLS and OAuth to internal/shared packages

### DIFF
--- a/.coverage-thresholds.yaml
+++ b/.coverage-thresholds.yaml
@@ -38,3 +38,4 @@ packages:
   internal/service/resources/db/repo: 89
   internal/service/resources/listener: 30
   internal/controllers/utils/spokeclient: 75
+  internal/shared/tls: 50

--- a/internal/cmd/operator/start_controller_manager.go
+++ b/internal/cmd/operator/start_controller_manager.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -208,7 +209,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 			slog.Any("error", err))
 		return exit.Error(1)
 	}
-	tlsProfile, err := ctlrutils.FetchAPIServerTLSProfile(ctx, directClient)
+	tlsProfile, err := sharedtls.FetchAPIServerTLSProfile(ctx, directClient)
 	if err != nil {
 		logger.ErrorContext(ctx, "Unable to fetch cluster TLS profile, using Intermediate default",
 			slog.Any("error", err))
@@ -231,7 +232,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		})
 	}
 	// Profile configurator is appended last so http/2 disabling (NextProtos) is not overridden.
-	tlsOpts = append(tlsOpts, ctlrutils.NewTLSConfiguratorFromProfile(tlsProfile))
+	tlsOpts = append(tlsOpts, sharedtls.NewTLSConfiguratorFromProfile(tlsProfile))
 
 	operatorNamespace := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
 
@@ -316,7 +317,7 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 		Client:         mgr.GetClient(),
 		Logger:         logger.With(slog.String("controller", "O-Cloud Manager")),
 		Image:          c.image,
-		TLSProfileHash: ctlrutils.TLSProfileHash(tlsProfile),
+		TLSProfileHash: sharedtls.TLSProfileHash(tlsProfile),
 		TLSMinVersion:  string(tlsProfile.MinTLSVersion),
 		TLSCiphers:     strings.Join(tlsProfile.Ciphers, ","),
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/controllers/envtest/tls_profile_watcher_test.go
+++ b/internal/controllers/envtest/tls_profile_watcher_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 )
 
 var _ = Describe("TLS Profile Watcher Integration", Label("envtest"), func() {
@@ -29,7 +29,7 @@ var _ = Describe("TLS Profile Watcher Integration", Label("envtest"), func() {
 		})
 
 		It("should fetch the default Intermediate profile when no APIServer exists", func() {
-			profile, err := ctlrutils.FetchAPIServerTLSProfile(ctx, k8sClient)
+			profile, err := sharedtls.FetchAPIServerTLSProfile(ctx, k8sClient)
 			if err != nil {
 				errMsg := err.Error()
 				if strings.Contains(errMsg, "no matches for kind") ||
@@ -58,7 +58,7 @@ var _ = Describe("TLS Profile Watcher Integration", Label("envtest"), func() {
 				_ = k8sClient.Delete(ctx, apiServer)
 			}()
 
-			profile, err := ctlrutils.FetchAPIServerTLSProfile(ctx, k8sClient)
+			profile, err := sharedtls.FetchAPIServerTLSProfile(ctx, k8sClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(profile.MinTLSVersion).To(Equal(configv1.VersionTLS13))
 		})
@@ -86,7 +86,7 @@ var _ = Describe("TLS Profile Watcher Integration", Label("envtest"), func() {
 				_ = k8sClient.Delete(ctx, apiServer)
 			}()
 
-			profile, err := ctlrutils.FetchAPIServerTLSProfile(ctx, k8sClient)
+			profile, err := sharedtls.FetchAPIServerTLSProfile(ctx, k8sClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(profile.MinTLSVersion).To(Equal(configv1.VersionTLS13))
 			Expect(profile.Ciphers).To(Equal([]string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"}))
@@ -94,7 +94,7 @@ var _ = Describe("TLS Profile Watcher Integration", Label("envtest"), func() {
 
 		It("should produce a valid tls.Config from the fetched profile", func() {
 			profile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-			configurator := ctlrutils.NewTLSConfiguratorFromProfile(profile)
+			configurator := sharedtls.NewTLSConfiguratorFromProfile(profile)
 
 			cfg := &tls.Config{}
 			configurator(cfg)
@@ -107,8 +107,8 @@ var _ = Describe("TLS Profile Watcher Integration", Label("envtest"), func() {
 			intermediate := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 			modern := *configv1.TLSProfiles[configv1.TLSProfileModernType]
 
-			hashIntermediate := ctlrutils.TLSProfileHash(intermediate)
-			hashModern := ctlrutils.TLSProfileHash(modern)
+			hashIntermediate := sharedtls.TLSProfileHash(intermediate)
+			hashModern := sharedtls.TLSProfileHash(modern)
 
 			Expect(hashIntermediate).ToNot(Equal(hashModern))
 			Expect(hashIntermediate).To(HaveLen(16))
@@ -132,7 +132,7 @@ var _ = Describe("TLS Profile Watcher Integration", Label("envtest"), func() {
 				_ = k8sClient.Delete(ctx, apiServer)
 			}()
 
-			profile1, err := ctlrutils.FetchAPIServerTLSProfile(ctx, k8sClient)
+			profile1, err := sharedtls.FetchAPIServerTLSProfile(ctx, k8sClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(profile1.MinTLSVersion).To(Equal(configv1.VersionTLS12))
 
@@ -142,7 +142,7 @@ var _ = Describe("TLS Profile Watcher Integration", Label("envtest"), func() {
 			}
 			Expect(k8sClient.Update(ctx, apiServer)).To(Succeed())
 
-			profile2, err := ctlrutils.FetchAPIServerTLSProfile(ctx, k8sClient)
+			profile2, err := sharedtls.FetchAPIServerTLSProfile(ctx, k8sClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(profile2.MinTLSVersion).To(Equal(configv1.VersionTLS13))
 		})

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -39,6 +39,8 @@ import (
 	inventoryv1alpha1 "github.com/openshift-kni/oran-o2ims/api/inventory/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	sharedoauth "github.com/openshift-kni/oran-o2ims/internal/shared/oauth"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 )
 
 //+kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;watch
@@ -410,8 +412,8 @@ func (t *reconcilerTask) setupOAuthClient(ctx context.Context) (*http.Client, er
 		}
 	}
 
-	config := ctlrutils.OAuthClientConfig{
-		TLSConfig: &ctlrutils.TLSConfig{CaBundle: []byte(caBundle)},
+	config := sharedoauth.OAuthClientConfig{
+		TLSConfig: &sharedoauth.TLSConfig{CaBundle: []byte(caBundle)},
 	}
 
 	oAuthConfig := t.object.Spec.SmoConfig.OAuthConfig
@@ -431,7 +433,7 @@ func (t *reconcilerTask) setupOAuthClient(ctx context.Context) (*http.Client, er
 			return nil, fmt.Errorf("failed to get client-secret from secret: %s, %w", oAuthConfig.ClientSecretName, err)
 		}
 
-		o := ctlrutils.OAuthConfig{
+		o := sharedoauth.OAuthConfig{
 			ClientID:     clientId,
 			ClientSecret: clientSecret,
 			TokenURL:     fmt.Sprintf("%s%s", oAuthConfig.URL, oAuthConfig.TokenEndpoint),
@@ -447,10 +449,10 @@ func (t *reconcilerTask) setupOAuthClient(ctx context.Context) (*http.Client, er
 			return nil, fmt.Errorf("failed to get certificate and key from secret: %w", err)
 		}
 
-		config.TLSConfig.ClientCert = ctlrutils.NewStaticKeyPairLoader(cert, key)
+		config.TLSConfig.ClientCert = sharedoauth.NewStaticKeyPairLoader(cert, key)
 	}
 
-	httpClient, err := ctlrutils.SetupOAuthClient(ctx, t.logger, &config)
+	httpClient, err := sharedoauth.SetupOAuthClient(ctx, t.logger, &config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup OAuth client: %w", err)
 	}
@@ -882,11 +884,11 @@ func (t *reconcilerTask) deployServer(ctx context.Context, serverName string) (c
 	// TLS profile env vars (operator-resolved, avoids server pods needing API access)
 	envVars = append(envVars, []corev1.EnvVar{
 		{
-			Name:  ctlrutils.TLSProfileMinVersionEnvName,
+			Name:  sharedtls.TLSProfileMinVersionEnvName,
 			Value: t.tlsMinVersion,
 		},
 		{
-			Name:  ctlrutils.TLSProfileCiphersEnvName,
+			Name:  sharedtls.TLSProfileCiphersEnvName,
 			Value: t.tlsCiphers,
 		},
 	}...)

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -133,12 +133,6 @@ const (
 	SearchApiLabelValue = "search-api"
 )
 
-// Default values for backend URL and token:
-const (
-	defaultApiServerURL    = "https://" + constants.KubernetesAPIService
-	defaultBackendCABundle = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" // nolint: gosec // hardcoded path only
-)
-
 // Default timeout values
 const (
 	DefaultHardwareProvisioningTimeout = 90 * time.Minute
@@ -208,12 +202,6 @@ const (
 	OperationTypeCreated = "created"
 	OperationTypeUpdated = "updated"
 	OperationTypeDryRun  = "validated with dry-run"
-)
-
-// Environment variable names
-const (
-	TLSProfileMinVersionEnvName = "TLS_PROFILE_MIN_VERSION"
-	TLSProfileCiphersEnvName    = "TLS_PROFILE_CIPHERS"
 )
 
 // Label specific to ACM child policies.

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -8,11 +8,8 @@ package utils
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"reflect"
@@ -21,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"k8s.io/apimachinery/pkg/util/net"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	ibguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
@@ -834,91 +830,6 @@ func GetDefaultsFromSlices[K comparable, V any](
 		}
 	}
 	return editable, immutable, nil
-}
-
-// loadDefaultCABundles loads the default service account and ingress CA bundles.
-func loadDefaultCABundles(config *tls.Config) error {
-	config.RootCAs = x509.NewCertPool()
-	if data, err := os.ReadFile(defaultBackendCABundle); err != nil {
-		// This should not happen unless the binary is being tested in standalone mode in which case the developer
-		// should have disabled the TLS verification which would prevent this function from being invoked.
-		return fmt.Errorf("failed to read CA bundle '%s': %w", defaultBackendCABundle, err)
-		// This should not happen, but if it does continue anyway
-	} else {
-		// This will enable accessing public facing API endpoints signed by the default ingress controller certificate
-		config.RootCAs.AppendCertsFromPEM(data)
-	}
-
-	if data, err := os.ReadFile(constants.DefaultServiceCAFile); err != nil {
-		return fmt.Errorf("failed to read service CA file '%s': %w", constants.DefaultServiceCAFile, err)
-	} else {
-		// This will enable accessing internal services signed by the service account signer.
-		config.RootCAs.AppendCertsFromPEM(data)
-	}
-
-	return nil
-}
-
-// GetDefaultTLSConfig sets the TLS configuration attributes appropriately to enable communication between internal
-// services and accessing the public facing API endpoints. TLS version and cipher suites are inherited from the
-// cluster TLS security profile (via operator-injected environment variables).
-// When loadCAs is true, default in-cluster CA bundles are loaded.
-// Pass loadCAs=false when the caller provides its own trust anchors (e.g., a pinned service CA).
-func GetDefaultTLSConfig(config *tls.Config, loadCAs bool) (*tls.Config, error) {
-	profile := newTLSProfileFromEnv()
-	tlsConfig, err := NewOutboundTLSConfig(profile, config)
-	if err != nil {
-		return nil, err
-	}
-
-	if loadCAs {
-		if err := loadDefaultCABundles(tlsConfig); err != nil {
-			return nil, fmt.Errorf("error loading default CABundles: %w", err)
-		}
-	}
-
-	return tlsConfig, nil
-}
-
-// AddCABundle to an existing TLS configuration
-func AddCABundle(config *tls.Config, caBundle string) error {
-	data, err := os.ReadFile(caBundle)
-	if err != nil {
-		return fmt.Errorf("failed to read CA bundle '%s': %w", caBundle, err)
-	}
-
-	if config.RootCAs == nil {
-		config.RootCAs = x509.NewCertPool()
-	}
-	config.RootCAs.AppendCertsFromPEM(data)
-
-	return nil
-}
-
-// GetClientTLSConfig creates a tls.Config for outbound mTLS connections with dynamic cert/key rotation.
-// TLS version and cipher suites are inherited from the cluster TLS security profile
-// (via operator-injected environment variables).
-func GetClientTLSConfig(ctx context.Context, certFile, keyFile, caFile string) (*tls.Config, error) {
-	profile := newTLSProfileFromEnv()
-	return NewOutboundMTLSConfig(ctx, profile, certFile, keyFile, caFile)
-}
-
-// GetServerTLSConfig creates a tls.Config for accepting incoming connections with dynamic cert/key rotation.
-// TLS version and cipher suites are inherited from the cluster TLS security profile
-// (via operator-injected environment variables).
-func GetServerTLSConfig(ctx context.Context, certFile, keyFile string) (*tls.Config, error) {
-	profile := newTLSProfileFromEnv()
-	return NewInboundTLSConfig(ctx, profile, certFile, keyFile)
-}
-
-// GetDefaultBackendTransport returns an HTTP transport with the proper TLS defaults set.
-func GetDefaultBackendTransport() (http.RoundTripper, error) {
-	tlsConfig, err := GetDefaultTLSConfig(nil, true)
-	if err != nil {
-		return nil, err
-	}
-
-	return net.SetTransportDefaults(&http.Transport{TLSClientConfig: tlsConfig}), nil
 }
 
 // GetEnvOrDefault returns the value of the named environment variable or the supplied default value if the environment

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -8,16 +8,7 @@ package utils
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
-	"math/big"
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -1662,95 +1653,6 @@ var _ = Describe("Server predicate functions", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(args).To(BeNil())
 		})
-	})
-})
-
-var _ = Describe("TLS profile-based configuration", func() {
-	const (
-		testMinVersion = "VersionTLS12"
-		testCipher1    = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-		testCipher2    = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
-	)
-
-	BeforeEach(func() {
-		os.Setenv(TLSProfileMinVersionEnvName, testMinVersion)
-		os.Setenv(TLSProfileCiphersEnvName, testCipher1+","+testCipher2)
-		DeferCleanup(func() {
-			os.Unsetenv(TLSProfileMinVersionEnvName)
-			os.Unsetenv(TLSProfileCiphersEnvName)
-		})
-	})
-
-	expectedCiphers := []uint16{
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-	}
-
-	It("should apply profile cipher suites on GetClientTLSConfig", func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		cfg, err := GetClientTLSConfig(ctx, "", "", "")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
-		Expect(cfg.CipherSuites).To(Equal(expectedCiphers))
-	})
-
-	It("should apply profile cipher suites on GetDefaultTLSConfig", func() {
-		cfg, err := GetDefaultTLSConfig(nil, false)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
-		Expect(cfg.CipherSuites).To(Equal(expectedCiphers))
-	})
-
-	It("should override caller-provided cipher suites with profile on GetDefaultTLSConfig", func() {
-		custom := &tls.Config{
-			MinVersion:   tls.VersionTLS10,                           //nolint:gosec
-			CipherSuites: []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA}, //nolint:gosec
-		}
-		cfg, err := GetDefaultTLSConfig(custom, false)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
-		Expect(cfg.CipherSuites).To(Equal(expectedCiphers))
-	})
-
-	It("should apply profile cipher suites on GetServerTLSConfig", func() {
-		dir := GinkgoT().TempDir()
-		certFile := filepath.Join(dir, "tls.crt")
-		keyFile := filepath.Join(dir, "tls.key")
-
-		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		Expect(err).ToNot(HaveOccurred())
-
-		template := &x509.Certificate{SerialNumber: big.NewInt(1)}
-		certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
-		Expect(err).ToNot(HaveOccurred())
-
-		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
-		keyDER, err := x509.MarshalECPrivateKey(key)
-		Expect(err).ToNot(HaveOccurred())
-		keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
-
-		Expect(os.WriteFile(certFile, certPEM, 0o600)).To(Succeed())
-		Expect(os.WriteFile(keyFile, keyPEM, 0o600)).To(Succeed())
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		cfg, err := GetServerTLSConfig(ctx, certFile, keyFile)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
-		Expect(cfg.CipherSuites).To(Equal(expectedCiphers))
-	})
-
-	It("should fall back to Intermediate profile when env vars are not set", func() {
-		os.Unsetenv(TLSProfileMinVersionEnvName)
-		os.Unsetenv(TLSProfileCiphersEnvName)
-
-		cfg, err := GetDefaultTLSConfig(nil, false)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
-		Expect(cfg.CipherSuites).ToNot(BeEmpty())
 	})
 })
 

--- a/internal/service/alarms/internal/alertmanager/api.go
+++ b/internal/service/alarms/internal/alertmanager/api.go
@@ -20,6 +20,7 @@ import (
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/db/repo"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/infrastructure"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -220,7 +221,7 @@ func (c *AMClient) createAlertmanagerClient() (*http.Client, string, error) {
 
 	// Create HTTP client with the CA certificate and cluster TLS profile.
 	// Pass loadCAs=false since we pin the service CA explicitly.
-	tlsConfig, err := ctlrutils.GetDefaultTLSConfig(nil, false)
+	tlsConfig, err := sharedtls.GetDefaultTLSConfig(nil, false)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create TLS config: %w", err)
 	}

--- a/internal/service/alarms/internal/infrastructure/clusterserver.go
+++ b/internal/service/alarms/internal/infrastructure/clusterserver.go
@@ -22,6 +22,7 @@ import (
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/infrastructure/clusterserver/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 )
 
 const (
@@ -61,7 +62,7 @@ func (r *ClusterServer) Setup() error {
 	}
 
 	// Set up transport
-	tr, err := ctlrutils.GetDefaultBackendTransport()
+	tr, err := sharedtls.GetDefaultBackendTransport()
 	if err != nil {
 		return fmt.Errorf("failed to create http transport: %w", err)
 	}

--- a/internal/service/alarms/internal/infrastructure/resourceserver.go
+++ b/internal/service/alarms/internal/infrastructure/resourceserver.go
@@ -22,6 +22,7 @@ import (
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/alarms/internal/infrastructure/resourceserver/generated"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 )
 
 const (
@@ -58,7 +59,7 @@ func (r *ResourceServer) Setup() error {
 	}
 
 	// Set up transport
-	tr, err := ctlrutils.GetDefaultBackendTransport()
+	tr, err := sharedtls.GetDefaultBackendTransport()
 	if err != nil {
 		return fmt.Errorf("failed to create http transport: %w", err)
 	}

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 )
 
 // Alarm server config values
@@ -230,7 +231,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 		middleware.TrailingSlashStripper(),
 	)
 
-	serverTLSConfig, err := ctlrutils.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
+	serverTLSConfig, err := sharedtls.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
 	if err != nil {
 		return fmt.Errorf("failed to get server TLS config: %w", err)
 	}

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -18,10 +18,10 @@ import (
 	"time"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/auth"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 
 	"github.com/getkin/kin-openapi/openapi3"
 
@@ -132,7 +132,7 @@ func Serve(config *api.ArtifactsServerConfig) error {
 		middleware.TrailingSlashStripper(),
 	)
 
-	serverTLSConfig, err := ctlrutils.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
+	serverTLSConfig, err := sharedtls.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
 	if err != nil {
 		return fmt.Errorf("failed to get server TLS config: %w", err)
 	}

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 	repo2 "github.com/openshift-kni/oran-o2ims/internal/service/common/repo"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 )
 
 // Resource server config values
@@ -191,7 +192,7 @@ func Serve(config *api.ClusterServerConfig) error {
 		middleware.TrailingSlashStripper(),
 	)
 
-	serverTLSConfig, err := ctlrutils.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
+	serverTLSConfig, err := sharedtls.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
 	if err != nil {
 		return fmt.Errorf("failed to get server TLS config: %w", err)
 	}

--- a/internal/service/common/auth/middleware.go
+++ b/internal/service/common/auth/middleware.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/client-go/rest"
 
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
 	svcutils "github.com/openshift-kni/oran-o2ims/internal/service/common/utils"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 )
 
 // GetAuthenticator builds authentication middleware to be used to extract user/group identity from incoming requests
@@ -29,7 +29,7 @@ func GetAuthenticator(ctx context.Context, config *svcutils.CommonServerConfig) 
 	}
 
 	// Create a client TLS config suitable to be used with entities outside the cluster
-	clientTLSConfig, err := ctlrutils.GetClientTLSConfig(ctx, config.TLS.ClientCertFile, config.TLS.ClientKeyFile, config.TLS.CABundleFile)
+	clientTLSConfig, err := sharedtls.GetClientTLSConfig(ctx, config.TLS.ClientCertFile, config.TLS.ClientKeyFile, config.TLS.CABundleFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client TLS config: %w", err)
 	}

--- a/internal/service/common/notifier/provider.go
+++ b/internal/service/common/notifier/provider.go
@@ -17,7 +17,8 @@ import (
 	"k8s.io/client-go/transport"
 
 	commonapi "github.com/openshift-kni/oran-o2ims/api/common"
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	sharedoauth "github.com/openshift-kni/oran-o2ims/internal/shared/oauth"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 )
 
 // ErrCrossHostRedirect is returned when an HTTP redirect targets a different host.
@@ -45,7 +46,7 @@ func BlockCrossHostRedirects(client *http.Client) {
 // ClientFactory is a utility used to abstract building an HTTP client based on the type of callback
 // URL supplied.
 type ClientFactory struct {
-	oauthConfig      *ctlrutils.OAuthClientConfig
+	oauthConfig      *sharedoauth.OAuthClientConfig
 	serviceTokenFile string
 }
 
@@ -56,7 +57,7 @@ type ClientProvider interface {
 }
 
 // NewClientFactory creates a new factory
-func NewClientFactory(oauthConfig *ctlrutils.OAuthClientConfig, serviceTokenFile string) ClientProvider {
+func NewClientFactory(oauthConfig *sharedoauth.OAuthClientConfig, serviceTokenFile string) ClientProvider {
 	return &ClientFactory{
 		oauthConfig:      oauthConfig,
 		serviceTokenFile: serviceTokenFile,
@@ -64,7 +65,7 @@ func NewClientFactory(oauthConfig *ctlrutils.OAuthClientConfig, serviceTokenFile
 }
 
 func (f *ClientFactory) newClusterClient(ctx context.Context) (*http.Client, error) {
-	tlsConfig, err := ctlrutils.GetDefaultTLSConfig(nil, true)
+	tlsConfig, err := sharedtls.GetDefaultTLSConfig(nil, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}
@@ -81,7 +82,7 @@ func (f *ClientFactory) newClusterClient(ctx context.Context) (*http.Client, err
 }
 
 func (f *ClientFactory) newOAuthClient(ctx context.Context) (*http.Client, error) {
-	client, err := ctlrutils.SetupOAuthClient(ctx, nil, f.oauthConfig)
+	client, err := sharedoauth.SetupOAuthClient(ctx, nil, f.oauthConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup oauth client")
 	}

--- a/internal/service/common/utils/config.go
+++ b/internal/service/common/utils/config.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	sharedoauth "github.com/openshift-kni/oran-o2ims/internal/shared/oauth"
 )
 
 // OAuthConfig defines the attributes used to communicate with the OAuth server
@@ -196,15 +196,15 @@ func (c *CommonServerConfig) Validate() error {
 }
 
 // CreateOAuthConfig builds an OAuthClientConfig from the specified parameters
-func (c *CommonServerConfig) CreateOAuthConfig(ctx context.Context) (*ctlrutils.OAuthClientConfig, error) {
-	config := ctlrutils.OAuthClientConfig{}
+func (c *CommonServerConfig) CreateOAuthConfig(ctx context.Context) (*sharedoauth.OAuthClientConfig, error) {
+	config := sharedoauth.OAuthClientConfig{}
 	if c.TLS.CABundleFile != "" {
 		// Load the bundle
 		bytes, err := os.ReadFile(c.TLS.CABundleFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read CA bundle file '%s': %w", c.TLS.CABundleFile, err)
 		}
-		config.TLSConfig = &ctlrutils.TLSConfig{CaBundle: bytes}
+		config.TLSConfig = &sharedoauth.TLSConfig{CaBundle: bytes}
 		slog.DebugContext(ctx, "using CA bundle", slog.String("path", c.TLS.CABundleFile))
 	}
 
@@ -215,7 +215,7 @@ func (c *CommonServerConfig) CreateOAuthConfig(ctx context.Context) (*ctlrutils.
 			return nil, fmt.Errorf("failed to create dynamic client certificate loader: %w", err)
 		}
 		if config.TLSConfig == nil {
-			config.TLSConfig = &ctlrutils.TLSConfig{}
+			config.TLSConfig = &sharedoauth.TLSConfig{}
 		}
 		config.TLSConfig.ClientCert = dynamicClientCert
 		slog.DebugContext(ctx, "using TLS client config", slog.String("cert", c.TLS.ClientCertFile), slog.String("key", c.TLS.ClientKeyFile))
@@ -229,7 +229,7 @@ func (c *CommonServerConfig) CreateOAuthConfig(ctx context.Context) (*ctlrutils.
 		return nil, fmt.Errorf("failed to construct token URL: %w", err)
 	}
 
-	config.OAuthConfig = &ctlrutils.OAuthConfig{
+	config.OAuthConfig = &sharedoauth.OAuthConfig{
 		TokenURL:     tokenURL,
 		ClientID:     c.OAuth.ClientID,
 		ClientSecret: c.OAuth.ClientSecret,

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -17,10 +17,10 @@ import (
 	"syscall"
 	"time"
 
-	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/auth"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 
 	"github.com/getkin/kin-openapi/openapi3"
 
@@ -129,7 +129,7 @@ func Serve(config *api.ProvisioningServerConfig) error {
 		middleware.TrailingSlashStripper(),
 	)
 
-	serverTLSConfig, err := ctlrutils.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
+	serverTLSConfig, err := sharedtls.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
 	if err != nil {
 		return fmt.Errorf("failed to get server TLS config: %w", err)
 	}

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/collector"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/db/repo"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/listener"
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 )
 
 // Resource server config values
@@ -233,7 +234,7 @@ func Serve(config *api.ResourceServerConfig) error {
 		middleware.TrailingSlashStripper(),
 	)
 
-	serverTLSConfig, err := ctlrutils.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
+	serverTLSConfig, err := sharedtls.GetServerTLSConfig(ctx, config.TLS.CertFile, config.TLS.KeyFile)
 	if err != nil {
 		return fmt.Errorf("failed to get server TLS config: %w", err)
 	}

--- a/internal/shared/oauth/oauth.go
+++ b/internal/shared/oauth/oauth.go
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: Red Hat
 SPDX-License-Identifier: Apache-2.0
 */
 
-package utils
+package oauth
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"time"
 
+	sharedtls "github.com/openshift-kni/oran-o2ims/internal/shared/tls"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
@@ -87,7 +88,7 @@ func SetupOAuthClient(ctx context.Context, logger *slog.Logger, config *OAuthCli
 	if logger == nil {
 		logger = slog.Default()
 	}
-	tlsConfig, err := GetDefaultTLSConfig(nil, true)
+	tlsConfig, err := sharedtls.GetDefaultTLSConfig(nil, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}

--- a/internal/shared/tls/suite_test.go
+++ b/internal/shared/tls/suite_test.go
@@ -1,0 +1,19 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tls
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTLS(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TLS Suite")
+}

--- a/internal/shared/tls/tls.go
+++ b/internal/shared/tls/tls.go
@@ -4,23 +4,37 @@ SPDX-FileCopyrightText: Red Hat
 SPDX-License-Identifier: Apache-2.0
 */
 
-package utils
+package tls
 
 import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	tlspkg "github.com/openshift/controller-runtime-common/pkg/tls"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 )
+
+// Environment variable names for TLS profile configuration injected by the operator.
+const (
+	TLSProfileMinVersionEnvName = "TLS_PROFILE_MIN_VERSION"
+	TLSProfileCiphersEnvName    = "TLS_PROFILE_CIPHERS"
+)
+
+// Default CA bundle path for the service account.
+const defaultBackendCABundle = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" // nolint: gosec // hardcoded path only
 
 // FetchAPIServerTLSProfile retrieves the cluster TLS security profile from the APIServer resource.
 // If no profile is configured, the Intermediate profile is returned as the default.
@@ -110,8 +124,8 @@ func NewOutboundMTLSConfig(ctx context.Context, profile configv1.TLSProfileSpec,
 }
 
 // NewOutboundTLSConfig creates a tls.Config for general outbound connections applying only the
-// TLS profile (MinVersion, CipherSuites). It does not load CA bundles; that is handled by the
-// GetDefaultTLSConfig wrapper in utils.go.
+// TLS profile (MinVersion, CipherSuites). It does not load CA bundles; use GetDefaultTLSConfig
+// for connections that need in-cluster CA trust.
 func NewOutboundTLSConfig(profile configv1.TLSProfileSpec, config *tls.Config) (*tls.Config, error) {
 	if config == nil {
 		config = &tls.Config{} //nolint:gosec
@@ -180,4 +194,84 @@ var validTLSVersions = map[string]bool{
 
 func isValidTLSVersion(v string) bool {
 	return validTLSVersions[v]
+}
+
+// loadDefaultCABundles loads the default service account and ingress CA bundles.
+func loadDefaultCABundles(config *tls.Config) error {
+	config.RootCAs = x509.NewCertPool()
+	if data, err := os.ReadFile(defaultBackendCABundle); err != nil {
+		return fmt.Errorf("failed to read CA bundle '%s': %w", defaultBackendCABundle, err)
+	} else {
+		config.RootCAs.AppendCertsFromPEM(data)
+	}
+
+	if data, err := os.ReadFile(constants.DefaultServiceCAFile); err != nil {
+		return fmt.Errorf("failed to read service CA file '%s': %w", constants.DefaultServiceCAFile, err)
+	} else {
+		config.RootCAs.AppendCertsFromPEM(data)
+	}
+
+	return nil
+}
+
+// GetDefaultTLSConfig sets the TLS configuration attributes appropriately to enable communication between internal
+// services and accessing the public facing API endpoints. TLS version and cipher suites are inherited from the
+// cluster TLS security profile (via operator-injected environment variables).
+// When loadCAs is true, default in-cluster CA bundles are loaded.
+// Pass loadCAs=false when the caller provides its own trust anchors (e.g., a pinned service CA).
+func GetDefaultTLSConfig(config *tls.Config, loadCAs bool) (*tls.Config, error) {
+	profile := newTLSProfileFromEnv()
+	tlsConfig, err := NewOutboundTLSConfig(profile, config)
+	if err != nil {
+		return nil, err
+	}
+
+	if loadCAs {
+		if err := loadDefaultCABundles(tlsConfig); err != nil {
+			return nil, fmt.Errorf("error loading default CABundles: %w", err)
+		}
+	}
+
+	return tlsConfig, nil
+}
+
+// AddCABundle appends a PEM-encoded CA bundle file to the TLS configuration's root CA pool.
+func AddCABundle(config *tls.Config, caBundle string) error {
+	data, err := os.ReadFile(caBundle)
+	if err != nil {
+		return fmt.Errorf("failed to read CA bundle '%s': %w", caBundle, err)
+	}
+
+	if config.RootCAs == nil {
+		config.RootCAs = x509.NewCertPool()
+	}
+	config.RootCAs.AppendCertsFromPEM(data)
+
+	return nil
+}
+
+// GetClientTLSConfig creates a tls.Config for outbound mTLS connections with dynamic cert/key rotation.
+// TLS version and cipher suites are inherited from the cluster TLS security profile
+// (via operator-injected environment variables).
+func GetClientTLSConfig(ctx context.Context, certFile, keyFile, caFile string) (*tls.Config, error) {
+	profile := newTLSProfileFromEnv()
+	return NewOutboundMTLSConfig(ctx, profile, certFile, keyFile, caFile)
+}
+
+// GetServerTLSConfig creates a tls.Config for accepting incoming connections with dynamic cert/key rotation.
+// TLS version and cipher suites are inherited from the cluster TLS security profile
+// (via operator-injected environment variables).
+func GetServerTLSConfig(ctx context.Context, certFile, keyFile string) (*tls.Config, error) {
+	profile := newTLSProfileFromEnv()
+	return NewInboundTLSConfig(ctx, profile, certFile, keyFile)
+}
+
+// GetDefaultBackendTransport returns an HTTP transport with the proper TLS defaults set.
+func GetDefaultBackendTransport() (http.RoundTripper, error) {
+	tlsConfig, err := GetDefaultTLSConfig(nil, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return utilnet.SetTransportDefaults(&http.Transport{TLSClientConfig: tlsConfig}), nil
 }

--- a/internal/shared/tls/tls_test.go
+++ b/internal/shared/tls/tls_test.go
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: Red Hat
 SPDX-License-Identifier: Apache-2.0
 */
 
-package utils
+package tls
 
 import (
 	"bytes"


### PR DESCRIPTION
Move TLS configuration functions from controllers/utils to internal/shared/tls/ and OAuth client setup to internal/shared/oauth/. This establishes a shared middleware layer with a clear import hierarchy: api/ -> internal/shared/ -> everything else.

The service layer (internal/service/) no longer imports controllers/utils for TLS operations, reducing coupling between the service and controller packages. Three service files (provider.go, config.go, middleware.go) had their ctlrutils import fully eliminated.