### PR TITLE
CNF-24954: skip govulncheck workflow on forks

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   govulncheck:
+    if: github.repository == 'openshift-kni/oran-o2ims'
     name: Scan for vulnerabilities
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Scheduled workflows run on the default branch of every fork. Add a repository check so the scan only runs in the upstream repo.