### PR TITLE
fix: pin SCRIPT_RUNNER_IMAGE to digest in FBC pipeline

### DIFF
--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -144,7 +144,7 @@ spec:
         - name: ociArtifactExpiresAfter
           value: $(params.image-expires-after)
         - name: SCRIPT_RUNNER_IMAGE
-          value: quay.io/konflux-ci/yq:latest
+          value: quay.io/konflux-ci/yq@sha256:9eeedda1aea13b76c0fcc6d618cbe25810949fd35ce2b93dce8283cc3be8784d
         # update catalog template
         - name: SCRIPT
           value: ./telco5g-konflux/scripts/catalog/konflux-update-catalog-template.sh --set-catalog-template-input-file .konflux/catalog/catalog-template.in.yaml --set-bundle-builds-file .konflux/catalog/bundle.builds.in.yaml


### PR DESCRIPTION
## Summary

- Pin `SCRIPT_RUNNER_IMAGE` (`quay.io/konflux-ci/yq`) by digest in the FBC pipeline, eliminating the only mutable image reference. The digest matches the one already pinned in `.konflux/Dockerfile.bundle`.

Backport of #3024 (digest-only, without the Renovate custom manager rule).

## Test plan

- [ ] Verify FBC pipeline runs successfully with the pinned digest


Made with [Cursor](https://cursor.com)