### PR TITLE
chore: improve scorecard test output and fix sample status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -715,11 +715,19 @@ ci-job: deps-update go-generate generate fmt vet lint test test-e2e test-envtest
 clean:
 	-rm $(LOCALBIN)/$(BINARY_NAME)
 
+SCORECARD_VERBOSE ?= false
+SCORECARD_STRICT ?= true
+
 .PHONY: scorecard-test
 scorecard-test: operator-sdk
 	@test -n "$(KUBECONFIG)" || (echo "The environment variable KUBECONFIG must not empty" && false)
 	oc create ns $(OCLOUD_MANAGER_NAMESPACE) --dry-run=client -o yaml | oc apply -f -
+ifeq ($(SCORECARD_VERBOSE),true)
 	$(OPERATOR_SDK) scorecard bundle -o text --kubeconfig "$(KUBECONFIG)" -n $(OCLOUD_MANAGER_NAMESPACE) --pod-security=restricted --wait-time=120s
+else
+	@$(OPERATOR_SDK) scorecard bundle -o json --kubeconfig "$(KUBECONFIG)" -n $(OCLOUD_MANAGER_NAMESPACE) --pod-security=restricted --wait-time=120s | \
+		python3 $(PROJECT_DIR)/hack/scorecard-summary.py $(if $(filter true,$(SCORECARD_STRICT)),--strict)
+endif
 
 # markdownlint rules, following: https://github.com/openshift/enhancements/blob/master/Makefile
 .PHONY: markdownlint-image

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -827,6 +827,18 @@ metadata:
           "spec": {
             "address": "123 Technology Way, Ashburn, VA 20147, USA",
             "description": "Primary east coast data center facility"
+          },
+          "status": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2026-07-07T14:23:06Z",
+                "message": "Location is ready",
+                "observedGeneration": 1,
+                "reason": "Ready",
+                "status": "True",
+                "type": "Ready"
+              }
+            ]
           }
         },
         {
@@ -839,6 +851,18 @@ metadata:
           "spec": {
             "description": "Primary compute site at east data center",
             "globalLocationName": "east-datacenter"
+          },
+          "status": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2026-07-07T14:23:06Z",
+                "message": "OCloudSite is ready",
+                "observedGeneration": 1,
+                "reason": "Ready",
+                "status": "True",
+                "type": "Ready"
+              }
+            ]
           }
         },
         {
@@ -851,6 +875,18 @@ metadata:
           "spec": {
             "description": "Compute resources for production workloads",
             "oCloudSiteName": "site-east-1"
+          },
+          "status": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2026-07-07T14:23:06Z",
+                "message": "ResourcePool is ready",
+                "observedGeneration": 1,
+                "reason": "Ready",
+                "status": "True",
+                "type": "Ready"
+              }
+            ]
           }
         }
       ]

--- a/config/samples/v1alpha1_location.yaml
+++ b/config/samples/v1alpha1_location.yaml
@@ -7,3 +7,11 @@ metadata:
 spec:
   description: "Primary east coast data center facility"
   address: "123 Technology Way, Ashburn, VA 20147, USA"
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    reason: Ready
+    message: "Location is ready"
+    observedGeneration: 1
+    lastTransitionTime: "2026-07-07T14:23:06Z"

--- a/config/samples/v1alpha1_ocloudsite.yaml
+++ b/config/samples/v1alpha1_ocloudsite.yaml
@@ -9,3 +9,11 @@ spec:
   # References parent Location by its metadata.name
   globalLocationName: "east-datacenter"
   description: "Primary compute site at east data center"
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    reason: Ready
+    message: "OCloudSite is ready"
+    observedGeneration: 1
+    lastTransitionTime: "2026-07-07T14:23:06Z"

