### PR TITLE
CNF-23722: Add Prometheus metrics and alerts for authentication failures

### DIFF
--- a/.coverage-thresholds.yaml
+++ b/.coverage-thresholds.yaml
@@ -30,6 +30,7 @@ packages:
   internal/service/common/api/middleware: 31
   internal/service/common/async: 48
   internal/service/common/auth: 29
+  internal/service/common/metrics: 75
   internal/service/common/db: 1
   internal/service/common/notifier: 71
   internal/service/common/utils: 12

--- a/bundle/manifests/oran-o2ims-alarms-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/oran-o2ims-alarms-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -4,21 +4,18 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: oran-o2ims
-    app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/part-of: oran-o2ims
-    control-plane: controller-manager
-  name: oran-o2ims-controller-manager-metrics-monitor
+  name: oran-o2ims-alarms-server-metrics-monitor
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     path: /metrics
-    port: https
+    port: api
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: oran-o2ims-controller-manager-metrics-service.oran-o2ims.svc
+      serverName: alarms-server.oran-o2ims.svc
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: alarms-server

--- a/bundle/manifests/oran-o2ims-artifacts-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/oran-o2ims-artifacts-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -4,11 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: oran-o2ims
-    app.kubernetes.io/instance: o2ims-services-metrics-monitor
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/part-of: oran-o2ims
-  name: oran-o2ims-o2ims-services-metrics-monitor
+  name: oran-o2ims-artifacts-server-metrics-monitor
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -16,7 +14,8 @@ spec:
     port: api
     scheme: https
     tlsConfig:
-      insecureSkipVerify: true
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: artifacts-server.oran-o2ims.svc
   selector:
     matchLabels:
-      oran-o2ims/metrics: "true"
+      app: artifacts-server

--- a/bundle/manifests/oran-o2ims-cluster-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/oran-o2ims-cluster-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -4,21 +4,18 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: oran-o2ims
-    app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/part-of: oran-o2ims
-    control-plane: controller-manager
-  name: oran-o2ims-controller-manager-metrics-monitor
+  name: oran-o2ims-cluster-server-metrics-monitor
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     path: /metrics
-    port: https
+    port: api
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: oran-o2ims-controller-manager-metrics-service.oran-o2ims.svc
+      serverName: cluster-server.oran-o2ims.svc
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: cluster-server

--- a/bundle/manifests/oran-o2ims-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/oran-o2ims-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/part-of: oran-o2ims
+    control-plane: controller-manager
+  name: oran-o2ims-controller-manager-metrics-monitor
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/bundle/manifests/oran-o2ims-o2ims-auth-alerts_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/oran-o2ims-o2ims-auth-alerts_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -1,0 +1,41 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/instance: o2ims-auth-alerts
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: prometheusrule
+    app.kubernetes.io/part-of: oran-o2ims
+  name: oran-o2ims-o2ims-auth-alerts
+spec:
+  groups:
+  - name: o2ims-auth
+    rules:
+    - alert: O2IMSHighAuthFailureRate
+      annotations:
+        description: 'Service {{ $labels.service }} is experiencing more than 10 {{
+          $labels.type }} failures per minute over the last 5 minutes. Current rate:
+          {{ $value | humanize }}/s.'
+        runbook_url: https://github.com/openshift-kni/oran-o2ims/blob/main/docs/dev/prometheus-metrics.md#alert-rules-prometheusrule
+        summary: High authentication failure rate on {{ $labels.service }}
+      expr: |
+        sum(rate(o2ims_auth_failures_total[5m])) by (service, type) > 0.1667
+      for: 5m
+      labels:
+        namespace: oran-o2ims
+        severity: warning
+    - alert: O2IMSCertificateBindingFailure
+      annotations:
+        description: Service {{ $labels.service }} rejected a request due to RFC 8705
+          certificate-bound token verification failure (method={{ $labels.method }},
+          path={{ $labels.path }}). This may indicate a stolen token replay attempt.
+        runbook_url: https://github.com/openshift-kni/oran-o2ims/blob/main/docs/dev/prometheus-metrics.md#alert-rules-prometheusrule
+        summary: Certificate binding failure on {{ $labels.service }}
+      expr: |
+        increase(o2ims_auth_failures_total{type="certificate_binding"}[10m]) > 0
+      for: 1m
+      labels:
+        namespace: oran-o2ims
+        severity: critical

--- a/bundle/manifests/oran-o2ims-o2ims-services-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/oran-o2ims-o2ims-services-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/instance: o2ims-services-metrics-monitor
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/part-of: oran-o2ims
+  name: oran-o2ims-o2ims-services-metrics-monitor
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: api
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      oran-o2ims/metrics: "true"

--- a/bundle/manifests/oran-o2ims-prometheus-metrics-reader_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/oran-o2ims-prometheus-metrics-reader_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: oran-o2ims-prometheus-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oran-o2ims-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/bundle/manifests/oran-o2ims-provisioning-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/oran-o2ims-provisioning-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -4,21 +4,18 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: oran-o2ims
-    app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/part-of: oran-o2ims
-    control-plane: controller-manager
-  name: oran-o2ims-controller-manager-metrics-monitor
+  name: oran-o2ims-provisioning-server-metrics-monitor
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     path: /metrics
-    port: https
+    port: api
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: oran-o2ims-controller-manager-metrics-service.oran-o2ims.svc
+      serverName: provisioning-server.oran-o2ims.svc
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: provisioning-server

--- a/bundle/manifests/oran-o2ims-resource-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/oran-o2ims-resource-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -4,21 +4,18 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: oran-o2ims
-    app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/part-of: oran-o2ims
-    control-plane: controller-manager
-  name: oran-o2ims-controller-manager-metrics-monitor
+  name: oran-o2ims-resource-server-metrics-monitor
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     path: /metrics
-    port: https
+    port: api
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: oran-o2ims-controller-manager-metrics-service.oran-o2ims.svc
+      serverName: resource-server.oran-o2ims.svc
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: resource-server

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -905,6 +905,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.21.0 <4.23.0'
+    operatorframework.io/cluster-monitoring: "true"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.openshift.io/tech-preview: "true"
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
@@ -1961,6 +1962,18 @@ spec:
           - monitoring.coreos.com
           resources:
           - prometheusrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
           verbs:
           - get
           - list

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -905,7 +905,6 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.21.0 <4.23.0'
-    operatorframework.io/cluster-monitoring: "true"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.openshift.io/tech-preview: "true"
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1961,17 +1961,6 @@ spec:
           - monitoring.coreos.com
           resources:
           - prometheusrules
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
           - servicemonitors
           verbs:
           - get

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -23,7 +23,7 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/created-by: oran-o2ims
     app.kubernetes.io/part-of: oran-o2ims
     app.kubernetes.io/managed-by: kustomize
+    openshift.io/cluster-monitoring: "true"
   name: system
 ---
 apiVersion: apps/v1

--- a/config/prometheus/auth-alerts.yaml
+++ b/config/prometheus/auth-alerts.yaml
@@ -1,0 +1,46 @@
+# PrometheusRule for O2IMS authentication/authorization failure alerts
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheusrule
+    app.kubernetes.io/instance: o2ims-auth-alerts
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/part-of: oran-o2ims
+    app.kubernetes.io/managed-by: kustomize
+  name: o2ims-auth-alerts
+  namespace: system
+spec:
+  groups:
+    - name: o2ims-auth
+      rules:
+        - alert: O2IMSHighAuthFailureRate
+          expr: |
+            sum(rate(o2ims_auth_failures_total[5m])) by (service, type) > 0.1667
+          for: 5m
+          labels:
+            severity: warning
+            namespace: oran-o2ims
+          annotations:
+            summary: "High authentication failure rate on {{ $labels.service }}"
+            description: >-
+              Service {{ $labels.service }} is experiencing more than 10
+              {{ $labels.type }} failures per minute over the last 5 minutes.
+              Current rate: {{ $value | humanize }}/s.
+            runbook_url: https://github.com/openshift-kni/oran-o2ims/blob/main/docs/dev/prometheus-metrics.md#alert-rules-prometheusrule
+        - alert: O2IMSCertificateBindingFailure
+          expr: |
+            increase(o2ims_auth_failures_total{type="certificate_binding"}[10m]) > 0
+          for: 1m
+          labels:
+            severity: critical
+            namespace: oran-o2ims
+          annotations:
+            summary: "Certificate binding failure on {{ $labels.service }}"
+            description: >-
+              Service {{ $labels.service }} rejected a request due to RFC 8705
+              certificate-bound token verification failure
+              (method={{ $labels.method }}, path={{ $labels.path }}).
+              This may indicate a stolen token replay attempt.
+            runbook_url: https://github.com/openshift-kni/oran-o2ims/blob/main/docs/dev/prometheus-metrics.md#alert-rules-prometheusrule

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
 - monitor.yaml
 - services-monitor.yaml
+- auth-alerts.yaml

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - monitor.yaml
+- services-monitor.yaml

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -19,7 +19,8 @@ spec:
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
-        insecureSkipVerify: true
+        serverName: oran-o2ims-controller-manager-metrics-service.oran-o2ims.svc
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/config/prometheus/services-monitor.yaml
+++ b/config/prometheus/services-monitor.yaml
@@ -1,0 +1,24 @@
+# Prometheus Monitor for O2IMS service pods (alarms, cluster, resource, provisioning, artifacts)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/instance: o2ims-services-metrics-monitor
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/part-of: oran-o2ims
+    app.kubernetes.io/managed-by: kustomize
+  name: o2ims-services-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: api
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      oran-o2ims/metrics: "true"

--- a/config/prometheus/services-monitor.yaml
+++ b/config/prometheus/services-monitor.yaml
@@ -1,15 +1,16 @@
-# Prometheus Monitor for O2IMS service pods (alarms, cluster, resource, provisioning, artifacts)
+# Per-service Prometheus ServiceMonitors for O2IMS API pods.
+# Each service gets its own monitor so that tlsConfig.serverName matches
+# the serving certificate SAN (<service-name>.<namespace>.svc).
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/name: servicemonitor
-    app.kubernetes.io/instance: o2ims-services-metrics-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: oran-o2ims
     app.kubernetes.io/part-of: oran-o2ims
     app.kubernetes.io/managed-by: kustomize
