### PR TITLE
CNF-25403: Add SECURITY.md for vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Security Response
+
+If you've found a security issue that you'd like to disclose confidentially please contact
+Red Hat's Product Security team. Details at [Red Hat Product Security](https://access.redhat.com/security/team/contact).


### PR DESCRIPTION
## Summary
- Adds a `SECURITY.md` file directing security vulnerability reporters to Red Hat's Product Security team
- Standard disclosure policy file used across Red Hat projects

## Test plan
- [x] `make markdownlint` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)