### PR TITLE
CNF-22692: support AllNamespaces install mode for OLMv1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ catalog-deploy: ## Deploy from catalog image.
 		--namespace $(OCLOUD_MANAGER_NAMESPACE) \
 		--catalog-image $(CATALOG_IMG) \
 		--channel $(CHANNEL) \
-		--install-mode OwnNamespace \
+		--install-mode AllNamespaces \
 		| oc create -f -
 
 # Undeploy from catalog image.

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -2447,7 +2447,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - ORAN

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -2441,7 +2441,7 @@ spec:
         serviceAccountName: oran-o2ims-controller-manager
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
   - supported: false
     type: SingleNamespace

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -622,7 +622,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - ORAN

--- a/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-o2ims.clusterserviceversion.yaml
@@ -616,7 +616,7 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
   - supported: false
     type: SingleNamespace

--- a/docs/user-guide/environment-setup.md
+++ b/docs/user-guide/environment-setup.md
@@ -151,7 +151,7 @@ hack/generate-catalog-deploy.sh \
         --namespace oran-o2ims \
         --catalog-image quay.io/${MY_REPO}/oran-o2ims-catalog:v5.0.0 \
         --channel alpha \
-        --install-mode OwnNamespace \
+        --install-mode AllNamespaces \
         | oc create -f -
 catalogsource.operators.coreos.com/oran-o2ims created
 namespace/oran-o2ims created


### PR DESCRIPTION
Enable AllNamespaces install mode in the CSV to support OLMv1, which requires operators to run in AllNamespaces mode. The controller-runtime Manager cache is already cluster-scoped (no namespace filter), and RBAC uses ClusterRoleBindings, so no code changes are needed beyond the CSV and the Makefile catalog-deploy target.

Both OwnNamespace and AllNamespaces are now supported, maintaining backward compatibility with existing OLMv0 installations.