-  name: o2ims-services-metrics-monitor
+  name: alarms-server-metrics-monitor
   namespace: system
 spec:
   endpoints:
@@ -18,7 +19,100 @@ spec:
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
-        insecureSkipVerify: true
+        serverName: alarms-server.oran-o2ims.svc
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
   selector:
     matchLabels:
-      oran-o2ims/metrics: "true"
+      app: alarms-server
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/part-of: oran-o2ims
+    app.kubernetes.io/managed-by: kustomize
+  name: artifacts-server-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: api
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        serverName: artifacts-server.oran-o2ims.svc
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+  selector:
+    matchLabels:
+      app: artifacts-server
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/part-of: oran-o2ims
+    app.kubernetes.io/managed-by: kustomize
+  name: cluster-server-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: api
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        serverName: cluster-server.oran-o2ims.svc
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+  selector:
+    matchLabels:
+      app: cluster-server
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/part-of: oran-o2ims
+    app.kubernetes.io/managed-by: kustomize
+  name: provisioning-server-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: api
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        serverName: provisioning-server.oran-o2ims.svc
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+  selector:
+    matchLabels:
+      app: provisioning-server
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/part-of: oran-o2ims
+    app.kubernetes.io/managed-by: kustomize
+  name: resource-server-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: api
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        serverName: resource-server.oran-o2ims.svc
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+  selector:
+    matchLabels:
+      app: resource-server

--- a/config/rbac/clusterrolebindings_services.yaml
+++ b/config/rbac/clusterrolebindings_services.yaml
@@ -171,6 +171,20 @@ subjects:
   name: alertmanager-client
   namespace: system
 ---
+# Prometheus binding — allows platform Prometheus to scrape /metrics on service pods
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
 # Alertmanager binding — allows ACM alertmanager to send alerts to the alarms server
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -267,6 +267,18 @@ rules:
   resources:
   - prometheusrules
   verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
   - get
   - list
   - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -266,17 +266,6 @@ rules:
   - monitoring.coreos.com
   resources:
   - prometheusrules
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
   - servicemonitors
   verbs:
   - get

