### PR TITLE
OCPBUGS-92057: fix non-deterministic node-to-host assignment in applyNodeConfiguration

### DIFF
--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -9,6 +9,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -21,6 +22,9 @@ import (
 func collectNodeDetails(nodeList *hwmgmtv1alpha1.AllocatedNodeList) (map[string][]ctlrutils.NodeInfo, error) {
 	// hwNodes maps a group name to a slice of NodeInfo
 	hwNodes := make(map[string][]ctlrutils.NodeInfo)
+	sort.Slice(nodeList.Items, func(i, j int) bool {
+		return nodeList.Items[i].Name < nodeList.Items[j].Name
+	})
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
 

--- a/internal/controllers/helpers_test.go
+++ b/internal/controllers/helpers_test.go
@@ -1,0 +1,138 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+)
+
+var _ = Describe("collectNodeDetails", func() {
+	It("sorts nodes by name for deterministic ordering", func() {
+		nodeList := &hwmgmtv1alpha1.AllocatedNodeList{
+			Items: []hwmgmtv1alpha1.AllocatedNode{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-z"},
+					Spec:       hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker"},
+					Status: hwmgmtv1alpha1.AllocatedNodeStatus{
+						BMC: &hwmgmtv1alpha1.BMC{Address: "10.0.0.3", CredentialsName: "secret-z"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+					Spec:       hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker"},
+					Status: hwmgmtv1alpha1.AllocatedNodeStatus{
+						BMC: &hwmgmtv1alpha1.BMC{Address: "10.0.0.1", CredentialsName: "secret-a"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-m"},
+					Spec:       hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker"},
+					Status: hwmgmtv1alpha1.AllocatedNodeStatus{
+						BMC: &hwmgmtv1alpha1.BMC{Address: "10.0.0.2", CredentialsName: "secret-m"},
+					},
+				},
+			},
+		}
+
+		hwNodes, err := collectNodeDetails(nodeList)
+		Expect(err).ToNot(HaveOccurred())
+
+		workers := hwNodes["worker"]
+		Expect(workers).To(HaveLen(3))
+		Expect(workers[0].NodeID).To(Equal("node-a"))
+		Expect(workers[1].NodeID).To(Equal("node-m"))
+		Expect(workers[2].NodeID).To(Equal("node-z"))
+	})
+
+	It("returns error when node has no BMC details", func() {
+		nodeList := &hwmgmtv1alpha1.AllocatedNodeList{
+			Items: []hwmgmtv1alpha1.AllocatedNode{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Spec:       hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker"},
+					Status:     hwmgmtv1alpha1.AllocatedNodeStatus{},
+				},
+			},
+		}
+
+		_, err := collectNodeDetails(nodeList)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("does not have BMC details"))
+	})
+
+	It("returns error when node has empty BMC credentials", func() {
+		nodeList := &hwmgmtv1alpha1.AllocatedNodeList{
+			Items: []hwmgmtv1alpha1.AllocatedNode{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Spec:       hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker"},
+					Status: hwmgmtv1alpha1.AllocatedNodeStatus{
+						BMC: &hwmgmtv1alpha1.BMC{Address: "10.0.0.1", CredentialsName: ""},
+					},
+				},
+			},
+		}
+
+		_, err := collectNodeDetails(nodeList)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("does not have BMC details"))
+	})
+
+	It("groups nodes by group name across multiple groups", func() {
+		nodeList := &hwmgmtv1alpha1.AllocatedNodeList{
+			Items: []hwmgmtv1alpha1.AllocatedNode{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "worker-2"},
+					Spec:       hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker"},
+					Status: hwmgmtv1alpha1.AllocatedNodeStatus{
+						BMC: &hwmgmtv1alpha1.BMC{Address: "10.0.0.2", CredentialsName: "secret-w2"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "master-1"},
+					Spec:       hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "controller"},
+					Status: hwmgmtv1alpha1.AllocatedNodeStatus{
+						BMC: &hwmgmtv1alpha1.BMC{Address: "10.0.0.3", CredentialsName: "secret-m1"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+					Spec:       hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker"},
+					Status: hwmgmtv1alpha1.AllocatedNodeStatus{
+						BMC: &hwmgmtv1alpha1.BMC{Address: "10.0.0.1", CredentialsName: "secret-w1"},
+					},
+				},
+			},
+		}
+
+		hwNodes, err := collectNodeDetails(nodeList)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(hwNodes).To(HaveLen(2))
+
+		workers := hwNodes["worker"]
+		Expect(workers).To(HaveLen(2))
+		Expect(workers[0].NodeID).To(Equal("worker-1"))
+		Expect(workers[1].NodeID).To(Equal("worker-2"))
+
+		controllers := hwNodes["controller"]
+		Expect(controllers).To(HaveLen(1))
+		Expect(controllers[0].NodeID).To(Equal("master-1"))
+	})
+
+	It("returns empty map for empty node list", func() {
+		nodeList := &hwmgmtv1alpha1.AllocatedNodeList{}
+
+		hwNodes, err := collectNodeDetails(nodeList)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hwNodes).To(BeEmpty())
+	})
+})

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -342,7 +342,7 @@ func (t *provisioningRequestReconcilerTask) applyClusterInstance(ctx context.Con
 			// Returning a conflict error will cause the reconciler to retry the operation.
 			return fmt.Errorf("conflict during server-side apply: %w", err)
 		}
