### PR TITLE
docs: clarify extraLabels/extraAnnotations merge behavior with default ConfigMap

### DIFF
--- a/docs/user-guide/cluster-provisioning.md
+++ b/docs/user-guide/cluster-provisioning.md
@@ -71,7 +71,7 @@ The `status.provisioningStatus` tracks the overall provisioning state.
 > [!NOTE]
 
 > - The `metadata.name` of a ProvisioningRequest CR must be a valid UUID. Any attempt to create a ProvisioningRequest with an invalid `metadata.name` will be rejected by the webhook.
-> - The ProvisioningRequest cannot override extraLabels that are already set in the defaults. If the same key appears in both the ClusterTemplate defaults and the ProvisioningRequest (for example, `extraLabels.ManagedCluster.cluster-version` is `4.18` in the defaults ConfigMap and `4.19` in the ProvisioningRequest),
+> - The `extraLabels` and `extraAnnotations` in `clusterInstanceParameters` cannot override those already set in the `clusterInstanceDefaults` ConfigMap. If the same key appears in both (for example, `extraLabels.ManagedCluster.cluster-version` is `4.18` in the defaults ConfigMap and `4.19` in the ProvisioningRequest),
 > the value from the defaults ConfigMap is used.
 > - Once cluster installation has started (`provisioningPhase` is `progressing` and `provisioningDetails` shows `Cluster installation is in progress`), any updates to the ClusterInstance fields are disallowed and will be rejected by the webhook.
 

--- a/docs/user-guide/template-overview.md
+++ b/docs/user-guide/template-overview.md
@@ -47,6 +47,8 @@ The [CRD](../../config/crd/bases/clcm.openshift.io_clustertemplates.yaml)'s `spe
 
 The ClusterTemplate references defaults stored in Git (for example, installation and policy defaults) and, through its `templateParameterSchema`, specifies the inputs that the SMO can supply in the ProvisioningRequest.
 At provisioning time, the O‑Cloud Manager validates the SMO‑supplied values against the schema and merges them with the template’s defaults to render the concrete artifacts used to install and configure the cluster.
+When both the ProvisioningRequest and the ClusterTemplate defaults provide the same field, the ProvisioningRequest value takes precedence, with one exception: `extraLabels` and `extraAnnotations` provided in the ProvisioningRequest's `clusterInstanceParameters` cannot override those already
+set in the `clusterInstanceDefaults` ConfigMap. Only new `extraLabels` and `extraAnnotations` that do not exist in the defaults can be appended through the ProvisioningRequest.
 
 Complete examples of ClusterTemplate are available under the GitOps sample content:
 [SNO](../samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1.yaml),


### PR DESCRIPTION
Document that extraLabels and extraAnnotations in clusterInstanceParameters cannot override those already set in the clusterInstanceDefaults ConfigMap, and that only new entries can be appended through the ProvisioningRequest.