--- a/docs/dev/prometheus-metrics.md
+++ b/docs/dev/prometheus-metrics.md
@@ -1,0 +1,722 @@
+# Prometheus Metrics
+
+This document describes how Prometheus metrics are configured and collected
+for the O-Cloud Manager operator **and** its O2IMS service pods.
+
+## Table of Contents
+
+- [Architecture](#architecture)
+- [Configuration Files](#configuration-files)
+- [TLS, Authentication and Authorization](#tls-authentication-and-authorization)
+  - [Audience-scoped token exemption for /metrics](#audience-scoped-token-exemption-for-metrics)
+- [Network Policies](#network-policies)
+- [RBAC](#rbac)
+- [Operator Metrics (controller-manager)](#operator-metrics-controller-manager)
+- [Service Pod Metrics (O2IMS API Servers)](#service-pod-metrics-o2ims-api-servers)
+- [Alert Rules (PrometheusRule)](#alert-rules-prometheusrule)
+- [End-to-End Verification](#end-to-end-verification)
+- [Adding New Metrics](#adding-new-metrics)
+
+## Architecture
+
+The O-Cloud Manager exposes Prometheus metrics at two layers:
+
+1. **Operator layer** — The `controller-manager` pod uses controller-runtime's
+   built-in metrics server on port 6443, serving reconciliation and workqueue
+   metrics.
+2. **Service layer** — Each O2IMS API service pod (`alarms-server`,
+   `cluster-server`, `provisioning-server`, `resource-server`,
+   `artifacts-server`) exposes application-level metrics on its existing TLS
+   port 8443 at `/metrics`.
+
+Both layers are scraped by the OpenShift platform Prometheus via dedicated
+`ServiceMonitor` resources.
+
+```mermaid
+flowchart LR
+    subgraph oran_ns [oran-o2ims namespace]
+        CM[controller-manager :6443 /metrics]
+        RS[resource-server :8443 /metrics]
+        CS[cluster-server :8443 /metrics]
+        AS[alarms-server :8443 /metrics]
+        PS[provisioning-server :8443 /metrics]
+        ARS[artifacts-server :8443 /metrics]
+        SM1[ServiceMonitor operator]
+        SM2[ServiceMonitors per-service]
+    end
+
+    subgraph monitoring [openshift-monitoring]
+        Prom[Prometheus]
+    end
+
+    Prom -->|scrapes| SM1
+    Prom -->|scrapes| SM2
+    SM1 --> CM
+    SM2 --> RS
+    SM2 --> CS
+    SM2 --> AS
+    SM2 --> PS
+    SM2 --> ARS
+```
+
+For the platform Prometheus instance (in `openshift-monitoring`) to discover
+ServiceMonitors in the operator namespace, the namespace must carry the label
+`openshift.io/cluster-monitoring: "true"`. The Inventory controller ensures
+this label is present on the operator namespace at every reconciliation cycle.
+
+## Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `config/prometheus/monitor.yaml` | ServiceMonitor for the operator (controller-manager) |
+| `config/prometheus/services-monitor.yaml` | Per-service ServiceMonitors for O2IMS API service pods |
+| `config/prometheus/auth-alerts.yaml` | PrometheusRule with authentication failure alerts |
+| `config/prometheus/kustomization.yaml` | Kustomize resource list for the prometheus overlay |
+| `config/rbac/metrics_service.yaml` | Service exposing port 8443 with OCP serving-cert annotation |
+| `config/rbac/metrics_service_clusterrole.yaml` | ClusterRole granting GET on `/metrics` non-resource URL |
+| `config/rbac/clusterrolebindings_services.yaml` | ClusterRoleBinding for Prometheus SA to `metrics-reader` |
+| `config/default/kustomization.yaml` | Includes `../prometheus` to deploy both ServiceMonitors and PrometheusRule |
+
+---
+
+## TLS, Authentication and Authorization
+
+The service pod `/metrics` endpoints are served over TLS on the same port
+(8443) as the API endpoints. They inherit the cluster-wide TLS security
+profile from
+`apiservers.config.openshift.io/cluster`, ensuring cipher suites and minimum
+TLS version comply with the cluster administrator's policy.
+
+### How TLS is applied to metrics
+
+The `/metrics` handler shares the HTTP server's `tls.Config`, which is
+configured at startup via `GetServerTLSConfig()`. This means:
+
+- The serving certificate is auto-provisioned by the OpenShift `service-ca`
+  controller (via the `service.beta.openshift.io/serving-cert-secret-name`
+  annotation on the Service).
+- The certificate SAN matches `<service-name>.<namespace>.svc`.
+- The TLS minimum version and cipher suites are dynamically inherited from
+  the cluster's API Server TLS profile (propagated as environment variables
+  `TLS_PROFILE_MIN_VERSION` and `TLS_PROFILE_CIPHERS`).
+- Certificate rotation is handled transparently via dynamic cert loading
+  (no pod restart needed).
+
+### Prometheus TLS verification
+
+The ServiceMonitor `tlsConfig` instructs Prometheus to verify the server
+certificate against the service-ca CA bundle:
+
+```yaml
+tlsConfig:
+  serverName: <service-name>.oran-o2ims.svc
+  caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+```
+
+This ensures Prometheus verifies the server's identity during the TLS
+handshake (preventing man-in-the-middle attacks), complementing the
+authentication and authorization that the server performs at the application
+level.
+
+| Layer | Purpose | Who verifies whom | Mechanism |
+|-------|---------|-------------------|-----------|
+| TLS | Server identity | Prometheus verifies the server | Certificate chain + SAN verification via `caFile` and `serverName` |
+| Authentication | Caller identity | Server verifies Prometheus | Bearer token → TokenReview (validates token, returns user/groups) |
+| Authorization | Access control | Server checks permissions | SubjectAccessReview (checks RBAC: is this user allowed GET `/metrics`?) |
+
+```mermaid
+sequenceDiagram
+    participant Prom as Prometheus
+    participant TLS as TLS Handshake
+    participant Authn as Authenticator middleware
+    participant Authz as Authorizer middleware
+    participant Handler as promhttp.Handler
+    participant API as kube-apiserver
+
+    Prom->>TLS: ClientHello + verify server cert
+    TLS-->>Prom: Server identity confirmed
+
+    Prom->>Authn: GET /metrics + Authorization: Bearer eyJ...
+    Authn->>API: TokenReview
+    API-->>Authn: user=prometheus-k8s, groups=[...]
+    Authn->>Authz: request + user context
+
+    Authz->>API: SubjectAccessReview {user, verb=get, path=/metrics}
+    API-->>Authz: allowed=true
+    Authz->>Handler: next.ServeHTTP()
+    Handler-->>Prom: 200 OK + metrics payload
+```
+
+> **Note — middleware chain and parameter validation:** The complete
+> middleware chain executes in this order:
+>
+> `LogDuration → authn → authz → ResponseFilter → OpenAPIValidation → handler`
+>
+> However, the oapi-codegen generated route wrappers validate and parse
+> typed path parameters (e.g., UUID format) **before** constructing this
+> middleware chain. This means only requests with valid UUID path
+> parameters (or collection endpoints with no path parameters) can reach
+> the `authn`/`authz` layers. The `NormalizePath` function replaces UUID
+> segments with `{id}` to keep metric cardinality bounded — non-UUID
+> values cannot reach the auth counter because they are rejected earlier
+> with 400 Bad Request by the generated parameter binding.
+
+### Audience-scoped token exemption for `/metrics`
+
+The API services configure audience-scoped TokenReview validation (e.g.,
+`--audience=resource-server`). This means the Kubernetes authenticator sends a
+TokenReview with `spec.audiences: ["resource-server"]`, and the API server only
+accepts tokens issued for that specific audience.
+
+The Prometheus ServiceAccount token (`prometheus-k8s`) is a standard projected
+SA token with the default `api` audience — it does **not** carry the
+service-specific audience. Without exemption, every Prometheus scrape would
+fail with 401 Unauthorized.
+
+The solution is to add `/metrics` to `AudienceExemptPaths`:
+
+```go
+config.AudienceExemptPaths = append(config.AudienceExemptPaths, metrics.MetricsPath)
+```
+
+When a request targets an exempt path, the Kubernetes authenticator sends the
+TokenReview **without** `spec.audiences`. The token is still validated
+(identity is confirmed) and RBAC is still enforced (SubjectAccessReview checks
+the `metrics-reader` ClusterRole), but the audience constraint is not applied.
+
+This is safe because:
+
+1. The Prometheus SA token is only mounted inside the `openshift-monitoring`
+   namespace (pod-level isolation).
+2. Network access is restricted by NetworkPolicy (only `openshift-monitoring`
+   can reach port 8443).
+3. RBAC limits the token to `GET /metrics` only (minimal privilege via
+   `metrics-reader` ClusterRole).
+4. The token is still validated by TokenReview (cannot be forged).
+
+### Verifying TLS compliance with the TLS scanner
+
+The [tls-scanner](https://github.com/openshift/tls-scanner) tool can validate
+that all metrics endpoints comply with the cluster's TLS policy. For detailed
+instructions on building, running, and interpreting the scanner results, see
+the [TLS Scanner](tls-configuration.md#tls-scanner) section of the TLS
+Configuration document.
+
+A quick scan of the `oran-o2ims` namespace confirms all service pods on port
+8443 (where `/metrics` is served) offer only compliant cipher suites, enforce
+the configured minimum TLS version, and support ML-KEM for post-quantum
+readiness.
+
+---
+
+## Network Policies
+
+The operator creates a `NetworkPolicy` for each server pod (CNF-24945) that
+restricts ingress to explicitly allowed sources. Since Prometheus runs in the
+`openshift-monitoring` namespace (outside the operator namespace), the
+NetworkPolicy must explicitly permit monitoring traffic; otherwise scraping
+will be blocked.
+
+### Ingress rules by server type
+
+| Server | Ingress allowed from |
+|--------|---------------------|
+| API servers (resource, cluster, alarms, artifacts, provisioning) | OpenShift ingress controller, OpenShift monitoring, same namespace |
+| Alarms server (additional) | ACM alertmanager (`open-cluster-management-observability`) |
+| Database (postgres) | Same namespace only |
+
+### How monitoring ingress is granted
+
+All servers with `ExternalIngress` scope include a rule that allows traffic
+from any namespace labeled `network.openshift.io/policy-group: monitoring`.
+In a standard OpenShift cluster, the `openshift-monitoring` namespace carries
+this label, enabling Prometheus to reach port 8443 on the service pods:
+
+```yaml
+- from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+  ports:
+    - protocol: TCP
+      port: 8443
+```
+
+The database (`postgres-server`) has `InternalOnly` scope and does **not**
+receive this rule since it does not expose a `/metrics` endpoint.
+
+### RBAC for metrics
+
+The **operator metrics** (controller-manager) are protected by controller-runtime's
+built-in authn/authz middleware, which validates bearer tokens against the
+kube-apiserver. The `metrics-reader` ClusterRole grants GET on the `/metrics`
+non-resource URL so that Prometheus's ServiceAccount token is authorized.
+
+The **service pod metrics** are protected by the same TokenReview +
+SubjectAccessReview middleware chain used for API endpoints. The `/metrics`
+handler is wrapped with the `Authenticator` and `Authorizer` middleware so
+the bearer token in each scrape request is validated against the
+kube-apiserver. The `metrics-reader` ClusterRole grants GET on the `/metrics`
+non-resource URL, and the `prometheus-metrics-reader` ClusterRoleBinding
+(in `config/rbac/clusterrolebindings_services.yaml`) binds the platform
+Prometheus ServiceAccount (`prometheus-k8s` in `openshift-monitoring`) to
+that role.
+
+In addition to application-level auth, the following layers provide
+defense-in-depth:
+
+1. **Network layer** — NetworkPolicy restricts which namespaces can reach
+   port 8443: `openshift-monitoring` (Prometheus scraping),
+   `openshift-ingress` (external API traffic via Routes), and
+   same-namespace pods (inter-service communication).
+2. **TLS transport** — The connection uses the service's serving certificate
+   (signed by the OpenShift service-ca). Prometheus validates the certificate
+   chain against the service-ca CA bundle and verifies the `serverName`
+   matches the service FQDN.
+
+---
+
+## RBAC
+
+The operator's ClusterRole includes permissions for `monitoring.coreos.com`
+resources:
+
+- `servicemonitors`: get, list, watch
+- `prometheusrules`: get, list, watch
+
+These are generated from `//+kubebuilder:rbac` markers and propagated via
+`make generate && make manifests && make bundle`.
+
+---
+
+## Operator Metrics (controller-manager)
+
+The controller-runtime framework automatically registers the following metrics
+(among others):
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `controller_runtime_reconcile_total` | Counter | Total reconciliations by controller and result |
+| `controller_runtime_reconcile_errors_total` | Counter | Total reconciliation errors |
+| `controller_runtime_reconcile_time_seconds` | Histogram | Reconciliation duration |
+| `workqueue_depth` | Gauge | Current depth of the work queue |
+| `workqueue_adds_total` | Counter | Total items added to the work queue |
+| `workqueue_queue_duration_seconds` | Histogram | Time items spend in the queue |
+
+Standard Go runtime metrics (`go_goroutines`, `go_memstats_*`, `process_*`)
+are also exposed.
+
+---
+
+## Service Pod Metrics (O2IMS API Servers)
+
+### Design
+
+The O2IMS service pods are plain `net/http` TLS servers (not controller-runtime
+processes). To expose Prometheus metrics without adding new ports or changing
+the deployment topology, we register `promhttp.Handler()` on each service's
+existing `http.ServeMux` at the `/metrics` path.
+
+Key design choices:
+
+- **Same port (8443)** — The `/metrics` endpoint shares the existing TLS port.
+  No new Service ports, container ports, or Deployment changes are needed.
+- **Auth-protected** — The `/metrics` handler is wrapped with the same
+  `Authenticator` and `Authorizer` middleware used for API endpoints.
+  Prometheus authenticates via its ServiceAccount bearer token, which is
+  authorized by the `metrics-reader` ClusterRole.
+- **Shared metrics package** — All metric definitions live in
+  `internal/service/common/metrics/metrics.go` to avoid duplication.
+- **Per-service ServiceMonitors** — Each API service gets its own
+  ServiceMonitor (in `config/prometheus/services-monitor.yaml`) so that
+  `tlsConfig.serverName` matches the serving certificate SAN. The database
+  (`postgres-server`) is excluded. The hardware manager uses the
+  controller-runtime metrics server pattern and is not selected by these
+  monitors.
+
+### Metrics Exposed
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `o2ims_auth_failures_total` | Counter | `service`, `type`, `method`, `path` | Authentication/authorization failures |
+
+Label values:
+
+- **`service`** — identifies the pod: `alarms-server`, `cluster-server`,
+  `provisioning-server`, `resource-server`, `artifacts-server`
+- **`type`** — failure category: `authentication` (HTTP 401),
+  `authorization` (HTTP 403), or `certificate_binding` (RFC 8705 mTLS
+  verification failure)
+- **`method`** — HTTP method: `GET`, `POST`, `PATCH`, `DELETE`
+- **`path`** — normalized request URL path. UUID segments are replaced by
+  `{id}` to keep metric cardinality bounded. Static path components
+  (collection names, API prefixes, versions) are preserved as-is.
+  Only requests with valid UUID path parameters or collection endpoints
+  (no path parameters) can reach the auth middleware — the oapi-codegen
+  generated wrappers reject non-UUID values with 400 before the
+  middleware chain runs. Examples:
+  - `/o2ims-infrastructureInventory/v2/resourcePools/{id}/resources/{id}`
+  - `/o2ims-infrastructureMonitoring/v1/alarms` (collection, no UUID)
+
+Example scrape output:
+
+```text
+o2ims_auth_failures_total{service="alarms-server",type="authentication",method="GET",path="/o2ims-infrastructureMonitoring/v1/alarms"} 12
+o2ims_auth_failures_total{service="cluster-server",type="authorization",method="POST",path="/o2ims-infrastructureCluster/v1/nodeClusters/{id}"} 3
+o2ims_auth_failures_total{service="resource-server",type="certificate_binding",method="GET",path="/o2ims-infrastructureInventory/v2/resourcePools/{id}"} 1
+o2ims_auth_failures_total{service="resource-server",type="authentication",method="GET",path="/o2ims-infrastructureInventory/v2/resourcePools"} 7
+```
+
+Standard Go runtime metrics and default process metrics are also served since
+they are automatically registered in the default Prometheus registry.
+
+### ServiceMonitors for Services
+
+Each API service has its own ServiceMonitor defined in
+`config/prometheus/services-monitor.yaml`. They share the same structure,
+differing only in the `selector` and `serverName`:
+
+```yaml
+spec:
+  endpoints:
+    - path: /metrics
+      port: api
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        serverName: <service-name>.oran-o2ims.svc
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+  selector:
+    matchLabels:
+      app: <service-name>
+```
+
+The `caFile` points to the OpenShift service-ca CA bundle already mounted in
+the platform Prometheus pod. The `serverName` matches the SAN in each
+service's serving certificate (provisioned by the `service-ca` operator via
+the `service.beta.openshift.io/serving-cert-secret-name` annotation).
+
+Per-service monitors are required because a single ServiceMonitor can only
+specify one `serverName`, and each service has a distinct serving certificate.
+
+---
+
+## Alert Rules (PrometheusRule)
+
+A `PrometheusRule` resource (`config/prometheus/auth-alerts.yaml`) defines
+alerting rules for authentication failures. These are evaluated by the
+platform Prometheus and route through AlertManager.
+
+| Alert | Severity | Condition | Description |
+|-------|----------|-----------|-------------|
+| `O2IMSHighAuthFailureRate` | warning | `sum(rate(o2ims_auth_failures_total[5m])) by (service, type) > 0.1667` sustained for 5 min (>10/min) | A service is experiencing a high rate of authentication or authorization failures |
+| `O2IMSCertificateBindingFailure` | critical | Any `certificate_binding` failure in the last 10 min | RFC 8705 client certificate mismatch — potential stolen token replay |
+
+The `O2IMSCertificateBindingFailure` alert is critical because it may indicate
+a token theft: the bearer token is valid but the presenting client does not
+possess the private key corresponding to the certificate bound to the token.
+
+### Verifying alert rules
+
+After deployment, confirm the PrometheusRule is loaded:
+
+```bash
+oc get prometheusrule -n oran-o2ims
+```
+
+Check that Prometheus has loaded the rules:
+
+```bash
+oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+  curl -s http://localhost:9090/api/v1/rules | \
+  jq '.data.groups[] | select(.name=="o2ims-auth") | .rules[].name'
+```
+
+Expected output:
+
+```text
+"O2IMSHighAuthFailureRate"
+"O2IMSCertificateBindingFailure"
+```
+
+### Testing alert lifecycle (inactive → pending → firing)
+
+To fully exercise the `O2IMSHighAuthFailureRate` alert and observe its
+lifecycle transitions, generate sustained authentication failures above the
+threshold (>10/min) for longer than the `for: 5m` duration.
+
+#### Step 1: Start sustained load
+
+From the Prometheus pod, send unauthenticated requests at ~30/min (one every
+2 seconds). This exceeds the 10/min threshold:
+
+```bash
+oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+  sh -c 'for i in $(seq 1 200); do
+    wget -qO- \
+      --ca-certificate=/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt \
+      https://resource-server.oran-o2ims.svc:8443/o2ims-infrastructureInventory/v2/resourcePools 2>/dev/null
+    sleep 2
+  done'
+```
+
+This runs for ~400 seconds (~6.7 minutes), which is enough to trigger and
+sustain the alert.
+
+#### Step 2: Monitor the current rate
+
+After ~2 minutes, the 5-minute rolling rate should cross the 0.1667/s
+threshold:
+
+```bash
+oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+  curl -s --data-urlencode \
+    'query=sum by (service, type) (rate(o2ims_auth_failures_total[5m]))' \
+    http://localhost:9090/api/v1/query | \
+  jq '.data.result[] | {service: .metric.service, type: .metric.type, rate_per_sec: .value[1]}'
+```
+
+Expected output (rate > 0.1667):
+
+```json
+{
+  "service": "resource-server",
+  "type": "authentication",
+  "rate_per_sec": "0.29"
+}
+```
+
+#### Step 3: Observe state transitions
+
+Check the alert rule state via the rules API:
+
+```bash
+oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+  curl -s http://localhost:9090/api/v1/rules | \
+  jq '.data.groups[] | select(.name=="o2ims-auth") | .rules[] |
+      {name: .name, state: .state, alerts: [.alerts[] | {state, activeAt: .activeAt}]}'
+```
+
+Expected lifecycle (assuming no prior failures in the 5-minute rate window):
+
+| Time after load starts | Expected state | Explanation |
+|------------------------|---------------|-------------|
+| 0–2 min | `inactive` | Rate is still below threshold (building up in the 5m window) |
+| ~2 min | `pending` | Rate crosses 0.1667/s; the `for: 5m` timer starts |
+| ~7 min (2 + 5) | `firing` | Rate has been above threshold for 5 consecutive minutes |
+| ~5–7 min after load stops | `inactive` | The 5m rate window clears and drops below threshold |
+
+> **Note:** If prior test failures already exist in the 5-minute rate window
+> (e.g., from manual "Triggering test data" commands), the timeline
+> compresses — the alert may reach `pending` or even `firing` faster than
+> the table suggests.
+
+#### Step 4: Confirm the alert in the alerts API
+
+Once the alert is `firing`, verify it appears in the alerts endpoint (the same
+data that AlertManager receives):
+
+```bash
+oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+  curl -s http://localhost:9090/api/v1/alerts | \
+  jq '.data.alerts[] | select(.labels.alertname | startswith("O2IMS"))'
+```
+
+Expected output:
+
+```json
+{
+  "labels": {
+    "alertname": "O2IMSHighAuthFailureRate",
+    "namespace": "oran-o2ims",
+    "service": "resource-server",
+    "severity": "warning",
+    "type": "authentication"
+  },
+  "annotations": {
+    "description": "Service resource-server is experiencing more than 10 authentication failures per minute over the last 5 minutes. Current rate: 322.2m/s.",
+    "runbook_url": "https://github.com/openshift-kni/oran-o2ims/blob/main/docs/dev/prometheus-metrics.md#alert-rules-prometheusrule",
+    "summary": "High authentication failure rate on resource-server"
+  },
+  "state": "firing"
+}
+```
+
+#### Step 5: Verify alert resolves
+
+After the load generator finishes, the rate will decay as the 5-minute window
+advances past the period of failures. Once the rate drops below 0.1667/s, the
+alert returns to `inactive`. Confirm by re-running the rules query from Step 3
+after ~5–7 minutes of inactivity.
+
+---
+
+## End-to-End Verification
+
+Testing metrics on a live cluster is a **two-phase** process:
+
+1. **Phase 1: Target Discovery** — Verify Prometheus has discovered the
+   ServiceMonitor and the service endpoints appear as active targets.
+2. **Phase 2: Metric Scraping** — Confirm metrics are actually being collected
+   and queryable via PromQL.
+
+### Phase 1: Target Discovery
+
+#### Pre-requisite: Namespace monitoring label
+
+The platform Prometheus only watches namespaces with the
+`openshift.io/cluster-monitoring: "true"` label. The Inventory controller
+applies this label automatically. Confirm it is present:
+
+```bash
+oc get ns oran-o2ims --show-labels | grep cluster-monitoring
+```
+
+If the label is missing, ServiceMonitors in the namespace will **not** be
+discovered by Prometheus regardless of their configuration.
+
+#### Check ServiceMonitors are deployed
+
+```bash
+oc get servicemonitor -n oran-o2ims
+```
+
+Expected output:
+
+```text
+NAME                                           AGE
+oran-o2ims-alarms-server-metrics-monitor       ...
+oran-o2ims-artifacts-server-metrics-monitor    ...
+oran-o2ims-cluster-server-metrics-monitor      ...
+oran-o2ims-controller-manager-metrics-monitor  ...
+oran-o2ims-provisioning-server-metrics-monitor ...
+oran-o2ims-resource-server-metrics-monitor     ...
+```
+
+#### Verify Prometheus discovered the targets
+
+From the CLI, query the Prometheus targets API:
+
+```bash
+oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+  curl -s http://localhost:9090/api/v1/targets | \
+  jq '.data.activeTargets[] | select(.labels.namespace=="oran-o2ims") | {endpoint: .scrapeUrl, health: .health}'
+```
+
+You should see entries for the controller-manager (port 6443) and each API
+service pod (port 8443) with `"health": "up"`:
+
+```json
+{"endpoint": "https://10.x.x.x:6443/metrics", "health": "up"}
+{"endpoint": "https://10.x.x.x:8443/metrics", "health": "up"}
+{"endpoint": "https://10.x.x.x:8443/metrics", "health": "up"}
+...
+```
+
+Alternatively, in the OpenShift web console navigate to **Observe > Targets**
+and filter by namespace `oran-o2ims`. All targets should show status **Up**.
+
+> **Note:** After deploying a new ServiceMonitor, Prometheus may take 1–3
+> minutes to reload its configuration and discover the new targets. Target
+> discovery depends on the prometheus-operator watch cycle (which detects
+> the new ServiceMonitor) and Prometheus's configuration reload. If targets
+> don't appear immediately, wait and retry. You can check when the
+> configuration was last reloaded with:
+>
+> ```bash
+> oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+>   curl -s http://localhost:9090/api/v1/status/runtimeinfo | \
+>   jq '.data.lastConfigTime'
+> ```
+
+### Phase 2: Metric Scraping via PromQL
+
+Once targets are **Up**, metrics are being scraped. Verify with PromQL queries.
+
+> **Note:** Metrics only appear in PromQL results after at least one scrape
+> cycle has collected them. OpenShift's platform Prometheus uses a **30-second
+> global scrape interval** by default. If you trigger a counter increment and
+> query immediately, wait up to 30 seconds for the value to appear in query
+> results. You can verify the configured interval with:
+>
+> ```bash
+> oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+>   curl -s http://localhost:9090/api/v1/status/config | \
+>   jq -r '.data.yaml' | grep 'scrape_interval'
+> ```
+
+#### Via the CLI (from the Prometheus pod)
+
+```bash
+oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+  curl -s 'http://localhost:9090/api/v1/query?query=o2ims_auth_failures_total' | jq .
+```
+
+#### Via the OpenShift web console
+
+Open **Observe > Metrics** and run:
+
+```promql
+o2ims_auth_failures_total{namespace="oran-o2ims"}
+```
+
+To see failures broken down by service and type:
+
+```promql
+sum by (service, type) (o2ims_auth_failures_total{namespace="oran-o2ims"})
+```
+
+For operator metrics, use:
+
+```promql
+controller_runtime_reconcile_total{namespace="oran-o2ims"}
+```
+
+#### Triggering test data
+
+The `o2ims_auth_failures_total` counter only appears after at least one
+authentication or authorization failure has occurred. To trigger a test failure,
+send an unauthenticated request to a **registered** API route. The request path
+must match a route defined in the service's OpenAPI spec — otherwise the Go
+HTTP mux returns 404 directly without invoking the auth middleware, and no
+counter is incremented. The resource-server uses **v2** for its Inventory API
+paths; other services (alarms, cluster, provisioning, artifacts) use v1:
+
+```bash
+oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+  wget -qO- \
+  --ca-certificate=/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt \
+  https://resource-server.oran-o2ims.svc:8443/o2ims-infrastructureInventory/v2/resourcePools 2>&1 || true
+```
+
+Then re-query with PromQL — the counter should now appear with
+`type="authentication"`.
+
+#### Direct endpoint check (optional)
+
+You can also scrape a service directly from the Prometheus pod to verify the
+raw metrics output:
+
+```bash
+oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+  wget -qO- \
+  --ca-certificate=/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt \
+  --header="Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  https://resource-server.oran-o2ims.svc:8443/metrics
+```
+
+---
+
+## Adding New Metrics
+
+To add new application-specific metrics to the service pods:
+
+1. Define the metric in `internal/service/common/metrics/metrics.go` using the
+   `prometheus` client library (Counter, Gauge, Histogram, or Summary).
+2. Register it with `prometheus.MustRegister()` in the package `init()`.
+3. Increment/observe in the relevant code paths, using the `service` label to
+   identify which pod reported the metric.
+4. The metric is automatically served on the existing `/metrics` endpoint via
+   `promhttp.Handler()` (no additional registration needed).
+5. Optionally add a `PrometheusRule` in `config/prometheus/` to define alerts
+   based on the new metric.

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	github.com/openshift/hive/apis v0.0.0-20251117181851-acea5e9196a2
 	github.com/pashagolub/pgxmock/v4 v4.9.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.89.0
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/r3labs/diff/v3 v3.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -140,8 +142,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pquerna/cachecontrol v0.2.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494 // indirect

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -41,8 +41,10 @@ import (
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 )
 
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;update;patch
 //+kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;watch
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
@@ -648,6 +650,11 @@ func (t *reconcilerTask) run(ctx context.Context) (nextReconcile ctrl.Result, er
 			return
 		}
 	}
+
+	err = t.ensureNamespaceMonitoringLabel(ctx)
+	if err != nil {
+		ctlrutils.LogError(ctx, t.logger, "Failed to ensure namespace monitoring label; continuing reconciliation", err)
+	}
 	ctlrutils.LogPhaseComplete(ctx, t.logger, "infrastructure_setup", time.Since(phaseStartTime))
 
 	// Phase 2: Database setup
@@ -1051,6 +1058,21 @@ func (t *reconcilerTask) createNetworkPolicy(ctx context.Context, serverName str
 					{Protocol: &protocol, Port: &portVal},
 				},
 			},
+			{
+				// Allow from the OpenShift monitoring stack (Prometheus metrics scraping)
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"network.openshift.io/policy-group": "monitoring",
+							},
+						},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Protocol: &protocol, Port: &portVal},
+				},
+			},
 		}, ingressRules...)
 	}
 
@@ -1106,12 +1128,16 @@ func (t *reconcilerTask) createServiceAccount(ctx context.Context, resourceName 
 func (t *reconcilerTask) createService(ctx context.Context, resourceName string, port int32, targetPort string) error {
 	t.logger.DebugContext(ctx, "[createService]")
 	// Build the Service object.
+	labels := map[string]string{
+		"app": resourceName,
+	}
+	if resourceName != ctlrutils.InventoryDatabaseServerName && resourceName != ctlrutils.HardwareManagerServerName {
+		labels["oran-o2ims/metrics"] = "true"
+	}
 	serviceMeta := metav1.ObjectMeta{
 		Name:      resourceName,
 		Namespace: t.object.Namespace,
-		Labels: map[string]string{
-			"app": resourceName,
-		},
+		Labels:    labels,
 		Annotations: map[string]string{
 			"service.beta.openshift.io/serving-cert-secret-name": fmt.Sprintf("%s-tls", resourceName),
 		},
@@ -1386,6 +1412,35 @@ func (t *reconcilerTask) updateInventoryDeploymentStatus(ctx context.Context) er
 		return fmt.Errorf("failed to update inventory deployment CR status: %w", err)
 	}
 
+	return nil
+}
+
+// ensureNamespaceMonitoringLabel ensures the operator namespace has the
+// openshift.io/cluster-monitoring label so that the platform Prometheus
+// instance discovers ServiceMonitors in this namespace.
+func (t *reconcilerTask) ensureNamespaceMonitoringLabel(ctx context.Context) error {
+	ns := &corev1.Namespace{}
+	if err := t.client.Get(ctx, types.NamespacedName{Name: t.object.Namespace}, ns); err != nil {
+		return fmt.Errorf("failed to get namespace %s: %w", t.object.Namespace, err)
+	}
+
+	const monitoringLabel = "openshift.io/cluster-monitoring"
+	if ns.Labels[monitoringLabel] == "true" {
+		return nil
+	}
+
+	patch := client.MergeFrom(ns.DeepCopy())
+	if ns.Labels == nil {
+		ns.Labels = make(map[string]string)
+	}
+	ns.Labels[monitoringLabel] = "true"
+
+	if err := t.client.Patch(ctx, ns, patch); err != nil {
+		return fmt.Errorf("failed to label namespace %s with %s: %w", t.object.Namespace, monitoringLabel, err)
+	}
+
+	t.logger.InfoContext(ctx, "Labeled namespace for cluster monitoring",
+		slog.String("namespace", t.object.Namespace))
 	return nil
 }
 

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -44,7 +44,7 @@ import (
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;update;patch
 //+kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;watch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch
 //+kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -340,6 +340,19 @@ var _ = Describe("Inventory Controller", func() {
 					return false
 				}
 
+				hasMonitoringRule := func(np *networkingv1.NetworkPolicy) bool {
+					for _, rule := range np.Spec.Ingress {
+						for _, peer := range rule.From {
+							if peer.NamespaceSelector != nil && peer.PodSelector == nil {
+								if peer.NamespaceSelector.MatchLabels["network.openshift.io/policy-group"] == "monitoring" {
+									return true
+								}
+							}
+						}
+					}
+					return false
+				}
+
 				hasAlertmanagerRule := func(np *networkingv1.NetworkPolicy) bool {
 					for _, rule := range np.Spec.Ingress {
 						for _, peer := range rule.From {
@@ -356,7 +369,7 @@ var _ = Describe("Inventory Controller", func() {
 					return false
 				}
 
-				// API servers and hardware manager should allow ingress-controller traffic.
+				// API servers and hardware manager should allow ingress-controller and monitoring traffic.
 				for _, serverName := range []string{
 					ctlrutils.InventoryResourceServerName,
 					ctlrutils.InventoryClusterServerName,
@@ -373,6 +386,8 @@ var _ = Describe("Inventory Controller", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(hasIngressControllerRule(np)).To(BeTrue(),
 						"expected ingress-controller rule on %s NetworkPolicy", serverName)
+					Expect(hasMonitoringRule(np)).To(BeTrue(),
+						"expected monitoring rule on %s NetworkPolicy", serverName)
 					Expect(hasSameNamespaceRule(np)).To(BeTrue(),
 						"expected same-namespace rule on %s NetworkPolicy", serverName)
 				}
@@ -387,7 +402,7 @@ var _ = Describe("Inventory Controller", func() {
 				Expect(hasAlertmanagerRule(alarmNP)).To(BeTrue(),
 					"expected alertmanager ingress rule on alarm server NetworkPolicy")
 
-				// Database should NOT allow ingress-controller traffic but SHOULD allow same-namespace traffic.
+				// Database should NOT allow ingress-controller or monitoring traffic but SHOULD allow same-namespace traffic.
 				dbNP := &networkingv1.NetworkPolicy{}
 				err = reconciler.Client.Get(context.TODO(), types.NamespacedName{
 					Name:      ctlrutils.InventoryDatabaseServerName,
@@ -396,6 +411,8 @@ var _ = Describe("Inventory Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hasIngressControllerRule(dbNP)).To(BeFalse(),
 					"database NetworkPolicy should not allow ingress-controller traffic")
+				Expect(hasMonitoringRule(dbNP)).To(BeFalse(),
+					"database NetworkPolicy should not allow monitoring traffic")
 				Expect(hasSameNamespaceRule(dbNP)).To(BeTrue(),
 					"database NetworkPolicy should allow same-namespace traffic")
 			},

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -209,11 +209,10 @@ func HasApiEndpoints(serverName string) bool {
 		serverName == InventoryProvisioningServerName
 }
 
-// HasMetrics determines whether a server exposes a metrics endpoint that
-// requires TLS. Servers with API endpoints also serve metrics, but this
-// function identifies servers that serve metrics without API endpoints.
+// HasMetrics determines whether a server exposes a /metrics endpoint.
+// All API servers and the hardware manager server expose metrics.
 func HasMetrics(serverName string) bool {
-	return serverName == HardwareManagerServerName
+	return HasApiEndpoints(serverName) || serverName == HardwareManagerServerName
 }
 
 // NeedsServingCert determines whether a server needs a TLS serving

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -210,9 +210,10 @@ func HasApiEndpoints(serverName string) bool {
 }
 
 // HasMetrics determines whether a server exposes a /metrics endpoint.
-// All API servers and the hardware manager server expose metrics.
+// All API servers except the database and the hardware manager server expose metrics.
 func HasMetrics(serverName string) bool {
-	return HasApiEndpoints(serverName) || serverName == HardwareManagerServerName
+	return (HasApiEndpoints(serverName) && serverName != InventoryDatabaseServerName) ||
+		serverName == HardwareManagerServerName
 }
 
 // NeedsServingCert determines whether a server needs a TLS serving

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -1586,10 +1586,17 @@ var _ = Describe("Server predicate functions", func() {
 			}
 		})
 
-		It("returns true for API servers", func() {
+		It("returns true for API servers that expose metrics", func() {
 			for _, name := range apiServers {
+				if name == InventoryDatabaseServerName {
+					continue
+				}
 				Expect(HasMetrics(name)).To(BeTrue(), "expected true for %s", name)
 			}
+		})
+
+		It("returns false for the database server", func() {
+			Expect(HasMetrics(InventoryDatabaseServerName)).To(BeFalse())
 		})
 
 		It("returns false for unknown servers", func() {

--- a/internal/controllers/utils/utils_test.go
+++ b/internal/controllers/utils/utils_test.go
@@ -1586,10 +1586,14 @@ var _ = Describe("Server predicate functions", func() {
 			}
 		})
 
-		It("returns false for API servers", func() {
+		It("returns true for API servers", func() {
 			for _, name := range apiServers {
-				Expect(HasMetrics(name)).To(BeFalse(), "expected false for %s", name)
+				Expect(HasMetrics(name)).To(BeTrue(), "expected true for %s", name)
 			}
+		})
+
+		It("returns false for unknown servers", func() {
+			Expect(HasMetrics("unknown-server")).To(BeFalse())
 		})
 	})
 

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -215,7 +215,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 	// spec. These endpoints are exempt from audience-scoped token validation
 	// because their callers (e.g., ACM alertmanager) cannot send audience-
 	// scoped tokens. See the overlay for per-endpoint rationale.
-	config.AudienceExemptPaths = auth.GetAudienceExemptPaths(swagger)
+	config.AudienceExemptPaths = append(auth.GetAudienceExemptPaths(swagger), metrics.MetricsPath)
 
 	// Create authn/authz middleware
 	authn, err := auth.GetAuthenticator(ctx, &config.CommonServerConfig)

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/auth"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/metrics"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 )
 
@@ -55,6 +56,7 @@ const (
 // Serve start alarms server
 func Serve(config *api.AlarmsServerConfig) error {
 	slog.Info("Starting Alarm server")
+	auth.ServiceName = "alarms-server"
 
 	// Get and validate the openapi spec file
 	swagger, err := generated.GetSwagger()
@@ -227,6 +229,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 	}
 
 	baseRouter := http.NewServeMux()
+	metrics.RegisterMetricsHandler(baseRouter)
 	opt := generated.StdHTTPServerOptions{
 		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here

--- a/internal/service/alarms/serve.go
+++ b/internal/service/alarms/serve.go
@@ -229,7 +229,7 @@ func Serve(config *api.AlarmsServerConfig) error {
 	}
 
 	baseRouter := http.NewServeMux()
-	metrics.RegisterMetricsHandler(baseRouter)
+	metrics.RegisterMetricsHandler(baseRouter, authn, authz)
 	opt := generated.StdHTTPServerOptions{
 		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -22,6 +22,7 @@ import (
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/auth"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/metrics"
 
 	"github.com/getkin/kin-openapi/openapi3"
 
@@ -42,6 +43,7 @@ const (
 // Serve start artifacts server
 func Serve(config *api.ArtifactsServerConfig) error {
 	slog.Info("Starting artifacts server")
+	auth.ServiceName = "artifacts-server"
 
 	// Get and validate the openapi spec file
 	swagger, err := generated.GetSwagger()
@@ -110,6 +112,7 @@ func Serve(config *api.ArtifactsServerConfig) error {
 	}
 
 	baseRouter := http.NewServeMux()
+	metrics.RegisterMetricsHandler(baseRouter)
 	opt := generated.StdHTTPServerOptions{
 		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -100,6 +100,10 @@ func Serve(config *api.ArtifactsServerConfig) error {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}
 
+	// Exempt /metrics from audience-scoped token validation so Prometheus
+	// can scrape using its default-audience SA token.
+	config.AudienceExemptPaths = append(config.AudienceExemptPaths, metrics.MetricsPath)
+
 	// Create authn/authz middleware
 	authn, err := auth.GetAuthenticator(ctx, &config.CommonServerConfig)
 	if err != nil {

--- a/internal/service/artifacts/serve.go
+++ b/internal/service/artifacts/serve.go
@@ -112,7 +112,7 @@ func Serve(config *api.ArtifactsServerConfig) error {
 	}
 
 	baseRouter := http.NewServeMux()
-	metrics.RegisterMetricsHandler(baseRouter)
+	metrics.RegisterMetricsHandler(baseRouter, authn, authz)
 	opt := generated.StdHTTPServerOptions{
 		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -20,6 +20,7 @@ import (
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/auth"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/metrics"
 
 	"github.com/getkin/kin-openapi/openapi3"
 
@@ -48,6 +49,7 @@ const (
 // Serve start alarms server
 func Serve(config *api.ClusterServerConfig) error {
 	slog.Info("Starting cluster server")
+	auth.ServiceName = "cluster-server"
 
 	// Get and validate the openapi spec file
 	swagger, err := generated.GetSwagger()
@@ -168,6 +170,7 @@ func Serve(config *api.ClusterServerConfig) error {
 	}
 
 	baseRouter := http.NewServeMux()
+	metrics.RegisterMetricsHandler(baseRouter)
 	opt := generated.StdHTTPServerOptions{
 		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -158,6 +158,10 @@ func Serve(config *api.ClusterServerConfig) error {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}
 
+	// Exempt /metrics from audience-scoped token validation so Prometheus
+	// can scrape using its default-audience SA token.
+	config.AudienceExemptPaths = append(config.AudienceExemptPaths, metrics.MetricsPath)
+
 	// Create authn/authz middleware
 	authn, err := auth.GetAuthenticator(ctx, &config.CommonServerConfig)
 	if err != nil {

--- a/internal/service/cluster/serve.go
+++ b/internal/service/cluster/serve.go
@@ -170,7 +170,7 @@ func Serve(config *api.ClusterServerConfig) error {
 	}
 
 	baseRouter := http.NewServeMux()
-	metrics.RegisterMetricsHandler(baseRouter)
+	metrics.RegisterMetricsHandler(baseRouter, authn, authz)
 	opt := generated.StdHTTPServerOptions{
 		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here

--- a/internal/service/common/api/middleware/errors.go
+++ b/internal/service/common/api/middleware/errors.go
@@ -64,6 +64,10 @@ func (e *interceptor) Write(data []byte) (int, error) {
 func ErrorJsonifier() Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/metrics" {
+				next.ServeHTTP(w, r)
+				return
+			}
 			next.ServeHTTP(&interceptor{original: w}, r)
 		})
 	}

--- a/internal/service/common/api/middleware/errors.go
+++ b/internal/service/common/api/middleware/errors.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api/generated"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/metrics"
 )
 
 // interceptor defines an implementation of a workaround for a limitation of the http.ServeMux.
@@ -64,7 +65,7 @@ func (e *interceptor) Write(data []byte) (int, error) {
 func ErrorJsonifier() Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/metrics" {
+			if r.URL.Path == metrics.MetricsPath {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/service/common/auth/auth.go
+++ b/internal/service/common/auth/auth.go
@@ -22,7 +22,11 @@ import (
 
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/metrics"
 )
+
+// ServiceName identifies this pod for metrics labeling. Set by each service at startup.
+var ServiceName string
 
 var containerID string
 
@@ -119,6 +123,7 @@ func Authenticator(oauthHandler, kubernetesHandler authenticator.Request) middle
 				args := []any{slog.Any("error", err), slog.String("method", req.Method), slog.String("path", req.URL.Path)}
 				args = append(args, tokenClaimsAttrs(req)...)
 				slog.WarnContext(req.Context(), "authentication failed", args...)
+				metrics.AuthFailures.WithLabelValues(ServiceName, "authentication", req.Method, metrics.NormalizePath(req.URL.Path)).Inc()
 				middleware.ProblemDetails(w, fmt.Sprintf("failed to authenticate request: %v", err), http.StatusUnauthorized)
 				return
 			}
@@ -127,6 +132,7 @@ func Authenticator(oauthHandler, kubernetesHandler authenticator.Request) middle
 				args := []any{slog.String("method", req.Method), slog.String("path", req.URL.Path)}
 				args = append(args, tokenClaimsAttrs(req)...)
 				slog.WarnContext(req.Context(), "authentication rejected", args...)
+				metrics.AuthFailures.WithLabelValues(ServiceName, "authentication", req.Method, metrics.NormalizePath(req.URL.Path)).Inc()
 				middleware.ProblemDetails(w, "unable to authenticate request", http.StatusUnauthorized)
 				return
 			}
@@ -200,6 +206,7 @@ func Authorizer(kubernetesAuthorizer authorizer.Authorizer) middleware.Middlewar
 					slog.String("user", user.GetName()), slog.Any("groups", user.GetGroups()),
 					slog.String("verb", attributes.Verb), slog.String("path", attributes.Path),
 					slog.Any("decision", decision), slog.String("reason", reason))
+				metrics.AuthFailures.WithLabelValues(ServiceName, "authorization", req.Method, metrics.NormalizePath(req.URL.Path)).Inc()
 				middleware.ProblemDetails(w, msg, http.StatusForbidden)
 				return
 			}

--- a/internal/service/common/auth/auth_rfc8705.go
+++ b/internal/service/common/auth/auth_rfc8705.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/metrics"
 )
 
 // From HAProxy
@@ -147,28 +149,35 @@ func (w *withClientVerification) AuthenticateRequest(req *http.Request) (*authen
 		return response, true, nil
 	}
 
+	normalizedPath := metrics.NormalizePath(req.URL.Path)
+
 	clientFingerprint, present, err := getClientCertificateFingerprint(req)
 	if err != nil {
 		slog.ErrorContext(req.Context(), "error extracting client certificate fingerprint", slog.Any("error", err))
+		metrics.AuthFailures.WithLabelValues(ServiceName, "certificate_binding", req.Method, normalizedPath).Inc()
 		return nil, false, err
 	}
 
 	if !present {
+		metrics.AuthFailures.WithLabelValues(ServiceName, "certificate_binding", req.Method, normalizedPath).Inc()
 		return nil, false, fmt.Errorf("a client certificate is required")
 	}
 
 	if len(tokenFingerprintValues) != 1 {
 		slog.ErrorContext(req.Context(), "unexpected number of fingerprint values", slog.Any("values", tokenFingerprintValues))
+		metrics.AuthFailures.WithLabelValues(ServiceName, "certificate_binding", req.Method, normalizedPath).Inc()
 		return nil, false, fmt.Errorf("unexpected number of fingerprint values")
 	}
 
 	if tokenFingerprintValues[0] == "" {
 		slog.ErrorContext(req.Context(), "empty fingerprint value in token binding claim")
+		metrics.AuthFailures.WithLabelValues(ServiceName, "certificate_binding", req.Method, normalizedPath).Inc()
 		return nil, false, fmt.Errorf("empty fingerprint value in token binding claim")
 	}
 
 	if tokenFingerprintValues[0] != clientFingerprint {
 		slog.DebugContext(req.Context(), "fingerprint values do not match", slog.String("client", clientFingerprint), slog.String("token", tokenFingerprintValues[0]))
+		metrics.AuthFailures.WithLabelValues(ServiceName, "certificate_binding", req.Method, normalizedPath).Inc()
 		return nil, false, fmt.Errorf("client certificate fingerprint mismatch")
 	}
 

--- a/internal/service/common/auth/auth_rfc8705_test.go
+++ b/internal/service/common/auth/auth_rfc8705_test.go
@@ -14,14 +14,19 @@ import (
 	"encoding/pem"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/util/cert"
+
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/metrics"
 )
 
 var _ = Describe("WithClientVerification", func() {
@@ -65,10 +70,15 @@ var _ = Describe("WithClientVerification", func() {
 			Error: nil,
 		}
 		tokenAuthenticator = WithClientVerification(&noopAuthenticator)
-		request = http.Request{Header: http.Header{
-			sslClientCertKey:  []string{testStdCertificate},
-			sslClientChainKey: []string{testStdCertificate},
-		}}
+		request = http.Request{
+			Method: http.MethodGet,
+			URL:    &url.URL{Path: "/o2ims-infrastructureInventory/v1/resourcePools"},
+			Header: http.Header{
+				sslClientCertKey:  []string{testStdCertificate},
+				sslClientChainKey: []string{testStdCertificate},
+			},
+		}
+		ServiceName = "test-service"
 		Expect(tokenAuthenticator).ToNot(BeNil())
 	})
 
@@ -205,4 +215,50 @@ var _ = Describe("WithClientVerification", func() {
 		Expect(logOutput).To(ContainSubstring(`"clientIp":"10.0.0.99"`))
 	})
 
+	Context("metrics instrumentation", func() {
+		BeforeEach(func() {
+			metrics.AuthFailures.Reset()
+		})
+
+		It("increments certificate_binding counter on missing client certificate", func() {
+			request.Header.Del(sslClientCertKey)
+			_, _, _ = tokenAuthenticator.AuthenticateRequest(&request)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "certificate_binding", "GET", "/o2ims-infrastructureInventory/v1/resourcePools")).To(Equal(float64(1)))
+		})
+
+		It("increments certificate_binding counter on fingerprint mismatch", func() {
+			noopAuthenticator.Response.User.GetExtra()[fingerprintKey] = []string{"other"}
+			_, _, _ = tokenAuthenticator.AuthenticateRequest(&request)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "certificate_binding", "GET", "/o2ims-infrastructureInventory/v1/resourcePools")).To(Equal(float64(1)))
+		})
+
+		It("increments certificate_binding counter on empty fingerprint", func() {
+			noopAuthenticator.Response.User.GetExtra()[fingerprintKey] = []string{""}
+			_, _, _ = tokenAuthenticator.AuthenticateRequest(&request)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "certificate_binding", "GET", "/o2ims-infrastructureInventory/v1/resourcePools")).To(Equal(float64(1)))
+		})
+
+		It("increments certificate_binding counter on multiple fingerprints", func() {
+			noopAuthenticator.Response.User.GetExtra()[fingerprintKey] = []string{"foo", "bar"}
+			_, _, _ = tokenAuthenticator.AuthenticateRequest(&request)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "certificate_binding", "GET", "/o2ims-infrastructureInventory/v1/resourcePools")).To(Equal(float64(1)))
+		})
+
+		It("does not increment counter on success", func() {
+			_, _, _ = tokenAuthenticator.AuthenticateRequest(&request)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "certificate_binding", "GET", "/o2ims-infrastructureInventory/v1/resourcePools")).To(Equal(float64(0)))
+		})
+	})
 })
+
+func getCounterValue(cv *prometheus.CounterVec, labels ...string) float64 {
+	counter, err := cv.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		return 0
+	}
+	m := &dto.Metric{}
+	if err := counter.Write(m); err != nil {
+		return 0
+	}
+	return m.GetCounter().GetValue()
+}

--- a/internal/service/common/auth/auth_test.go
+++ b/internal/service/common/auth/auth_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/metrics"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -242,6 +243,39 @@ var _ = Describe("Authenticator", func() {
 		Expect(logOutput).To(ContainSubstring(`"container"`))
 		Expect(logOutput).To(ContainSubstring(`"clientIp":"10.20.30.40"`))
 	})
+
+	Context("metrics instrumentation", func() {
+		BeforeEach(func() {
+			ServiceName = "test-service"
+			metrics.AuthFailures.Reset()
+		})
+
+		It("increments authentication counter on error", func() {
+			k8sAuthenticator.Error = errors.New("token expired")
+			handler.ServeHTTP(recorder, &req)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "authentication", "GET", "/api/test")).To(Equal(float64(1)))
+		})
+
+		It("increments authentication counter on rejection", func() {
+			k8sAuthenticator.Ok = false
+			handler.ServeHTTP(recorder, &req)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "authentication", "GET", "/api/test")).To(Equal(float64(1)))
+		})
+
+		It("does not increment counter on success", func() {
+			handler.ServeHTTP(recorder, &req)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "authentication", "GET", "/api/test")).To(Equal(float64(0)))
+		})
+
+		It("records correct method and path labels", func() {
+			req.Method = http.MethodPost
+			req.URL.Path = "/o2ims-infrastructureInventory/v1/alarmSubscriptions"
+			k8sAuthenticator.Error = errors.New("invalid token")
+			handler = Authenticator(&oauthAuthenticator, &k8sAuthenticator)(next)
+			handler.ServeHTTP(recorder, &req)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "authentication", "POST", "/o2ims-infrastructureInventory/v1/alarmSubscriptions")).To(Equal(float64(1)))
+		})
+	})
 })
 
 var _ = Describe("Authorizer", func() {
@@ -342,5 +376,35 @@ var _ = Describe("Authorizer", func() {
 		logOutput := logBuffer.String()
 		Expect(logOutput).To(ContainSubstring(`"container"`))
 		Expect(logOutput).To(ContainSubstring(`"clientIp":"10.0.0.60"`))
+	})
+
+	Context("metrics instrumentation", func() {
+		BeforeEach(func() {
+			ServiceName = "test-service"
+			metrics.AuthFailures.Reset()
+		})
+
+		It("increments authorization counter on denial", func() {
+			k8sAuthorizer.Decision = authorizer.DecisionDeny
+			handler.ServeHTTP(recorder, req)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "authorization", "GET", "/some/path")).To(Equal(float64(1)))
+		})
+
+		It("increments authorization counter on no opinion", func() {
+			k8sAuthorizer.Decision = authorizer.DecisionNoOpinion
+			handler.ServeHTTP(recorder, req)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "authorization", "GET", "/some/path")).To(Equal(float64(1)))
+		})
+
+		It("does not increment counter on allow", func() {
+			handler.ServeHTTP(recorder, req)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "authorization", "GET", "/some/path")).To(Equal(float64(0)))
+		})
+
+		It("does not increment authorization counter on authorizer error", func() {
+			k8sAuthorizer.Error = errors.New("some error")
+			handler.ServeHTTP(recorder, req)
+			Expect(getCounterValue(metrics.AuthFailures, "test-service", "authorization", "GET", "/some/path")).To(Equal(float64(0)))
+		})
 	})
 })

