### PR TITLE
CNF-23722: fix misleading HasMetrics comment

### DIFF
--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -210,7 +210,8 @@ func HasApiEndpoints(serverName string) bool {
 }
 
 // HasMetrics determines whether a server exposes a /metrics endpoint.
-// All API servers except the database and the hardware manager server expose metrics.
+// This includes all API servers except the database, plus the hardware
+// manager server.
 func HasMetrics(serverName string) bool {
 	return (HasApiEndpoints(serverName) && serverName != InventoryDatabaseServerName) ||
 		serverName == HardwareManagerServerName


### PR DESCRIPTION
## Summary

- Fix misleading `HasMetrics` comment that read "except the database and the hardware manager" — implying both were excluded, when the hardware manager IS included
- Follow-up from [PR #3002 review comment](https://github.com/openshift-kni/oran-o2ims/pull/3002#discussion_r3595802194) by @donpenney

## Test plan

- [x] Comment-only change, no functional impact
- [x] `make golangci-lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>