### PR TITLE
CNF-25886: add MNO worker node scale-out support (Phase 1)

### DIFF
--- a/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -63,6 +63,12 @@ type ClusterDetails struct {
 
 	// ClusterUpgradeStatus holds the state of a cluster upgrade in progress.
 	ClusterUpgradeStatus *ClusterUpgradeStatus `json:"clusterUpgradeStatus,omitempty"`
+
+	// FulfilledNodeCount records the number of nodes at the time the PR last
+	// reached Fulfilled. Used to detect scale-out operations on subsequent
+	// reconciles — if the rendered ClusterInstance has more nodes than this
+	// value, a scale-out is in progress.
+	FulfilledNodeCount int `json:"fulfilledNodeCount,omitempty"`
 }
 
 // ClusterUpgradeStatus holds the persisted state for a cluster upgrade lifecycle.

--- a/api/provisioning/v1alpha1/provisioningrequest_webhook.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_webhook.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -234,11 +235,14 @@ func (v *provisioningRequestValidator) validateCreateOrUpdate(ctx context.Contex
 		}
 
 		if len(scalingNodes) > 0 {
-			// Reject scaling while an upgrade is in progress
+			// Reject scaling while an upgrade is active or in a non-healthy state.
+			// Check Status != True (rather than Reason == InProgress) to also block
+			// scaling during Pending, Unknown, Failed, TimedOut, and
+			// PreconditionChecksFailed states when the cluster may not be healthy.
 			upgradeCond := meta.FindStatusCondition(
 				newPr.Status.Conditions, string(PRconditionTypes.UpgradeCompleted))
-			if upgradeCond != nil && upgradeCond.Reason == string(CRconditionReasons.InProgress) {
-				return fmt.Errorf("node scaling is not supported while a cluster upgrade is in progress")
+			if upgradeCond != nil && upgradeCond.Status != metav1.ConditionTrue {
+				return fmt.Errorf("node scaling is not supported while a cluster upgrade is in progress or incomplete")
 			}
 		}
 

--- a/api/provisioning/v1alpha1/provisioningrequest_webhook.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_webhook.go
@@ -226,11 +226,20 @@ func (v *provisioningRequestValidator) validateCreateOrUpdate(ctx context.Contex
 	} else if crProvisionedCond.Reason == string(CRconditionReasons.Completed) {
 		// Allow specific fields and node scaling after installation completes
 		// This enables Day 2 operations like annotation/label updates and cluster scaling
-		disallowedFields, _, err = FindClusterInstanceImmutableFieldUpdates(
+		disallowedFields, scalingNodes, err = FindClusterInstanceImmutableFieldUpdates(
 			oldPrClusterInstanceInput.(map[string]any), newPrClusterInstanceInput.(map[string]any),
 			[][]string{}, AllowedClusterInstanceFields)
 		if err != nil {
 			return fmt.Errorf("failed to find immutable field updates for ClusterInstance (%s): %w", newPr.Name, err)
+		}
+
+		if len(scalingNodes) > 0 {
+			// Reject scaling while an upgrade is in progress
+			upgradeCond := meta.FindStatusCondition(
+				newPr.Status.Conditions, string(PRconditionTypes.UpgradeCompleted))
+			if upgradeCond != nil && upgradeCond.Reason == string(CRconditionReasons.InProgress) {
+				return fmt.Errorf("node scaling is not supported while a cluster upgrade is in progress")
+			}
 		}
 
 		// Only reject disallowed field changes; node scaling is explicitly allowed

--- a/api/provisioning/v1alpha1/provisioningrequest_webhook_test.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_webhook_test.go
@@ -623,6 +623,59 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
 					Expect(err).ToNot(HaveOccurred())
 				})
+
+				It("should reject node scaling while upgrade is in progress", func() {
+					// Old PR has 2 nodes (MNO, not SNO)
+					oldPr.Spec.TemplateParameters.Raw = []byte(`{
+				"oCloudSiteId": "local-123",
+				"nodeClusterName": "exampleCluster",
+				"clusterInstanceParameters": {
+					"clusterName": "test-cluster",
+					"baseDomain": "example.com",
+					"nodes": [
+						{
+							"hostName": "node1.example.com"
+						},
+						{
+							"hostName": "node2.example.com"
+						}
+					]
+				},
+				"policyTemplateParameters": {"sriov-network-vlan-1": "140"}
+			}`)
+
+					newPr.Status.Conditions = append(newPr.Status.Conditions, metav1.Condition{
+						Type:   string(PRconditionTypes.UpgradeCompleted),
+						Status: metav1.ConditionFalse,
+						Reason: string(CRconditionReasons.InProgress),
+					})
+
+					// Add a third node
+					newPr.Spec.TemplateParameters.Raw = []byte(`{
+				"oCloudSiteId": "local-123",
+				"nodeClusterName": "exampleCluster",
+				"clusterInstanceParameters": {
+					"clusterName": "test-cluster",
+					"baseDomain": "example.com",
+					"nodes": [
+						{
+							"hostName": "node1.example.com"
+						},
+						{
+							"hostName": "node2.example.com"
+						},
+						{
+							"hostName": "node3.example.com"
+						}
+					]
+				},
+				"policyTemplateParameters": {"sriov-network-vlan-1": "140"}
+			}`)
+
+					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("not supported while a cluster upgrade is in progress"))
+				})
 			})
 
 			Context("When ClusterProvisioned condition is Unknown or Failed", func() {

--- a/api/provisioning/v1alpha1/provisioningrequest_webhook_test.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_webhook_test.go
@@ -674,7 +674,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 
 					_, err := validator.ValidateUpdate(ctx, oldPr, newPr)
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("not supported while a cluster upgrade is in progress"))
+					Expect(err.Error()).To(ContainSubstring("not supported while a cluster upgrade is in progress or incomplete"))
 				})
 			})
 

--- a/bundle/manifests/clcm.openshift.io_provisioningrequests.yaml
+++ b/bundle/manifests/clcm.openshift.io_provisioningrequests.yaml
@@ -183,6 +183,13 @@ spec:
                             format: date-time
                             type: string
                         type: object
+                      fulfilledNodeCount:
+                        description: |-
+                          FulfilledNodeCount records the number of nodes at the time the PR last
+                          reached Fulfilled. Used to detect scale-out operations on subsequent
+                          reconciles — if the rendered ClusterInstance has more nodes than this
+                          value, a scale-out is in progress.
+                        type: integer
                       name:
                         description: Contains the name of the created ClusterInstance.
                         type: string

--- a/config/crd/bases/clcm.openshift.io_provisioningrequests.yaml
+++ b/config/crd/bases/clcm.openshift.io_provisioningrequests.yaml
@@ -183,6 +183,13 @@ spec:
                             format: date-time
                             type: string
                         type: object
+                      fulfilledNodeCount:
+                        description: |-
+                          FulfilledNodeCount records the number of nodes at the time the PR last
+                          reached Fulfilled. Used to detect scale-out operations on subsequent
+                          reconciles — if the rendered ClusterInstance has more nodes than this
+                          value, a scale-out is in progress.
+                        type: integer
                       name:
                         description: Contains the name of the created ClusterInstance.
                         type: string