--- a/internal/service/common/metrics/metrics.go
+++ b/internal/service/common/metrics/metrics.go
@@ -1,0 +1,43 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metrics
+
+import (
+	"net/http"
+	"regexp"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var uuidSegmentRe = regexp.MustCompile(
+	`/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`,
+)
+
+// NormalizePath replaces UUID path segments with {id} to keep metric
+// cardinality bounded. Paths without UUIDs pass through unchanged.
+func NormalizePath(path string) string {
+	return uuidSegmentRe.ReplaceAllString(path, "/{id}")
+}
+
+var AuthFailures *prometheus.CounterVec
+
+func init() {
+	AuthFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "o2ims_auth_failures_total",
+			Help: "Total authentication/authorization failures by service, type, method, and path",
+		},
+		[]string{"service", "type", "method", "path"},
+	)
+	prometheus.MustRegister(AuthFailures)
+}
+
+// RegisterMetricsHandler registers the /metrics endpoint on the given mux.
+func RegisterMetricsHandler(mux *http.ServeMux) {
+	mux.Handle("/metrics", promhttp.Handler())
+}

--- a/internal/service/common/metrics/metrics.go
+++ b/internal/service/common/metrics/metrics.go
@@ -37,7 +37,11 @@ func init() {
 	prometheus.MustRegister(AuthFailures)
 }
 
