### PR TITLE
Re-enable Tekton pipelines for release-4.22

### DIFF
--- a/.tekton/o-cloud-manager-4-22-pull-request.yaml
+++ b/.tekton/o-cloud-manager-4-22-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "release-4.22-disabled" &&
+      target_branch == "release-4.22" &&
       (
         '.konflux/Dockerfile'.pathChanged() ||
         '.tekton/build-pipeline.yaml'.pathChanged() ||

--- a/.tekton/o-cloud-manager-4-22-push.yaml
+++ b/.tekton/o-cloud-manager-4-22-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "release-4.22-disabled" &&
+      target_branch == "release-4.22" &&
       (
         '.konflux/Dockerfile'.pathChanged() ||
         '.tekton/build-pipeline.yaml'.pathChanged() ||

--- a/.tekton/o-cloud-manager-bundle-4-22-pull-request.yaml
+++ b/.tekton/o-cloud-manager-bundle-4-22-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "release-4.22-disabled" &&
+      target_branch == "release-4.22" &&
       !event_title.contains("[BRANCH-CUT]") &&
       (
         '.konflux/Dockerfile.bundle'.pathChanged() ||

--- a/.tekton/o-cloud-manager-bundle-4-22-push.yaml
+++ b/.tekton/o-cloud-manager-bundle-4-22-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "release-4.22-disabled" &&
+      target_branch == "release-4.22" &&
       !event_title.contains("[BRANCH-CUT]") &&
       (
         '.konflux/Dockerfile.bundle'.pathChanged() ||

--- a/.tekton/o-cloud-manager-fbc-4-22-pull-request.yaml
+++ b/.tekton/o-cloud-manager-fbc-4-22-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "release-4.22-disabled" &&
+      target_branch == "release-4.22" &&
       !event_title.contains("[BRANCH-CUT]") &&
       (
         '.konflux/catalog/***'.pathChanged() ||

--- a/.tekton/o-cloud-manager-fbc-4-22-push.yaml
+++ b/.tekton/o-cloud-manager-fbc-4-22-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "release-4.22-disabled" &&
+      target_branch == "release-4.22" &&
       !event_title.contains("[BRANCH-CUT]") &&
       (
         '.konflux/catalog/***'.pathChanged() ||


### PR DESCRIPTION
## Summary
- Reverts #3061, restoring `target_branch == "release-4.22"` in the CEL expressions of all 6 Tekton pipeline definitions.
- Pipelines will now trigger again on push and pull_request events targeting `release-4.22`.

## Test plan
- [x] Verify all 6 pipeline YAML files have `target_branch == "release-4.22"` restored
- [ ] Confirm pipelines trigger correctly on subsequent pushes/PRs to `release-4.22`

Made with [Cursor](https://cursor.com)