--- a/docs/dev/e2e-test-overview.md
+++ b/docs/dev/e2e-test-overview.md
@@ -26,6 +26,8 @@ feature, which parses test structure without executing tests.
   - [Performs day2 hardware configuration update successfully](#performs-day2-hardware-configuration-update-successfully)
   - [Handles day2 hardware configuration update with BMH error](#handles-day2-hardware-configuration-update-with-bmh-error)
   - [Handles mid-flight profile change by abandoning stale updates](#handles-mid-flight-profile-change-by-abandoning-stale-updates)
+- [MNO Scale-Out test [mno-scale-out]](#mno-scale-out-test-mno-scale-out)
+  - [Scale-out: add a worker node](#scale-out-add-a-worker-node)
 - [SNO End-to-end ProvisioningRequestReconcile with hardware manager [sno-provisioning]](#sno-end-to-end-provisioningrequestreconcile-with-hardware-manager-sno-provisioning)
 
 ## MNO Standard ClusterVersion Upgrade [mno-cv-upgrade]
@@ -135,6 +137,38 @@ File: `test/e2e/mno_hw_configuration_test.go`
    - Waiting for NAR to reach ConfigApplied after all workers converge
    - Verifying all 8 worker nodes converged to v2 profile
 1. Should PR reach HardwareConfigured=True
+
+## MNO Scale-Out test [mno-scale-out]
+
+File: `test/e2e/mno_scale_test.go`
+
+- Creating namespaces
+- Creating ConfigMaps
+- Creating ClusterTemplate and supporting resources
+- Creating 6 BMHs (3 masters + 3 workers: 2 initial + 1 extra for scale-out)
+- Waiting for all 6 BMHs to be visible
+- Waiting for ClusterTemplate reconciliation
+- Creating initial ProvisioningRequest with 3 masters + 2 workers
+- Waiting for NAR creation
+- Verifying initial NAR NodeGroup sizes
+- Waiting for all 5 AllocatedNodes to be created
+- Waiting for NAR Provisioned=True
+- Waiting for PR HardwareProvisioned=True
+- Capturing initial AllocatedNode names before scale-out
+- Simulating AllocatedNodeHostMap on PR
+- Simulating ClusterProvisioned=Completed on PR
+- Cleaning up scale test resources
+
+### Scale-out: add a worker node
+
+1. should increase NAR worker NodeGroup Size after PR update
+   - Creating CI defaults v2 with 3 workers and a new CT version
+   - Waiting for new CT reconciliation
+   - Updating PR to use new CT version and add worker-3
+   - Verifying NAR NodeGroup sizes after scale-out
+1. should create a new AllocatedNode for the added worker
+   - Waiting for 6 AllocatedNodes (3 masters + 3 workers)
+   - Verifying original nodes are preserved and new node is a worker
 
 ## SNO End-to-end ProvisioningRequestReconcile with hardware manager [sno-provisioning]
 

--- a/docs/user-guide/cluster-configuration.md
+++ b/docs/user-guide/cluster-configuration.md
@@ -15,6 +15,7 @@ SPDX-License-Identifier: Apache-2.0
     * [Adding a new manifest to an existing ACM PolicyGenerator](#adding-a-new-manifest-to-an-existing-acm-policygenerator)
     * [Updating the ClusterTemplate schemas](#updating-the-clustertemplate-schemas)
     * [Switching to a new hardware profile](#switching-to-a-new-hardware-profile)
+  * [Scaling Worker Nodes](#scaling-worker-nodes)
 
 ## Overview
 
@@ -720,3 +721,77 @@ The following steps are required:
         provisioningDetails: Provisioning request has completed successfully
         provisioningPhase: fulfilled
   ```
+
+### Scaling Worker Nodes
+
+After a multi-node (MNO) cluster is provisioned, you can add worker
+nodes by updating the ProvisioningRequest's
+`clusterInstanceParameters.nodes` array. Scale-in (removing worker
+nodes) is planned for a future release.
+
+> [!NOTE]
+> Scaling is only supported for worker nodes. Control plane (master)
+> nodes cannot be added or removed after initial provisioning. Scaling
+> is not supported on single-node (SNO) clusters. Scaling and upgrade
+> operations cannot run concurrently.
+
+#### Prerequisites
+
+* The cluster must be fully provisioned (`ClusterProvisioned=Completed`).
+* For scale-out: available BareMetalHosts must exist in the resource
+  pool matching the worker node group's `resourceSelector` labels.
+* The ClusterInstance defaults ConfigMap must include a node template
+  entry for the new worker (with `role: worker`).
+* No upgrade operation is currently in progress.
+
+#### Adding a worker node (scale-out)
+
+1. If needed, update the ClusterInstance defaults ConfigMap to add a
+   worker node template entry for the new node.
+
+2. Update the ProvisioningRequest to add the new worker node entry to
+   `spec.templateParameters.clusterInstanceParameters.nodes`:
+
+   ```yaml
+   spec:
+     templateParameters:
+       clusterInstanceParameters:
+         nodes:
+           - hostName: master-1.cluster.example.com
+           - hostName: master-2.cluster.example.com
+           - hostName: master-3.cluster.example.com
+           - hostName: worker-1.cluster.example.com
+           - hostName: worker-2.cluster.example.com
+           - hostName: worker-3.cluster.example.com  # new worker
+             nodeNetwork:
+               config:
+                 dns-resolver:
+                   config:
+                     server:
+                       - 198.51.100.1
+   ```
+
+3. The controller detects the new node and:
+   * Increases the NodeAllocationRequest worker `NodeGroup.Size`.
+   * The hardware manager allocates a new BareMetalHost and creates an
+     AllocatedNode CR.
+   * The new node's BMC address and MAC are mapped to the ClusterInstance.
+   * The ClusterInstance is updated via Server-Side Apply and siteconfig
+     provisions the new node.
+
+4. Monitor progress:
+
+   ```bash
+   oc get pr <pr-name> -o jsonpath='{.status.provisioningStatus}'
+   ```
+
+   The ProvisioningRequest transitions from `fulfilled` → `pending` →
+   `progressing` → `fulfilled` once the new node joins the cluster.
+
+#### Removing a worker node (scale-in)
+
+> [!IMPORTANT]
+> Scale-in is not yet supported. Do not remove worker nodes from the
+> ProvisioningRequest nodes array. When scale-in support is added in a
+> future release, the controller will drain nodes before removal to
+> minimize workload disruption.

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -97,6 +97,13 @@ func (t *provisioningRequestReconcilerTask) buildClusterInstance(
 		}
 	}
 
+	// Validate that node scaling only affects worker nodes
+	if ciExists && ctlrutils.IsClusterProvisionCompleted(t.object) {
+		if err := validateScaleWorkerOnly(existingCIUnstructured, renderedCIUnstructured); err != nil {
+			return nil, err
+		}
+	}
+
 	// Validate the rendered ClusterInstance with dry-run. The defaults defined in the
 	// ClusterInstance CRD will be applied by the APIserver after the dry-run.
 	// NOTE: ClusterInstance immutable field validation is handled by ACM 2.13+
@@ -577,6 +584,87 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstanceUpgrade(
 	}
 
 	return nil
+}
+
+// validateScaleWorkerOnly ensures that node scaling only adds worker nodes.
+// It compares the existing and rendered ClusterInstance node lists and rejects
+// any operation that removes nodes (scale-in is not yet supported), adds
+// non-worker nodes, or scales a single-node cluster.
+func validateScaleWorkerOnly(existingCI, renderedCI *unstructured.Unstructured) error {
+	existingNodes := getNodeRolesByHostname(existingCI)
+	renderedNodes := getNodeRolesByHostname(renderedCI)
+
+	// No scaling detected
+	if len(existingNodes) == len(renderedNodes) {
+		same := true
+		for hostname := range existingNodes {
+			if _, exists := renderedNodes[hostname]; !exists {
+				same = false
+				break
+			}
+		}
+		if same {
+			return nil
+		}
+	}
+
+	// Reject scaling on single-node clusters
+	masterCount := 0
+	for _, role := range existingNodes {
+		if role == "master" || role == "control-plane" {
+			masterCount++
+		}
+	}
+	if len(existingNodes) == 1 || (len(existingNodes) == masterCount && masterCount <= 1) {
+		return typederrors.NewInputError("node scaling is not supported on single-node clusters")
+	}
+
+	// Reject any node removals — scale-in is not yet supported
+	for hostname, role := range existingNodes {
+		if _, exists := renderedNodes[hostname]; !exists {
+			return typederrors.NewInputError(
+				"node removal is not yet supported: cannot remove %s node %q",
+				role, hostname)
+		}
+	}
+
+	// Check for added nodes with non-worker role
+	for hostname, role := range renderedNodes {
+		if _, exists := existingNodes[hostname]; !exists {
+			if role != "worker" {
+				return typederrors.NewInputError(
+					"node scaling is restricted to worker nodes: cannot add %s node %q",
+					role, hostname)
+			}
+		}
+	}
+
+	return nil
+}
+
+// getNodeRolesByHostname extracts a map of hostname → role from a ClusterInstance.
+func getNodeRolesByHostname(ci *unstructured.Unstructured) map[string]string {
+	result := make(map[string]string)
+	spec, ok := ci.Object["spec"].(map[string]any)
+	if !ok {
+		return result
+	}
+	nodes, ok := spec["nodes"].([]any)
+	if !ok {
+		return result
+	}
+	for _, node := range nodes {
+		nodeMap, ok := node.(map[string]any)
+		if !ok {
+			continue
+		}
+		hostname, _ := nodeMap["hostName"].(string)
+		role, _ := nodeMap["role"].(string)
+		if hostname != "" && role != "" {
+			result[hostname] = role
+		}
+	}
+	return result
 }
 
 // extractNodeDetails extracts necessary node details from the existing ClusterInstance

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -8,10 +8,16 @@ package controllers
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +30,7 @@ import (
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils/spokeclient"
 	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -214,6 +221,84 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx contex
 		// Update the ProvisioningRequest status with the clusterInstance details
 		if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
 			return fmt.Errorf("failed to update status for ProvisioningRequest %s: %w", t.object.Name, updateErr)
+		}
+	}
+
+	// Detect scale-out: if the rendered CI has more nodes than the last fulfilled
+	// count, proactively transition the PR to Progressing. Without this, the PR
+	// stays at Fulfilled because siteconfig doesn't reset the CI's Provisioned
+	// condition when nodes are added to an already-provisioned cluster.
+	fulfilledCount := 0
+	if t.object.Status.Extensions.ClusterDetails != nil {
+		fulfilledCount = t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount
+	}
+	renderedNodeCount := len(getNodeRolesByHostname(clusterInstance))
+	if fulfilledCount > 0 && renderedNodeCount > fulfilledCount {
+		t.logger.InfoContext(ctx, "Scale-out in progress",
+			slog.Int("fulfilledNodeCount", fulfilledCount),
+			slog.Int("renderedNodeCount", renderedNodeCount))
+
+		// Only set InProgress on the first detection (when ClusterProvisioned is
+		// still Completed).
+		if ctlrutils.IsClusterProvisionCompleted(t.object) {
+			message := fmt.Sprintf("Scale-out: waiting for new node to join the cluster (%d → %d nodes)",
+				fulfilledCount, renderedNodeCount)
+			t.logger.InfoContext(ctx, message)
+			ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
+				provisioningv1alpha1.PRconditionTypes.ClusterProvisioned,
+				provisioningv1alpha1.CRconditionReasons.InProgress,
+				metav1.ConditionFalse,
+				message,
+			)
+			ctlrutils.SetProvisioningStateInProgress(t.object, message)
+			currentTime := metav1.Now()
+			t.object.Status.Extensions.ClusterDetails.ClusterProvisionStartedAt = &currentTime
+			if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
+				return fmt.Errorf("failed to update scale-out status for ProvisioningRequest %s: %w", t.object.Name, updateErr)
+			}
+		}
+
+		// WORKAROUND: Approve pending CSRs for scale-out worker nodes.
+		// The Assisted Service Agent controller should handle day-2 CSR approval
+		// via tryApproveDay2CSRs(), but it is not firing for scale-out workers
+		// (the Agent stays in installing-in-progress:Rebooting with empty
+		// csrStatus). This workaround can be removed once the Assisted Service
+		// bug is fixed. See: project_scaleout_csr_approval.md
+		if err := t.approveScaleOutCSRs(ctx, clusterInstance); err != nil {
+			t.logger.WarnContext(ctx, "Scale-out CSR approval attempt failed, will retry",
+				slog.Any("error", err))
+		}
+
+		// Check if all rendered nodes have joined the spoke cluster. If so,
+		// update fulfilledNodeCount and let the normal finalization flow run.
+		allJoined, checkErr := t.checkAllNodesJoined(ctx, clusterInstance)
+		if checkErr != nil {
+			t.logger.WarnContext(ctx, "Failed to check spoke node status, will retry",
+				slog.Any("error", checkErr))
+		}
+		t.logger.InfoContext(ctx, "Scale-out node join check",
+			slog.Bool("allJoined", allJoined))
+
+		if allJoined {
+			t.logger.InfoContext(ctx, "All scale-out nodes have joined the cluster")
+			t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount = renderedNodeCount
+			ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
+				provisioningv1alpha1.PRconditionTypes.ClusterProvisioned,
+				provisioningv1alpha1.CRconditionReasons.Completed,
+				metav1.ConditionTrue,
+				"Provisioning completed",
+			)
+			if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
+				return fmt.Errorf("failed to update scale-out completion status: %w", updateErr)
+			}
+			// Fall through to normal finalization
+		} else {
+			// Don't fall through to checkClusterProvisionStatus while scale-out
+			// is in progress. Siteconfig doesn't reset the CI's Provisioned
+			// condition for scale-out, so checkClusterProvisionStatus would
+			// overwrite our InProgress status back to Completed, causing
+			// premature finalization.
+			return nil
 		}
 	}
 
@@ -640,6 +725,205 @@ func validateScaleWorkerOnly(existingCI, renderedCI *unstructured.Unstructured) 
 	}
 
 	return nil
+}
+
+// scaleOutCSRRBACRules defines the RBAC permissions delivered to the spoke cluster
+// for approving CSRs during scale-out operations.
+var scaleOutCSRRBACRules = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{"certificates.k8s.io"},
+		Resources: []string{"certificatesigningrequests"},
+		Verbs:     []string{"get", "list", "watch"},
+	},
+	{
+		APIGroups: []string{"certificates.k8s.io"},
+		Resources: []string{"certificatesigningrequests/approval"},
+		Verbs:     []string{"update"},
+	},
+	{
+		APIGroups: []string{"certificates.k8s.io"},
+		Resources: []string{"signers"},
+		ResourceNames: []string{
+			"kubernetes.io/kube-apiserver-client-kubelet",
+			"kubernetes.io/kubelet-serving",
+		},
+		Verbs: []string{"approve"},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"nodes"},
+		Verbs:     []string{"get", "list"},
+	},
+}
+
+// scaleOutSpokeScheme is the scheme used by the spoke client for CSR operations.
+var scaleOutSpokeScheme = spokeclient.NewSpokeScheme(certificatesv1.AddToScheme, corev1.AddToScheme)
+
+// approveScaleOutCSRs is a WORKAROUND for an Assisted Service bug where
+// tryApproveDay2CSRs() does not fire for scale-out worker nodes. It connects
+// to the spoke cluster and approves pending CSRs whose CN matches a node
+// hostname in the rendered ClusterInstance.
+//
+// This workaround can be removed once the Assisted Service bug is fixed.
+// See: project_scaleout_csr_approval.md
+func (t *provisioningRequestReconcilerTask) approveScaleOutCSRs(
+	ctx context.Context, clusterInstance *unstructured.Unstructured) error {
+
+	clusterName := clusterInstance.GetName()
+	msaName := t.object.Name + "-scaleout"
+	mwName := t.object.Name + "-scaleout-rbac"
+
+	spokeClient, ready, err := spokeclient.EnsureSpokeClient(
+		ctx, t.client, t.logger, clusterName,
+		msaName, mwName,
+		scaleOutCSRRBACRules, scaleOutSpokeScheme)
+	if err != nil {
+		return fmt.Errorf("failed to setup spoke client for CSR approval: %w", err)
+	}
+	if !ready {
+		t.logger.InfoContext(ctx, "Spoke client for CSR approval not ready yet, will retry")
+		return nil
+	}
+
+	// Build set of valid hostnames from the rendered CI
+	validHostnames := getNodeRolesByHostname(clusterInstance)
+
+	// List all CSRs on the spoke
+	csrList := &certificatesv1.CertificateSigningRequestList{}
+	if err := spokeClient.List(ctx, csrList); err != nil {
+		return fmt.Errorf("failed to list CSRs on spoke cluster: %w", err)
+	}
+
+	for i := range csrList.Items {
+		csr := &csrList.Items[i]
+
+		// Skip already approved/denied CSRs
+		if isCSRApprovedOrDenied(csr) {
+			continue
+		}
+
+		// Only handle node bootstrap and kubelet serving CSRs
+		if csr.Spec.SignerName != "kubernetes.io/kube-apiserver-client-kubelet" &&
+			csr.Spec.SignerName != "kubernetes.io/kubelet-serving" {
+			continue
+		}
+
+		// Extract the node hostname from the CSR's CN
+		hostname, err := extractNodeHostnameFromCSR(csr)
+		if err != nil {
+			t.logger.WarnContext(ctx, "Failed to parse CSR subject",
+				slog.String("csr", csr.Name), slog.Any("error", err))
+			continue
+		}
+
+		// Only approve if the hostname is in the rendered CI
+		if _, ok := validHostnames[hostname]; !ok {
+			continue
+		}
+
+		// Approve the CSR
+		csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+			Type:           certificatesv1.CertificateApproved,
+			Status:         corev1.ConditionTrue,
+			Reason:         "O2IMSScaleOutApproval",
+			Message:        "CSR approved by O-Cloud Manager for scale-out worker node",
+			LastUpdateTime: metav1.Now(),
+		})
+		if err := spokeClient.SubResource("approval").Update(ctx, csr); err != nil {
+			t.logger.WarnContext(ctx, "Failed to approve CSR",
+				slog.String("csr", csr.Name), slog.String("hostname", hostname),
+				slog.Any("error", err))
+			continue
+		}
+		t.logger.InfoContext(ctx, "Approved scale-out CSR",
+			slog.String("csr", csr.Name), slog.String("hostname", hostname),
+			slog.String("signerName", csr.Spec.SignerName))
+	}
+
+	return nil
+}
+
+// isCSRApprovedOrDenied checks if a CSR has already been approved or denied.
+func isCSRApprovedOrDenied(csr *certificatesv1.CertificateSigningRequest) bool {
+	for _, c := range csr.Status.Conditions {
+		if c.Type == certificatesv1.CertificateApproved || c.Type == certificatesv1.CertificateDenied {
+			return true
+		}
+	}
+	return false
+}
+
+// extractNodeHostnameFromCSR parses the PEM-encoded CSR request and returns
+// the node hostname from the CN (expected format: "system:node:<hostname>").
+func extractNodeHostnameFromCSR(csr *certificatesv1.CertificateSigningRequest) (string, error) {
+	block, _ := pem.Decode(csr.Spec.Request)
+	if block == nil {
+		return "", fmt.Errorf("failed to decode PEM block from CSR %s", csr.Name)
+	}
+	req, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse certificate request from CSR %s: %w", csr.Name, err)
+	}
+	cn := req.Subject.CommonName
+	const nodePrefix = "system:node:"
+	if !strings.HasPrefix(cn, nodePrefix) {
+		return "", fmt.Errorf("csr %s CN %q does not have expected prefix %q", csr.Name, cn, nodePrefix)
+	}
+	return cn[len(nodePrefix):], nil
+}
+
+// checkAllNodesJoined verifies that all hostnames in the rendered ClusterInstance
+// exist as nodes on the spoke cluster. Returns true only if every rendered
+// hostname has a corresponding node.
+func (t *provisioningRequestReconcilerTask) checkAllNodesJoined(
+	ctx context.Context, clusterInstance *unstructured.Unstructured) (bool, error) {
+
+	clusterName := clusterInstance.GetName()
+	msaName := t.object.Name + "-scaleout"
+	mwName := t.object.Name + "-scaleout-rbac"
+
+	spokeClient, ready, err := spokeclient.EnsureSpokeClient(
+		ctx, t.client, t.logger, clusterName,
+		msaName, mwName,
+		scaleOutCSRRBACRules, scaleOutSpokeScheme)
+	if err != nil {
+		return false, fmt.Errorf("failed to setup spoke client for node check: %w", err)
+	}
+	if !ready {
+		return false, nil
+	}
+
+	// List nodes on the spoke
+	nodeList := &corev1.NodeList{}
+	if err := spokeClient.List(ctx, nodeList); err != nil {
+		return false, fmt.Errorf("failed to list nodes on spoke cluster: %w", err)
+	}
+
+	spokeNodes := make(map[string]bool, len(nodeList.Items))
+	for _, node := range nodeList.Items {
+		spokeNodes[node.Name] = true
+	}
+
+	// Check that every rendered hostname exists as a spoke node
+	renderedHostnames := getNodeRolesByHostname(clusterInstance)
+	for hostname := range renderedHostnames {
+		if !spokeNodes[hostname] {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// cleanupScaleOutSpokeAccess removes the spoke client resources created for
+// scale-out CSR approval.
+func (t *provisioningRequestReconcilerTask) cleanupScaleOutSpokeAccess(ctx context.Context, clusterName string) {
+	msaName := t.object.Name + "-scaleout"
+	mwName := t.object.Name + "-scaleout-rbac"
+	if err := spokeclient.CleanupSpokeAccess(ctx, t.client, clusterName, msaName, mwName); err != nil {
+		t.logger.WarnContext(ctx, "Failed to cleanup scale-out spoke access",
+			slog.Any("error", err))
+	}
 }
 
 // getNodeRolesByHostname extracts a map of hostname → role from a ClusterInstance.

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -679,13 +679,19 @@ func validateScaleWorkerOnly(existingCI, renderedCI *unstructured.Unstructured) 
 	existingNodes := getNodeRolesByHostname(existingCI)
 	renderedNodes := getNodeRolesByHostname(renderedCI)
 
-	// No scaling detected
+	// No scaling detected — but check for in-place role changes
 	if len(existingNodes) == len(renderedNodes) {
 		same := true
-		for hostname := range existingNodes {
-			if _, exists := renderedNodes[hostname]; !exists {
+		for hostname, existingRole := range existingNodes {
+			renderedRole, exists := renderedNodes[hostname]
+			if !exists {
 				same = false
 				break
+			}
+			if existingRole != renderedRole {
+				return typederrors.NewInputError(
+					"in-place role change is not supported: node %q role changed from %s to %s",
+					hostname, existingRole, renderedRole)
 			}
 		}
 		if same {

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -262,8 +262,8 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx contex
 		// The Assisted Service Agent controller should handle day-2 CSR approval
 		// via tryApproveDay2CSRs(), but it is not firing for scale-out workers
 		// (the Agent stays in installing-in-progress:Rebooting with empty
-		// csrStatus). This workaround can be removed once the Assisted Service
-		// bug is fixed. See: project_scaleout_csr_approval.md
+		// csrStatus). This workaround can be removed once ACM-38075 is fixed.
+		// See: project_scaleout_csr_approval.md
 		if err := t.approveScaleOutCSRs(ctx, clusterInstance); err != nil {
 			t.logger.WarnContext(ctx, "Scale-out CSR approval attempt failed, will retry",
 				slog.Any("error", err))
@@ -759,12 +759,13 @@ var scaleOutCSRRBACRules = []rbacv1.PolicyRule{
 // scaleOutSpokeScheme is the scheme used by the spoke client for CSR operations.
 var scaleOutSpokeScheme = spokeclient.NewSpokeScheme(certificatesv1.AddToScheme, corev1.AddToScheme)
 
-// approveScaleOutCSRs is a WORKAROUND for an Assisted Service bug where
-// tryApproveDay2CSRs() does not fire for scale-out worker nodes. It connects
-// to the spoke cluster and approves pending CSRs whose CN matches a node
-// hostname in the rendered ClusterInstance.
+// approveScaleOutCSRs is a WORKAROUND for ACM-38075 where the Assisted Service
+// Agent controller's tryApproveDay2CSRs() does not fire for scale-out worker
+// nodes provisioned with pre-existing BMHs. It connects to the spoke cluster
+// and approves pending CSRs whose CN matches a node hostname in the rendered
+// ClusterInstance.
 //
-// This workaround can be removed once the Assisted Service bug is fixed.
+// This workaround can be removed once ACM-38075 is fixed.
 // See: project_scaleout_csr_approval.md
 func (t *provisioningRequestReconcilerTask) approveScaleOutCSRs(
 	ctx context.Context, clusterInstance *unstructured.Unstructured) error {

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -880,8 +880,8 @@ func extractNodeHostnameFromCSR(csr *certificatesv1.CertificateSigningRequest) (
 }
 
 // checkAllNodesJoined verifies that all hostnames in the rendered ClusterInstance
-// exist as nodes on the spoke cluster. Returns true only if every rendered
-// hostname has a corresponding node.
+// exist as Ready nodes on the spoke cluster. Returns true only if every rendered
+// hostname has a corresponding node in Ready state.
 func (t *provisioningRequestReconcilerTask) checkAllNodesJoined(
 	ctx context.Context, clusterInstance *unstructured.Unstructured) (bool, error) {
 
@@ -906,20 +906,32 @@ func (t *provisioningRequestReconcilerTask) checkAllNodesJoined(
 		return false, fmt.Errorf("failed to list nodes on spoke cluster: %w", err)
 	}
 
-	spokeNodes := make(map[string]bool, len(nodeList.Items))
+	readyNodes := make(map[string]bool, len(nodeList.Items))
 	for _, node := range nodeList.Items {
-		spokeNodes[node.Name] = true
+		if isNodeReady(&node) {
+			readyNodes[node.Name] = true
+		}
 	}
 
-	// Check that every rendered hostname exists as a spoke node
+	// Check that every rendered hostname exists as a Ready spoke node
 	renderedHostnames := getNodeRolesByHostname(clusterInstance)
 	for hostname := range renderedHostnames {
-		if !spokeNodes[hostname] {
+		if !readyNodes[hostname] {
 			return false, nil
 		}
 	}
 
 	return true, nil
+}
+
+// isNodeReady returns true if the node has a Ready condition with status True.
+func isNodeReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // cleanupScaleOutSpokeAccess removes the spoke client resources created for

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -862,3 +862,54 @@ var _ = Describe("validateScaleWorkerOnly", func() {
 		Expect(validateScaleWorkerOnly(existingCI, renderedCI)).To(Succeed())
 	})
 })
+
+var _ = Describe("scale-out detection via getNodeRolesByHostname", func() {
+	makeCI := func(nodes []map[string]any) *unstructured.Unstructured {
+		ci := &unstructured.Unstructured{}
+		ci.Object = map[string]any{
+			"spec": map[string]any{
+				"nodes": func() []any {
+					result := make([]any, len(nodes))
+					for i, n := range nodes {
+						result[i] = n
+					}
+					return result
+				}(),
+			},
+		}
+		return ci
+	}
+
+	It("should detect scale-out when rendered CI has more nodes than existing CI", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "master2", "role": "master"},
+			{"hostName": "master3", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "master2", "role": "master"},
+			{"hostName": "master3", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+			{"hostName": "worker2", "role": "worker"},
+		})
+		existingCount := len(getNodeRolesByHostname(existingCI))
+		renderedCount := len(getNodeRolesByHostname(renderedCI))
+		Expect(renderedCount).To(BeNumerically(">", existingCount))
+	})
+
+	It("should not detect scale-out when node counts are equal", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		existingCount := len(getNodeRolesByHostname(existingCI))
+		renderedCount := len(getNodeRolesByHostname(renderedCI))
+		Expect(renderedCount).To(Equal(existingCount))
+	})
+})

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -744,3 +744,121 @@ func TestAssignNodeDetails(t *testing.T) {
 		})
 	}
 }
+
+var _ = Describe("validateScaleWorkerOnly", func() {
+	makeCI := func(nodes []map[string]any) *unstructured.Unstructured {
+		ci := &unstructured.Unstructured{}
+		ci.Object = map[string]any{
+			"spec": map[string]any{
+				"nodes": func() []any {
+					result := make([]any, len(nodes))
+					for i, n := range nodes {
+						result[i] = n
+					}
+					return result
+				}(),
+			},
+		}
+		return ci
+	}
+
+	It("should allow adding worker nodes", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+			{"hostName": "worker2", "role": "worker"},
+		})
+		Expect(validateScaleWorkerOnly(existingCI, renderedCI)).To(Succeed())
+	})
+
+	It("should reject removing worker nodes (scale-in not yet supported)", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+			{"hostName": "worker2", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		err := validateScaleWorkerOnly(existingCI, renderedCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("node removal is not yet supported"))
+	})
+
+	It("should reject replacing a worker node (simultaneous add and remove)", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker2", "role": "worker"},
+		})
+		err := validateScaleWorkerOnly(existingCI, renderedCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("node removal is not yet supported"))
+	})
+
+	It("should reject adding master nodes", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "master2", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		err := validateScaleWorkerOnly(existingCI, renderedCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cannot add master node"))
+	})
+
+	It("should reject removing master nodes", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "master2", "role": "master"},
+			{"hostName": "master3", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "master2", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		err := validateScaleWorkerOnly(existingCI, renderedCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("node removal is not yet supported"))
+		Expect(err.Error()).To(ContainSubstring("master3"))
+	})
+
+	It("should reject scaling on single-node clusters", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		err := validateScaleWorkerOnly(existingCI, renderedCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not supported on single-node clusters"))
+	})
+
+	It("should pass when no scaling occurred", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		Expect(validateScaleWorkerOnly(existingCI, renderedCI)).To(Succeed())
+	})
+})

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -861,6 +861,36 @@ var _ = Describe("validateScaleWorkerOnly", func() {
 		})
 		Expect(validateScaleWorkerOnly(existingCI, renderedCI)).To(Succeed())
 	})
+
+	It("should reject in-place role change from worker to master", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "master"},
+		})
+		err := validateScaleWorkerOnly(existingCI, renderedCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("in-place role change is not supported"))
+		Expect(err.Error()).To(ContainSubstring("worker1"))
+	})
+
+	It("should reject in-place role change from master to worker", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "worker"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		err := validateScaleWorkerOnly(existingCI, renderedCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("in-place role change is not supported"))
+		Expect(err.Error()).To(ContainSubstring("master1"))
+	})
 })
 
 var _ = Describe("scale-out detection via getNodeRolesByHostname", func() {

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -325,11 +325,20 @@ func (t *provisioningRequestReconcilerTask) handlePostProvisioning(ctx context.C
 
 	// Check if we need to requeue for ongoing operations
 	if !ctlrutils.IsClusterProvisionCompleted(t.object) || requeueForConfig {
+		// Use a shorter interval during scale-out so CSR approval and node
+		// join checks run frequently
+		fulfilledCount := 0
+		if t.object.Status.Extensions.ClusterDetails != nil {
+			fulfilledCount = t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount
+		}
+		if fulfilledCount > 0 && len(getNodeRolesByHostname(renderedClusterInstance)) > fulfilledCount {
+			return requeueWithMediumInterval(), nil
+		}
 		return requeueWithLongInterval(), nil
 	}
 
 	// Finalize if everything is complete
-	err = t.finalizeProvisioningIfComplete(ctx)
+	err = t.finalizeProvisioningIfComplete(ctx, renderedClusterInstance)
 	if err != nil {
 		result, _ := requeueWithError(err)
 		return result, err
@@ -721,7 +730,7 @@ func (t *provisioningRequestReconcilerTask) checkClusterDeployConfigState(ctx co
 		return requeueWithLongInterval(), nil
 	}
 
-	err = t.finalizeProvisioningIfComplete(ctx)
+	err = t.finalizeProvisioningIfComplete(ctx, nil)
 	if err != nil {
 		return requeueWithError(err)
 	}
@@ -1283,10 +1292,18 @@ func (r *ProvisioningRequestReconciler) handleObservabilityAddonCleanup(ctx cont
 // finalizeProvisioningIfComplete checks if the provisioning/upgrade process is completed.
 // If so, it sets the provisioning state to "fulfilled" and updates the provisioned
 // resources in the status.
-func (t *provisioningRequestReconcilerTask) finalizeProvisioningIfComplete(ctx context.Context) error {
+func (t *provisioningRequestReconcilerTask) finalizeProvisioningIfComplete(
+	ctx context.Context, renderedClusterInstance *unstructured.Unstructured) error {
 	if ctlrutils.IsClusterProvisionCompleted(t.object) && ctlrutils.IsClusterConfigCompleted(t.object) &&
 		ctlrutils.IsHardwareConfigCompleted(t.object) &&
 		(!ctlrutils.IsClusterUpgradeInitiated(t.object) || ctlrutils.IsClusterUpgradeCompleted(t.object)) {
+
+		// Record the fulfilled node count so scale-out can be detected on future reconciles.
+		// This must be set here (not earlier) to ensure it only updates when the PR
+		// genuinely reaches Fulfilled with all nodes provisioned.
+		if renderedClusterInstance != nil && t.object.Status.Extensions.ClusterDetails != nil {
+			t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount = len(getNodeRolesByHostname(renderedClusterInstance))
+		}
 
 		ctlrutils.SetProvisioningStateFulfilled(t.object)
 		mcl, err := t.updateOCloudNodeClusterId(ctx)
@@ -1312,6 +1329,11 @@ func (t *provisioningRequestReconcilerTask) finalizeProvisioningIfComplete(ctx c
 		if err := t.setNARClusterProvisioned(ctx); err != nil {
 			return fmt.Errorf("failed to set clusterProvisioned on NAR: %w", err)
 		}
+		// Clean up scale-out spoke access resources (MSA, ManifestWork) if they exist
+		if t.object.Status.Extensions.ClusterDetails != nil {
+			t.cleanupScaleOutSpokeAccess(ctx, t.object.Status.Extensions.ClusterDetails.Name)
+		}
+
 		if err := t.syncNARSkipCleanup(ctx); err != nil {
 			return fmt.Errorf("failed to sync skipCleanup on NAR: %w", err)
 		}

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -1301,8 +1301,19 @@ func (t *provisioningRequestReconcilerTask) finalizeProvisioningIfComplete(
 		// Record the fulfilled node count so scale-out can be detected on future reconciles.
 		// This must be set here (not earlier) to ensure it only updates when the PR
 		// genuinely reaches Fulfilled with all nodes provisioned.
-		if renderedClusterInstance != nil && t.object.Status.Extensions.ClusterDetails != nil {
-			t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount = len(getNodeRolesByHostname(renderedClusterInstance))
+		if t.object.Status.Extensions.ClusterDetails != nil {
+			if renderedClusterInstance != nil {
+				t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount = len(getNodeRolesByHostname(renderedClusterInstance))
+			} else if t.object.Status.Extensions.ClusterDetails.Name != "" {
+				// Fallback for the monitoring path (checkClusterDeployConfigState)
+				// where the rendered CI is not available.
+				existingCI, err := t.getExistingClusterInstance(ctx)
+				if err == nil && existingCI != nil {
+					if ciUnstructured, convErr := ctlrutils.ConvertToUnstructured(*existingCI); convErr == nil {
+						t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount = len(getNodeRolesByHostname(ciUnstructured))
+					}
+				}
+			}
 		}
 
 		ctlrutils.SetProvisioningStateFulfilled(t.object)

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -207,13 +207,26 @@ func (t *provisioningRequestReconcilerTask) updateClusterInstance(ctx context.Co
 
 	configErr := t.applyNodeConfiguration(ctx, hwNodes, nodeAllocationRequest, clusterInstance)
 	if configErr != nil {
-		msg := "Failed to apply node configuration to the rendered ClusterInstance: " + configErr.Error()
-		ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
-			provisioningv1alpha1.PRconditionTypes.HardwareNodeConfigApplied,
-			provisioningv1alpha1.CRconditionReasons.NotApplied,
-			metav1.ConditionFalse,
-			msg)
-		ctlrutils.SetProvisioningStateFailed(t.object, msg)
+		if ctlrutils.IsClusterProvisionCompleted(t.object) {
+			// During scale-out, the new AllocatedNode may not exist yet when the
+			// first reconcile runs. Treat this as in-progress rather than failed
+			// so the user sees "progressing" while the HW manager allocates the node.
+			msg := "Waiting for hardware allocation for new nodes"
+			ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
+				provisioningv1alpha1.PRconditionTypes.HardwareNodeConfigApplied,
+				provisioningv1alpha1.CRconditionReasons.InProgress,
+				metav1.ConditionFalse,
+				msg)
+			ctlrutils.SetProvisioningStateInProgress(t.object, msg)
+		} else {
+			failMsg := "Failed to apply node configuration to the rendered ClusterInstance: " + configErr.Error()
+			ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
+				provisioningv1alpha1.PRconditionTypes.HardwareNodeConfigApplied,
+				provisioningv1alpha1.CRconditionReasons.NotApplied,
+				metav1.ConditionFalse,
+				failMsg)
+			ctlrutils.SetProvisioningStateFailed(t.object, failMsg)
+		}
 	} else {
 		ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
 			provisioningv1alpha1.PRconditionTypes.HardwareNodeConfigApplied,

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -256,13 +256,24 @@ func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestStatus(
 	var timedOutOrFailed bool
 	var err error
 
+	// Guard against consuming stale Provisioned status during scale-out.
+	// After patching the NAR with a larger NodeGroup.Size, the NAR may still
+	// carry Provisioned=True from the previous provisioning until the hardware
+	// manager's handleScaleOut detects the Size increase and sets it to
+	// InProgress. Skip the check and requeue until ObservedGeneration catches up.
+	if condition == hwmgmtv1alpha1.Provisioned &&
+		nodeAllocationRequestResponse.ObjectMeta.Generation != nodeAllocationRequestResponse.Status.ObservedGeneration {
+		t.logger.InfoContext(ctx, "Skipping stale NAR Provisioned status — hardware manager has not observed new generation",
+			slog.Int64("generation", nodeAllocationRequestResponse.ObjectMeta.Generation),
+			slog.Int64("observedGeneration", nodeAllocationRequestResponse.Status.ObservedGeneration))
+		return false, false, nil
+	}
+
 	// Guard against consuming stale Configured status during day-2 retries.
 	// After a PR spec change, the NAR may still carry a Configured condition
 	// from the previous attempt (Failed, TimedOut, or True from a prior success)
 	// until the hardware manager processes the new ConfigTransactionId. Skip the update
 	// and requeue until the hardware manager has observed the new transaction.
-	// This only applies to Configured — the Provisioned condition transitions
-	// once during initial provisioning and is not affected by spec changes.
 	if condition == hwmgmtv1alpha1.Configured &&
 		nodeAllocationRequestResponse.Spec.ConfigTransactionId != 0 &&
 		nodeAllocationRequestResponse.Status.ObservedConfigTransactionId != nodeAllocationRequestResponse.Spec.ConfigTransactionId {

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -256,17 +256,23 @@ func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestStatus(
 	var timedOutOrFailed bool
 	var err error
 
-	// Guard against consuming stale Provisioned status during scale-out.
+	// Guard against consuming stale Provisioned=True during scale-out.
 	// After patching the NAR with a larger NodeGroup.Size, the NAR may still
 	// carry Provisioned=True from the previous provisioning until the hardware
 	// manager's handleScaleOut detects the Size increase and sets it to
 	// InProgress. Skip the check and requeue until ObservedGeneration catches up.
+	// Only applies when Provisioned is True — if handleScaleOut has already set
+	// it to InProgress, the condition is no longer stale. This avoids blocking
+	// day-2 hwProfile changes where generation advances but Provisioned is valid.
 	if condition == hwmgmtv1alpha1.Provisioned &&
 		nodeAllocationRequestResponse.ObjectMeta.Generation != nodeAllocationRequestResponse.Status.ObservedGeneration {
-		t.logger.InfoContext(ctx, "Skipping stale NAR Provisioned status — hardware manager has not observed new generation",
-			slog.Int64("generation", nodeAllocationRequestResponse.ObjectMeta.Generation),
-			slog.Int64("observedGeneration", nodeAllocationRequestResponse.Status.ObservedGeneration))
-		return false, false, nil
+		provCond := meta.FindStatusCondition(nodeAllocationRequestResponse.Status.Conditions, string(hwmgmtv1alpha1.Provisioned))
+		if provCond != nil && provCond.Status == metav1.ConditionTrue {
+			t.logger.InfoContext(ctx, "Skipping stale NAR Provisioned status — hardware manager has not observed new generation",
+				slog.Int64("generation", nodeAllocationRequestResponse.ObjectMeta.Generation),
+				slog.Int64("observedGeneration", nodeAllocationRequestResponse.Status.ObservedGeneration))
+			return false, false, nil
+		}
 	}
 
 	// Guard against consuming stale Configured status during day-2 retries.

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -256,25 +256,6 @@ func (t *provisioningRequestReconcilerTask) checkNodeAllocationRequestStatus(
 	var timedOutOrFailed bool
 	var err error
 
-	// Guard against consuming stale Provisioned=True during scale-out.
-	// After patching the NAR with a larger NodeGroup.Size, the NAR may still
-	// carry Provisioned=True from the previous provisioning until the hardware
-	// manager's handleScaleOut detects the Size increase and sets it to
-	// InProgress. Skip the check and requeue until ObservedGeneration catches up.
-	// Only applies when Provisioned is True — if handleScaleOut has already set
-	// it to InProgress, the condition is no longer stale. This avoids blocking
-	// day-2 hwProfile changes where generation advances but Provisioned is valid.
-	if condition == hwmgmtv1alpha1.Provisioned &&
-		nodeAllocationRequestResponse.ObjectMeta.Generation != nodeAllocationRequestResponse.Status.ObservedGeneration {
-		provCond := meta.FindStatusCondition(nodeAllocationRequestResponse.Status.Conditions, string(hwmgmtv1alpha1.Provisioned))
-		if provCond != nil && provCond.Status == metav1.ConditionTrue {
-			t.logger.InfoContext(ctx, "Skipping stale NAR Provisioned status — hardware manager has not observed new generation",
-				slog.Int64("generation", nodeAllocationRequestResponse.ObjectMeta.Generation),
-				slog.Int64("observedGeneration", nodeAllocationRequestResponse.Status.ObservedGeneration))
-			return false, false, nil
-		}
-	}
-
 	// Guard against consuming stale Configured status during day-2 retries.
 	// After a PR spec change, the NAR may still carry a Configured condition
 	// from the previous attempt (Failed, TimedOut, or True from a prior success)

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -95,6 +95,40 @@ func hasNodeGroupHwProfileChanges(
 	return false, nil
 }
 
+// hasNodeGroupSizeIncreases checks whether any node group in the NAR spec has a
+// Size larger than the current number of allocated nodes for that group. This
+// indicates a scale-out operation where additional nodes need to be allocated.
+func hasNodeGroupSizeIncreases(
+	ctx context.Context,
+	noncachedClient client.Reader,
+	logger *slog.Logger,
+	namespace string,
+	nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest,
+) (bool, error) {
+	childNodes, err := hwmgrutils.GetChildNodesUncached(ctx, noncachedClient, namespace, nodeAllocationRequest.Name)
+	if err != nil {
+		return false, fmt.Errorf("failed to list child nodes for size check: %w", err)
+	}
+
+	for _, group := range nodeAllocationRequest.Spec.NodeGroup {
+		allocatedCount := 0
+		for _, node := range childNodes.Items {
+			if node.Spec.GroupName == group.NodeGroupData.Name {
+				allocatedCount++
+			}
+		}
+		if allocatedCount < group.Size {
+			logger.InfoContext(ctx, "NodeGroup needs additional nodes",
+				slog.String("group", group.NodeGroupData.Name),
+				slog.Int("allocated", allocatedCount),
+				slog.Int("desired", group.Size))
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // enableBMOManagementForIBINodes sets spec.online=true and removes the detached annotation
 // on IBI-provisioned BMHs (externallyProvisioned=true with detached annotation) so that BMO
 // can fully manage them. This is called when the cluster is reported as fully provisioned.

--- a/internal/hardwaremanager/controller/helpers_test.go
+++ b/internal/hardwaremanager/controller/helpers_test.go
@@ -3608,4 +3608,105 @@ var _ = Describe("Helpers", func() {
 			Expect(clusterName).To(Equal("actual-cluster-name"))
 		})
 	})
+
+	Describe("hasNodeGroupSizeIncreases", func() {
+		var (
+			testScheme *runtime.Scheme
+			testClient client.Client
+		)
+
+		BeforeEach(func() {
+			testScheme = runtime.NewScheme()
+			Expect(hwmgmtv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		})
+
+		It("should return true when allocated count is less than desired size", func() {
+			nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-nar", Namespace: "oran-o2ims"},
+				Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+					NodeGroup: []hwmgmtv1alpha1.NodeGroup{
+						{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker", Role: "worker"}, Size: 3},
+					},
+				},
+			}
+			// Only 2 AllocatedNodes exist for the worker group
+			node1 := &hwmgmtv1alpha1.AllocatedNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1", Namespace: "oran-o2ims",
+					Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"},
+				},
+				Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker", NodeAllocationRequest: "test-nar"},
+			}
+			node2 := &hwmgmtv1alpha1.AllocatedNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2", Namespace: "oran-o2ims",
+					Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"},
+				},
+				Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker", NodeAllocationRequest: "test-nar"},
+			}
+			testClient = fake.NewClientBuilder().WithScheme(testScheme).
+				WithObjects(node1, node2).Build()
+
+			result, err := hasNodeGroupSizeIncreases(ctx, testClient, logger, "oran-o2ims", nar)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false when allocated count equals desired size", func() {
+			nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-nar", Namespace: "oran-o2ims"},
+				Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+					NodeGroup: []hwmgmtv1alpha1.NodeGroup{
+						{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker", Role: "worker"}, Size: 2},
+					},
+				},
+			}
+			node1 := &hwmgmtv1alpha1.AllocatedNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1", Namespace: "oran-o2ims",
+					Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"},
+				},
+				Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker", NodeAllocationRequest: "test-nar"},
+			}
+			node2 := &hwmgmtv1alpha1.AllocatedNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2", Namespace: "oran-o2ims",
+					Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"},
+				},
+				Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker", NodeAllocationRequest: "test-nar"},
+			}
+			testClient = fake.NewClientBuilder().WithScheme(testScheme).
+				WithObjects(node1, node2).Build()
+
+			result, err := hasNodeGroupSizeIncreases(ctx, testClient, logger, "oran-o2ims", nar)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should only detect increases for the specific group", func() {
+			nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-nar", Namespace: "oran-o2ims"},
+				Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+					NodeGroup: []hwmgmtv1alpha1.NodeGroup{
+						{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "master", Role: "master"}, Size: 3},
+						{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker", Role: "worker"}, Size: 3},
+					},
+				},
+			}
+			// 3 masters (satisfied) + 2 workers (needs 1 more)
+			nodes := []client.Object{
+				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "master", NodeAllocationRequest: "test-nar"}},
+				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "m2", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "master", NodeAllocationRequest: "test-nar"}},
+				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "m3", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "master", NodeAllocationRequest: "test-nar"}},
+				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "w1", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker", NodeAllocationRequest: "test-nar"}},
+				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "w2", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker", NodeAllocationRequest: "test-nar"}},
+			}
+			testClient = fake.NewClientBuilder().WithScheme(testScheme).
+				WithObjects(nodes...).Build()
+
+			result, err := hasNodeGroupSizeIncreases(ctx, testClient, logger, "oran-o2ims", nar)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
 })

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -302,6 +302,34 @@ func (r *NodeAllocationRequestReconciler) handleNewNodeAllocationRequestCreate(
 	return hwmgrutils.DoNotRequeue(), nil
 }
 
+// handleScaleOut checks if NodeGroup sizes increased and re-enters the allocation
+// flow if additional nodes need to be allocated. Returns (result, handled, error).
+func (r *NodeAllocationRequestReconciler) handleScaleOut(
+	ctx context.Context,
+	nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest,
+) (ctrl.Result, bool, error) {
+	sizeIncreased, err := hasNodeGroupSizeIncreases(ctx, r.NoncachedClient, r.Logger, r.Namespace, nodeAllocationRequest)
+	if err != nil {
+		return hwmgrutils.RequeueWithShortInterval(), false, err
+	}
+	if !sizeIncreased {
+		return ctrl.Result{}, false, nil
+	}
+
+	r.Logger.InfoContext(ctx, "NodeGroup size increase detected, re-entering allocation flow")
+	if err := hwmgrutils.UpdateNodeAllocationRequestStatusCondition(ctx, r.Client, nodeAllocationRequest,
+		hwmgmtv1alpha1.Provisioned, hwmgmtv1alpha1.InProgress,
+		metav1.ConditionFalse, "Allocating additional nodes for scale-out"); err != nil {
+		return hwmgrutils.RequeueWithShortInterval(), false,
+			fmt.Errorf("failed to update status for scale-out: %w", err)
+	}
+	if err := hwmgrutils.UpdateNodeAllocationRequestObservedGeneration(ctx, r.Client, nodeAllocationRequest); err != nil {
+		return hwmgrutils.RequeueWithShortInterval(), false,
+			fmt.Errorf("failed to update ObservedGeneration for scale-out: %w", err)
+	}
+	return hwmgrutils.RequeueImmediately(), true, nil
+}
+
 func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestSpecChanged(
 	ctx context.Context,
 	nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest) (ctrl.Result, error) {
@@ -328,6 +356,11 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestSpecChanged
 	configInProgress := configuredCondition != nil &&
 		configuredCondition.Status == metav1.ConditionFalse &&
 		configuredCondition.Reason == string(hwmgmtv1alpha1.InProgress)
+
+	// Check if NodeGroup sizes increased (scale-out).
+	if result, handled, err := r.handleScaleOut(ctx, nodeAllocationRequest); handled || err != nil {
+		return result, err
+	}
 
 	// Check whether the HW profile has changed.
 	hwProfileChanged, err := hasNodeGroupHwProfileChanges(ctx, r.Client, r.Logger, nodeAllocationRequest)

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -323,10 +323,11 @@ func (r *NodeAllocationRequestReconciler) handleScaleOut(
 		return hwmgrutils.RequeueWithShortInterval(), false,
 			fmt.Errorf("failed to update status for scale-out: %w", err)
 	}
-	if err := hwmgrutils.UpdateNodeAllocationRequestObservedGeneration(ctx, r.Client, nodeAllocationRequest); err != nil {
-		return hwmgrutils.RequeueWithShortInterval(), false,
-			fmt.Errorf("failed to update ObservedGeneration for scale-out: %w", err)
-	}
+	// Do not advance ObservedGeneration here. Setting Provisioned=InProgress
+	// routes the FSM directly to Processing for allocation. After allocation
+	// completes and Provisioned returns to True, the FSM will re-enter
+	// SpecChanged (since ObservedGeneration != Generation) to process any
+	// other spec changes in this generation (e.g., HwProfile updates).
 	return hwmgrutils.RequeueImmediately(), true, nil
 }
 

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -364,5 +365,111 @@ var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 				Expect(conditionType).To(Equal(hwmgmtv1alpha1.ConditionType("")))
 			})
 		})
+	})
+})
+
+var _ = Describe("handleScaleOut", func() {
+	var (
+		reconciler *NodeAllocationRequestReconciler
+		fakeClient client.Client
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		testLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		scheme := runtime.NewScheme()
+		Expect(hwmgmtv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(&hwmgmtv1alpha1.NodeAllocationRequest{}).Build()
+
+		reconciler = &NodeAllocationRequestReconciler{
+			Client:          fakeClient,
+			NoncachedClient: fakeClient,
+			Logger:          testLogger,
+			Namespace:       "oran-o2ims",
+		}
+	})
+
+	It("should set Provisioned=InProgress when NodeGroup size increased", func() {
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-nar",
+				Namespace:  "oran-o2ims",
+				Generation: 3,
+			},
+			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
+					{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker", Role: "worker"}, Size: 3},
+				},
+			},
+		}
+		Expect(fakeClient.Create(ctx, nar)).To(Succeed())
+		hwmgrutils.SetStatusCondition(&nar.Status.Conditions,
+			string(hwmgmtv1alpha1.Provisioned), string(hwmgmtv1alpha1.Completed),
+			metav1.ConditionTrue, "Provisioned")
+		Expect(fakeClient.Status().Update(ctx, nar)).To(Succeed())
+
+		// Only 2 AllocatedNodes exist — Size is 3, so scale-out needed
+		for _, name := range []string{"w1", "w2"} {
+			node := &hwmgmtv1alpha1.AllocatedNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name, Namespace: "oran-o2ims",
+					Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"},
+				},
+				Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
+					GroupName:             "worker",
+					NodeAllocationRequest: "test-nar",
+				},
+			}
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+		}
+
+		_, handled, err := reconciler.handleScaleOut(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeTrue())
+
+		// Verify Provisioned condition was set to InProgress
+		updatedNAR := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nar), updatedNAR)).To(Succeed())
+		provCond := meta.FindStatusCondition(updatedNAR.Status.Conditions, string(hwmgmtv1alpha1.Provisioned))
+		Expect(provCond).ToNot(BeNil())
+		Expect(provCond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(provCond.Reason).To(Equal(string(hwmgmtv1alpha1.InProgress)))
+	})
+
+	It("should not trigger when allocated count matches desired size", func() {
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-nar",
+				Namespace:  "oran-o2ims",
+				Generation: 2,
+			},
+			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
+					{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker", Role: "worker"}, Size: 2},
+				},
+			},
+		}
+		Expect(fakeClient.Create(ctx, nar)).To(Succeed())
+
+		for _, name := range []string{"w1", "w2"} {
+			node := &hwmgmtv1alpha1.AllocatedNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name, Namespace: "oran-o2ims",
+					Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"},
+				},
+				Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
+					GroupName:             "worker",
+					NodeAllocationRequest: "test-nar",
+				},
+			}
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+		}
+
+		_, handled, err := reconciler.handleScaleOut(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeFalse())
 	})
 })

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
@@ -437,6 +437,11 @@ var _ = Describe("handleScaleOut", func() {
 		Expect(provCond).ToNot(BeNil())
 		Expect(provCond.Status).To(Equal(metav1.ConditionFalse))
 		Expect(provCond.Reason).To(Equal(string(hwmgmtv1alpha1.InProgress)))
+
+		// ObservedGeneration must NOT be advanced, so that the FSM re-enters
+		// SpecChanged after allocation completes to process other spec changes
+		// (e.g., HwProfile updates in the same generation).
+		Expect(updatedNAR.Status.ObservedGeneration).To(Equal(int64(0)))
 	})
 
 	It("should not trigger when allocated count matches desired size", func() {

--- a/test/e2e/mno_scale_test.go
+++ b/test/e2e/mno_scale_test.go
@@ -1,0 +1,484 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controllersE2Etest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
+	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+)
+
+var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
+	const (
+		timeout     = time.Minute * 2
+		interval    = time.Second * 3
+		master      = "master"
+		worker      = "worker"
+		masterCount = 3
+		workerCount = 2
+
+		scalePoolR740   = "scale-r740-pool"
+		scalePoolXR8620 = "scale-xr8620t-pool"
+	)
+
+	var (
+		testCtx     context.Context
+		clusterName = "scale-cluster"
+		ctNamespace = "scale-4-20-16"
+		prName      string
+
+		pr                        *provisioningv1alpha1.ProvisioningRequest
+		nar                       *hwmgmtv1alpha1.NodeAllocationRequest
+		initialAllocatedNodeNames map[string]bool
+	)
+
+	testCtx = context.Background()
+
+	resourceDir := "../resources/mno_scale"
+
+	cmYamls := []string{
+		resourceDir + "/clusterinstance-defaults-v1.yaml",
+		resourceDir + "/policytemplate-defaults-v1.yaml",
+	}
+
+	BeforeAll(func() {
+		pr = &provisioningv1alpha1.ProvisioningRequest{}
+		nar = &hwmgmtv1alpha1.NodeAllocationRequest{}
+
+		By("Creating namespaces")
+		for _, ns := range []string{ctNamespace, "ztp-" + ctNamespace, scalePoolR740, scalePoolXR8620} {
+			err := K8SClient.Create(testCtx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: ns},
+			})
+			if err != nil && !errors.IsAlreadyExists(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}
+
+		By("Creating ConfigMaps")
+		for _, yaml := range cmYamls {
+			cm, err := testutils.LoadYAML[corev1.ConfigMap](yaml)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(K8SClient.Create(testCtx, cm)).To(Succeed())
+		}
+
+		By("Creating ClusterTemplate and supporting resources")
+		ct, err := testutils.LoadYAML[provisioningv1alpha1.ClusterTemplate](resourceDir + "/ct-scale.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(K8SClient.Create(testCtx, ct)).To(Succeed())
+
+		pullSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "pull-secret", Namespace: ctNamespace},
+			Data:       map[string][]byte{".dockerconfigjson": []byte(testutils.TestSecretDataStr)},
+			Type:       corev1.SecretTypeDockerConfigJson,
+		}
+		clusterImageSet := &hivev1.ClusterImageSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "4.20.16"},
+			Spec: hivev1.ClusterImageSetSpec{
+				ReleaseImage: "quay.io/openshift-release-dev/ocp-release:4.20.16-x86_64",
+			},
+		}
+		extraManifests := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "clustertemplate-sample.v1.0.0-extramanifests",
+				Namespace: ctNamespace,
+			},
+			Data: map[string]string{},
+		}
+		for _, r := range []client.Object{pullSecret, extraManifests, clusterImageSet} {
+			if err := K8SClient.Create(testCtx, r); err != nil && !errors.IsAlreadyExists(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}
+
+		By("Creating 6 BMHs (3 masters + 3 workers: 2 initial + 1 extra for scale-out)")
+		bmhList := scaleBMHs(masterCount, workerCount+1)
+		for _, bmhData := range bmhList {
+			bmh := testutils.CreateBareMetalHost(bmhData)
+			bmcSecret := testutils.CreateBMCSecret(bmhData.Name)
+			Expect(K8SClient.Create(testCtx, bmh)).To(Succeed())
+			Expect(K8SClient.Create(testCtx, bmcSecret)).To(Succeed())
+
+			bmh.Status = metal3v1alpha1.BareMetalHostStatus{
+				Provisioning: metal3v1alpha1.ProvisionStatus{State: metal3v1alpha1.StateAvailable},
+				HardwareDetails: &metal3v1alpha1.HardwareDetails{
+					CPU: metal3v1alpha1.CPU{Arch: "x86_64"},
+					NIC: []metal3v1alpha1.NIC{
+						{Name: "eno1", MAC: bmhData.MacAddress},
+					},
+				},
+			}
+			Expect(K8SClient.Status().Update(testCtx, bmh)).To(Succeed())
+
+			hwData := &metal3v1alpha1.HardwareData{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bmhData.Name,
+					Namespace: bmhData.Namespace,
+				},
+				Spec: metal3v1alpha1.HardwareDataSpec{
+					HardwareDetails: &metal3v1alpha1.HardwareDetails{
+						CPU: metal3v1alpha1.CPU{Arch: "x86_64"},
+						NIC: []metal3v1alpha1.NIC{
+							{Name: "eno1", MAC: bmhData.MacAddress},
+						},
+					},
+				},
+			}
+			Expect(K8SClient.Create(testCtx, hwData)).To(Succeed())
+
+			hfs := testutils.CreateHostFirmwareSettings(bmhData.Name, bmhData.Namespace)
+			Expect(K8SClient.Create(testCtx, hfs)).To(Succeed())
+			hfs.Status = testutils.UpdateHostFirmwareSettingsStatus(
+				fmt.Sprintf("schema-%s", bmhData.Name), bmhData.Namespace,
+				map[string]string{}, metav1.ConditionTrue, metav1.ConditionFalse, hfs.Generation)
+			Expect(K8SClient.Status().Update(testCtx, hfs)).To(Succeed())
+
+			hfc := testutils.CreateHostFirmwareComponents(bmhData.Name, bmhData.Namespace)
+			Expect(K8SClient.Create(testCtx, hfc)).To(Succeed())
+			hfc.Status = testutils.UpdateHostFirmwareComponentsStatus(
+				bmhData.Name, bmhData.Namespace,
+				[]metal3v1alpha1.FirmwareComponentStatus{
+					{Component: "bios", CurrentVersion: "2.0.0"},
+					{Component: "bmc", CurrentVersion: "6.0.0"},
+				},
+				metav1.ConditionTrue, metav1.ConditionFalse, hfc.Generation)
+			Expect(K8SClient.Status().Update(testCtx, hfc)).To(Succeed())
+		}
+
+		poolSel := labels.NewSelector()
+		req, reqErr := labels.NewRequirement(constants.LabelResourcePoolName, selection.In,
+			[]string{scalePoolR740, scalePoolXR8620})
+		Expect(reqErr).ToNot(HaveOccurred())
+		poolSel = poolSel.Add(*req)
+
+		By("Waiting for all 6 BMHs to be visible")
+		Eventually(func() int {
+			bmhListResult := &metal3v1alpha1.BareMetalHostList{}
+			Expect(K8SClient.List(testCtx, bmhListResult,
+				client.MatchingLabelsSelector{Selector: poolSel})).To(Succeed())
+			available := 0
+			for _, b := range bmhListResult.Items {
+				if b.Status.Provisioning.State == metal3v1alpha1.StateAvailable {
+					available++
+				}
+			}
+			return available
+		}, timeout, interval).Should(Equal(masterCount + workerCount + 1))
+
+		By("Waiting for ClusterTemplate reconciliation")
+		Eventually(func() bool {
+			newct := &provisioningv1alpha1.ClusterTemplate{}
+			Expect(K8SClient.Get(testCtx, client.ObjectKeyFromObject(ct), newct)).To(Succeed())
+			return newct.Status.Conditions != nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("Creating initial ProvisioningRequest with 3 masters + 2 workers")
+		prFromYAML, err := testutils.LoadYAML[provisioningv1alpha1.ProvisioningRequest](resourceDir + "/pr-scale-initial.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		prName = prFromYAML.Name
+		Expect(K8SClient.Create(testCtx, prFromYAML)).To(Succeed())
+
+		By("Waiting for NAR creation")
+		Eventually(func() error {
+			return K8SClient.Get(testCtx, types.NamespacedName{
+				Name: prName, Namespace: constants.DefaultNamespace}, nar)
+		}, timeout, interval).Should(Succeed())
+
+		By("Verifying initial NAR NodeGroup sizes")
+		Expect(K8SClient.Get(testCtx, client.ObjectKeyFromObject(nar), nar)).To(Succeed())
+		verifyNodeGroupSizes(nar, map[string]int{master: masterCount, worker: workerCount})
+
+		By("Waiting for all 5 AllocatedNodes to be created")
+		Eventually(func() int {
+			return len(testNonCachingListAllocatedNodesForNAR(testCtx, prName).Items)
+		}, timeout, interval).Should(Equal(masterCount + workerCount))
+
+		By("Waiting for NAR Provisioned=True")
+		Eventually(func() bool {
+			Expect(K8SClient.Get(testCtx, client.ObjectKeyFromObject(nar), nar)).To(Succeed())
+			cond := meta.FindStatusCondition(nar.Status.Conditions, string(hwmgmtv1alpha1.Provisioned))
+			return cond != nil && cond.Status == metav1.ConditionTrue
+		}, timeout, interval).Should(BeTrue())
+
+		By("Waiting for PR HardwareProvisioned=True")
+		Eventually(func() bool {
+			Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
+			cond := meta.FindStatusCondition(pr.Status.Conditions, string(provisioningv1alpha1.PRconditionTypes.HardwareProvisioned))
+			return cond != nil && cond.Status == metav1.ConditionTrue
+		}, timeout, interval).Should(BeTrue())
+
+		By("Capturing initial AllocatedNode names before scale-out")
+		initialNodes := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
+		initialAllocatedNodeNames = make(map[string]bool, len(initialNodes.Items))
+		for _, n := range initialNodes.Items {
+			initialAllocatedNodeNames[n.Name] = true
+		}
+
+		By("Simulating AllocatedNodeHostMap on PR")
+		Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
+		nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
+		hostMap := make(map[string]string)
+		masterIdx, workerIdx := 1, 1
+		for _, node := range nodeList.Items {
+			hostname := ""
+			switch node.Spec.GroupName {
+			case master:
+				hostname = fmt.Sprintf("master-%d.%s.example.com", masterIdx, clusterName)
+				masterIdx++
+			case worker:
+				hostname = fmt.Sprintf("worker-%d.%s.example.com", workerIdx, clusterName)
+				workerIdx++
+			}
+			hostMap[node.Name] = hostname
+		}
+		pr.Status.Extensions.AllocatedNodeHostMap = hostMap
+		Expect(K8SClient.Status().Update(testCtx, pr)).To(Succeed())
+
+		By("Simulating ClusterProvisioned=Completed on PR")
+		Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
+		meta.SetStatusCondition(&pr.Status.Conditions, metav1.Condition{
+			Type:   string(provisioningv1alpha1.PRconditionTypes.ClusterProvisioned),
+			Status: metav1.ConditionTrue,
+			Reason: string(provisioningv1alpha1.CRconditionReasons.Completed),
+		})
+		pr.Status.ProvisioningStatus.ProvisioningPhase = provisioningv1alpha1.StateFulfilled
+		Expect(K8SClient.Status().Update(testCtx, pr)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		By("Cleaning up scale test resources")
+		// Delete PR (strip finalizer first)
+		prObj := &provisioningv1alpha1.ProvisioningRequest{}
+		if err := K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, prObj); err == nil {
+			prObj.Finalizers = nil
+			_ = K8SClient.Update(testCtx, prObj)
+			_ = K8SClient.Delete(testCtx, prObj)
+		}
+
+		// Delete NAR (strip finalizer)
+		narObj := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		if err := K8SClient.Get(testCtx, types.NamespacedName{
+			Name: prName, Namespace: constants.DefaultNamespace,
+		}, narObj); err == nil {
+			narObj.Finalizers = nil
+			_ = K8SClient.Update(testCtx, narObj)
+			_ = K8SClient.Delete(testCtx, narObj)
+		}
+
+		// Delete AllocatedNodes
+		anList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
+		for i := range anList.Items {
+			_ = K8SClient.Delete(testCtx, &anList.Items[i])
+		}
+
+		// Delete BMHs and associated resources
+		bmhList := scaleBMHs(masterCount, workerCount+1)
+		for _, bmhData := range bmhList {
+			for _, obj := range []client.Object{
+				&metal3v1alpha1.BareMetalHost{ObjectMeta: metav1.ObjectMeta{Name: bmhData.Name, Namespace: bmhData.Namespace}},
+				&metal3v1alpha1.HardwareData{ObjectMeta: metav1.ObjectMeta{Name: bmhData.Name, Namespace: bmhData.Namespace}},
+				&metal3v1alpha1.HostFirmwareSettings{ObjectMeta: metav1.ObjectMeta{Name: bmhData.Name, Namespace: bmhData.Namespace}},
+				&metal3v1alpha1.HostFirmwareComponents{ObjectMeta: metav1.ObjectMeta{Name: bmhData.Name, Namespace: bmhData.Namespace}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-bmc-secret", bmhData.Name), Namespace: constants.DefaultNamespace}},
+			} {
+				existing := obj.DeepCopyObject().(client.Object)
+				if err := K8SClient.Get(testCtx, client.ObjectKeyFromObject(obj), existing); err == nil {
+					_ = K8SClient.Delete(testCtx, existing)
+				}
+			}
+		}
+
+		// Delete ClusterTemplates
+		for _, ctName := range []string{"scale-test.v4-20-16-v1", "scale-test.v4-20-16-v2"} {
+			ct := &provisioningv1alpha1.ClusterTemplate{}
+			if err := K8SClient.Get(testCtx, types.NamespacedName{Name: ctName, Namespace: ctNamespace}, ct); err == nil {
+				_ = K8SClient.Delete(testCtx, ct)
+			}
+		}
+
+		// Delete ConfigMaps
+		for _, cmName := range []string{"clusterinstance-defaults-v1", "clusterinstance-defaults-v2", "policytemplate-defaults-v1", "clustertemplate-sample.v1.0.0-extramanifests"} {
+			cm := &corev1.ConfigMap{}
+			if err := K8SClient.Get(testCtx, types.NamespacedName{Name: cmName, Namespace: ctNamespace}, cm); err == nil {
+				_ = K8SClient.Delete(testCtx, cm)
+			}
+		}
+
+		// Delete ClusterImageSet
+		cis := &hivev1.ClusterImageSet{}
+		if err := K8SClient.Get(testCtx, types.NamespacedName{Name: "4.20.16"}, cis); err == nil {
+			_ = K8SClient.Delete(testCtx, cis)
+		}
+	})
+
+	Describe("Scale-out: add a worker node", func() {
+		It("should increase NAR worker NodeGroup Size after PR update", func() {
+			By("Creating CI defaults v2 with 3 workers and a new CT version")
+			ciDefaultsV2, err := testutils.LoadYAML[corev1.ConfigMap](resourceDir + "/clusterinstance-defaults-v2.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(K8SClient.Create(testCtx, ciDefaultsV2)).To(Succeed())
+
+			ctV2 := &provisioningv1alpha1.ClusterTemplate{}
+			Expect(K8SClient.Get(testCtx, types.NamespacedName{
+				Name: "scale-test.v4-20-16-v1", Namespace: ctNamespace,
+			}, ctV2)).To(Succeed())
+			ctV2New := ctV2.DeepCopy()
+			ctV2New.ResourceVersion = ""
+			ctV2New.UID = ""
+			ctV2New.Name = "scale-test.v4-20-16-v2"
+			ctV2New.Spec.Version = "v4-20-16-v2"
+			ctV2New.Spec.TemplateDefaults.ClusterInstanceDefaults = "clusterinstance-defaults-v2"
+			ctV2New.Status = provisioningv1alpha1.ClusterTemplateStatus{}
+			Expect(K8SClient.Create(testCtx, ctV2New)).To(Succeed())
+
+			By("Waiting for new CT reconciliation")
+			Eventually(func() bool {
+				ct := &provisioningv1alpha1.ClusterTemplate{}
+				Expect(K8SClient.Get(testCtx, types.NamespacedName{
+					Name: "scale-test.v4-20-16-v2", Namespace: ctNamespace,
+				}, ct)).To(Succeed())
+				return ct.Status.Conditions != nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Updating PR to use new CT version and add worker-3")
+			Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
+			pr.Spec.TemplateVersion = "v4-20-16-v2"
+
+			var templateParams map[string]any
+			Expect(json.Unmarshal(pr.Spec.TemplateParameters.Raw, &templateParams)).To(Succeed())
+			ciParams := templateParams["clusterInstanceParameters"].(map[string]any)
+			nodes := ciParams["nodes"].([]any)
+
+			newWorkerNode := map[string]any{
+				"hostName": fmt.Sprintf("worker-3.%s.example.com", clusterName),
+				"nodeNetwork": map[string]any{
+					"config": map[string]any{
+						"dns-resolver": map[string]any{
+							"config": map[string]any{
+								"search": []any{"example.com"},
+								"server": []any{"198.51.100.1"},
+							},
+						},
+						"routes": map[string]any{
+							"config": []any{
+								map[string]any{"next-hop-address": "192.0.2.254"},
+							},
+						},
+						"interfaces": []any{
+							map[string]any{
+								"ipv4": map[string]any{
+									"address": []any{
+										map[string]any{"ip": "192.0.2.52", "prefix-length": 24},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			nodes = append(nodes, newWorkerNode)
+			ciParams["nodes"] = nodes
+			templateParams["clusterInstanceParameters"] = ciParams
+
+			updatedParams, err := json.Marshal(templateParams)
+			Expect(err).ToNot(HaveOccurred())
+			pr.Spec.TemplateParameters.Raw = updatedParams
+			Expect(K8SClient.Update(testCtx, pr)).To(Succeed())
+
+			By("Verifying NAR NodeGroup sizes after scale-out")
+			Eventually(func() bool {
+				Expect(K8SClient.Get(testCtx, client.ObjectKeyFromObject(nar), nar)).To(Succeed())
+				sizes := nodeGroupSizeMap(nar)
+				return sizes[worker] == workerCount+1 && sizes[master] == masterCount
+			}, timeout, interval).Should(BeTrue(),
+				"Worker Size should be 3 and master Size should remain 3")
+		})
+
+		It("should create a new AllocatedNode for the added worker", func() {
+			By("Waiting for 6 AllocatedNodes (3 masters + 3 workers)")
+			Eventually(func() int {
+				return len(testNonCachingListAllocatedNodesForNAR(testCtx, prName).Items)
+			}, timeout, interval).Should(Equal(masterCount + workerCount + 1))
+
+			By("Verifying original nodes are preserved and new node is a worker")
+			allNodes := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
+			newWorkerCount := 0
+			for _, n := range allNodes.Items {
+				if !initialAllocatedNodeNames[n.Name] {
+					Expect(n.Spec.GroupName).To(Equal(worker),
+						"New AllocatedNode should be in the worker group")
+					newWorkerCount++
+				}
+			}
+			Expect(newWorkerCount).To(Equal(1), "Exactly one new worker should be allocated")
+		})
+	})
+})
+
+func scaleBMHs(masterCount, workerCount int) []testutils.BMHData {
+	var bmhs []testutils.BMHData
+	for i := 1; i <= masterCount; i++ {
+		bmhs = append(bmhs, testutils.BMHData{
+			Name:           fmt.Sprintf("scale-master%d", i),
+			Namespace:      "scale-r740-pool",
+			MacAddress:     fmt.Sprintf("aa:bb:cc:33:00:%02x", i),
+			BmcAddress:     fmt.Sprintf("redfish://192.168.3.%d/redfish/v1/Systems/1", 100+i),
+			ServerType:     "R740",
+			Colour:         "green",
+			ResourcePoolId: "scale-r740-pool",
+		})
+	}
+	for i := 1; i <= workerCount; i++ {
+		bmhs = append(bmhs, testutils.BMHData{
+			Name:           fmt.Sprintf("scale-worker%d", i),
+			Namespace:      "scale-xr8620t-pool",
+			MacAddress:     fmt.Sprintf("aa:bb:cc:44:00:%02x", i),
+			BmcAddress:     fmt.Sprintf("redfish://192.168.4.%d/redfish/v1/Systems/1", 100+i),
+			ServerType:     "XR8620t",
+			Colour:         "blue",
+			ResourcePoolId: "scale-xr8620t-pool",
+		})
+	}
+	return bmhs
+}
+
+func nodeGroupSizeMap(nar *hwmgmtv1alpha1.NodeAllocationRequest) map[string]int {
+	sizes := make(map[string]int)
+	for _, ng := range nar.Spec.NodeGroup {
+		sizes[ng.NodeGroupData.Role] = ng.Size
+	}
+	return sizes
+}
+
+func verifyNodeGroupSizes(nar *hwmgmtv1alpha1.NodeAllocationRequest, expected map[string]int) {
+	sizes := nodeGroupSizeMap(nar)
+	for role, expectedSize := range expected {
+		Expect(sizes).To(HaveKey(role), "NodeGroup for role %q should exist", role)
+		Expect(sizes[role]).To(Equal(expectedSize),
+			"NodeGroup.Size for role %q should be %d", role, expectedSize)
+	}
+}

--- a/test/e2e/mno_scale_test.go
+++ b/test/e2e/mno_scale_test.go
@@ -297,9 +297,11 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 			_ = K8SClient.Delete(testCtx, narObj)
 		}
 
-		// Delete AllocatedNodes
+		// Delete AllocatedNodes (strip finalizers first to avoid leftovers)
 		anList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 		for i := range anList.Items {
+			anList.Items[i].Finalizers = nil
+			_ = K8SClient.Update(testCtx, &anList.Items[i])
 			_ = K8SClient.Delete(testCtx, &anList.Items[i])
 		}
 

--- a/test/e2e/mno_scale_test.go
+++ b/test/e2e/mno_scale_test.go
@@ -54,6 +54,7 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 		pr                        *provisioningv1alpha1.ProvisioningRequest
 		nar                       *hwmgmtv1alpha1.NodeAllocationRequest
 		initialAllocatedNodeNames map[string]bool
+		createdClusterImageSet    bool
 	)
 
 	testCtx = context.Background()
@@ -109,10 +110,17 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 			},
 			Data: map[string]string{},
 		}
-		for _, r := range []client.Object{pullSecret, extraManifests, clusterImageSet} {
+		for _, r := range []client.Object{pullSecret, extraManifests} {
 			if err := K8SClient.Create(testCtx, r); err != nil && !errors.IsAlreadyExists(err) {
 				Expect(err).ToNot(HaveOccurred())
 			}
+		}
+		if err := K8SClient.Create(testCtx, clusterImageSet); err != nil {
+			if !errors.IsAlreadyExists(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		} else {
+			createdClusterImageSet = true
 		}
 
 		By("Creating 6 BMHs (3 masters + 3 workers: 2 initial + 1 extra for scale-out)")
@@ -328,10 +336,12 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 			}
 		}
 
-		// Delete ClusterImageSet
-		cis := &hivev1.ClusterImageSet{}
-		if err := K8SClient.Get(testCtx, types.NamespacedName{Name: "4.20.16"}, cis); err == nil {
-			_ = K8SClient.Delete(testCtx, cis)
+		// Delete ClusterImageSet only if this test created it
+		if createdClusterImageSet {
+			cis := &hivev1.ClusterImageSet{}
+			if err := K8SClient.Get(testCtx, types.NamespacedName{Name: "4.20.16"}, cis); err == nil {
+				_ = K8SClient.Delete(testCtx, cis)
+			}
 		}
 	})
 

--- a/test/resources/mno_scale/clusterinstance-defaults-v1.yaml
+++ b/test/resources/mno_scale/clusterinstance-defaults-v1.yaml
@@ -1,0 +1,159 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clusterinstance-defaults-v1
+  namespace: scale-4-20-16
+data:
+  clusterinstance-defaults: |
+    baseDomain: example.com
+    extraLabels:
+      ManagedCluster:
+        cluster-version: "v4-20-16"
+        std-policy: "v1"
+    clusterType: HighlyAvailable
+    clusterImageSetNameRef: "4.20.16"
+    pullSecretRef:
+      name: pull-secret
+    networkType: OVNKubernetes
+    sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTca4Qyu5AYBmZbSl74cNTKuNINJ7d+ceBRzKUrhHcQpMbl8UnAYhjh/ffTyVCsgwzm1RjTAm6/tPj9euEa+YX4U78Sx+ioLHmjDvACYsti4DekIR+opFwfIw+JTDXoyVv06lOPaTOa/vtgpe+gDEL364j47f3p9H/tGhsLmpjeG3DVAhbqSh3s0IHpd4OzF/r6g6mbPyHadvedkBZp/qeUX054Gc2QqJeg/s/eddPlQDJbmL8yRVkZu+SsFTOEOAtrdA3czeaEaA8s+aWP9PN3X539Ddw3qahyOSCXpCE2eJXPh8DJCBWVEcFFYgmIFVvCQ+o9cjEmIYg6drGGvRV
+    installConfigOverrides: '{"capabilities": {"baselineCapabilitySet": "None", "additionalEnabledCapabilities": ["NodeTuning", "OperatorLifecycleManager", "Ingress", "baremetal", "MachineAPI"]}}'
+    ignitionConfigOverride: '{"ignition": {"version": "3.2.0"}, "storage": {"files": [{"overwrite": true, "path": "/etc/containers/policy.json", "contents": {"source":"data:text/plain;base64,ewogICAgImRlZmF1bHQiOiBbCiAgICAgICAgewogICAgICAgICAgICAidHlwZSI6ICJpbnNlY3VyZUFjY2VwdEFueXRoaW5nIgogICAgICAgIH0KICAgIF0sCiAgICAidHJhbnNwb3J0cyI6CiAgICAgICAgewogICAgICAgICAgICAiZG9ja2VyLWRhZW1vbiI6CiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgIiI6IFt7InR5cGUiOiJpbnNlY3VyZUFjY2VwdEFueXRoaW5nIn1dCiAgICAgICAgICAgICAgICB9CiAgICAgICAgfQp9Cgo="}}]}}'
+    clusterNetwork:
+      - cidr: 203.0.113.0/24
+        hostPrefix: 27
+    serviceNetwork:
+      - cidr: 233.252.0.0/24
+    additionalNTPSources:
+      - 1.pool.ntp.org
+    templateRefs:
+      - name: ai-cluster-templates-v1
+        namespace: open-cluster-management
+    cpuPartitioningMode: AllNodes
+    extraManifestsRefs:
+      - name: clustertemplate-sample.v1.0.0-extramanifests
+    nodes:
+      - role: master
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: master
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: master
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: worker
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: worker
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management

--- a/test/resources/mno_scale/clusterinstance-defaults-v2.yaml
+++ b/test/resources/mno_scale/clusterinstance-defaults-v2.yaml
@@ -1,0 +1,184 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clusterinstance-defaults-v2
+  namespace: scale-4-20-16
+data:
+  clusterinstance-defaults: |
+    baseDomain: example.com
+    extraLabels:
+      ManagedCluster:
+        cluster-version: "v4-20-16"
+        std-policy: "v1"
+    clusterType: HighlyAvailable
+    clusterImageSetNameRef: "4.20.16"
+    pullSecretRef:
+      name: pull-secret
+    networkType: OVNKubernetes
+    sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTca4Qyu5AYBmZbSl74cNTKuNINJ7d+ceBRzKUrhHcQpMbl8UnAYhjh/ffTyVCsgwzm1RjTAm6/tPj9euEa+YX4U78Sx+ioLHmjDvACYsti4DekIR+opFwfIw+JTDXoyVv06lOPaTOa/vtgpe+gDEL364j47f3p9H/tGhsLmpjeG3DVAhbqSh3s0IHpd4OzF/r6g6mbPyHadvedkBZp/qeUX054Gc2QqJeg/s/eddPlQDJbmL8yRVkZu+SsFTOEOAtrdA3czeaEaA8s+aWP9PN3X539Ddw3qahyOSCXpCE2eJXPh8DJCBWVEcFFYgmIFVvCQ+o9cjEmIYg6drGGvRV
+    installConfigOverrides: '{"capabilities": {"baselineCapabilitySet": "None", "additionalEnabledCapabilities": ["NodeTuning", "OperatorLifecycleManager", "Ingress", "baremetal", "MachineAPI"]}}'
+    ignitionConfigOverride: '{"ignition": {"version": "3.2.0"}, "storage": {"files": [{"overwrite": true, "path": "/etc/containers/policy.json", "contents": {"source":"data:text/plain;base64,ewogICAgImRlZmF1bHQiOiBbCiAgICAgICAgewogICAgICAgICAgICAidHlwZSI6ICJpbnNlY3VyZUFjY2VwdEFueXRoaW5nIgogICAgICAgIH0KICAgIF0sCiAgICAidHJhbnNwb3J0cyI6CiAgICAgICAgewogICAgICAgICAgICAiZG9ja2VyLWRhZW1vbiI6CiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgIiI6IFt7InR5cGUiOiJpbnNlY3VyZUFjY2VwdEFueXRoaW5nIn1dCiAgICAgICAgICAgICAgICB9CiAgICAgICAgfQp9Cgo="}}]}}'
+    clusterNetwork:
+      - cidr: 203.0.113.0/24
+        hostPrefix: 27
+    serviceNetwork:
+      - cidr: 233.252.0.0/24
+    additionalNTPSources:
+      - 1.pool.ntp.org
+    templateRefs:
+      - name: ai-cluster-templates-v1
+        namespace: open-cluster-management
+    cpuPartitioningMode: AllNodes
+    extraManifestsRefs:
+      - name: clustertemplate-sample.v1.0.0-extramanifests
+    nodes:
+      - role: master
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: master
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: master
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: worker
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: worker
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: worker
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management

--- a/test/resources/mno_scale/ct-scale.yaml
+++ b/test/resources/mno_scale/ct-scale.yaml
@@ -1,0 +1,228 @@
+apiVersion: clcm.openshift.io/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: scale-test.v4-20-16-v1
+  namespace: scale-4-20-16
+spec:
+  name: scale-test
+  version: v4-20-16-v1
+  release: 4.20.16
+  templateDefaults:
+    hwMgmtDefaults:
+      hardwareProvisioningTimeout: "90m"
+      nodeGroupData:
+        - name: master
+          role: master
+          resourcePoolId: scale-r740-pool
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "R740"
+            "resourceselector.clcm.openshift.io/server-colour": "green"
+        - name: worker
+          role: worker
+          resourcePoolId: scale-xr8620t-pool
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "XR8620t"
+            "resourceselector.clcm.openshift.io/server-colour": "blue"
+    clusterInstanceDefaults: clusterinstance-defaults-v1
+    policyTemplateDefaults: policytemplate-defaults-v1
+  templateParameterSchema:
+    properties:
+      nodeClusterName:
+        type: string
+      oCloudSiteId:
+        type: string
+      hwMgmtParameters:
+        type: object
+        properties:
+          hardwareProvisioningTimeout:
+            type: string
+          nodeGroupData:
+            type: array
+            items:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                role:
+                  type: string
+                  enum:
+                    - master
+                    - worker
+                hwProfile:
+                  type: string
+                resourcePoolId:
+                  type: string
+                resourceSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+      policyTemplateParameters:
+        description: policyTemplateSchema defines the available parameters for cluster configuration
+        properties:
+          sriov-network-vlan-1:
+            type: string
+          sriov-network-pfNames-1:
+            type: string
+          cpu-isolated:
+            type: string
+          cpu-reserved:
+            type: string
+          hugepages-default:
+            type: string
+          hugepages-size:
+            type: string
+          hugepages-count:
+            type: string
+          install-plan-approval:
+            type: string
+        type: object
+      clusterInstanceParameters:
+        description: clusterInstanceParameters defines the available parameters for cluster installation
+        properties:
+          additionalNTPSources:
+            description: AdditionalNTPSources is a list of NTP sources (hostname
+              or IP) to be added to all cluster hosts. They are added to any NTP
+              sources that were configured through other means.
+            items:
+              type: string
+            type: array
+          apiVIPs:
+            description: APIVIPs are the virtual IPs used to reach the OpenShift
+              cluster's API. Enter one IP address for single-stack clusters, or
+              up to two for dual-stack clusters (at most one IP address per IP
+              stack used). The order of stacks should be the same as order of
+              subnets in Cluster Networks, Service Networks, and Machine Networks.
+            items:
+              type: string
+            maxItems: 2
+            type: array
+          baseDomain:
+            description: BaseDomain is the base domain to use for the deployed
+              cluster.
+            type: string
+          clusterName:
+            description: ClusterName is the name of the cluster.
+            type: string
+          extraAnnotations:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            description: Additional cluster-wide annotations to be applied to
+              the rendered templates
+            type: object
+          extraLabels:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            description: Additional cluster-wide labels to be applied to the rendered
+              templates
+            type: object
+          ingressVIPs:
+            description: IngressVIPs are the virtual IPs used for cluster ingress
+              traffic. Enter one IP address for single-stack clusters, or up to
+              two for dual-stack clusters (at most one IP address per IP stack
+              used). The order of stacks should be the same as order of subnets
+              in Cluster Networks, Service Networks, and Machine Networks.
+            items:
+              type: string
+            maxItems: 2
+            type: array
+          machineNetwork:
+            description: MachineNetwork is the list of IP address pools for machines.
+            items:
+              description: MachineNetworkEntry is a single IP address block for
+                node IP blocks.
+              properties:
+                cidr:
+                  description: CIDR is the IP block address pool for machines
+                    within the cluster.
+                  type: string
+              required:
+              - cidr
+              type: object
+            type: array
+          nodes:
+            items:
+              description: NodeSpec
+              properties:
+                extraAnnotations:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Additional node-level annotations to be applied
+                    to the rendered templates
+                  type: object
+                extraLabels:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Additional node-level labels to be applied to the
+                    rendered templates
+                  type: object
+                hostName:
+                  description: Hostname is the desired hostname for the host
+                  type: string
+                nodeLabels:
+                  additionalProperties:
+                    type: string
+                  description: NodeLabels allows the specification of custom roles
+                    for your nodes in your managed clusters. These are additional
+                    roles are not used by any OpenShift Container Platform components,
+                    only by the user. When you add a custom role, it can be associated
+                    with a custom machine config pool that references a specific
+                    configuration for that role. Adding custom labels or roles
+                    during installation makes the deployment process more effective
+                    and prevents the need for additional reboots after the installation
+                    is complete.
+                  type: object
+                nodeNetwork:
+                  description: NodeNetwork is a set of configurations pertaining
+                    to the network settings for the node.
+                  properties:
+                    config:
+                      description: yaml that can be processed by nmstate, using
+                        custom marshaling/unmarshaling that will allow to populate
+                        nmstate config as plain yaml.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+              required:
+              - hostName
+              type: object
+            type: array
+          serviceNetwork:
+            description: ServiceNetwork is the list of IP address pools for services.
+            items:
+              description: ServiceNetworkEntry is a single IP address block for
+                node IP blocks.
+              properties:
+                cidr:
+                  description: CIDR is the IP block address pool for machines
+                    within the cluster.
+                  type: string
+              required:
+              - cidr
+              type: object
+            type: array
+          sshPublicKey:
+            description: SSHPublicKey is the public Secure Shell (SSH) key to
+              provide access to instances. This key will be added to the host
+              to allow ssh access
+            type: string
+        required:
+        - clusterName
+        - nodes
+        type: object
+    required:
+      - nodeClusterName
+      - oCloudSiteId
+      - policyTemplateParameters
+      - clusterInstanceParameters
+    type: object

--- a/test/resources/mno_scale/policytemplate-defaults-v1.yaml
+++ b/test/resources/mno_scale/policytemplate-defaults-v1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: policytemplate-defaults-v1
+  namespace: scale-4-20-16
+data:
+  # clusterConfigurationTimeout is optional.
+  # The value should be a duration string
+  # (e.g., "40m" for 40 minutes)
+  # clusterConfigurationTimeout: "40m"
+  policytemplate-defaults: |
+    sriov-network-vlan-1: "140"
+    sriov-network-pfNames-1: '["ens4f1"]'
+    cpu-isolated: "0-1,64-65"
+    cpu-reserved: "2-10"
+    hugepages-default: "1G"
+    hugepages-size: "1G"
+    hugepages-count: "32"
+    install-plan-approval: "Automatic"

--- a/test/resources/mno_scale/pr-scale-initial.yaml
+++ b/test/resources/mno_scale/pr-scale-initial.yaml
@@ -1,0 +1,110 @@
+apiVersion: clcm.openshift.io/v1alpha1
+kind: ProvisioningRequest
+metadata:
+  name: a5eb40c2-6f3d-4e0b-8c9a-1b2d3e4f5a6b
+spec:
+  name: "scale-test-pr"
+  templateName: scale-test
+  templateVersion: v4-20-16-v1
+  templateParameters:
+    nodeClusterName: scale-test
+    oCloudSiteId: "local-123"
+    hwMgmtParameters:
+      nodeGroupData:
+        - name: master
+        - name: worker
+    policyTemplateParameters: {}
+    clusterInstanceParameters:
+      clusterName: scale-cluster
+      apiVIPs:
+        - 192.0.2.2
+      ingressVIPs:
+        - 192.0.2.4
+      machineNetwork:
+        - cidr: 192.0.2.0/24
+      nodes:
+      - hostName: master-1.scale-cluster.example.com
+        nodeNetwork:
+          config:
+            dns-resolver:
+              config:
+                search:
+                  - example.com
+                server:
+                  - 8.8.8.8
+            routes:
+              config:
+                - next-hop-address: 192.0.2.254
+            interfaces:
+              - ipv4:
+                  address:
+                    - ip: 192.0.2.10
+                      prefix-length: 24
+      - hostName: master-2.scale-cluster.example.com
+        nodeNetwork:
+          config:
+            dns-resolver:
+              config:
+                search:
+                  - example.com
+                server:
+                  - 8.8.8.8
+            routes:
+              config:
+                - next-hop-address: 192.0.2.254
+            interfaces:
+              - ipv4:
+                  address:
+                    - ip: 192.0.2.17
+                      prefix-length: 24
+      - hostName: master-3.scale-cluster.example.com
+        nodeNetwork:
+          config:
+            dns-resolver:
+              config:
+                search:
+                  - example.com
+                server:
+                  - 8.8.8.8
+            routes:
+              config:
+                - next-hop-address: 192.0.2.254
+            interfaces:
+              - ipv4:
+                  address:
+                    - ip: 192.0.2.18
+                      prefix-length: 24
+      - hostName: worker-1.scale-cluster.example.com
+        nodeNetwork:
+          config:
+            dns-resolver:
+              config:
+                search:
+                  - example.com
+                server:
+                  - 8.8.8.8
+            routes:
+              config:
+                - next-hop-address: 192.0.2.254
+            interfaces:
+              - ipv4:
+                  address:
+                    - ip: 192.0.2.123
+                      prefix-length: 24
+      - hostName: worker-2.scale-cluster.example.com
+        nodeNetwork:
+          config:
+            dns-resolver:
+              config:
+                search:
+                  - example.com
+                server:
+                  - 8.8.8.8
+            routes:
+              config:
+                - next-hop-address: 192.0.2.254
+            interfaces:
+              - ipv4:
+                  address:
+                    - ip: 192.0.2.51
+                      prefix-length: 24


### PR DESCRIPTION
Add support for scaling out worker nodes on provisioned MNO clusters by updating the ProvisioningRequest nodes array.

Webhook validation:
- Reject node scaling while a cluster upgrade is in progress

Controller validation:
- Reject scaling on single-node clusters (after CI rendering where node count is known)
- Reject adding or removing control-plane nodes (workers only)

Hardware manager:
- Detect NodeGroup.Size increases on already-provisioned NARs in handleNodeAllocationRequestSpecChanged and re-enter the allocation flow to provision additional nodes

E2E test:
- Provision a 3-master + 2-worker cluster with 1 extra BMH in pool
- Scale out by adding a third worker via new CT version
- Verify NAR worker Size increases, new AllocatedNode is created, and master Size is unchanged

Documentation:
- Add "Scaling Worker Nodes" section to the Day-2 configuration guide