-// RegisterMetricsHandler registers the /metrics endpoint on the given mux.
-func RegisterMetricsHandler(mux *http.ServeMux) {
-	mux.Handle("/metrics", promhttp.Handler())
+// RegisterMetricsHandler registers the /metrics endpoint on the given mux,
+// wrapping it with authentication and authorization middleware.
+func RegisterMetricsHandler(mux *http.ServeMux, authn, authz func(http.Handler) http.Handler) {
+	var handler http.Handler = promhttp.Handler()
+	handler = authz(handler)
+	handler = authn(handler)
+	mux.Handle("/metrics", handler)
 }

--- a/internal/service/common/metrics/metrics.go
+++ b/internal/service/common/metrics/metrics.go
@@ -14,6 +14,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const MetricsPath = "/metrics"
+
 var uuidSegmentRe = regexp.MustCompile(
 	`/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`,
 )
@@ -43,5 +45,5 @@ func RegisterMetricsHandler(mux *http.ServeMux, authn, authz func(http.Handler) 
 	var handler http.Handler = promhttp.Handler()
 	handler = authz(handler)
 	handler = authn(handler)
-	mux.Handle("/metrics", handler)
+	mux.Handle(MetricsPath, handler)
 }

--- a/internal/service/common/metrics/metrics_test.go
+++ b/internal/service/common/metrics/metrics_test.go
@@ -1,0 +1,135 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NormalizePath", func() {
+	DescribeTable("replaces UUID segments with {id}",
+		func(input, expected string) {
+			Expect(NormalizePath(input)).To(Equal(expected))
+		},
+		Entry("collection endpoint unchanged",
+			"/o2ims-infrastructureInventory/v1/resourcePools",
+			"/o2ims-infrastructureInventory/v1/resourcePools",
+		),
+		Entry("single UUID replaced",
+			"/o2ims-infrastructureInventory/v1/resourcePools/bf3f8f2e-6f37-4882-96ad-c0b9cef6fc04",
+			"/o2ims-infrastructureInventory/v1/resourcePools/{id}",
+		),
+		Entry("nested resource with two UUIDs",
+			"/o2ims-infrastructureInventory/v1/resourcePools/bf3f8f2e-6f37-4882-96ad-c0b9cef6fc04/resources/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			"/o2ims-infrastructureInventory/v1/resourcePools/{id}/resources/{id}",
+		),
+		Entry("uppercase UUID replaced",
+			"/o2ims-infrastructureCluster/v1/nodeClusters/BF3F8F2E-6F37-4882-96AD-C0B9CEF6FC04",
+			"/o2ims-infrastructureCluster/v1/nodeClusters/{id}",
+		),
+		Entry("path without UUIDs unchanged",
+			"/o2ims-infrastructureMonitoring/v1/alarms",
+			"/o2ims-infrastructureMonitoring/v1/alarms",
+		),
+		Entry("empty path unchanged", "", ""),
+		Entry("root path unchanged", "/", "/"),
+	)
+})
+
+var _ = Describe("RegisterMetricsHandler", func() {
+	It("registers the handler at /metrics with middleware applied in correct order", func() {
+		mux := http.NewServeMux()
+		var callOrder []string
+
+		authn := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callOrder = append(callOrder, "authn")
+				next.ServeHTTP(w, r)
+			})
+		}
+		authz := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callOrder = append(callOrder, "authz")
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		RegisterMetricsHandler(mux, authn, authz)
+
+		req := httptest.NewRequest(http.MethodGet, MetricsPath, nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(callOrder).To(Equal([]string{"authn", "authz"}))
+	})
+
+	It("returns 404 for paths other than /metrics", func() {
+		mux := http.NewServeMux()
+		noop := func(next http.Handler) http.Handler { return next }
+
+		RegisterMetricsHandler(mux, noop, noop)
+
+		req := httptest.NewRequest(http.MethodGet, "/not-metrics", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusNotFound))
+	})
+
+	It("blocks unauthenticated requests when authn rejects", func() {
+		mux := http.NewServeMux()
+
+		authn := func(_ http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			})
+		}
+		authz := func(next http.Handler) http.Handler { return next }
+
+		RegisterMetricsHandler(mux, authn, authz)
+
+		req := httptest.NewRequest(http.MethodGet, MetricsPath, nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("blocks unauthorized requests when authz rejects", func() {
+		mux := http.NewServeMux()
+
+		authn := func(next http.Handler) http.Handler { return next }
+		authz := func(_ http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			})
+		}
+
+		RegisterMetricsHandler(mux, authn, authz)
+
+		req := httptest.NewRequest(http.MethodGet, MetricsPath, nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusForbidden))
+	})
+})
+
+var _ = Describe("AuthFailures counter", func() {
+	It("is registered and can be incremented", func() {
+		AuthFailures.WithLabelValues("test-service", "authn", "GET", "/test").Inc()
+
+		metric, err := AuthFailures.GetMetricWithLabelValues("test-service", "authn", "GET", "/test")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(metric).ToNot(BeNil())
+	})
+})

