### PR TITLE
OCPBUGS-93226: fix provisioningDetails bounce on hardware completion

### DIFF
--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -186,7 +186,7 @@ func (t *provisioningRequestReconcilerTask) run(ctx context.Context) (ctrl.Resul
 
 	// Execute the main reconciliation phases
 	renderedClusterInstance, result, err := t.executeProvisioningPhases(ctx)
-	if err != nil || result.Requeue || result.RequeueAfter > 0 {
+	if err != nil || renderedClusterInstance == nil || result.Requeue || result.RequeueAfter > 0 {
 		// Check for overall provisioning timeout before returning error/requeue
 		if timeoutResult := t.checkOverallProvisioningTimeout(ctx); timeoutResult.RequeueAfter > 0 {
 			return timeoutResult, nil
@@ -209,9 +209,8 @@ func (t *provisioningRequestReconcilerTask) executeProvisioningPhases(ctx contex
 	}
 
 	// Phase 2: Hardware provisioning
-	result, err = t.executeHardwareProvisioningPhase(ctx, unstructuredClusterInstance)
-	if err != nil || result.Requeue || result.RequeueAfter > 0 ||
-		t.object.Status.ProvisioningStatus.ProvisioningPhase == provisioningv1alpha1.StateFailed {
+	result, proceed, err := t.executeHardwareProvisioningPhase(ctx, unstructuredClusterInstance)
+	if err != nil || !proceed || result.RequeueAfter > 0 {
 		return nil, result, err
 	}
 
@@ -253,28 +252,30 @@ func (t *provisioningRequestReconcilerTask) executePreProvisioningPhase(ctx cont
 	return renderedClusterInstance, unstructuredClusterInstance, ctrl.Result{}, nil
 }
 
-// executeHardwareProvisioningPhase handles hardware provisioning
+// executeHardwareProvisioningPhase handles hardware provisioning.
+// The returned bool (proceed) indicates whether the caller should continue to the next phase;
+// false means hardware provisioning is still in progress, failed, or timed out.
 func (t *provisioningRequestReconcilerTask) executeHardwareProvisioningPhase(ctx context.Context,
-	unstructuredClusterInstance *unstructured.Unstructured) (ctrl.Result, error) {
+	unstructuredClusterInstance *unstructured.Unstructured) (ctrl.Result, bool, error) {
 
 	if t.isHardwareProvisionSkipped() {
 		t.logger.InfoContext(ctx, "Hardware provisioning skipped")
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, true, nil
 	}
 
 	ctx = ctlrutils.LogPhaseStart(ctx, t.logger, "hardware_provisioning")
 	phaseStartTime := time.Now()
 
 	res, proceed, err := t.handleNodeAllocationRequestProvisioning(ctx, unstructuredClusterInstance)
-	if err != nil || (res == doNotRequeue() && !proceed) || res.RequeueAfter > 0 {
+	if err != nil || !proceed || res.RequeueAfter > 0 {
 		if err != nil {
 			ctlrutils.LogError(ctx, t.logger, "Hardware provisioning phase failed", err)
 		}
-		return res, err
+		return res, false, err
 	}
 
 	ctlrutils.LogPhaseComplete(ctx, t.logger, "hardware_provisioning", time.Since(phaseStartTime))
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, true, nil
 }
 
 // executeClusterInstallationPhase handles cluster installation

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -588,18 +588,16 @@ func (t *provisioningRequestReconcilerTask) processExistingHardwareCondition(
 
 	// Ensure a consistent message for the provisioning request, regardless of which hardware manager is used.
 	// The message is augmented with additional NAR context for in-progress, failure, and success states.
-	// - Success: update provisioningStatus to indicate hardware provisioning/configuration is complete
+	// - Success: build a completion message for hardware conditions
 	// - Timeout/Failure: enrich the base failure message with detailed NAR error context
 	// - In-progress: enrich the message with NAR context when available, otherwise provide a generic in-progress message
 	if status == metav1.ConditionTrue {
 		// Hardware provisioning/configuration completed successfully
-		// Update provisioningStatus to reflect completion and allow progression to next phase
 		if strings.TrimSpace(message) != "" {
 			message = fmt.Sprintf("Hardware %s completed: %s", ctlrutils.GetStatusMessage(condition), message)
 		} else {
 			message = fmt.Sprintf("Hardware %s completed", ctlrutils.GetStatusMessage(condition))
 		}
-		ctlrutils.SetProvisioningStateInProgress(t.object, message)
 	} else if status == metav1.ConditionFalse {
 		if reason == string(hwmgmtv1alpha1.Failed) || reason == string(hwmgmtv1alpha1.TimedOut) {
 			timedOutOrFailed = true

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -2486,7 +2486,7 @@ var _ = Describe("processExistingHardwareCondition", func() {
 	})
 
 	Context("when HardwareProvisioned completes successfully", func() {
-		It("updates provisioningStatus with success message", func() {
+		It("preserves completion message in PR condition", func() {
 			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Provisioned),
 				Status:  metav1.ConditionTrue,
@@ -2500,14 +2500,12 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			Expect(reason).To(Equal(string(hwmgmtv1alpha1.Completed)))
 			Expect(timedOutOrFailed).To(BeFalse())
 			Expect(message).To(Equal("Hardware provisioning completed: Created"))
-			// Verify provisioningStatus is updated to progressing
-			Expect(task.object.Status.ProvisioningStatus.ProvisioningPhase).To(Equal(provisioningv1alpha1.StateProgressing))
-			Expect(task.object.Status.ProvisioningStatus.ProvisioningDetails).To(ContainSubstring("Hardware provisioning completed"))
+			Expect(task.object.Status.ProvisioningStatus.ProvisioningPhase).To(BeEmpty())
 		})
 	})
 
 	Context("when HardwareConfigured completes successfully", func() {
-		It("updates provisioningStatus with success message", func() {
+		It("preserves completion message in PR condition", func() {
 			hwCondition := &metav1.Condition{
 				Type:    string(hwmgmtv1alpha1.Configured),
 				Status:  metav1.ConditionTrue,
@@ -2521,9 +2519,7 @@ var _ = Describe("processExistingHardwareCondition", func() {
 			Expect(reason).To(Equal(string(hwmgmtv1alpha1.Completed)))
 			Expect(timedOutOrFailed).To(BeFalse())
 			Expect(message).To(Equal("Hardware configuring completed: Configuration applied"))
-			// Verify provisioningStatus is updated to progressing
-			Expect(task.object.Status.ProvisioningStatus.ProvisioningPhase).To(Equal(provisioningv1alpha1.StateProgressing))
-			Expect(task.object.Status.ProvisioningStatus.ProvisioningDetails).To(ContainSubstring("Hardware configuring completed"))
+			Expect(task.object.Status.ProvisioningStatus.ProvisioningPhase).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
## Summary

After hardware provisioning completes, processExistingHardwareCondition
called SetProvisioningStateInProgress on every reconcile, overwriting
whatever provisioningDetails any subsequent active phase (cluster
installation, upgrade, policy configuration) had set in the previous
reconcile. This caused status.provisioningDetails to bounce between the
hardware completion message and the active operation status.

Remove the SetProvisioningStateInProgress call from the hardware
completion branch — the completed state is already captured in the
HardwareProvisioned condition and does not need to update
provisioningDetails.

Also fix a fragile requeue decision in executeProvisioningPhases: the
old code checked ProvisioningPhase == StateFailed as a side-channel
signal to stop phase progression. Replace this with a proceed bool
returned from executeHardwareProvisioningPhase, making the contract
explicit in the function signature rather than relying on status fields
that any earlier handler could have set.

## Test plan

- [x] Unit tests
- [x] Tested on STD cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)