-		if errors.IsInvalid(err) || errors.IsBadRequest(err) {
+		if errors.IsInvalid(err) || errors.IsBadRequest(err) || errors.IsForbidden(err) {
 			return typederrors.NewInputError("invalid ClusterInstance configuration: %w", err)
 		}
 		return fmt.Errorf("failed to apply ClusterInstance: %w", err)

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -437,6 +437,22 @@ func (t *provisioningRequestReconcilerTask) applyNodeConfiguration(
 		return fmt.Errorf("spec.nodes not found in cluster instance")
 	}
 
+	// Classify hardware nodes into two groups based on existing AllocatedNodeHostMap:
+	//   - assignedByHost: nodes with an existing host assignment (preserve on re-reconciliation)
+	//   - availableByGroup: nodes available for fresh assignment, ordered by the sorted
+	//     input from collectNodeDetails so initial assignment is deterministic
+	assignedByHost := make(map[string]ctlrutils.NodeInfo)
+	availableByGroup := make(map[string][]ctlrutils.NodeInfo)
+	for groupName, nodeInfos := range hwNodes {
+		for _, ni := range nodeInfos {
+			if hostName, ok := t.object.Status.Extensions.AllocatedNodeHostMap[ni.NodeID]; ok {
+				assignedByHost[groupName+"/"+hostName] = ni
+			} else {
+				availableByGroup[groupName] = append(availableByGroup[groupName], ni)
+			}
+		}
+	}
+
 	for i, n := range nodes {
 		nodeMap, ok := n.(map[string]interface{})
 		if !ok {
@@ -447,8 +463,24 @@ func (t *provisioningRequestReconcilerTask) applyNodeConfiguration(
 		hostName, _, _ := unstructured.NestedString(nodeMap, "hostName")
 		groupName := roleToNodeGroupName[role]
 
-		nodeInfos, exists := hwNodes[groupName]
-		if !exists || len(nodeInfos) == 0 {
+		var nodeInfo ctlrutils.NodeInfo
+		matched := false
+
+		// Resolve nodeInfo: prefer existing assignment, fall back to available nodes
+		if ni, ok := assignedByHost[groupName+"/"+hostName]; ok {
+			nodeInfo = ni
+			matched = true
+		}
+
+		if !matched {
+			if candidates := availableByGroup[groupName]; len(candidates) > 0 {
+				nodeInfo = candidates[0]
+				availableByGroup[groupName] = candidates[1:]
+				matched = true
+			}
+		}
+
+		if !matched {
 			unmatchedNodes[i] = hostName
 			continue
 		}
@@ -457,42 +489,39 @@ func (t *provisioningRequestReconcilerTask) applyNodeConfiguration(
 		updatedNode := maps.Clone(nodeMap)
 
 		// Set BMC info
-		updatedNode["bmcAddress"] = nodeInfos[0].BmcAddress
+		updatedNode["bmcAddress"] = nodeInfo.BmcAddress
 		updatedNode["bmcCredentialsName"] = map[string]interface{}{
-			"name": nodeInfos[0].BmcCredentials,
+			"name": nodeInfo.BmcCredentials,
 		}
 
-		if nodeInfos[0].HwMgrNodeId != "" && nodeInfos[0].HwMgrNodeNs != "" {
+		if nodeInfo.HwMgrNodeId != "" && nodeInfo.HwMgrNodeNs != "" {
 			hostRef, ok := updatedNode["hostRef"].(map[string]interface{})
 			if !ok {
 				hostRef = make(map[string]interface{})
 			}
-			hostRef["name"] = nodeInfos[0].HwMgrNodeId
-			hostRef["namespace"] = nodeInfos[0].HwMgrNodeNs
+			hostRef["name"] = nodeInfo.HwMgrNodeId
+			hostRef["namespace"] = nodeInfo.HwMgrNodeNs
 			updatedNode["hostRef"] = hostRef
 		}
 		// Boot MAC
-		bootMAC, err := ctlrutils.GetBootMacAddress(nodeInfos[0].Interfaces, constants.BootInterfaceLabel)
+		bootMAC, err := ctlrutils.GetBootMacAddress(nodeInfo.Interfaces, constants.BootInterfaceLabel)
 		if err != nil {
 			return fmt.Errorf("failed to get boot MAC for node '%s': %w", hostName, err)
 		}
 		updatedNode["bootMACAddress"] = bootMAC
 
 		// Assign MACs to interfaces
-		if err := ctlrutils.AssignMacAddress(t.clusterInput.clusterInstanceData, nodeInfos[0].Interfaces, updatedNode); err != nil {
+		if err := ctlrutils.AssignMacAddress(t.clusterInput.clusterInstanceData, nodeInfo.Interfaces, updatedNode); err != nil {
 			return fmt.Errorf("failed to assign MACs for node '%s': %w", hostName, err)
 		}
 
 		// Update AllocatedNodeHostMap
-		if err := t.updateAllocatedNodeHostMap(ctx, nodeInfos[0].NodeID, hostName); err != nil {
+		if err := t.updateAllocatedNodeHostMap(ctx, nodeInfo.NodeID, hostName); err != nil {
 			return fmt.Errorf("failed to update status for node '%s': %w", hostName, err)
 		}
 
 		// Update the node only after all mutations succeed
 		nodes[i] = updatedNode
-
-		// Consume the nodeInfo
-		hwNodes[groupName] = nodeInfos[1:]
 	}
 
 	// Final write back to clusterInstance

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -1587,6 +1587,19 @@ var _ = Describe("applyNodeConfiguration", func() {
 							},
 						},
 					},
+					map[string]interface{}{
+						"role":     "worker",
+						"hostName": "worker-02",
+						"nodeNetwork": map[string]interface{}{
+							"interfaces": []interface{}{
+								map[string]interface{}{
+									"name":       "eno1",
+									"label":      constants.BootInterfaceLabel,
+									"macAddress": "",
+								},
+							},
+						},
+					},
 				},
 			},
 		}
@@ -1670,6 +1683,20 @@ var _ = Describe("applyNodeConfiguration", func() {
 						},
 					},
 				},
+				{
+					BmcAddress:     "192.168.1.102",
+					BmcCredentials: "worker-02-bmc-secret",
+					NodeID:         "node-worker-02",
+					HwMgrNodeId:    "bmh-worker-02",
+					HwMgrNodeNs:    "hardware-ns",
+					Interfaces: []*hwmgmtv1alpha1.Interface{
+						{
+							Name:       "eno1",
+							MACAddress: "aa:bb:cc:dd:ee:22",
+							Label:      constants.BootInterfaceLabel,
+						},
+					},
+				},
 			},
 		}
 
@@ -1747,13 +1774,26 @@ var _ = Describe("applyNodeConfiguration", func() {
 								},
 							},
 						},