--- a/internal/service/common/metrics/suite_test.go
+++ b/internal/service/common/metrics/suite_test.go
@@ -1,0 +1,19 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -109,7 +109,7 @@ func Serve(config *api.ProvisioningServerConfig) error {
 	}
 
 	baseRouter := http.NewServeMux()
-	metrics.RegisterMetricsHandler(baseRouter)
+	metrics.RegisterMetricsHandler(baseRouter, authn, authz)
 	opt := generated.StdHTTPServerOptions{
 		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -97,6 +97,10 @@ func Serve(config *api.ProvisioningServerConfig) error {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}
 
+	// Exempt /metrics from audience-scoped token validation so Prometheus
+	// can scrape using its default-audience SA token.
+	config.AudienceExemptPaths = append(config.AudienceExemptPaths, metrics.MetricsPath)
+
 	// Create authn/authz middleware
 	authn, err := auth.GetAuthenticator(ctx, &config.CommonServerConfig)
 	if err != nil {

--- a/internal/service/provisioning/serve.go
+++ b/internal/service/provisioning/serve.go
@@ -21,6 +21,7 @@ import (
 	common "github.com/openshift-kni/oran-o2ims/internal/service/common/api"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/api/middleware"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/auth"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/metrics"
 
 	"github.com/getkin/kin-openapi/openapi3"
 
@@ -39,6 +40,7 @@ const (
 // Serve start provisioning server
 func Serve(config *api.ProvisioningServerConfig) error {
 	slog.Info("Starting Provisioning server")
+	auth.ServiceName = "provisioning-server"
 
 	// Get and validate the openapi spec file
 	swagger, err := generated.GetSwagger()
@@ -107,6 +109,7 @@ func Serve(config *api.ProvisioningServerConfig) error {
 	}
 
 	baseRouter := http.NewServeMux()
+	metrics.RegisterMetricsHandler(baseRouter)
 	opt := generated.StdHTTPServerOptions{
 		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -201,6 +201,10 @@ func Serve(config *api.ResourceServerConfig) error {
 		return fmt.Errorf("error creating filter filterAdapter: %w", err)
 	}
 
+	// Exempt /metrics from audience-scoped token validation so Prometheus
+	// can scrape using its default-audience SA token.
+	config.AudienceExemptPaths = append(config.AudienceExemptPaths, metrics.MetricsPath)
+
 	// Create authn/authz middleware
 	authn, err := auth.GetAuthenticator(ctx, &config.CommonServerConfig)
 	if err != nil {

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/auth"
 	k8sclient "github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/db"
+	"github.com/openshift-kni/oran-o2ims/internal/service/common/metrics"
 	"github.com/openshift-kni/oran-o2ims/internal/service/common/notifier"
 	repo2 "github.com/openshift-kni/oran-o2ims/internal/service/common/repo"
 	"github.com/openshift-kni/oran-o2ims/internal/service/resources/api"
@@ -49,6 +50,7 @@ const (
 // Serve start alarms server
 func Serve(config *api.ResourceServerConfig) error {
 	slog.Info("Starting resource server")
+	auth.ServiceName = "resource-server"
 
 	// Get and validate the openapi spec file
 	swagger, err := generated.GetSwagger()
@@ -211,6 +213,7 @@ func Serve(config *api.ResourceServerConfig) error {
 	}
 
 	baseRouter := http.NewServeMux()
+	metrics.RegisterMetricsHandler(baseRouter)
 	opt := generated.StdHTTPServerOptions{
 		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here

--- a/internal/service/resources/serve.go
+++ b/internal/service/resources/serve.go
@@ -213,7 +213,7 @@ func Serve(config *api.ResourceServerConfig) error {
 	}
 
 	baseRouter := http.NewServeMux()
-	metrics.RegisterMetricsHandler(baseRouter)
+	metrics.RegisterMetricsHandler(baseRouter, authn, authz)
 	opt := generated.StdHTTPServerOptions{
 		BaseRouter: baseRouter,
 		Middlewares: []generated.MiddlewareFunc{ // Add middlewares here

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -135,6 +135,9 @@ var _ = BeforeSuite(func() {
 	// Get the managers for O2IMS controllers.
 	ProvisioningManager, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: testScheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics listener in tests
+		},
 	})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(ProvisioningManager).ToNot(BeNil())


### PR DESCRIPTION
## Why these changes?

The O2IMS operator and its API service pods had no Prometheus observability. Security-related
events (authentication, authorization, RFC 8705 certificate-binding failures) were only
visible in logs, with no way to alert or trend on them. This PR builds the full metrics
pipeline from instrumentation to alerting.



## Summary

### 1. Controller-manager metrics scraping

* Uncomment the `../prometheus` kustomize component in `config/default/kustomization.yaml`.
* Add `openshift.io/cluster-monitoring: "true"` label to the operator namespace so the
  platform Prometheus discovers ServiceMonitors.
* Add a ServiceMonitor for the controller-manager pod (port 8443, `/metrics`) with
  TLS verification (`serverName` includes the kustomize `oran-o2ims-` prefix).
* Grant RBAC for `monitoring.coreos.com` resources (servicemonitors, prometheusrules).

### 2. `/metrics` endpoint on all API service pods

* Register `promhttp.Handler()` on each service's existing TLS mux at `/metrics`
  (alarms, artifacts, cluster, provisioning, resources), wrapped with
  Authenticator and Authorizer middleware (TokenReview + SubjectAccessReview).
* Exempt `/metrics` from audience-scoped token validation so the Prometheus
  ServiceAccount's default-audience token is accepted.
* Introduce the `o2ims_auth_failures_total` counter with bounded labels
  (`service`, `type`, `method`, `path`). UUID path segments are normalized to `{id}`
  to prevent cardinality explosion.
* Instrument the three auth failure paths: `Authenticator`, `Authorizer`, and
  RFC 8705 `withClientVerification`.
* Add per-service ServiceMonitors with full TLS certificate verification
  (`serverName` matching the service-ca SAN, `caFile` pointing to the
  service-ca CA bundle mounted in Prometheus).
* Add the `oran-o2ims/metrics` label to API service `Service` objects
  (excludes database and hardware-manager).
* Add NetworkPolicy ingress rules allowing the `openshift-monitoring` namespace
  to scrape service pods.
* Programmatically ensure the namespace monitoring label via the
  `InventoryController` reconciler.
* Bind the `prometheus-k8s` ServiceAccount to the `metrics-reader` ClusterRole
  (grants `GET` on the `/metrics` non-resource URL).
* Unit tests for `NormalizePath`, `RegisterMetricsHandler` middleware ordering,
  `AuthFailures` counter, `Authenticator` metric increments, and
  `withClientVerification` metric increments.

### 3. PrometheusRule alert definitions

* `O2IMSHighAuthFailureRate` — fires when auth failures exceed 10/min sustained over 5 minutes
  (severity: warning).
* `O2IMSCertificateBindingFailure` — fires on any RFC 8705 certificate-binding rejection
  within a 10-minute window (severity: critical), as it may indicate a stolen-token replay.

### 4. Developer documentation

* `docs/dev/prometheus-metrics.md` covering architecture, TLS/authentication/authorization
  flow (with sequence diagram), ServiceMonitor config, metric definitions, alert rules,
  RBAC/NetworkPolicy setup, OLM verification, and alert lifecycle testing steps.

## Test plan

* `make test` — unit tests pass for the new `metrics` package, `auth` instrumentation, and `inventory_controller` changes
* `make test-e2e` — all 21 e2e specs pass (fixed port conflict)
* `make ci-job` — full CI pipeline passes
* Deploy to an OCP cluster and verify:
  * `oc get servicemonitor -n oran-o2ims` shows all monitors
  * `oc get prometheusrule -n oran-o2ims` shows `o2ims-auth-alerts`
  * Prometheus targets page shows all service pods as UP
  * `o2ims_auth_failures_total` metric appears after sending an unauthenticated request
  * `O2IMSHighAuthFailureRate` alert transitions to pending/firing when generating sustained failures
  * TLS scanner confirms all metrics endpoints are TLS-only with cluster-compliant cipher suites