### PR TITLE
OCPBUGS-91953: support digest-referenced ClusterImageSets in validation

### DIFF
--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -851,19 +851,13 @@ func (t *clusterTemplateReconcilerTask) validateClusterImageSetMatchesRelease(ct
 		return fmt.Errorf("failed to get ClusterImageSet %s: %w", clusterImageSetName, err)
 	}
 
-	// Extract the release image from the ClusterImageSet spec
-	releaseImage := clusterImageSet.Spec.ReleaseImage
-	if releaseImage == "" {
-		return fmt.Errorf("releaseImage not found in ClusterImageSet %s spec", clusterImageSetName)
-	}
-
-	// Extract version from the release image URL
-	// Release image URLs typically contain the version, e.g.,
-	// "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64"
-	imageVersion := extractVersionFromReleaseImage(releaseImage)
+	// Extract the version from the ClusterImageSet. ACM 2.17+ adds a releaseTag
+	// label (e.g., "4.20.4-x86_64") and uses digest references in releaseImage.
+	// Older ACM versions use tagged image references (e.g., ":4.20.4-x86_64").
+	imageVersion := extractVersionFromClusterImageSet(clusterImageSet)
 	if imageVersion == "" {
-		return fmt.Errorf("could not extract version from ClusterImageSet %s release image: %s",
-			clusterImageSetName, releaseImage)
+		return fmt.Errorf("could not extract version from ClusterImageSet %s: no releaseTag label and release image %s has no parseable tag",
+			clusterImageSetName, clusterImageSet.Spec.ReleaseImage)
 	}
 
 	// Compare with the ClusterTemplate release version
@@ -884,28 +878,39 @@ func (t *clusterTemplateReconcilerTask) validateClusterImageSetMatchesRelease(ct
 	return nil
 }
 
-// extractVersionFromReleaseImage extracts the OpenShift version from a release image URL
+// extractVersionFromClusterImageSet extracts the OpenShift version from a ClusterImageSet.
+// It first checks the releaseTag label (added by ACM 2.17+ alongside digest references),
+// then falls back to parsing the version from a tagged release image reference.
+func extractVersionFromClusterImageSet(cis *hivev1.ClusterImageSet) string {
+	if tag, ok := cis.Labels["releaseTag"]; ok && tag != "" {
+		if v := extractVersionFromTag(tag); v != "" {
+			return v
+		}
+	}
+
+	return extractVersionFromReleaseImage(cis.Spec.ReleaseImage)
+}
+
+// extractVersionFromReleaseImage extracts the OpenShift version from a tagged release image URL.
 // Examples:
 //   - "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64" -> "4.17.0"
-//   - "registry.redhat.io/ubi8/ubi:4.16.1" -> "4.16.1"
+//   - "quay.io/openshift-release-dev/ocp-release@sha256:abc123" -> "" (digest, no tag)
 func extractVersionFromReleaseImage(releaseImage string) string {
-	// Split by ':' to get the tag part
 	parts := strings.Split(releaseImage, ":")
 	if len(parts) < 2 {
 		return ""
 	}
+	return extractVersionFromTag(parts[len(parts)-1])
+}
 
-	tag := parts[len(parts)-1]
-
-	// Look for version pattern (X.Y.Z with optional pre-release) in the tag
-	// This regex matches semantic version patterns, excluding architecture suffixes
-	// Architecture patterns like -x86_64, -aarch64 are NOT part of semver
+// extractVersionFromTag extracts a semantic version (X.Y.Z) from a tag string,
+// ignoring architecture suffixes like -x86_64 or -aarch64.
+func extractVersionFromTag(tag string) string {
 	versionRegex := `(\d+\.\d+\.\d+(?:-(?:rc|alpha|beta)[0-9\.]*)*)`
 	matches := regexp.MustCompile(versionRegex).FindStringSubmatch(tag)
 	if len(matches) > 1 {
 		return matches[1]
 	}
-
 	return ""
 }
 

--- a/internal/controllers/clustertemplate_controller_test.go
+++ b/internal/controllers/clustertemplate_controller_test.go
@@ -1979,7 +1979,7 @@ baseDomain: example.com
 
 		err := task.validateClusterImageSetMatchesRelease(ctx)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("releaseImage not found in ClusterImageSet"))