+						map[string]any{
+							"hostName": "worker-02",
+							"role":     "worker",
+							"nodeNetwork": map[string]any{
+								"interfaces": []any{
+									map[string]any{
+										"name":       "eno1",
+										"label":      constants.BootInterfaceLabel,
+										"macAddress": "",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
 		}
 	})
 
-	It("successfully applies node configuration", func() {
+	It("successfully applies node configuration for fresh assignment", func() {
 		err := task.applyNodeConfiguration(ctx, hwNodes, nar, ci)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -1761,7 +1801,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 		nodes, found, err := unstructured.NestedSlice(ci.Object, "spec", "nodes")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(found).To(BeTrue())
-		Expect(nodes).To(HaveLen(2))
+		Expect(nodes).To(HaveLen(3))
 
 		// Check master node
 		masterNode := nodes[0].(map[string]interface{})
@@ -1782,14 +1822,14 @@ var _ = Describe("applyNodeConfiguration", func() {
 		Expect(found).To(BeTrue())
 		Expect(hostRefNs).To(Equal("hardware-ns"))
 
-		// Check worker node
-		workerNode := nodes[1].(map[string]interface{})
-		Expect(workerNode["bmcAddress"]).To(Equal("192.168.1.101"))
-		bmcCreds, found, err = unstructured.NestedString(workerNode, "bmcCredentialsName", "name")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(found).To(BeTrue())
-		Expect(bmcCreds).To(Equal("worker-01-bmc-secret"))
-		Expect(workerNode["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:11"))
+		// Check worker nodes — both should get different BMC addresses from the worker group
+		workerNode1 := nodes[1].(map[string]interface{})
+		Expect(workerNode1["bmcAddress"]).To(Equal("192.168.1.101"))
+		Expect(workerNode1["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:11"))
+
+		workerNode2 := nodes[2].(map[string]interface{})
+		Expect(workerNode2["bmcAddress"]).To(Equal("192.168.1.102"))
+		Expect(workerNode2["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:22"))
 	})
 
 	It("returns error when spec.nodes not found in cluster instance", func() {
@@ -1869,6 +1909,20 @@ var _ = Describe("applyNodeConfiguration", func() {
 						},
 					},
 				},
+				{
+					BmcAddress:     "192.168.1.102",
+					BmcCredentials: "worker-02-bmc-secret",
+					NodeID:         "node-worker-02",
+					HwMgrNodeId:    "", // empty
+					HwMgrNodeNs:    "", // empty
+					Interfaces: []*hwmgmtv1alpha1.Interface{
+						{
+							Name:       "eno1",
+							MACAddress: "aa:bb:cc:dd:ee:22",
+							Label:      constants.BootInterfaceLabel,
+						},
+					},
+				},
 			},
 		}
 
@@ -1879,7 +1933,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 		nodes, found, err := unstructured.NestedSlice(ci.Object, "spec", "nodes")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(found).To(BeTrue())
-		Expect(nodes).To(HaveLen(2))
+		Expect(nodes).To(HaveLen(3))
 
 		masterNode := nodes[0].(map[string]interface{})
 		Expect(masterNode["bmcAddress"]).To(Equal("192.168.1.100"))
@@ -1889,7 +1943,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 		Expect(found).To(BeFalse())
 	})
 
-	It("correctly consumes hardware nodes as they are assigned", func() {
+	It("assigns distinct hardware nodes to multiple nodes of the same role", func() {
 		// Create multiple nodes of the same role to verify consumption
 		ci.Object = map[string]interface{}{
 			"spec": map[string]interface{}{
@@ -1940,14 +1994,10 @@ var _ = Describe("applyNodeConfiguration", func() {
 			},
 		})
 
-		initialControllerCount := len(hwNodes["controller"])
-		Expect(initialControllerCount).To(Equal(2))
+		Expect(hwNodes["controller"]).To(HaveLen(2))
 
 		err := task.applyNodeConfiguration(ctx, hwNodes, nar, ci)
 		Expect(err).ToNot(HaveOccurred())
-
-		// Verify that all controller nodes have been consumed
-		Expect(len(hwNodes["controller"])).To(Equal(0))
 
 		// Verify both nodes were configured with different BMC addresses
 		nodes, found, err := unstructured.NestedSlice(ci.Object, "spec", "nodes")
@@ -1958,10 +2008,89 @@ var _ = Describe("applyNodeConfiguration", func() {
 		masterNode1 := nodes[0].(map[string]interface{})
 		masterNode2 := nodes[1].(map[string]interface{})
 
-		// First node should get first hardware node
+		// Both nodes should get different BMC addresses from the available pool
 		Expect(masterNode1["bmcAddress"]).To(Equal("192.168.1.100"))
-		// Second node should get second hardware node
 		Expect(masterNode2["bmcAddress"]).To(Equal("192.168.1.102"))
+	})
+
+	It("preserves existing AllocatedNodeHostMap assignments on re-reconciliation", func() {
+		// Pre-populate AllocatedNodeHostMap with reverse ordering for workers:
+		// node-worker-02 → worker-01, node-worker-01 → worker-02
+		// This is opposite to what fresh assignment would produce.
+		cr.Status.Extensions.AllocatedNodeHostMap = map[string]string{
+			"node-master-01": "master-01",
+			"node-worker-02": "worker-01",
+			"node-worker-01": "worker-02",
+		}
+
+		err := task.applyNodeConfiguration(ctx, hwNodes, nar, ci)
+		Expect(err).ToNot(HaveOccurred())
+
+		nodes, found, err := unstructured.NestedSlice(ci.Object, "spec", "nodes")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(nodes).To(HaveLen(3))
+
+		// master-01 should keep its original mapping
+		masterNode := nodes[0].(map[string]interface{})
+		Expect(masterNode["bmcAddress"]).To(Equal("192.168.1.100"))
+
+		// worker-01 should get node-worker-02's BMC (from existing mapping)
+		worker01 := nodes[1].(map[string]interface{})
+		Expect(worker01["bmcAddress"]).To(Equal("192.168.1.102"))
+		Expect(worker01["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:22"))
+
+		// worker-02 should get node-worker-01's BMC (from existing mapping)
+		worker02 := nodes[2].(map[string]interface{})
+		Expect(worker02["bmcAddress"]).To(Equal("192.168.1.101"))
+		Expect(worker02["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:11"))
+	})
+
+	It("uses assigned map for existing host and available map for new host", func() {
+		// Replace node-worker-02 with a new node (node-worker-03).
+		// worker-01 has an existing mapping to node-worker-01,
+		// worker-02 should get the new available node.
+		hwNodes["worker"] = []utils.NodeInfo{
+			hwNodes["worker"][0], // keep node-worker-01
+			{
+				BmcAddress:     "192.168.1.103",
+				BmcCredentials: "worker-03-bmc-secret",
+				NodeID:         "node-worker-03",
+				HwMgrNodeId:    "bmh-worker-03",
+				HwMgrNodeNs:    "hardware-ns",
+				Interfaces: []*hwmgmtv1alpha1.Interface{
+					{Name: "eno1", MACAddress: "aa:bb:cc:dd:ee:33", Label: constants.BootInterfaceLabel},
+				},
+			},
+		}
+
+		// master-01 and worker-01 have existing mappings; worker-02's old node was replaced
+		cr.Status.Extensions.AllocatedNodeHostMap = map[string]string{
+			"node-master-01": "master-01",
+			"node-worker-01": "worker-01",
+		}
+
+		err := task.applyNodeConfiguration(ctx, hwNodes, nar, ci)
+		Expect(err).ToNot(HaveOccurred())
+
+		nodes, found, err := unstructured.NestedSlice(ci.Object, "spec", "nodes")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(nodes).To(HaveLen(3))
+
+		// master-01 should keep its original mapping
+		masterNode := nodes[0].(map[string]interface{})
+		Expect(masterNode["bmcAddress"]).To(Equal("192.168.1.100"))
+
+		// worker-01 should keep node-worker-01's BMC from the assigned map
+		worker01 := nodes[1].(map[string]interface{})
+		Expect(worker01["bmcAddress"]).To(Equal("192.168.1.101"))
+		Expect(worker01["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:11"))
+
+		// worker-02 should get the new node-worker-03 from the available map
+		worker02 := nodes[2].(map[string]interface{})
+		Expect(worker02["bmcAddress"]).To(Equal("192.168.1.103"))
+		Expect(worker02["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:33"))
 	})
 })
 


### PR DESCRIPTION
## Summary

- Fix intermittent SiteConfig webhook rejection (`unauthorized change to bmcAddress/bootMACAddress`) on re-reconciliation of MNO clusters with 2+ nodes in the same hardware group. The issue is caused by non-deterministic Kubernetes List ordering in `collectNodeDetails`, which shuffles BMC-to-host assignments across reconciliations.
- Sort AllocatedNode list by name before building per-group slices for deterministic initial assignment
- Preserve existing `AllocatedNodeHostMap` assignments in `applyNodeConfiguration` on re-reconciliation, falling back to fresh assignment only for unmapped nodes
- Add `errors.IsForbidden` to `applyClusterInstance` error classification so admission webhook denials are properly classified as `InputError`

## Test plan

- [x] Unit tests for `collectNodeDetails` sorting (helpers_test.go)
- [x] Unit tests for `applyNodeConfiguration` — fresh assignment, preserved assignment on re-reconciliation, mixed assigned+available nodes
- [x] `make test`, `make golangci-lint`, and `make test-envtest` pass
- [x] Verified on STD cluster with 3 masters + 2 workers — switching ClusterTemplate no longer triggers webhook rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)