### PR TITLE
fix: pin SCRIPT_RUNNER_IMAGE to digest in FBC pipeline

### DIFF
--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -144,7 +144,7 @@ spec:
         - name: ociArtifactExpiresAfter
           value: $(params.image-expires-after)
         - name: SCRIPT_RUNNER_IMAGE
-          value: quay.io/konflux-ci/yq:latest
+          value: quay.io/konflux-ci/yq@sha256:9eeedda1aea13b76c0fcc6d618cbe25810949fd35ce2b93dce8283cc3be8784d
         # update catalog template
         - name: SCRIPT
           value: ./telco5g-konflux/scripts/catalog/konflux-update-catalog-template.sh --set-catalog-template-input-file .konflux/catalog/catalog-template.in.yaml --set-bundle-builds-file .konflux/catalog/bundle.builds.in.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,18 @@
                 "(?<depName>[\\w\\-\\.\\/]+):?(?<currentValue>[\\w\\-\\.]+)?@(?<currentDigest>sha256:[a-f0-9]+)"
             ],
             "versioningTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "datasourceTemplate": "docker",
+            "description": "Pin and update image digests in Tekton pipeline parameters",
+            "managerFilePatterns": [
+                "/^\\.tekton/.*\\.yaml$/"
+            ],
+            "matchStrings": [
+                "(?<depName>[\\w\\-\\.\\/]+):?(?<currentValue>[\\w\\-\\.]+)?@(?<currentDigest>sha256:[a-f0-9]+)"
+            ],
+            "versioningTemplate": "docker"
         }
     ],
     "git-submodules": {
@@ -46,7 +58,8 @@
             "enabled": true,
             "ignoreTests": false,
             "includePaths": [
-                ".konflux/**"
+                ".konflux/**",
+                ".tekton/**"
             ],
             "matchManagers": [
                 "custom.regex"


### PR DESCRIPTION
## Summary

- Pin `SCRIPT_RUNNER_IMAGE` (`quay.io/konflux-ci/yq`) by digest in the FBC pipeline, eliminating the only mutable image reference while all 13 task bundles were already digest-pinned.
- Add a Renovate custom manager so MintMaker automatically keeps the digest current, matching the existing pattern used for `.konflux/Dockerfile.*` images.

## Details

The FBC pipeline passed `quay.io/konflux-ci/yq:latest` as `SCRIPT_RUNNER_IMAGE` to a digest-pinned task bundle. That mutable image executes before OPM rendering, dependency prefetch, and image build, so a changed upstream tag could alter catalog artifact generation without a repository change.

The digest used matches the one already pinned in `.konflux/Dockerfile.bundle`.

## Test plan

- [ ] Verify FBC pipeline runs successfully with the pinned digest
- [ ] Confirm MintMaker detects the new custom manager and can propose digest updates


Made with [Cursor](https://cursor.com)