+		Expect(err.Error()).To(ContainSubstring("could not extract version from ClusterImageSet"))
 	})
 
 	It("should fail when ClusterImageSet releaseImage contains no extractable version", func() {
@@ -2102,6 +2102,12 @@ var _ = Describe("extractVersionFromReleaseImage", func() {
 		}
 	})
 
+	It("should return empty string for digest references", func() {
+		version := extractVersionFromReleaseImage(
+			"quay.io/openshift-release-dev/ocp-release@sha256:5b87a665045cdfe0a1b271024be936a0c46de17b25a112d6a136c5af89d861c4")
+		Expect(version).To(Equal(""))
+	})
+
 	It("should return empty string for invalid release images", func() {
 		testCases := []struct {
 			description  string
@@ -2120,6 +2126,10 @@ var _ = Describe("extractVersionFromReleaseImage", func() {
 				releaseImage: "quay.io/openshift-release-dev/ocp-release:4.17",
 			},
 			{
+				description:  "digest reference",
+				releaseImage: "quay.io/openshift-release-dev/ocp-release@sha256:5b87a665045cdfe0a1b271024be936a0c46de17b25a112d6a136c5af89d861c4",
+			},
+			{
 				description:  "empty string",
 				releaseImage: "",
 			},
@@ -2134,6 +2144,58 @@ var _ = Describe("extractVersionFromReleaseImage", func() {
 			version := extractVersionFromReleaseImage(tc.releaseImage)
 			Expect(version).To(Equal(""))
 		}
+	})
+})
+
+var _ = Describe("extractVersionFromClusterImageSet", func() {
+	It("should extract version from releaseTag label (ACM 2.17+ with digest reference)", func() {
+		cis := &hivev1.ClusterImageSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "img4.20.4-x86-64-appsub",
+				Labels: map[string]string{"releaseTag": "4.20.4-x86_64"},
+			},
+			Spec: hivev1.ClusterImageSetSpec{
+				ReleaseImage: "quay.io/openshift-release-dev/ocp-release@sha256:5b87a665045cdfe0a1b271024be936a0c46de17b25a112d6a136c5af89d861c4",
+			},
+		}
+		Expect(extractVersionFromClusterImageSet(cis)).To(Equal("4.20.4"))
+	})
+
+	It("should fall back to tagged release image when releaseTag label is absent", func() {
+		cis := &hivev1.ClusterImageSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "img4.17.0-x86-64-appsub",
+			},
+			Spec: hivev1.ClusterImageSetSpec{
+				ReleaseImage: "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
+			},
+		}
+		Expect(extractVersionFromClusterImageSet(cis)).To(Equal("4.17.0"))
+	})
+
+	It("should return empty when neither releaseTag nor tagged image is available", func() {
+		cis := &hivev1.ClusterImageSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "img4.20.4-x86-64-appsub",
+			},
+			Spec: hivev1.ClusterImageSetSpec{
+				ReleaseImage: "quay.io/openshift-release-dev/ocp-release@sha256:5b87a665045cdfe0a1b271024be936a0c46de17b25a112d6a136c5af89d861c4",
+			},
+		}
+		Expect(extractVersionFromClusterImageSet(cis)).To(Equal(""))
+	})
+
+	It("should prefer releaseTag label over tagged release image", func() {
+		cis := &hivev1.ClusterImageSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "img4.20.4-x86-64-appsub",
+				Labels: map[string]string{"releaseTag": "4.20.5-x86_64"},
+			},
+			Spec: hivev1.ClusterImageSetSpec{
+				ReleaseImage: "quay.io/openshift-release-dev/ocp-release:4.20.4-x86_64",
+			},
+		}
+		Expect(extractVersionFromClusterImageSet(cis)).To(Equal("4.20.5"))
 	})
 })
 


### PR DESCRIPTION
ACM 2.17+ creates ClusterImageSets with digest references (@sha256:...) and a releaseTag label instead of tagged image references. The version extraction now checks the releaseTag label first, falling back to parsing the image tag for older ACM versions.