### PR TITLE
fix(e2e): filter AllocatedNode check by NAR and strip finalizers in cleanup

### DIFF
--- a/test/e2e/mno_cv_upgrade_test.go
+++ b/test/e2e/mno_cv_upgrade_test.go
@@ -272,6 +272,8 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 		}
 		anList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 		for i := range anList.Items {
+			anList.Items[i].Finalizers = nil
+			Expect(K8SClient.Update(testCtx, &anList.Items[i])).To(Succeed())
 			Expect(client.IgnoreNotFound(K8SClient.Delete(testCtx, &anList.Items[i]))).To(Succeed())
 		}
 

--- a/test/e2e/mno_hw_configuration_test.go
+++ b/test/e2e/mno_hw_configuration_test.go
@@ -407,6 +407,8 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		}
 		anList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 		for i := range anList.Items {
+			anList.Items[i].Finalizers = nil
+			_ = K8SClient.Update(testCtx, &anList.Items[i])
 			_ = K8SClient.Delete(testCtx, &anList.Items[i])
 		}
 

--- a/test/e2e/sno_provisioning_test.go
+++ b/test/e2e/sno_provisioning_test.go
@@ -450,6 +450,8 @@ defaultHugepagesSize: "1G"`,
 			}
 			anList := testNonCachingListAllocatedNodesForNAR(testCtx, crName)
 			for i := range anList.Items {
+				anList.Items[i].Finalizers = nil
+				_ = K8SClient.Update(testCtx, &anList.Items[i])
 				_ = K8SClient.Delete(testCtx, &anList.Items[i])
 			}
 		}
@@ -621,12 +623,11 @@ defaultHugepagesSize: "1G"`,
 		Expect(singleNodeGroup.NodeGroupData.HwProfile).To(Equal(testutils.TestHwProfileName))
 
 		By("Waiting for AllocatedNode to be created by hardware manager")
-		allocatedNodes := &hwmgmtv1alpha1.AllocatedNodeList{}
-		Eventually(func() bool {
-			err := K8SClient.List(testCtx, allocatedNodes, client.InNamespace(constants.DefaultNamespace))
-			Expect(err).ToNot(HaveOccurred())
-			return len(allocatedNodes.Items) == 1 && allocatedNodes.Items[0].Spec.NodeAllocationRequest == crName
-		}, timeout, interval).Should(BeTrue())
+		var allocatedNodes *hwmgmtv1alpha1.AllocatedNodeList
+		Eventually(func() int {
+			allocatedNodes = testNonCachingListAllocatedNodesForNAR(testCtx, crName)
+			return len(allocatedNodes.Items)
+		}, timeout, interval).Should(Equal(1))
 
 		// Save the single allocated node for later use
 		allocatedNode = &allocatedNodes.Items[0]


### PR DESCRIPTION
Fix the flaky SNO e2e test that intermittently fails in "Waiting for the creation of AllocatedNode".

Filter the SNO e2e AllocatedNode wait by NAR name instead of listing all AllocatedNodes in the namespace and asserting len == 1. The unfiltered list fails when AllocatedNodes from other suites have not yet been garbage collected.

Strip AllocatedNode finalizers in all three e2e AfterAll cleanups before deleting. Without this, Delete only sets deletionTimestamp and the objects linger until the AllocatedNodeReconciler processes the finalizer asynchronously.