### PR TITLE
fix: pin delve debugger to v1.26.3 for Go 1.24 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build the manager binary
 FROM registry.hub.docker.com/library/golang:1.24 AS dlvbuilder
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
+# Pin delve to v1.26.3 — the last version compatible with Go 1.24.
+# Later versions require Go 1.25+.
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.26.3
 
 FROM dlvbuilder AS builder
 ARG GOBUILD_GCFLAGS=""


### PR DESCRIPTION
delve @latest now requires Go 1.25, breaking the CI build on release-4.21 which uses Go 1.24. Pin to v1.26.3, the last version compatible with Go 1.24.