### PR TITLE
Temporarily disable Tekton pipelines for release-4.22

### DIFF
--- a/.tekton/o-cloud-manager-4-22-pull-request.yaml
+++ b/.tekton/o-cloud-manager-4-22-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "release-4.22" &&
+      target_branch == "release-4.22-disabled" &&
       (
         '.konflux/Dockerfile'.pathChanged() ||
         '.tekton/build-pipeline.yaml'.pathChanged() ||

--- a/.tekton/o-cloud-manager-4-22-push.yaml
+++ b/.tekton/o-cloud-manager-4-22-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "release-4.22" &&
+      target_branch == "release-4.22-disabled" &&
       (
         '.konflux/Dockerfile'.pathChanged() ||
         '.tekton/build-pipeline.yaml'.pathChanged() ||

--- a/.tekton/o-cloud-manager-bundle-4-22-pull-request.yaml
+++ b/.tekton/o-cloud-manager-bundle-4-22-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "release-4.22" &&
+      target_branch == "release-4.22-disabled" &&
       !event_title.contains("[BRANCH-CUT]") &&
       (
         '.konflux/Dockerfile.bundle'.pathChanged() ||

--- a/.tekton/o-cloud-manager-bundle-4-22-push.yaml
+++ b/.tekton/o-cloud-manager-bundle-4-22-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "release-4.22" &&
+      target_branch == "release-4.22-disabled" &&
       !event_title.contains("[BRANCH-CUT]") &&
       (
         '.konflux/Dockerfile.bundle'.pathChanged() ||

--- a/.tekton/o-cloud-manager-fbc-4-22-pull-request.yaml
+++ b/.tekton/o-cloud-manager-fbc-4-22-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "release-4.22" &&
+      target_branch == "release-4.22-disabled" &&
       !event_title.contains("[BRANCH-CUT]") &&
       (
         '.konflux/catalog/***'.pathChanged() ||

--- a/.tekton/o-cloud-manager-fbc-4-22-push.yaml
+++ b/.tekton/o-cloud-manager-fbc-4-22-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "release-4.22" &&
+      target_branch == "release-4.22-disabled" &&
       !event_title.contains("[BRANCH-CUT]") &&
       (
         '.konflux/catalog/***'.pathChanged() ||


### PR DESCRIPTION
## Summary
- Change `target_branch` in CEL expressions from `"release-4.22"` to `"release-4.22-disabled"` across all 6 Tekton pipeline definitions (push + pull-request for operator, bundle, and FBC).
- This prevents all pipelines from triggering on push and pull_request events targeting `release-4.22` while the branch is being prepared.
- To re-enable, revert the `-disabled` suffix from the `target_branch` values.

## Test plan
- [x] Verify the CEL expressions no longer match `release-4.22` as target branch
- [ ] Confirm no pipelines trigger on subsequent pushes/PRs to `release-4.22`

Made with [Cursor](https://cursor.com)