--- a/config/samples/v1alpha1_resourcepool.yaml
+++ b/config/samples/v1alpha1_resourcepool.yaml
@@ -9,3 +9,11 @@ spec:
   # References parent OCloudSite by its metadata.name
   oCloudSiteName: "site-east-1"
   description: "Compute resources for production workloads"
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    reason: Ready
+    message: "ResourcePool is ready"
+    observedGeneration: 1
+    lastTransitionTime: "2026-07-07T14:23:06Z"

--- a/hack/scorecard-summary.py
+++ b/hack/scorecard-summary.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Parse scorecard JSON output and print a concise summary.
+
+Exits with code 1 if any test did not pass or no results are found.
+In --strict mode, suggestions are also treated as failures.
+Filters the verbose log output from the olm-crds-have-validation test,
+which dumps the entire CRD schema as raw Go structs.
+
+On failure, the full unfiltered results are printed first, followed by
+the summary, so that CI logs contain the details needed for debugging.
+"""
+
+import json
+import sys
+
+
+def format_summary(results, strict):
+    """Format the concise summary of test results."""
+    lines = []
+    lines.append("Scorecard Test Summary")
+    lines.append("(run with SCORECARD_VERBOSE=true for full unfiltered output)")
+    lines.append("")
+
+    suggestion_count = 0
+
+    for name, state, suggestions, errors, log in results:
+        lines.append(f"--- {name} --- [{state}]")
+
+        for error in errors:
+            lines.append(f"  Error: {error}")
+
+        for suggestion in suggestions:
+            suggestion_count += 1
+            prefix = "FAIL" if strict else "WARNING"
+            lines.append(f"  {prefix} - Suggestion: {suggestion}")
+
+        if log and name != "olm-crds-have-validation":
+            truncated = log[:500]
+            if len(log) > 500:
+                truncated += "..."
+            lines.append(f"  Log: {truncated}")
+
+        lines.append("")
+
+    if suggestion_count > 0:
+        if strict:
+            lines.append(f"** {suggestion_count} suggestion(s) found — "
+                         f"treated as failures (SCORECARD_STRICT=true) **")
+        else:
+            lines.append(f"** {suggestion_count} suggestion(s) found — "
+                         f"run with SCORECARD_STRICT=true to treat as failures **")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_full(results):
+    """Format the full unfiltered results for debugging."""
+    lines = []
+    lines.append("Full Scorecard Test Results")
+    lines.append("=" * 60)
+    lines.append("")
+
+    for name, state, suggestions, errors, log in results:
+        lines.append(f"--- {name} --- [{state}]")
+
+        for error in errors:
+            lines.append(f"  Error: {error}")
+
+        for suggestion in suggestions:
+            lines.append(f"  Suggestion: {suggestion}")
+
+        if log:
+            lines.append(f"  Log: {log}")
+
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    strict = "--strict" in sys.argv
+
+    data = json.load(sys.stdin)
+    results = []
+
+    for item in data.get("items", []):
+        for result in item.get("status", {}).get("results", []):
+            results.append((
+                result.get("name", ""),
+                result.get("state", ""),
+                result.get("suggestions", []),
+                result.get("errors", []),
+                result.get("log", "").strip(),
+            ))
+
+    if not results:
+        print("Error: no scorecard test results found", file=sys.stderr)
+        sys.exit(1)
+
+    failed = any(state != "pass" for _, state, _, _, _ in results)
+    has_suggestions = any(len(s) > 0 for _, _, s, _, _ in results)
+
+    if strict and has_suggestions:
+        failed = True
+
+    if failed:
+        print(format_full(results))
+        print()
+
+    print(format_summary(results, strict))
+
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add status sections with example conditions to the Location, OCloudSite, and ResourcePool sample CRs to resolve the olm-status-descriptors suggestions about missing status fields.

Add a scorecard summary script that filters the verbose olm-crds-have-validation log output (which dumps entire CRD schemas as raw Go structs). On failure, the full unfiltered output is printed first for debugging, followed by the summary. Options:
- SCORECARD_VERBOSE=true: bypass filtering, show full raw output
- SCORECARD_STRICT=true (default): treat suggestions as failures