### PR TITLE
simplify-fbc-pipeline: remove run-opm-pre-actions and use tags for released bundles

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,0 @@
----
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-4-21@sha256:b30e6351159b8411595c52b574d34a84e42e3d13de278eae498becc9ad49b05c
-

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -79,28 +79,27 @@ entries:
     package: o-cloud-manager
     schema: olm.channel
   # v4.21.0
-  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:1a6e85788354257b0ea516d12583636489683eb7c24c06894010b0f6d718e35c
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle:v4.21.0
     schema: olm.bundle
   # v4.21.1
-  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:b288271e64680a48c33a4af055ec3efa3885eb9aca62f3e767021b90dd39e0bc
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle:v4.21.1
     schema: olm.bundle
   # v4.21.2
-  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:7ef59628b50f7fde127445b27ff95af1b3fccf9efee678bb2ca5587ef1c79d1f
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle:v4.21.2
     schema: olm.bundle
   # v4.21.3
-  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:c3f7f016662084afd9560919394d66b033aaa9b8847742cc13c4de15b3cf085d
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle:v4.21.3
     schema: olm.bundle
   # v4.21.4
-  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:18d6f26410eae6ee34617dce99af624eca9d770734086a3ee642d2724896c416
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle:v4.21.4
     schema: olm.bundle
   # v4.21.5
-  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:ccae35ceb7fd1197a8072a4dfdff64a701dbd8d207430b812cd1cdfea9361f0c
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle:v4.21.5
     schema: olm.bundle
   # v4.21.6
-  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:08546866948a7bb9731a1b9dbb8dbbadfa65bc21e44bf906d50e10501661156d
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle:v4.21.6
     schema: olm.bundle
-  # v4.21.7 bundle
-  # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
-  - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
+  # v4.21.7
+  - image: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-4-21@sha256:b30e6351159b8411595c52b574d34a84e42e3d13de278eae498becc9ad49b05c
     schema: olm.bundle
 schema: olm.template.basic

--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -137,36 +137,10 @@ spec:
       workspaces:
         - name: basic-auth
           workspace: git-auth
-    - name: run-opm-pre-actions
-      params:
-        - name: ociStorage
-          value: $(params.output-image).script
-        - name: ociArtifactExpiresAfter
-          value: $(params.image-expires-after)
-        - name: SCRIPT_RUNNER_IMAGE
-          value: quay.io/konflux-ci/yq:latest
-        # update catalog template
-        - name: SCRIPT
-          value: ./telco5g-konflux/scripts/catalog/konflux-update-catalog-template.sh --set-catalog-template-input-file .konflux/catalog/catalog-template.in.yaml --set-bundle-builds-file .konflux/catalog/bundle.builds.in.yaml
-        - name: HERMETIC
-          value: $(params.hermetic)
-        - name: SOURCE_ARTIFACT
-          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-      runAfter:
-        - clone-repository
-      taskRef:
-        params:
-        - name: name
-          value: run-script-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:0e13a74cc02c945e7119ecd4cc0c9148e7591b50f87e415b212154caad0479c0
-        - name: kind
-          value: task
-        resolver: bundles
     - name: run-opm-command
       params:
         - name: SOURCE_ARTIFACT
-          value: $(tasks.run-opm-pre-actions.results.SCRIPT_ARTIFACT)
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
         - name: ociStorage
           value: $(params.output-image).opm
         - name: ociArtifactExpiresAfter
@@ -187,7 +161,7 @@ spec:
         - name: FILE_TO_UPDATE_PULLSPEC
           value: ".konflux/catalog/o-cloud-manager/catalog.json"
       runAfter:
-        - run-opm-pre-actions
+        - clone-repository
       taskRef:
         params:
           - name: name
@@ -253,9 +227,6 @@ spec:
           value: $(params.build-args-file)
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-        - name: ADDITIONAL_BASE_IMAGES
-          value:
-            - $(tasks.run-opm-pre-actions.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         - name: IMAGE_APPEND_PLATFORM


### PR DESCRIPTION
## Summary

Simplify the FBC pipeline by removing the `run-opm-pre-actions` task and
leveraging the upstream `convert-image-tags-to-digests` step built into
`run-opm-command-oci-ta`. Released bundle images now use human-readable
version tags instead of sha256 digests.

**Skill**: simplify-fbc-pipeline

## Background

The upstream Konflux `run-opm-command-oci-ta` task now includes a
`convert-image-tags-to-digests` step
([build-definitions#3075](https://github.com/konflux-ci/build-definitions/pull/3075))
that automatically resolves image tags to sha256 digests via `skopeo` during
`opm render`. This eliminates the need for the `run-opm-pre-actions` task,
the `bundle.builds.in.yaml` file, and the `konflux-update-catalog-template.sh`
script.

## Changes

- **Deleted** `.konflux/catalog/bundle.builds.in.yaml` — no longer needed
- **Edited** `.konflux/catalog/catalog-template.in.yaml`:
  - Converted released bundle images (v4.21.0–v4.21.6) from `@sha256:<digest>`
    to `:v4.21.x` tags
  - Set unreleased bundle (v4.21.7) to its quay.io digest
  - Removed placeholder comment about `update-catalog-template.sh`
- **Edited** `.tekton/fbc-pipeline.yaml`:
  - Removed the `run-opm-pre-actions` task entirely (26 lines)
  - Rewired `run-opm-command` `SOURCE_ARTIFACT` from
    `tasks.run-opm-pre-actions.results.SCRIPT_ARTIFACT` to
    `tasks.clone-repository.results.SOURCE_ARTIFACT`
  - Updated `run-opm-command` `runAfter` from `run-opm-pre-actions` to
    `clone-repository`
  - Removed `ADDITIONAL_BASE_IMAGES` parameter from `build-images` task

## Requirements Addressed

- [x] Delete `bundle.builds.in.yaml`
- [x] Convert released bundle images to tags
- [x] Set unreleased bundle to quay.io digest
- [x] Remove `run-opm-pre-actions` task from pipeline
- [x] Rewire `run-opm-command` source to `clone-repository`
- [x] Update `run-opm-command` runAfter
- [x] Task bundle already at correct version (includes `convert-image-tags-to-digests`)
- [x] Remove `ADDITIONAL_BASE_IMAGES` from `build-images`
- [x] Remove all stale references to `run-opm-pre-actions`
- [x] Validate pipeline YAML syntax and task chain

## Test Plan

- Verified YAML syntax validity
- Confirmed zero remaining references to `run-opm-pre-actions` in pipeline
- Confirmed zero remaining references to `bundle.builds.in.yaml` in repo
- Verified task dependency chain: `init` → `clone-repository` → `run-opm-command` → `prefetch-dependencies` → `build-images` → `build-image-index` → ...

## Notes

- The `run-opm-command-oci-ta` task bundle was already at the version that
  includes `convert-image-tags-to-digests`
  (`sha256:6a7c758802fd253735b15174c4e7ffffb6e271969adfddb3a083935986845166`),
  so no task bundle update was needed.
- Reference PR: [cluster-group-upgrades-operator#5571](https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/5571) (TALM blueprint)

Generated with [Claude Code](https://claude.com/claude-code)