### PR TITLE
CNF-24434: Auto-select EUS intermediate version from Cincinnati graph

### DIFF
--- a/.coverage-thresholds.yaml
+++ b/.coverage-thresholds.yaml
@@ -40,4 +40,5 @@ packages:
   internal/service/resources/collector: 8
   internal/service/resources/db/repo: 89
   internal/service/resources/listener: 30
+  internal/controllers/utils/cincinnati: 74
   internal/controllers/utils/spokeclient: 75

--- a/api/provisioning/v1alpha1/provisioningrequest_types.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_types.go
@@ -72,6 +72,11 @@ type ClusterUpgradeStatus struct {
 
 	// StartVersion is the current cluster version before the upgrade began.
 	StartVersion string `json:"startVersion,omitempty"`
+
+	// IntermediateVersion is the intermediate version selected for
+	// EUS-to-EUS upgrades, either from user configuration or
+	// auto-selected from the Cincinnati update graph.
+	IntermediateVersion string `json:"intermediateVersion,omitempty"`
 }
 
 // ResourceProvisioningPhase defines the provisioning phase of an individual infrastructure resource.

--- a/api/provisioning/v1alpha1/provisioningrequest_webhook_test.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_webhook_test.go
@@ -1377,7 +1377,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 
 			_, err := validator.ValidateCreate(ctx, pr)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid intermediateVersion"))
+			Expect(err.Error()).To(ContainSubstring("is not valid semver"))
 		})
 
 		It("should reject upgradeParameters with wrong intermediateVersion minor", func() {
@@ -1586,7 +1586,7 @@ var _ = Describe("ProvisioningRequestValidator", func() {
 
 			_, err := validator.ValidateCreate(ctx, pr)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid intermediateVersion"))
+			Expect(err.Error()).To(ContainSubstring("is not valid semver"))
 		})
 	})
 })

--- a/bundle/manifests/clcm.openshift.io_provisioningrequests.yaml
+++ b/bundle/manifests/clcm.openshift.io_provisioningrequests.yaml
@@ -173,6 +173,12 @@ spec:
                         description: ClusterUpgradeStatus holds the state of a cluster
                           upgrade in progress.
                         properties:
+                          intermediateVersion:
+                            description: |-
+                              IntermediateVersion is the intermediate version selected for
+                              EUS-to-EUS upgrades, either from user configuration or
+                              auto-selected from the Cincinnati update graph.
+                            type: string
                           startVersion:
                             description: StartVersion is the current cluster version
                               before the upgrade began.

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1874,6 +1874,7 @@ spec:
           resources:
           - apiservers
           - clusterversions
+          - proxies
           verbs:
           - get
           - list

--- a/config/crd/bases/clcm.openshift.io_provisioningrequests.yaml
+++ b/config/crd/bases/clcm.openshift.io_provisioningrequests.yaml
@@ -173,6 +173,12 @@ spec:
                         description: ClusterUpgradeStatus holds the state of a cluster
                           upgrade in progress.
                         properties:
+                          intermediateVersion:
+                            description: |-
+                              IntermediateVersion is the intermediate version selected for
+                              EUS-to-EUS upgrades, either from user configuration or
+                              auto-selected from the Cincinnati update graph.
+                            type: string
                           startVersion:
                             description: StartVersion is the current cluster version
                               before the upgrade began.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -179,6 +179,7 @@ rules:
   resources:
   - apiservers
   - clusterversions
+  - proxies
   verbs:
   - get
   - list

--- a/docs/dev/e2e-test-overview.md
+++ b/docs/dev/e2e-test-overview.md
@@ -74,7 +74,7 @@ File: `test/e2e/mno_cv_upgrade_test.go`
 
 1. should fail with MCPs not updated
 1. should fail with invalid intermediateVersion after fixing MCPs
-1. should start intermediate upgrade after fixing intermediateVersion
+1. should auto-select intermediateVersion and start intermediate upgrade
 1. should show intermediate upgrade in progress
 1. should start target upgrade after intermediate completes
 1. should show target upgrade in progress

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/mod v0.37.0
+	golang.org/x/net v0.56.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/term v0.44.0
@@ -177,7 +178,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792 // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/internal/controllers/clustertemplate_controller_test.go
+++ b/internal/controllers/clustertemplate_controller_test.go
@@ -1580,7 +1580,7 @@ var _ = Describe("validateUpgradeDefaults", func() {
 			err := t.validateUpgradeDefaults()
 			Expect(err).To(HaveOccurred())
 			Expect(typederrors.IsInputError(err)).To(BeTrue())
-			Expect(err.Error()).To(ContainSubstring("invalid intermediateVersion"))
+			Expect(err.Error()).To(ContainSubstring("is not valid semver"))
 		})
 
 		It("should reject intermediateVersion when major version does not match release major", func() {
@@ -1590,7 +1590,7 @@ var _ = Describe("validateUpgradeDefaults", func() {
 			err := t.validateUpgradeDefaults()
 			Expect(err).To(HaveOccurred())
 			Expect(typederrors.IsInputError(err)).To(BeTrue())
-			Expect(err.Error()).To(ContainSubstring("intermediateVersion major version (3) must equal spec.release major version (4)"))
+			Expect(err.Error()).To(ContainSubstring("major version (3) must equal ClusterTemplate's spec.release major version (4)"))
 		})
 
 		It("should reject intermediateVersion when minor+1 does not match release minor", func() {
@@ -1600,7 +1600,7 @@ var _ = Describe("validateUpgradeDefaults", func() {
 			err := t.validateUpgradeDefaults()
 			Expect(err).To(HaveOccurred())
 			Expect(typederrors.IsInputError(err)).To(BeTrue())
-			Expect(err.Error()).To(ContainSubstring("intermediateVersion 4.15.0 must be exactly one minor version below ClusterTemplate's release version 4.17.0"))
+			Expect(err.Error()).To(ContainSubstring("intermediateVersion 4.15.0 must be exactly one minor version below ClusterTemplate's spec.release version 4.17.0"))
 		})
 
 		It("should reject when clusterVersion value is not an object", func() {

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -103,6 +103,7 @@ func GetClusterTemplateRefName(name, version string) string {
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch;create;delete
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;delete
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=get;list;watch
+//+kubebuilder:rbac:groups="config.openshift.io",resources=proxies,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controllers/provisioningrequest_upgrade.go
+++ b/internal/controllers/provisioningrequest_upgrade.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -18,10 +20,13 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils/cincinnati"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils/spokeclient"
 	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
+	upgradevalidation "github.com/openshift-kni/oran-o2ims/internal/validation"
 	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -140,7 +145,6 @@ func parseUpgradeConfig(
 ) (*ctlrutils.UpgradeConfig, error) {
 	hasCV, hasIBGU := false, false
 	var timeout time.Duration
-	var intermediateVersion string
 
 	// Check ProvisioningRequest upgradeParameters first (takes precedence).
 	if pr.Spec.TemplateParameters.Size() > 0 {
@@ -166,9 +170,6 @@ func parseUpgradeConfig(
 				}
 				timeout = d
 			}
-			if iv, ok := upgradeParams[ctlrutils.UpgradeIntermediateVersionConfigKey].(string); ok {
-				intermediateVersion = iv
-			}
 		}
 	}
 
@@ -193,11 +194,6 @@ func parseUpgradeConfig(
 				timeout = d
 			}
 		}
-		if intermediateVersion == "" {
-			if iv, ok := defaults[ctlrutils.UpgradeIntermediateVersionConfigKey].(string); ok {
-				intermediateVersion = iv
-			}
-		}
 	}
 
 	if hasCV && hasIBGU {
@@ -208,16 +204,14 @@ func parseUpgradeConfig(
 
 	if hasCV {
 		return &ctlrutils.UpgradeConfig{
-			UpgradeType:         ctlrutils.UpgradeDefaultsClusterVersionKey,
-			Timeout:             timeout,
-			IntermediateVersion: intermediateVersion,
+			UpgradeType: ctlrutils.UpgradeDefaultsClusterVersionKey,
+			Timeout:     timeout,
 		}, nil
 	}
 	if hasIBGU {
 		return &ctlrutils.UpgradeConfig{
-			UpgradeType:         ctlrutils.UpgradeDefaultsIBGUKey,
-			Timeout:             timeout,
-			IntermediateVersion: intermediateVersion,
+			UpgradeType: ctlrutils.UpgradeDefaultsIBGUKey,
+			Timeout:     timeout,
 		}, nil
 	}
 	return nil, fmt.Errorf(
@@ -394,12 +388,19 @@ func (t *provisioningRequestReconcilerTask) prepareIBGU(
 	return ibguCR, nil
 }
 
-// prepareCVSpec merges and validates upgrade data, then parses the
-// clusterVersion spec into typed structs. Returns the ClusterVersionSpec
-// (for channel/upstream) and the cvSpec.DesiredUpdate (with version set to target).
+// prepareCVSpec merges and validates upgrade data, parses the
+// clusterVersion spec into typed struct, and sets DesiredUpdate.Version
+// to the upgrade step target. For EUS upgrades it also resolves the
+// intermediate version from configuration or the Cincinnati update graph,
+// updates action.UpgradeToVersion to the resolved version so the
+// upgrade continues in the same reconciliation, and persists it to
+// ClusterUpgradeStatus.IntermediateVersion so subsequent reconciliations
+// can drive the EUS state machine.
 func (t *provisioningRequestReconcilerTask) prepareCVSpec(
+	ctx context.Context,
 	clusterTemplate *provisioningv1alpha1.ClusterTemplate,
-	upgradeToVersion string,
+	cv *configv1.ClusterVersion,
+	action *ctlrutils.CVUpgradeAction,
 ) (*configv1.ClusterVersionSpec, error) {
 	// Merge and validate upgrade data against the schema.
 	mergedUpgradeData, err := t.mergeAndValidateUpgradeData(clusterTemplate)
@@ -431,8 +432,49 @@ func (t *provisioningRequestReconcilerTask) prepareCVSpec(
 			"the clusterVersion desiredUpdate version (%s) does not match the ClusterTemplate spec.release (%s)",
 			cvSpec.DesiredUpdate.Version, clusterTemplate.Spec.Release)
 	}
+
+	upgradeStatus := t.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus
+	// For EUS upgrades, resolve the intermediate version on the intermediate hop.
+	// If intermediateVersion is explicitly configured, use it directly.
+	// Otherwise, auto-select a valid intermediate version from the Cincinnati
+	// update graph.
+	// On the first reconciliation both action.UpgradeToVersion and
+	// upgradeStatus.IntermediateVersion are "" — the match is intentional:
+	// it enters this block to resolve the intermediate version, which then
+	// populates both fields for subsequent reconciliations.
+	isIntermediateHop := action.IsEUS && action.UpgradeToVersion == upgradeStatus.IntermediateVersion
+	if isIntermediateHop {
+		targetVersion := clusterTemplate.Spec.Release
+
+		configIntermediate := ""
+		if iv, ok := mergedUpgradeData[ctlrutils.UpgradeIntermediateVersionConfigKey].(string); ok {
+			configIntermediate = iv
+		}
+
+		if configIntermediate != "" {
+			if err := upgradevalidation.ValidateEUSIntermediate(
+				configIntermediate, targetVersion,
+			); err != nil {
+				return nil, fmt.Errorf("failed to validate intermediateVersion: %w", err)
+			}
+			action.UpgradeToVersion = configIntermediate
+		} else {
+			resolved, err := t.resolveEUSIntermediateVersion(
+				ctx, upgradeStatus.StartVersion, targetVersion, cv, &cvSpec)
+			if err != nil {
+				return nil, err
+			}
+			action.UpgradeToVersion = resolved
+		}
+		upgradeStatus.IntermediateVersion = action.UpgradeToVersion
+
+		// Intermediate upgrade is version-based; clear any user-configured
+		// image for target version.
+		cvSpec.DesiredUpdate.Image = ""
+	}
+
 	// Set the version to the actual upgrade step target (which may be the intermediate version for EUS).
-	cvSpec.DesiredUpdate.Version = upgradeToVersion
+	cvSpec.DesiredUpdate.Version = action.UpgradeToVersion
 
 	// Validate target version is valid semver.
 	if _, err := semver.NewVersion(cvSpec.DesiredUpdate.Version); err != nil {
@@ -440,6 +482,80 @@ func (t *provisioningRequestReconcilerTask) prepareCVSpec(
 	}
 
 	return &cvSpec, nil
+}
+
+// resolveEUSIntermediateVersion auto-selects the intermediate version from the Cincinnati update graph.
+func (t *provisioningRequestReconcilerTask) resolveEUSIntermediateVersion(
+	ctx context.Context,
+	startVersion, targetVersion string,
+	cv *configv1.ClusterVersion,
+	cvSpec *configv1.ClusterVersionSpec,
+) (string, error) {
+	if cvSpec.Channel == "" {
+		return "", typederrors.NewInputError(
+			"channel is required to auto-select intermediateVersion for EUS-to-EUS upgrades; " +
+				"set clusterVersion.channel in the upgrade configuration or specify intermediateVersion explicitly")
+	}
+
+	upstream := string(cvSpec.Upstream)
+	if upstream == "" {
+		upstream = cincinnati.DefaultGraphURL
+	}
+	upstreamURI, err := url.Parse(upstream)
+	if err != nil {
+		return "", typederrors.NewInputError("invalid upstream URL %q: %s", upstream, err.Error())
+	}
+	if upstreamURI.Host == "" || (upstreamURI.Scheme != "http" && upstreamURI.Scheme != "https") {
+		return "", typederrors.NewInputError(
+			"invalid upstream URL %q: must be an absolute HTTP or HTTPS URL", upstream)
+	}
+
+	arch, err := t.getClusterArchitecture(ctx, cv)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine cluster architecture: %w", err)
+	}
+
+	selected, err := cincinnati.SelectIntermediateVersion(
+		ctx, t.client, t.logger, upstreamURI, cvSpec.Channel, arch, startVersion, targetVersion)
+	if err != nil {
+		return "", fmt.Errorf("unable to auto-select intermediateVersion: %w", err)
+	}
+
+	t.logger.InfoContext(ctx, "Auto-selected intermediateVersion from Cincinnati graph",
+		slog.String("intermediateVersion", selected),
+		slog.String("targetVersion", targetVersion),
+		slog.String("channel", cvSpec.Channel),
+		slog.String("upstream", upstream))
+	return selected, nil
+}
+
+// getClusterArchitecture determines the cluster architecture for Cincinnati
+// graph queries. It checks (in order):
+//  1. spec.desiredUpdate.architecture on the spoke CV (explicit multi-arch transition)
+//  2. cpuArchitecture from the ClusterInstance on the hub
+//  3. Falls back to amd64
+func (t *provisioningRequestReconcilerTask) getClusterArchitecture(
+	ctx context.Context, cv *configv1.ClusterVersion,
+) (string, error) {
+	if cv.Spec.DesiredUpdate != nil && cv.Spec.DesiredUpdate.Architecture != "" {
+		return strings.ToLower(string(cv.Spec.DesiredUpdate.Architecture)), nil
+	}
+
+	ci, err := t.getExistingClusterInstance(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to read ClusterInstance for architecture: %w", err)
+	}
+
+	switch ci.Spec.CPUArchitecture {
+	case siteconfig.CPUArchitectureX86_64:
+		return "amd64", nil
+	case siteconfig.CPUArchitectureAarch64:
+		return "arm64", nil
+	case siteconfig.CPUArchitectureMulti:
+		return "multi", nil
+	default:
+		return "amd64", nil
+	}
 }
 
 // mergeAndValidateUpgradeData merges upgrade defaults from the ClusterTemplate with
@@ -548,7 +664,6 @@ func (t *provisioningRequestReconcilerTask) handleClusterVersionUpgrade(
 	var err error
 
 	targetVersion := clusterTemplate.Spec.Release
-	intermediateVersion := upgradeCfg.IntermediateVersion
 	msaName := t.object.Name + "-upgrade"
 	mwName := t.object.Name + "-upgrade-rbac"
 
@@ -568,8 +683,9 @@ func (t *provisioningRequestReconcilerTask) handleClusterVersionUpgrade(
 	}
 
 	// Check if the upgrade is an EUS upgrade.
-	startVersion := t.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus.StartVersion
-	isEUS, err := ctlrutils.IsEUSUpgrade(startVersion, intermediateVersion, targetVersion)
+	upgradeStatus := t.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus
+	startVersion := upgradeStatus.StartVersion
+	isEUS, err := ctlrutils.IsEUSUpgrade(startVersion, targetVersion)
 	if err != nil {
 		if updateErr := t.updateUpgradeStatus(ctx,
 			provisioningv1alpha1.CRconditionReasons.PreconditionChecksFailed, err.Error(),
@@ -623,6 +739,9 @@ func (t *provisioningRequestReconcilerTask) handleClusterVersionUpgrade(
 		return ctrl.Result{}, false, fmt.Errorf("failed to get spoke ClusterVersion: %w", err)
 	}
 
+	// Intermediate comes from status only; IntermediateVersion is resolved
+	// inside prepareCVSpec for EUS upgrades and stored in status.
+	intermediateVersion := upgradeStatus.IntermediateVersion
 	action := ctlrutils.ResolveCVUpgradeAction(
 		cv, targetVersion, intermediateVersion, isEUS)
 
@@ -635,7 +754,7 @@ func (t *provisioningRequestReconcilerTask) handleClusterVersionUpgrade(
 			// EUS intermediate upgrade: PreconditionChecksFailed means the upgrade
 			// was never triggered, so it's safe to unpause MCPs - no operators
 			// are mid-rollout.
-			if action.IsEUSIntermediate &&
+			if action.IsEUSIntermediate(intermediateVersion) &&
 				ctlrutils.IsClusterUpgradePreconditionChecksFailed(t.object) {
 				mcps, err := ctlrutils.ListNonMasterMCPs(ctx, spokeClient)
 				if err != nil {
@@ -679,7 +798,8 @@ func (t *provisioningRequestReconcilerTask) handleCVUpgradeCompleted(
 	ctx context.Context, spokeClient client.Client,
 	clusterName, msaName, mwName string, action *ctlrutils.CVUpgradeAction,
 ) (ctrl.Result, error) {
-	if action.IsEUS && !action.IsEUSIntermediate {
+	intermediateVersion := t.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus.IntermediateVersion
+	if action.IsEUS && !action.IsEUSIntermediate(intermediateVersion) {
 		mcps, err := ctlrutils.ListNonMasterMCPs(ctx, spokeClient)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to list MCPs: %w", err)
@@ -725,6 +845,7 @@ func (t *provisioningRequestReconcilerTask) handleCVUpgradeInProgress(
 	ctx context.Context, cv *configv1.ClusterVersion,
 	action *ctlrutils.CVUpgradeAction,
 ) (ctrl.Result, error) {
+	intermediateVersion := t.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus.IntermediateVersion
 	// Reset startAt to CVO's actual start time. The initial startAt was set
 	// when entering the upgrade flow (covering the pre-start/setup phase).
 	// Once CVO creates a history entry, we reset to its StartedTime so the
@@ -738,7 +859,7 @@ func (t *provisioningRequestReconcilerTask) handleCVUpgradeInProgress(
 	// rather than per-phase timeouts because the phases are sequential parts
 	// of one atomic operation, and individual phase durations vary widely
 	// depending on cluster size and workload.
-	shouldReset := !action.IsEUS || action.IsEUSIntermediate
+	shouldReset := !action.IsEUS || action.IsEUSIntermediate(intermediateVersion)
 	historyEntry := ctlrutils.FindCVHistoryEntry(cv, action.UpgradeToVersion)
 	if historyEntry != nil && shouldReset &&
 		!t.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus.StartedAt.Equal(&historyEntry.StartedTime) {
@@ -752,15 +873,15 @@ func (t *provisioningRequestReconcilerTask) handleCVUpgradeInProgress(
 	if progressing != nil && progressing.Status == configv1.ConditionTrue {
 		reason = provisioningv1alpha1.CRconditionReasons.InProgress
 		msg = fmt.Sprintf("Upgrading to %s version %s: %s",
-			action.VersionLabel(), action.UpgradeToVersion, progressing.Message)
+			action.VersionLabel(intermediateVersion), action.UpgradeToVersion, progressing.Message)
 	} else {
 		reason = provisioningv1alpha1.CRconditionReasons.Unknown
 		msg = fmt.Sprintf("Upgrading to %s version %s: CVO stalled",
-			action.VersionLabel(), action.UpgradeToVersion)
+			action.VersionLabel(intermediateVersion), action.UpgradeToVersion)
 		failing := ctlrutils.GetCVCondition(cv, ctlrutils.CVConditionFailing)
 		if failing != nil && failing.Status == configv1.ConditionTrue {
 			msg = fmt.Sprintf("Upgrading to %s version %s: %s",
-				action.VersionLabel(), action.UpgradeToVersion, failing.Message)
+				action.VersionLabel(intermediateVersion), action.UpgradeToVersion, failing.Message)
 		}
 	}
 	if err := t.updateUpgradeStatus(ctx, reason, msg); err != nil {
@@ -779,11 +900,18 @@ func (t *provisioningRequestReconcilerTask) handleCVUpgradePreStart(
 	action *ctlrutils.CVUpgradeAction,
 ) (ctrl.Result, error) {
 	// Always merge+validate — catches invalid input including updated PR params.
-	cvSpec, err := t.prepareCVSpec(clusterTemplate, action.UpgradeToVersion)
+	cvSpec, err := t.prepareCVSpec(ctx, clusterTemplate, cv, action)
 	if err != nil {
 		if !typederrors.IsInputError(err) {
-			return ctrl.Result{}, fmt.Errorf("failed to prepare CV upgrade spec: %w", err)
+			if err := t.updateUpgradeStatus(ctx,
+				provisioningv1alpha1.CRconditionReasons.Pending,
+				fmt.Sprintf("Preparing upgrade configuration: %s", err.Error()),
+			); err != nil {
+				return ctrl.Result{}, err
+			}
+			return requeueWithMediumInterval(), nil
 		}
+
 		if err := t.updateUpgradeStatus(ctx,
 			provisioningv1alpha1.CRconditionReasons.PreconditionChecksFailed, err.Error(),
 		); err != nil {
@@ -840,8 +968,9 @@ func (t *provisioningRequestReconcilerTask) handleCVUpgradePreStart(
 		return ctrl.Result{}, fmt.Errorf("failed to apply desiredUpdate: %w", err)
 	}
 	if changed {
+		intermediateVersion := t.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus.IntermediateVersion
 		msg := fmt.Sprintf("Upgrade to %s version %s triggered. Waiting for upgrade to start",
-			action.VersionLabel(), action.UpgradeToVersion)
+			action.VersionLabel(intermediateVersion), action.UpgradeToVersion)
 		if err := t.updateUpgradeStatus(ctx, provisioningv1alpha1.CRconditionReasons.Pending, msg); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -856,6 +985,7 @@ func (t *provisioningRequestReconcilerTask) handleCVUpgradePreStart(
 func (t *provisioningRequestReconcilerTask) monitorPostTriggerConditions(
 	ctx context.Context, cv *configv1.ClusterVersion, action *ctlrutils.CVUpgradeAction,
 ) (ctrl.Result, error) {
+	intermediateVersion := t.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus.IntermediateVersion
 	// Invalid=True — CVO won't retry on invalid input, terminal.
 	invalid := ctlrutils.GetCVCondition(cv, ctlrutils.CVConditionInvalid)
 	if invalid != nil && invalid.Status == configv1.ConditionTrue {
@@ -881,11 +1011,11 @@ func (t *provisioningRequestReconcilerTask) monitorPostTriggerConditions(
 	}
 
 	msg := fmt.Sprintf("Upgrading to %s version %s: upgrade not started yet",
-		action.VersionLabel(), action.UpgradeToVersion)
+		action.VersionLabel(intermediateVersion), action.UpgradeToVersion)
 	failing := ctlrutils.GetCVCondition(cv, ctlrutils.CVConditionFailing)
 	if failing != nil && failing.Status == configv1.ConditionTrue {
 		msg = fmt.Sprintf("Upgrading to %s version %s: %s",
-			action.VersionLabel(), action.UpgradeToVersion, failing.Message)
+			action.VersionLabel(intermediateVersion), action.UpgradeToVersion, failing.Message)
 	}
 	if err := t.updateUpgradeStatus(ctx,
 		provisioningv1alpha1.CRconditionReasons.Unknown, msg,
@@ -920,7 +1050,8 @@ func (t *provisioningRequestReconcilerTask) ensureMCPsPreconditions(
 		return true, nil
 	}
 
-	if action.IsEUSIntermediate {
+	intermediateVersion := t.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus.IntermediateVersion
+	if action.IsEUSIntermediate(intermediateVersion) {
 		mcps, err := ctlrutils.ListNonMasterMCPs(ctx, spokeClient)
 		if err != nil {
 			return false, fmt.Errorf("failed to list MCPs: %w", err)
@@ -1052,6 +1183,9 @@ func (t *provisioningRequestReconcilerTask) updateUpgradeStatus(
 	case provisioningv1alpha1.CRconditionReasons.PreconditionChecksFailed,
 		provisioningv1alpha1.CRconditionReasons.Failed,
 		provisioningv1alpha1.CRconditionReasons.TimedOut:
+		t.logger.ErrorContext(ctx, "Upgrade failed",
+			slog.String("reason", string(reason)),
+			slog.String("message", message))
 		ctlrutils.SetProvisioningStateFailed(t.object, message)
 		// Clear only StartedAt, preserving StartVersion so EUS detection
 		// remains stable if the user retries. StartVersion is eventually
@@ -1059,6 +1193,9 @@ func (t *provisioningRequestReconcilerTask) updateUpgradeStatus(
 		// condition when switching to a new CT that matches the current cluster version.
 		t.clearUpgradeStartTime()
 	default:
+		t.logger.InfoContext(ctx, "Upgrade status update",
+			slog.String("reason", string(reason)),
+			slog.String("message", message))
 		ctlrutils.SetProvisioningStateInProgress(t.object, message)
 	}
 

--- a/internal/controllers/provisioningrequest_upgrade_test.go
+++ b/internal/controllers/provisioningrequest_upgrade_test.go
@@ -9,7 +9,10 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -20,6 +23,7 @@ import (
 	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
 	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -255,6 +259,13 @@ var _ = Describe("prepareCVSpec", func() {
 			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
 				TemplateParameters: runtime.RawExtension{Raw: []byte(`{}`)},
 			},
+			Status: provisioningv1alpha1.ProvisioningRequestStatus{
+				Extensions: provisioningv1alpha1.Extensions{
+					ClusterDetails: &provisioningv1alpha1.ClusterDetails{
+						Name: "test-cluster",
+					},
+				},
+			},
 		}
 		clusterTemplate = &provisioningv1alpha1.ClusterTemplate{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-template.v1.0.0", Namespace: "test-ns"},
@@ -270,17 +281,35 @@ var _ = Describe("prepareCVSpec", func() {
 				},
 			},
 		}
+		testCI := &siteconfig.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "test-cluster",
+			},
+			Spec: siteconfig.ClusterInstanceSpec{
+				CPUArchitecture: siteconfig.CPUArchitectureX86_64,
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testCI).Build()
 		task = &provisioningRequestReconcilerTask{
+			client: c,
 			object: pr,
 			logger: slog.New(slog.DiscardHandler),
 		}
 	})
 
+	prepareAction := func(version string) *utils.CVUpgradeAction {
+		return &utils.CVUpgradeAction{UpgradeToVersion: version}
+	}
+	spokeCV := func() *configv1.ClusterVersion {
+		return &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+	}
+
 	It("should return cvSpec with version, channel, image, and force from upgrade defaults", func() {
 		clusterTemplate.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
 			Raw: []byte(`{"clusterVersion":{"channel":"stable-4.22","upstream":"https://custom.graph","desiredUpdate":{"version":"4.22.0","image":"quay.io/ocp:4.22.0","force":true}}}`),
 		}
-		cvSpec, err := task.prepareCVSpec(clusterTemplate, "4.22.0")
+		cvSpec, err := task.prepareCVSpec(context.Background(), clusterTemplate, spokeCV(), prepareAction("4.22.0"))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cvSpec.DesiredUpdate).ToNot(BeNil())
 		Expect(cvSpec.DesiredUpdate.Version).To(Equal("4.22.0"))
@@ -294,7 +323,7 @@ var _ = Describe("prepareCVSpec", func() {
 		clusterTemplate.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
 			Raw: []byte(`{"imageBasedGroupUpgrade":{}}`),
 		}
-		_, err := task.prepareCVSpec(clusterTemplate, "4.22.0")
+		_, err := task.prepareCVSpec(context.Background(), clusterTemplate, spokeCV(), prepareAction("4.22.0"))
 		Expect(err).To(HaveOccurred())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(ContainSubstring("not found in merged upgrade data"))
@@ -304,17 +333,315 @@ var _ = Describe("prepareCVSpec", func() {
 		clusterTemplate.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
 			Raw: []byte(`{"clusterVersion":{"desiredUpdate":{"version":"4.21.0"}}}`),
 		}
-		_, err := task.prepareCVSpec(clusterTemplate, "4.22.0")
+		_, err := task.prepareCVSpec(context.Background(), clusterTemplate, spokeCV(), prepareAction("4.22.0"))
 		Expect(err).To(HaveOccurred())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(ContainSubstring("does not match the ClusterTemplate spec.release"))
 	})
 
 	It("should return InputError when target version is not valid semver", func() {
-		_, err := task.prepareCVSpec(clusterTemplate, "invalid-version")
+		_, err := task.prepareCVSpec(context.Background(), clusterTemplate, spokeCV(), prepareAction("invalid-version"))
 		Expect(err).To(HaveOccurred())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(ContainSubstring("invalid target version"))
+	})
+
+	It("should use configured intermediateVersion for EUS intermediate upgrade", func() {
+		clusterTemplate.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
+			Raw: []byte(`{"clusterVersion":{"channel":"eus-4.22","desiredUpdate":{"version":"4.22.0"}},"intermediateVersion":"4.21.3"}`),
+		}
+		task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus = &provisioningv1alpha1.ClusterUpgradeStatus{
+			StartVersion: "4.20.0",
+		}
+		action := &utils.CVUpgradeAction{IsEUS: true, UpgradeToVersion: ""}
+		cvSpec, err := task.prepareCVSpec(context.Background(), clusterTemplate, spokeCV(), action)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cvSpec.DesiredUpdate.Version).To(Equal("4.21.3"))
+		Expect(task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus.IntermediateVersion).To(Equal("4.21.3"))
+	})
+
+	It("should clear desiredUpdate.image on EUS intermediate hop", func() {
+		clusterTemplate.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
+			Raw: []byte(`{"clusterVersion":{"channel":"eus-4.22","desiredUpdate":{"version":"4.22.0","image":"quay.io/ocp:4.22.0"}},"intermediateVersion":"4.21.3"}`),
+		}
+		task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus = &provisioningv1alpha1.ClusterUpgradeStatus{
+			StartVersion:        "4.20.0",
+			IntermediateVersion: "4.21.3",
+		}
+		action := &utils.CVUpgradeAction{IsEUS: true, UpgradeToVersion: "4.21.3"}
+		cvSpec, err := task.prepareCVSpec(context.Background(), clusterTemplate, spokeCV(), action)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cvSpec.DesiredUpdate.Version).To(Equal("4.21.3"))
+		Expect(cvSpec.DesiredUpdate.Image).To(BeEmpty())
+	})
+
+	It("should auto-select intermediateVersion from Cincinnati when intermediateVersion is not set", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.URL.Query().Get("channel")).To(Equal("eus-4.22"))
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"nodes": []map[string]string{
+					{"version": "4.20.0"},
+					{"version": "4.21.1"},
+					{"version": "4.21.5"},
+					{"version": "4.22.0"},
+				},
+				"edges": [][]int{{0, 1}, {0, 2}, {1, 3}, {2, 3}},
+			})
+		}))
+		defer srv.Close()
+
+		clusterTemplate.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
+			Raw: fmt.Appendf(nil, `{"clusterVersion":{"channel":"eus-4.22","upstream":%q,"desiredUpdate":{"version":"4.22.0"}}}`, srv.URL),
+		}
+		task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus = &provisioningv1alpha1.ClusterUpgradeStatus{
+			StartVersion: "4.20.0",
+		}
+
+		action := &utils.CVUpgradeAction{IsEUS: true, UpgradeToVersion: ""}
+		cvSpec, err := task.prepareCVSpec(context.Background(), clusterTemplate, spokeCV(), action)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cvSpec.DesiredUpdate.Version).To(Equal("4.21.5"))
+		Expect(task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus.IntermediateVersion).To(Equal("4.21.5"))
+	})
+
+})
+
+var _ = Describe("resolveEUSIntermediateVersion", func() {
+	var task *provisioningRequestReconcilerTask
+
+	BeforeEach(func() {
+		testCI := &siteconfig.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "test-cluster",
+			},
+			Spec: siteconfig.ClusterInstanceSpec{
+				CPUArchitecture: siteconfig.CPUArchitectureX86_64,
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testCI).Build()
+		pr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: "resolve-test-pr"},
+			Status: provisioningv1alpha1.ProvisioningRequestStatus{
+				Extensions: provisioningv1alpha1.Extensions{
+					ClusterDetails: &provisioningv1alpha1.ClusterDetails{Name: "test-cluster"},
+				},
+			},
+		}
+		task = &provisioningRequestReconcilerTask{
+			client: c,
+			object: pr,
+			logger: slog.New(slog.DiscardHandler),
+		}
+	})
+
+	It("should select the latest valid intermediate version", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"nodes": []map[string]string{
+					{"version": "4.20.0"},
+					{"version": "4.21.1"},
+					{"version": "4.21.5"},
+					{"version": "4.22.0"},
+				},
+				"edges": [][]int{{0, 1}, {0, 2}, {1, 3}, {2, 3}},
+			})
+		}))
+		defer srv.Close()
+
+		cv := &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+		cvSpec := &configv1.ClusterVersionSpec{
+			Channel:  "eus-4.22",
+			Upstream: configv1.URL(srv.URL),
+		}
+		selected, err := task.resolveEUSIntermediateVersion(
+			context.Background(), "4.20.0", "4.22.0", cv, cvSpec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(selected).To(Equal("4.21.5"))
+	})
+
+	It("should return error when Cincinnati is unavailable", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}))
+		defer srv.Close()
+
+		cv := &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+		cvSpec := &configv1.ClusterVersionSpec{
+			Channel:  "eus-4.22",
+			Upstream: configv1.URL(srv.URL),
+		}
+		_, err := task.resolveEUSIntermediateVersion(
+			context.Background(), "4.20.0", "4.22.0", cv, cvSpec)
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeFalse())
+		Expect(err.Error()).To(ContainSubstring("unable to auto-select intermediateVersion"))
+	})
+
+	It("should return InputError when channel is empty", func() {
+		cv := &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+		cvSpec := &configv1.ClusterVersionSpec{}
+		_, err := task.resolveEUSIntermediateVersion(
+			context.Background(), "4.20.0", "4.22.0", cv, cvSpec)
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("channel is required"))
+	})
+
+	It("should return InputError when upstream is not an absolute HTTP URL", func() {
+		cv := &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+		cvSpec := &configv1.ClusterVersionSpec{
+			Channel:  "eus-4.22",
+			Upstream: "graph",
+		}
+		_, err := task.resolveEUSIntermediateVersion(
+			context.Background(), "4.20.0", "4.22.0", cv, cvSpec)
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("must be an absolute HTTP or HTTPS URL"))
+	})
+
+	It("should return error when no valid intermediate path exists", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"nodes": []map[string]string{
+					{"version": "4.20.0"},
+					{"version": "4.22.0"},
+				},
+				"edges": [][]int{},
+			})
+		}))
+		defer srv.Close()
+
+		cv := &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+		cvSpec := &configv1.ClusterVersionSpec{
+			Channel:  "eus-4.22",
+			Upstream: configv1.URL(srv.URL),
+		}
+		_, err := task.resolveEUSIntermediateVersion(
+			context.Background(), "4.20.0", "4.22.0", cv, cvSpec)
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("unable to select intermediate version"))
+	})
+})
+
+var _ = Describe("getClusterArchitecture", func() {
+	var task *provisioningRequestReconcilerTask
+
+	BeforeEach(func() {
+		testCI := &siteconfig.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "arch-cluster",
+				Namespace: "arch-cluster",
+			},
+			Spec: siteconfig.ClusterInstanceSpec{
+				CPUArchitecture: siteconfig.CPUArchitectureX86_64,
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testCI).Build()
+		pr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: "arch-test-pr"},
+			Status: provisioningv1alpha1.ProvisioningRequestStatus{
+				Extensions: provisioningv1alpha1.Extensions{
+					ClusterDetails: &provisioningv1alpha1.ClusterDetails{Name: "arch-cluster"},
+				},
+			},
+		}
+		task = &provisioningRequestReconcilerTask{
+			client: c,
+			object: pr,
+			logger: slog.New(slog.DiscardHandler),
+		}
+	})
+
+	It("should return architecture from CV desiredUpdate when set", func() {
+		cv := &configv1.ClusterVersion{
+			ObjectMeta: metav1.ObjectMeta{Name: "version"},
+			Spec: configv1.ClusterVersionSpec{
+				DesiredUpdate: &configv1.Update{
+					Architecture: configv1.ClusterVersionArchitectureMulti,
+				},
+			},
+		}
+		arch, err := task.getClusterArchitecture(context.Background(), cv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(arch).To(Equal("multi"))
+	})
+
+	It("should return amd64 for x86_64 ClusterInstance", func() {
+		cv := &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+		arch, err := task.getClusterArchitecture(context.Background(), cv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(arch).To(Equal("amd64"))
+	})
+
+	It("should return arm64 for aarch64 ClusterInstance", func() {
+		testCI := &siteconfig.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "arch-cluster",
+				Namespace: "arch-cluster",
+			},
+			Spec: siteconfig.ClusterInstanceSpec{
+				CPUArchitecture: siteconfig.CPUArchitectureAarch64,
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testCI).Build()
+		task.client = c
+		cv := &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+		arch, err := task.getClusterArchitecture(context.Background(), cv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(arch).To(Equal("arm64"))
+	})
+
+	It("should return multi for multi-arch ClusterInstance", func() {
+		testCI := &siteconfig.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "arch-cluster",
+				Namespace: "arch-cluster",
+			},
+			Spec: siteconfig.ClusterInstanceSpec{
+				CPUArchitecture: siteconfig.CPUArchitectureMulti,
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testCI).Build()
+		task.client = c
+		cv := &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+		arch, err := task.getClusterArchitecture(context.Background(), cv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(arch).To(Equal("multi"))
+	})
+
+	It("should default to amd64 for unknown architecture", func() {
+		testCI := &siteconfig.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "arch-cluster",
+				Namespace: "arch-cluster",
+			},
+			Spec: siteconfig.ClusterInstanceSpec{
+				CPUArchitecture: "ppc64le",
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testCI).Build()
+		task.client = c
+		cv := &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+		arch, err := task.getClusterArchitecture(context.Background(), cv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(arch).To(Equal("amd64"))
+	})
+
+	It("should prefer CV desiredUpdate.architecture over ClusterInstance", func() {
+		cv := &configv1.ClusterVersion{
+			ObjectMeta: metav1.ObjectMeta{Name: "version"},
+			Spec: configv1.ClusterVersionSpec{
+				DesiredUpdate: &configv1.Update{
+					Architecture: "arm64",
+				},
+			},
+		}
+		arch, err := task.getClusterArchitecture(context.Background(), cv)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(arch).To(Equal("arm64"))
 	})
 })
 
@@ -592,49 +919,6 @@ var _ = Describe("parseUpgradeConfig", func() {
 		})
 	})
 
-	Context("intermediateVersion extraction", func() {
-		It("should extract intermediateVersion from PR params", func() {
-			ct.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
-				Raw: []byte(`{"clusterVersion":{}}`),
-			}
-			pr.Spec.TemplateParameters = runtime.RawExtension{
-				Raw: []byte(`{"upgradeParameters":{"intermediateVersion":"4.21.0"}}`),
-			}
-			cfg, err := parseUpgradeConfig(ct, pr)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cfg.IntermediateVersion).To(Equal("4.21.0"))
-		})
-
-		It("should fall back to CT defaults when PR has no intermediateVersion", func() {
-			ct.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
-				Raw: []byte(`{"clusterVersion":{},"intermediateVersion":"4.19.0"}`),
-			}
-			cfg, err := parseUpgradeConfig(ct, pr)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cfg.IntermediateVersion).To(Equal("4.19.0"))
-		})
-
-		It("should prefer PR intermediateVersion over CT defaults", func() {
-			ct.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
-				Raw: []byte(`{"clusterVersion":{},"intermediateVersion":"4.19.0"}`),
-			}
-			pr.Spec.TemplateParameters = runtime.RawExtension{
-				Raw: []byte(`{"upgradeParameters":{"intermediateVersion":"4.21.0"}}`),
-			}
-			cfg, err := parseUpgradeConfig(ct, pr)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cfg.IntermediateVersion).To(Equal("4.21.0"))
-		})
-
-		It("should return empty intermediateVersion when not set", func() {
-			ct.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
-				Raw: []byte(`{"clusterVersion":{}}`),
-			}
-			cfg, err := parseUpgradeConfig(ct, pr)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cfg.IntermediateVersion).To(BeEmpty())
-		})
-	})
 })
 
 var _ = Describe("handleUpgrade", func() {
@@ -812,7 +1096,7 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 				Release: "4.22.0",
 				TemplateDefaults: provisioningv1alpha1.TemplateDefaults{
 					UpgradeDefaults: runtime.RawExtension{
-						Raw: []byte(`{"clusterVersion":{"desiredUpdate":{}}}`),
+						Raw: []byte(`{"clusterVersion":{"desiredUpdate":{}},"intermediateVersion":"4.21.0"}`),
 					},
 				},
 				TemplateParameterSchema: runtime.RawExtension{
@@ -852,6 +1136,10 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 	setupWithSpokeReady := func(extraObjs ...client.Object) {
 		objs := []client.Object{
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterName}},
+			&siteconfig.ClusterInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				Spec:       siteconfig.ClusterInstanceSpec{CPUArchitecture: siteconfig.CPUArchitectureX86_64},
+			},
 			&addonv1alpha1.ManagedClusterAddOn{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "managed-serviceaccount", Namespace: clusterName,
@@ -958,10 +1246,12 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 	}
 
 	// setEUSStartVersion pre-sets ClusterUpgradeStatus with StartVersion=4.20.0
-	// so initUpgradeStatus skips the ManagedCluster read.
+	// and IntermediateVersion=4.21.0 so initUpgradeStatus skips the ManagedCluster
+	// read and ResolveCVUpgradeAction can drive the EUS state machine.
 	setEUSStartVersion := func() {
 		task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus = &provisioningv1alpha1.ClusterUpgradeStatus{
-			StartVersion: "4.20.0",
+			StartVersion:        "4.20.0",
+			IntermediateVersion: "4.21.0",
 		}
 	}
 
@@ -1483,7 +1773,7 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			setEUSStartVersion()
 
 			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName,
-				&utils.UpgradeConfig{IntermediateVersion: "4.21.0"})
+				&utils.UpgradeConfig{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(proceed).To(BeFalse())
 			Expect(result.RequeueAfter).To(BeZero())
@@ -1492,7 +1782,7 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 				"MachineConfigPools not updated")
 		})
 
-		It("[EUS] should pause worker MCPs and trigger intermediate version", func() {
+		It("[EUS] should pause worker MCPs and trigger intermediate version configured in ClusterTemplate", func() {
 			cv := newBaseCV()
 			cv.Status.History = []configv1.UpdateHistory{
 				{Version: "4.20.0", State: configv1.CompletedUpdate},
@@ -1512,7 +1802,7 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			setEUSStartVersion()
 
 			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName,
-				&utils.UpgradeConfig{IntermediateVersion: "4.21.0"})
+				&utils.UpgradeConfig{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(proceed).To(BeFalse())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
@@ -1521,6 +1811,50 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 				"Upgrade to intermediate version 4.21.0 triggered")
 			assertMCPPaused("worker", true)
 			assertMCPPaused("master", false)
+		})
+
+		It("[EUS] should auto-select intermediateVersion via Cincinnati when intermediateVersion is not configured", func() {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.URL.Query().Get("channel")).To(Equal("eus-4.22"))
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"nodes": []map[string]string{
+						{"version": "4.20.0"},
+						{"version": "4.21.7"},
+						{"version": "4.22.0"},
+					},
+					"edges": [][]int{{0, 1}, {1, 2}},
+				})
+			}))
+			defer srv.Close()
+
+			ct.Spec.TemplateDefaults.UpgradeDefaults = runtime.RawExtension{
+				Raw: fmt.Appendf(nil,
+					`{"clusterVersion":{"channel":"eus-4.22","upstream":%q,"desiredUpdate":{"version":"4.22.0"}}}`,
+					srv.URL),
+			}
+			cv := newBaseCV()
+			cv.Spec.Channel = "eus-4.22"
+			cv.Spec.Upstream = configv1.URL(srv.URL)
+			cv.Status.History = []configv1.UpdateHistory{
+				{Version: "4.20.0", State: configv1.CompletedUpdate},
+			}
+			cv.Status.Conditions = []configv1.ClusterOperatorStatusCondition{retrievedUpdatesTrue}
+			cv.Status.AvailableUpdates = []configv1.Release{{Version: "4.21.7"}}
+			buildSpoke(cv, newUpdatedWorkerMCP())
+			setupWithSpokeReady()
+			task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus = &provisioningv1alpha1.ClusterUpgradeStatus{
+				StartVersion: "4.20.0",
+			}
+
+			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName, &utils.UpgradeConfig{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(proceed).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			assertUpgradeCondition(string(provisioningv1alpha1.CRconditionReasons.Pending),
+				"Upgrade to intermediate version 4.21.7 triggered")
+			Expect(task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus.IntermediateVersion).
+				To(Equal("4.21.7"))
 		})
 
 		It("[EUS] should unpause worker MCPs on intermediate version PreconditionChecksFailed", func() {
@@ -1536,7 +1870,7 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			setEUSStartVersion()
 
 			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName,
-				&utils.UpgradeConfig{IntermediateVersion: "4.21.0"})
+				&utils.UpgradeConfig{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(proceed).To(BeFalse())
 			Expect(result.RequeueAfter).To(BeZero())
@@ -1559,7 +1893,7 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			setEUSStartVersion()
 
 			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName,
-				&utils.UpgradeConfig{IntermediateVersion: "4.21.0"})
+				&utils.UpgradeConfig{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(proceed).To(BeFalse())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
@@ -1580,7 +1914,7 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			setEUSStartVersion()
 
 			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName,
-				&utils.UpgradeConfig{IntermediateVersion: "4.21.0"})
+				&utils.UpgradeConfig{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(proceed).To(BeFalse())
 			Expect(result.RequeueAfter).To(BeZero())
@@ -1706,9 +2040,10 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			setupWithSpokeReady()
 			task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus = &provisioningv1alpha1.ClusterUpgradeStatus{
 				StartedAt: &now, StartVersion: "4.20.0",
+				IntermediateVersion: "4.21.0",
 			}
 
-			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName, &utils.UpgradeConfig{IntermediateVersion: "4.21.0"})
+			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName, &utils.UpgradeConfig{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(proceed).To(BeFalse())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
@@ -1733,10 +2068,11 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			setupWithSpokeReady()
 			task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus = &provisioningv1alpha1.ClusterUpgradeStatus{
 				StartedAt: &pastTime, StartVersion: "4.20.0",
+				IntermediateVersion: "4.21.0",
 			}
 
 			result, _, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName,
-				&utils.UpgradeConfig{IntermediateVersion: "4.21.0"})
+				&utils.UpgradeConfig{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeZero())
 
@@ -1758,10 +2094,11 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			setupWithSpokeReady()
 			task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus = &provisioningv1alpha1.ClusterUpgradeStatus{
 				StartedAt: &now, StartVersion: "4.20.0",
+				IntermediateVersion: "4.21.0",
 			}
 
 			_, _, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName,
-				&utils.UpgradeConfig{IntermediateVersion: "4.21.0", Timeout: 2 * time.Hour})
+				&utils.UpgradeConfig{Timeout: 2 * time.Hour})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(task.timeouts.clusterUpgrade).To(Equal(2 * time.Hour))
 		})
@@ -1807,10 +2144,11 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			now := metav1.Now()
 			task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus = &provisioningv1alpha1.ClusterUpgradeStatus{
 				StartedAt: &now, StartVersion: "4.20.0",
+				IntermediateVersion: "4.21.0",
 			}
 
 			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName,
-				&utils.UpgradeConfig{IntermediateVersion: "4.21.0"})
+				&utils.UpgradeConfig{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(proceed).To(BeFalse())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
@@ -1832,9 +2170,10 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			now := metav1.Now()
 			task.object.Status.Extensions.ClusterDetails.ClusterUpgradeStatus = &provisioningv1alpha1.ClusterUpgradeStatus{
 				StartedAt: &now, StartVersion: "4.20.0",
+				IntermediateVersion: "4.21.0",
 			}
 
-			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName, &utils.UpgradeConfig{IntermediateVersion: "4.21.0"})
+			result, proceed, err := task.handleClusterVersionUpgrade(ctx, ct, clusterName, &utils.UpgradeConfig{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(proceed).To(BeTrue())
 			Expect(result.RequeueAfter).To(BeZero())

--- a/internal/controllers/utils/cincinnati/cincinnati.go
+++ b/internal/controllers/utils/cincinnati/cincinnati.go
@@ -1,0 +1,323 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cincinnati
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
+	configv1 "github.com/openshift/api/config/v1"
+	"golang.org/x/net/http/httpproxy"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// DefaultGraphURL is the public Red Hat Cincinnati update graph endpoint.
+	DefaultGraphURL = "https://api.openshift.com/api/upgrades_info/v1/graph"
+	defaultTimeout  = 30 * time.Second
+
+	trustedCABundleNamespace = "openshift-config-managed"
+	trustedCABundleName      = "trusted-ca-bundle"
+	trustedCABundleKey       = "ca-bundle.crt"
+)
+
+// graph is a Cincinnati update graph response (unconditional upgrade paths only).
+type graph struct {
+	Nodes []node  `json:"nodes"`
+	Edges [][]int `json:"edges"` // each edge is [origin, destination] referencing Nodes by index
+}
+
+// node holds the version string of a release in the Cincinnati graph.
+type node struct {
+	Version string `json:"version"`
+}
+
+// SelectIntermediateVersion fetches the Cincinnati graph and selects the best
+// EUS intermediate version for an upgrade from currentVersion to targetVersion.
+// It builds an HTTP client with the cluster's trusted CA bundle and proxy
+// configuration so it works in connected, proxied, and disconnected environments.
+func SelectIntermediateVersion(
+	ctx context.Context, k8sClient client.Client, logger *slog.Logger,
+	upstream *url.URL, channel, arch, currentVersion, targetVersion string,
+) (string, error) {
+	httpClient, err := getHTTPClient(ctx, k8sClient, logger)
+	if err != nil {
+		return "", fmt.Errorf("unable to build HTTP client to retrieve update graph: %w", err)
+	}
+	g, err := getGraph(ctx, logger, httpClient, upstream, channel, arch)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve update graph: %w", err)
+	}
+	selected, err := findBestIntermediateVersion(g, upstream, channel, currentVersion, targetVersion)
+	if err != nil {
+		return "", typederrors.NewInputError("%s", err.Error())
+	}
+	return selected, nil
+}
+
+// getHTTPClient creates an HTTP client configured with:
+//   - Trusted CAs from openshift-config-managed/trusted-ca-bundle (contains both
+//     system CAs and custom CAs merged by the Cluster Network Operator)
+//   - Proxy configuration from the cluster Proxy CR
+//
+// Falls back gracefully if cluster resources are unavailable.
+func getHTTPClient(ctx context.Context, k8sClient client.Client, logger *slog.Logger) (*http.Client, error) {
+	transport := &http.Transport{}
+
+	if err := configureProxy(ctx, k8sClient, transport); err != nil {
+		return nil, err
+	}
+
+	tlsConfig, err := getTLSConfig(ctx, k8sClient, logger)
+	if err != nil {
+		return nil, err
+	}
+	if tlsConfig != nil {
+		transport.TLSClientConfig = tlsConfig
+	}
+
+	return &http.Client{
+		Timeout:   defaultTimeout,
+		Transport: transport,
+	}, nil
+}
+
+// getTLSConfig reads the cluster's trusted-ca-bundle and returns a TLS
+// config with those CAs for querying the update graph. If the ConfigMap
+// is not found, returns nil so the transport uses the system CA bundle.
+func getTLSConfig(ctx context.Context, k8sClient client.Client, logger *slog.Logger) (*tls.Config, error) {
+	cm := &corev1.ConfigMap{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: trustedCABundleNamespace,
+		Name:      trustedCABundleName,
+	}, cm); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil //nolint:nilnil // Not found is not an error
+		}
+		return nil, fmt.Errorf("failed to read trusted-ca-bundle: %w", err)
+	}
+
+	bundle, ok := cm.Data[trustedCABundleKey]
+	if !ok || bundle == "" {
+		return nil, nil //nolint:nilnil // No data is not an error
+	}
+
+	// The Cluster Network Operator merges system CAs and any custom CAs
+	// from openshift-config/user-ca-bundle into this ConfigMap, so the
+	// bundle already contains the full set of trusted certificates.
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM([]byte(bundle)); !ok {
+		return nil, fmt.Errorf(
+			"configMap %s/%s key %q contains no valid PEM certificates",
+			trustedCABundleNamespace, trustedCABundleName, trustedCABundleKey)
+	}
+	logger.InfoContext(ctx, "Loaded trusted CA bundle for Cincinnati TLS",
+		slog.String("configMap", trustedCABundleNamespace+"/"+trustedCABundleName))
+
+	return &tls.Config{
+		RootCAs: certPool,
+	}, nil
+}
+
+// configureProxy reads the cluster Proxy CR and configures the transport's
+// proxy function if proxy settings are present.
+func configureProxy(ctx context.Context, k8sClient client.Client, transport *http.Transport) error {
+	proxy := &configv1.Proxy{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "cluster"}, proxy); err != nil {
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read Proxy CR: %w", err)
+	}
+
+	// On OpenShift the Proxy CR is the authoritative source for proxy
+	// configuration. Setting transport.Proxy here intentionally overrides
+	// Go's default http.ProxyFromEnvironment. When all proxy fields are
+	// empty, connections go direct.
+	proxyConfig := &httpproxy.Config{
+		HTTPProxy:  proxy.Status.HTTPProxy,
+		HTTPSProxy: proxy.Status.HTTPSProxy,
+		NoProxy:    proxy.Status.NoProxy,
+	}
+	proxyFunc := proxyConfig.ProxyFunc()
+	transport.Proxy = func(req *http.Request) (*url.URL, error) {
+		if req.URL == nil {
+			return nil, nil //nolint:nilnil // No URL means no proxy, direct connection
+		}
+		return proxyFunc(req.URL)
+	}
+	return nil
+}
+
+// getGraph fetches the update graph for the given upstream URL, channel, and arch.
+func getGraph(ctx context.Context, logger *slog.Logger, httpClient *http.Client, upstream *url.URL, channel, arch string) (*graph, error) {
+	uri := *upstream
+	queryParams := uri.Query()
+	queryParams.Set("channel", channel)
+	queryParams.Set("arch", arch)
+	uri.RawQuery = queryParams.Encode()
+
+	// Download the update graph from the upstream URL.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		var dnsErr *net.DNSError
+		if stderrors.As(err, &dnsErr) && dnsErr.IsNotFound {
+			return nil, typederrors.NewInputError("%s", err.Error())
+		}
+		return nil, fmt.Errorf("unable to query update graph: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.ErrorContext(ctx, "Failed to close Cincinnati response body",
+				slog.Any("error", err))
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		err := fmt.Errorf("unexpected HTTP status: %d from %s",
+			resp.StatusCode, upstream.String())
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, typederrors.NewInputError("%s", err.Error())
+		}
+		return nil, err
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return nil, fmt.Errorf("unable to read HTTP response: %w", err)
+	}
+
+	// Parse the response body into a graph.
+	var graph graph
+	if err := json.Unmarshal(body, &graph); err != nil {
+		return nil, fmt.Errorf("unable to parse update graph: %w", err)
+	}
+	return &graph, nil
+}
+
+// findBestIntermediateVersion finds the best EUS intermediate version from the
+// Cincinnati graph for an upgrade from currentVersion to targetVersion.
+//
+// For example, upgrading 4.20.0 -> 4.22.0 requires an intermediate 4.21.z.
+// The function searches all 4.21.z nodes that satisfy two conditions:
+//   - A direct unconditional edge exists from currentVersion to the candidate
+//   - A direct unconditional edge exists from the candidate to targetVersion
+//
+// Among all qualifying candidates, it returns the one with the highest patch
+// version (e.g. 4.21.9 over 4.21.5).
+func findBestIntermediateVersion(g *graph, upstream *url.URL, channel, currentVersion, targetVersion string) (string, error) {
+	if g == nil {
+		return "", fmt.Errorf("cincinnati graph is nil")
+	}
+	if _, err := semver.NewVersion(currentVersion); err != nil {
+		return "", fmt.Errorf("invalid current version %q: %w", currentVersion, err)
+	}
+	target, err := semver.NewVersion(targetVersion)
+	if err != nil {
+		return "", fmt.Errorf("invalid target version %q: %w", targetVersion, err)
+	}
+
+	// Step 1: Parse all node versions and locate the current and target nodes
+	// by their exact version string.
+	currentIdx := -1
+	targetIdx := -1
+	nodes := make([]*semver.Version, len(g.Nodes))
+	for i, n := range g.Nodes {
+		v, err := semver.NewVersion(n.Version)
+		if err != nil {
+			continue
+		}
+		nodes[i] = v
+		if n.Version == currentVersion {
+			currentIdx = i
+		}
+		if n.Version == targetVersion {
+			targetIdx = i
+		}
+	}
+	if currentIdx < 0 {
+		return "", fmt.Errorf("current version %s not found in update graph %s with channel %s",
+			currentVersion, upstream.String(), channel)
+	}
+	if targetIdx < 0 {
+		return "", fmt.Errorf("target version %s not found in update graph %s with channel %s",
+			targetVersion, upstream.String(), channel)
+	}
+
+	// Step 2: Build an adjacency map from unconditional edges only.
+	// Conditional edges (with risks) are excluded — CVO evaluates those on
+	// the spoke and we don't want to auto-select a risky intermediate.
+	outEdges := make(map[int]map[int]struct{}, len(g.Nodes))
+	for _, e := range g.Edges {
+		if len(e) < 2 {
+			continue
+		}
+		from, to := e[0], e[1]
+		if outEdges[from] == nil {
+			outEdges[from] = map[int]struct{}{}
+		}
+		outEdges[from][to] = struct{}{}
+	}
+
+	// Step 3: Find the best intermediate — must be target.Minor-1 (e.g. 4.21
+	// for a 4.20 -> 4.22 upgrade), reachable from current, and with an edge to
+	// target. Pick the highest patch version among all qualifying candidates.
+	intermediateMinor := target.Minor - 1
+	var best string
+	var bestVer *semver.Version
+	for i, v := range nodes {
+		if v == nil {
+			continue
+		}
+		// Only consider nodes in the intermediate minor release.
+		if v.Major != target.Major || v.Minor != intermediateMinor {
+			continue
+		}
+		// Must have a direct edge: current -> candidate.
+		if _, ok := outEdges[currentIdx][i]; !ok {
+			continue
+		}
+		// Must have a direct edge: candidate -> target.
+		if _, ok := outEdges[i][targetIdx]; !ok {
+			continue
+		}
+		// Keep the highest patch version.
+		if bestVer == nil || v.Compare(*bestVer) > 0 {
+			bestVer = v
+			best = g.Nodes[i].Version
+		}
+	}
+	if best == "" {
+		return "", fmt.Errorf(
+			"unable to select intermediate version for %s to %s upgrade: "+
+				"no valid upgrade path found in the update graph %s with channel %s",
+			currentVersion, targetVersion, upstream.String(), channel)
+	}
+	return best, nil
+}

--- a/internal/controllers/utils/cincinnati/cincinnati_test.go
+++ b/internal/controllers/utils/cincinnati/cincinnati_test.go
@@ -1,0 +1,230 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cincinnati
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
+	fakeclient "github.com/openshift-kni/oran-o2ims/test/fakeclient"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var testUpstream, _ = url.Parse("https://test.example.com/graph")
+var testLogger = slog.New(slog.DiscardHandler)
+
+func TestCincinnati(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cincinnati Suite")
+}
+
+var _ = Describe("findBestIntermediate", func() {
+	// Graph layout (indices):
+	// 0: 4.20.0, 1: 4.21.1, 2: 4.21.5, 3: 4.22.0, 4: 4.21.3 (no edge to target)
+	testGraph := &graph{
+		Nodes: []node{
+			{Version: "4.20.0"},
+			{Version: "4.21.1"},
+			{Version: "4.21.5"},
+			{Version: "4.22.0"},
+			{Version: "4.21.3"},
+		},
+		Edges: [][]int{
+			{0, 1}, // 4.20.0 -> 4.21.1
+			{0, 2}, // 4.20.0 -> 4.21.5
+			{0, 4}, // 4.20.0 -> 4.21.3
+			{1, 3}, // 4.21.1 -> 4.22.0
+			{2, 3}, // 4.21.5 -> 4.22.0
+			// 4.21.3 has no edge to 4.22.0
+		},
+	}
+
+	It("should select the latest patch with edges from current and to target", func() {
+		selected, err := findBestIntermediateVersion(testGraph, testUpstream, "eus-4.22", "4.20.0", "4.22.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(selected).To(Equal("4.21.5"))
+	})
+
+	It("should error when current version is missing", func() {
+		_, err := findBestIntermediateVersion(testGraph, testUpstream, "eus-4.22", "4.20.99", "4.22.0")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("current version 4.20.99 not found in update graph"))
+	})
+
+	It("should error when target version is missing", func() {
+		_, err := findBestIntermediateVersion(testGraph, testUpstream, "eus-4.22", "4.20.0", "4.22.99")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("target version 4.22.99 not found in update graph"))
+	})
+
+	It("should error when no valid intermediate path exists", func() {
+		g := &graph{
+			Nodes: []node{
+				{Version: "4.20.0"},
+				{Version: "4.21.0"},
+				{Version: "4.22.0"},
+			},
+			Edges: [][]int{
+				{0, 1},
+			},
+		}
+		_, err := findBestIntermediateVersion(g, testUpstream, "eus-4.22", "4.20.0", "4.22.0")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unable to select intermediate version"))
+		Expect(err.Error()).To(ContainSubstring("no valid upgrade path found"))
+	})
+
+	It("should error for nil graph", func() {
+		_, err := findBestIntermediateVersion(nil, testUpstream, "eus-4.22", "4.20.0", "4.22.0")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("getGraph", func() {
+	It("should fetch and parse a graph response", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.URL.Query().Get("channel")).To(Equal("eus-4.22"))
+			Expect(r.URL.Query().Get("arch")).To(Equal("amd64"))
+			_ = json.NewEncoder(w).Encode(graph{
+				Nodes: []node{{Version: "4.20.0"}, {Version: "4.21.0"}, {Version: "4.22.0"}},
+				Edges: [][]int{{0, 1}, {1, 2}},
+			})
+		}))
+		defer srv.Close()
+
+		srvURL, _ := url.Parse(srv.URL)
+		g, err := getGraph(context.Background(), testLogger, srv.Client(), srvURL, "eus-4.22", "amd64")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(g.Nodes).To(HaveLen(3))
+		Expect(g.Edges).To(HaveLen(2))
+	})
+
+	It("should return error on non-OK status", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}))
+		defer srv.Close()
+
+		srvURL, _ := url.Parse(srv.URL)
+		_, err := getGraph(context.Background(), testLogger, srv.Client(), srvURL, "stable-4.22", "amd64")
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeFalse())
+		Expect(err.Error()).To(ContainSubstring("status: 502"))
+	})
+
+	It("should return InputError on 404", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		srvURL, _ := url.Parse(srv.URL)
+		_, err := getGraph(context.Background(), testLogger, srv.Client(), srvURL, "eus-4.22", "amd64")
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("status: 404"))
+	})
+
+	It("should return InputError on DNS not found", func() {
+		srvURL, _ := url.Parse("http://does-not-exist.invalid")
+		_, err := getGraph(context.Background(), testLogger, http.DefaultClient, srvURL, "eus-4.22", "amd64")
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("no such host"))
+	})
+})
+
+var _ = Describe("SelectIntermediateVersion", func() {
+	It("should select the latest intermediate version from a graph", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(graph{
+				Nodes: []node{
+					{Version: "4.20.0"},
+					{Version: "4.21.1"},
+					{Version: "4.21.5"},
+					{Version: "4.22.0"},
+				},
+				Edges: [][]int{{0, 1}, {0, 2}, {1, 3}, {2, 3}},
+			})
+		}))
+		defer srv.Close()
+
+		k8sClient := fake.NewClientBuilder().WithScheme(fakeclient.Scheme).Build()
+		srvURL, _ := url.Parse(srv.URL)
+		selected, err := SelectIntermediateVersion(
+			context.Background(), k8sClient, testLogger,
+			srvURL, "eus-4.22", "amd64", "4.20.0", "4.22.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(selected).To(Equal("4.21.5"))
+	})
+
+	It("should return InputError when no valid path exists", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(graph{
+				Nodes: []node{
+					{Version: "4.20.0"},
+					{Version: "4.21.0"},
+					{Version: "4.22.0"},
+				},
+				Edges: [][]int{{0, 1}},
+			})
+		}))
+		defer srv.Close()
+
+		k8sClient := fake.NewClientBuilder().WithScheme(fakeclient.Scheme).Build()
+		srvURL, _ := url.Parse(srv.URL)
+		_, err := SelectIntermediateVersion(
+			context.Background(), k8sClient, testLogger,
+			srvURL, "eus-4.22", "amd64", "4.20.0", "4.22.0")
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("no valid upgrade path found"))
+	})
+
+	It("should return error when server is unavailable", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}))
+		defer srv.Close()
+
+		k8sClient := fake.NewClientBuilder().WithScheme(fakeclient.Scheme).Build()
+		srvURL, _ := url.Parse(srv.URL)
+		_, err := SelectIntermediateVersion(
+			context.Background(), k8sClient, testLogger,
+			srvURL, "eus-4.22", "amd64", "4.20.0", "4.22.0")
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeFalse())
+		Expect(err.Error()).To(ContainSubstring("unable to retrieve update graph"))
+	})
+
+	It("should work when trusted-ca-bundle ConfigMap is not found", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(graph{
+				Nodes: []node{{Version: "4.20.0"}, {Version: "4.21.0"}, {Version: "4.22.0"}},
+				Edges: [][]int{{0, 1}, {1, 2}},
+			})
+		}))
+		defer srv.Close()
+
+		k8sClient := fake.NewClientBuilder().WithScheme(fakeclient.Scheme).Build()
+		srvURL, _ := url.Parse(srv.URL)
+		selected, err := SelectIntermediateVersion(
+			context.Background(), k8sClient, testLogger,
+			srvURL, "eus-4.22", "amd64", "4.20.0", "4.22.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(selected).To(Equal("4.21.0"))
+	})
+
+})

--- a/internal/controllers/utils/upgrade.go
+++ b/internal/controllers/utils/upgrade.go
@@ -30,9 +30,8 @@ const (
 // upgradeConfig holds the parsed upgrade configuration extracted from
 // ProvisioningRequest upgradeParameters and ClusterTemplate upgradeDefaults.
 type UpgradeConfig struct {
-	UpgradeType         string
-	Timeout             time.Duration
-	IntermediateVersion string
+	UpgradeType string
+	Timeout     time.Duration
 }
 
 // UpgradePhase represents the current phase of a ClusterVersion upgrade.
@@ -46,16 +45,21 @@ const (
 
 // CVUpgradeAction holds the resolved upgrade state for a ClusterVersion upgrade.
 type CVUpgradeAction struct {
-	UpgradeToVersion  string
-	Phase             UpgradePhase
-	IsEUS             bool
-	IsEUSIntermediate bool
+	UpgradeToVersion string
+	Phase            UpgradePhase
+	IsEUS            bool
+}
+
+// IsEUSIntermediate returns true when this action targets the EUS intermediate
+// version. intermediateVersion is typically read from status.IntermediateVersion.
+func (a *CVUpgradeAction) IsEUSIntermediate(intermediateVersion string) bool {
+	return a.IsEUS && a.UpgradeToVersion == intermediateVersion
 }
 
 // VersionLabel returns "intermediate" for EUS intermediate upgrades,
 // "desired" otherwise. Used in condition messages.
-func (a *CVUpgradeAction) VersionLabel() string {
-	if a.IsEUSIntermediate {
+func (a *CVUpgradeAction) VersionLabel(intermediateVersion string) string {
+	if a.IsEUSIntermediate(intermediateVersion) {
 		return "intermediate"
 	}
 	return "desired"
@@ -186,6 +190,9 @@ func ResolveCVUpgradeAction(
 	var phase UpgradePhase
 
 	if isEUS {
+		// When intermediateVersion is "" (not yet resolved), FindCVHistoryEntry
+		// returns nil, producing UpgradeToVersion="" / PhasePreStart. The
+		// PreStart phase handles resolving the actual intermediate version.
 		intEntry := FindCVHistoryEntry(cv, intermediateVersion)
 		switch {
 		case intEntry == nil:
@@ -216,20 +223,16 @@ func ResolveCVUpgradeAction(
 	}
 
 	return &CVUpgradeAction{
-		UpgradeToVersion:  upgradeToVersion,
-		Phase:             phase,
-		IsEUS:             isEUS,
-		IsEUSIntermediate: isEUS && upgradeToVersion == intermediateVersion,
+		UpgradeToVersion: upgradeToVersion,
+		Phase:            phase,
+		IsEUS:            isEUS,
 	}
 }
 
 // IsEUSUpgrade determines whether the upgrade is EUS-to-EUS based on the
-// start and target versions (both even minor, exactly 2 apart). When EUS is
-// detected, it validates that intermediateVersion is provided and exactly one
-// minor version below the target. Returns an error if intermediateVersion is
-// provided for a non-EUS upgrade, or if the version chain is invalid.
+// start and target versions (both even minor, exactly 2 apart).
 // Returns false with no error for empty start/target versions.
-func IsEUSUpgrade(startVersion, intermediateVersion, targetVersion string) (bool, error) {
+func IsEUSUpgrade(startVersion, targetVersion string) (bool, error) {
 	if startVersion == "" || targetVersion == "" {
 		return false, nil
 	}
@@ -243,41 +246,9 @@ func IsEUSUpgrade(startVersion, intermediateVersion, targetVersion string) (bool
 		return false, fmt.Errorf("failed to parse target version %q: %w", targetVersion, err)
 	}
 
-	isEUS := start.Major == target.Major &&
+	return start.Major == target.Major &&
 		start.Minor%2 == 0 && target.Minor%2 == 0 &&
-		target.Minor-start.Minor == 2
-
-	if !isEUS {
-		if intermediateVersion != "" {
-			return false, fmt.Errorf(
-				"intermediateVersion %s provided but upgrade from %s to %s is not EUS-to-EUS",
-				intermediateVersion, startVersion, targetVersion)
-		}
-		return false, nil
-	}
-
-	if intermediateVersion == "" {
-		return false, fmt.Errorf(
-			"intermediateVersion is required for EUS-to-EUS upgrades (current: %s, target: %s)",
-			startVersion, targetVersion)
-	}
-
-	intermediate, err := semver.NewVersion(intermediateVersion)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse intermediateVersion %q: %w", intermediateVersion, err)
-	}
-	if intermediate.Major != target.Major {
-		return false, fmt.Errorf(
-			"intermediateVersion %s major version must match targetVersion %s",
-			intermediateVersion, targetVersion)
-	}
-	if target.Minor-intermediate.Minor != 1 {
-		return false, fmt.Errorf(
-			"intermediateVersion %s must be exactly one minor version below targetVersion %s",
-			intermediateVersion, targetVersion)
-	}
-
-	return true, nil
+		target.Minor-start.Minor == 2, nil
 }
 
 // ListMCPs returns all MachineConfigPools.

--- a/internal/controllers/utils/upgrade_test.go
+++ b/internal/controllers/utils/upgrade_test.go
@@ -135,88 +135,58 @@ var _ = Describe("Upgrade helper functions", func() {
 	})
 
 	Describe("IsEUSUpgrade", func() {
-		It("should return true for 4.20->4.21->4.22", func() {
-			isEUS, err := IsEUSUpgrade("4.20.5", "4.21.0", "4.22.0")
+		It("should return true for 4.20->4.22", func() {
+			isEUS, err := IsEUSUpgrade("4.20.5", "4.22.0")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isEUS).To(BeTrue())
 		})
 
-		It("should return true for 4.18->4.19->4.20", func() {
-			isEUS, err := IsEUSUpgrade("4.18.0", "4.19.0", "4.20.3")
+		It("should return true for 4.18->4.20", func() {
+			isEUS, err := IsEUSUpgrade("4.18.0", "4.20.3")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isEUS).To(BeTrue())
 		})
 
-		It("should return false for 4.20->4.21 (odd target, no intermediate)", func() {
-			isEUS, err := IsEUSUpgrade("4.20.0", "", "4.21.0")
+		It("should return false for 4.20->4.21 (odd target)", func() {
+			isEUS, err := IsEUSUpgrade("4.20.0", "4.21.0")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isEUS).To(BeFalse())
 		})
 
-		It("should return false for 4.21->4.23 (odd current, no intermediate)", func() {
-			isEUS, err := IsEUSUpgrade("4.21.0", "", "4.23.0")
+		It("should return false for 4.21->4.23 (odd current)", func() {
+			isEUS, err := IsEUSUpgrade("4.21.0", "4.23.0")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isEUS).To(BeFalse())
 		})
 
-		It("should return false for 4.20->4.24 (gap of 4, no intermediate)", func() {
-			isEUS, err := IsEUSUpgrade("4.20.0", "", "4.24.0")
+		It("should return false for 4.20->4.24 (gap of 4)", func() {
+			isEUS, err := IsEUSUpgrade("4.20.0", "4.24.0")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isEUS).To(BeFalse())
 		})
 
-		It("should return false for cross-major 3.20->4.22 (different major)", func() {
-			isEUS, err := IsEUSUpgrade("3.20.0", "", "4.22.0")
+		It("should return false for cross-major 3.20->4.22", func() {
+			isEUS, err := IsEUSUpgrade("3.20.0", "4.22.0")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isEUS).To(BeFalse())
 		})
 
-		It("should return false for z-stream 4.20.0->4.20.3 (no intermediate)", func() {
-			isEUS, err := IsEUSUpgrade("4.20.0", "", "4.20.3")
+		It("should return false for z-stream 4.20.0->4.20.3", func() {
+			isEUS, err := IsEUSUpgrade("4.20.0", "4.20.3")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isEUS).To(BeFalse())
 		})
 
 		It("should return false with no error for empty start version", func() {
-			isEUS, err := IsEUSUpgrade("", "4.21.0", "4.22.0")
+			isEUS, err := IsEUSUpgrade("", "4.22.0")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isEUS).To(BeFalse())
 		})
 
 		It("should return error for invalid start version", func() {
-			_, err := IsEUSUpgrade("invalid", "", "4.22.0")
+			_, err := IsEUSUpgrade("invalid", "4.22.0")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to parse start version"))
-		})
-
-		It("should return error when intermediateVersion provided for non-EUS upgrade", func() {
-			_, err := IsEUSUpgrade("4.21.0", "4.21.0", "4.22.0")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("not EUS-to-EUS"))
-		})
-
-		It("should return error when EUS detected but intermediateVersion missing", func() {
-			_, err := IsEUSUpgrade("4.20.0", "", "4.22.0")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("intermediateVersion is required"))
-		})
-
-		It("should return error when intermediateVersion has wrong minor gap", func() {
-			_, err := IsEUSUpgrade("4.20.0", "4.20.5", "4.22.0")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("exactly one minor version below"))
-		})
-
-		It("should return error when intermediateVersion has wrong major version", func() {
-			_, err := IsEUSUpgrade("4.20.0", "99.21.0", "4.22.0")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("major version must match"))
-		})
-
-		It("should return error for invalid intermediateVersion", func() {
-			_, err := IsEUSUpgrade("4.20.0", "invalid", "4.22.0")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to parse intermediateVersion"))
 		})
 	})
 
@@ -263,6 +233,21 @@ var _ = Describe("Upgrade helper functions", func() {
 		})
 
 		Context("EUS upgrade", func() {
+			It("should return empty intermediate/PreStart when status intermediate is empty", func() {
+				cv := &configv1.ClusterVersion{
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{Version: "4.20.0", State: configv1.CompletedUpdate},
+						},
+					},
+				}
+				action := ResolveCVUpgradeAction(cv, "4.22.0", "", true)
+				Expect(action.UpgradeToVersion).To(Equal(""))
+				Expect(action.Phase).To(Equal(PhasePreStart))
+				Expect(action.IsEUS).To(BeTrue())
+				Expect(action.IsEUSIntermediate("")).To(BeTrue())
+			})
+
 			It("should return intermediate/PreStart when no intermediate history", func() {
 				cv := &configv1.ClusterVersion{
 					Status: configv1.ClusterVersionStatus{
@@ -275,7 +260,7 @@ var _ = Describe("Upgrade helper functions", func() {
 				Expect(action.UpgradeToVersion).To(Equal("4.21.0"))
 				Expect(action.Phase).To(Equal(PhasePreStart))
 				Expect(action.IsEUS).To(BeTrue())
-				Expect(action.IsEUSIntermediate).To(BeTrue())
+				Expect(action.IsEUSIntermediate("4.21.0")).To(BeTrue())
 			})
 
 			It("should return intermediate/InProgress when intermediate partial", func() {
@@ -290,7 +275,7 @@ var _ = Describe("Upgrade helper functions", func() {
 				action := ResolveCVUpgradeAction(cv, "4.22.0", "4.21.0", true)
 				Expect(action.UpgradeToVersion).To(Equal("4.21.0"))
 				Expect(action.Phase).To(Equal(PhaseInProgress))
-				Expect(action.IsEUSIntermediate).To(BeTrue())
+				Expect(action.IsEUSIntermediate("4.21.0")).To(BeTrue())
 			})
 
 			It("should return target/PreStart when intermediate completed", func() {
@@ -305,7 +290,7 @@ var _ = Describe("Upgrade helper functions", func() {
 				action := ResolveCVUpgradeAction(cv, "4.22.0", "4.21.0", true)
 				Expect(action.UpgradeToVersion).To(Equal("4.22.0"))
 				Expect(action.Phase).To(Equal(PhasePreStart))
-				Expect(action.IsEUSIntermediate).To(BeFalse())
+				Expect(action.IsEUSIntermediate("4.21.0")).To(BeFalse())
 			})
 
 			It("should return target/InProgress when target partial", func() {
@@ -321,7 +306,7 @@ var _ = Describe("Upgrade helper functions", func() {
 				action := ResolveCVUpgradeAction(cv, "4.22.0", "4.21.0", true)
 				Expect(action.UpgradeToVersion).To(Equal("4.22.0"))
 				Expect(action.Phase).To(Equal(PhaseInProgress))
-				Expect(action.IsEUSIntermediate).To(BeFalse())
+				Expect(action.IsEUSIntermediate("4.21.0")).To(BeFalse())
 			})
 
 			It("should return target/Completed when both completed", func() {

--- a/internal/validation/upgrade.go
+++ b/internal/validation/upgrade.go
@@ -58,29 +58,38 @@ func ValidateCVUpgradeData(upgradeData map[string]any, releaseVersion, contextLa
 	}
 
 	if intermediateVersionStr, ok := upgradeData["intermediateVersion"].(string); ok && intermediateVersionStr != "" {
-		intermediateVer, err := semver.NewVersion(intermediateVersionStr)
-		if err != nil {
-			return typederrors.NewInputError(
-				"invalid intermediateVersion %q in %s: %s",
-				intermediateVersionStr, contextLabel, err.Error())
-		}
-		releaseVer, err := semver.NewVersion(releaseVersion)
-		if err != nil {
-			return typederrors.NewInputError(
-				"cannot validate intermediateVersion: spec.release %q is not valid semver: %s",
-				releaseVersion, err.Error())
-		}
-		if intermediateVer.Major != releaseVer.Major {
-			return typederrors.NewInputError(
-				"intermediateVersion major version (%d) must equal spec.release major version (%d)",
-				intermediateVer.Major, releaseVer.Major)
-		}
-		if intermediateVer.Minor+1 != releaseVer.Minor {
-			return typederrors.NewInputError(
-				"intermediateVersion %s must be exactly one minor version below ClusterTemplate's release version %s",
-				intermediateVer, releaseVer)
+		if err := ValidateEUSIntermediate(intermediateVersionStr, releaseVersion); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+// ValidateEUSIntermediate checks that intermediateVersion is valid semver and
+// exactly one minor version below targetVersion with the same major.
+func ValidateEUSIntermediate(intermediateVersion, targetVersion string) error {
+	intermediateVer, err := semver.NewVersion(intermediateVersion)
+	if err != nil {
+		return typederrors.NewInputError(
+			"intermediateVersion %q is not valid semver: %s",
+			intermediateVersion, err.Error())
+	}
+	targetVer, err := semver.NewVersion(targetVersion)
+	if err != nil {
+		return typederrors.NewInputError(
+			"cannot validate intermediateVersion: ClusterTemplate's spec.release %q is not valid semver: %s",
+			targetVersion, err.Error())
+	}
+	if intermediateVer.Major != targetVer.Major {
+		return typederrors.NewInputError(
+			"intermediateVersion major version (%d) must equal ClusterTemplate's spec.release major version (%d)",
+			intermediateVer.Major, targetVer.Major)
+	}
+	if intermediateVer.Minor+1 != targetVer.Minor {
+		return typederrors.NewInputError(
+			"intermediateVersion %s must be exactly one minor version below ClusterTemplate's spec.release version %s",
+			intermediateVer, targetVer)
+	}
 	return nil
 }

--- a/internal/validation/upgrade_test.go
+++ b/internal/validation/upgrade_test.go
@@ -159,7 +159,7 @@ var _ = Describe("ValidateCVUpgradeData", func() {
 			err := ValidateCVUpgradeData(data, release, label)
 			Expect(err).To(HaveOccurred())
 			Expect(typederrors.IsInputError(err)).To(BeTrue())
-			Expect(err.Error()).To(ContainSubstring("invalid intermediateVersion"))
+			Expect(err.Error()).To(ContainSubstring("is not valid semver"))
 		})
 
 		It("should reject when major version differs", func() {
@@ -170,7 +170,7 @@ var _ = Describe("ValidateCVUpgradeData", func() {
 			err := ValidateCVUpgradeData(data, release, label)
 			Expect(err).To(HaveOccurred())
 			Expect(typederrors.IsInputError(err)).To(BeTrue())
-			Expect(err.Error()).To(ContainSubstring("major version (3) must equal spec.release major version (4)"))
+			Expect(err.Error()).To(ContainSubstring("major version (3) must equal ClusterTemplate's spec.release major version (4)"))
 		})
 
 		It("should reject when not exactly one minor below", func() {
@@ -210,7 +210,7 @@ var _ = Describe("ValidateCVUpgradeData", func() {
 			err := ValidateCVUpgradeData(data, release, label)
 			Expect(err).To(HaveOccurred())
 			Expect(typederrors.IsInputError(err)).To(BeTrue())
-			Expect(err.Error()).To(ContainSubstring("invalid intermediateVersion"))
+			Expect(err.Error()).To(ContainSubstring("is not valid semver"))
 		})
 	})
 
@@ -237,5 +237,39 @@ var _ = Describe("ValidateCVUpgradeData", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("does not match"))
 		})
+	})
+})
+
+var _ = Describe("ValidateEUSIntermediate", func() {
+	It("should accept intermediate one minor below target", func() {
+		Expect(ValidateEUSIntermediate("4.21.0", "4.22.0")).ToNot(HaveOccurred())
+	})
+
+	It("should reject wrong minor gap", func() {
+		err := ValidateEUSIntermediate("4.20.5", "4.22.0")
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("exactly one minor version below"))
+	})
+
+	It("should reject wrong major version", func() {
+		err := ValidateEUSIntermediate("99.21.0", "4.22.0")
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("must equal ClusterTemplate's spec.release major version"))
+	})
+
+	It("should reject invalid intermediateVersion", func() {
+		err := ValidateEUSIntermediate("invalid", "4.22.0")
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("is not valid semver"))
+	})
+
+	It("should reject invalid target version", func() {
+		err := ValidateEUSIntermediate("4.21.0", "not-semver")
+		Expect(err).To(HaveOccurred())
+		Expect(typederrors.IsInputError(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("ClusterTemplate's spec.release"))
 	})
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -40,6 +40,7 @@ import (
 	hwmgrcontrollers "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/controller"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
+	configv1 "github.com/openshift/api/config/v1"
 	assistedservicev1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
@@ -119,6 +120,8 @@ var _ = BeforeSuite(func() {
 	err = msav1beta1.AddToScheme(testScheme)
 	Expect(err).ToNot(HaveOccurred())
 	err = workv1.Install(testScheme)
+	Expect(err).ToNot(HaveOccurred())
+	err = configv1.Install(testScheme)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Get the needed external CRDs. Their details are under test/utils/vars.go - ExternalCrdsData.

--- a/test/e2e/mno_cv_upgrade_test.go
+++ b/test/e2e/mno_cv_upgrade_test.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"time"
@@ -692,18 +694,31 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 
 			waitForPRUpgradeCondition(testCtx, K8SClient,
 				string(provisioningv1alpha1.CRconditionReasons.PreconditionChecksFailed),
-				"intermediateVersion 4.20.3 must be exactly one minor version below targetVersion "+ctRelease4,
+				"intermediateVersion 4.20.3 must be exactly one minor version below ClusterTemplate's spec.release version "+ctRelease4,
 				provisioningv1alpha1.StateFailed,
 			)
 		})
 
-		It("should start intermediate upgrade after fixing intermediateVersion", func() {
+		It("should auto-select intermediateVersion and start intermediate upgrade", func() {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"nodes": []map[string]string{
+						{"version": ctRelease2},
+						{"version": eusIntermediateVersion},
+						{"version": ctRelease4},
+					},
+					"edges": [][]int{{0, 1}, {1, 2}},
+				})
+			}))
+			defer srv.Close()
+
 			updatePR(testCtx, K8SClient, "", map[string]any{
 				constants.TemplateParamUpgrade: map[string]any{
 					ctlrutils.UpgradeDefaultsClusterVersionKey: map[string]any{
+						"channel":       "eus-4.22",
+						"upstream":      srv.URL,
 						"desiredUpdate": map[string]any{"version": ctRelease4},
 					},
-					ctlrutils.UpgradeIntermediateVersionConfigKey: eusIntermediateVersion,
 				},
 			})
 

--- a/test/fakeclient/fakeclient.go
+++ b/test/fakeclient/fakeclient.go
@@ -63,7 +63,9 @@ func init() {
 		&policiesv1.Policy{}, &policiesv1.PolicyList{})
 	Scheme.AddKnownTypes(clusterv1.SchemeGroupVersion,
 		&clusterv1.ManagedCluster{}, &clusterv1.ManagedClusterList{})
-	Scheme.AddKnownTypes(openshiftv1.SchemeGroupVersion, &openshiftv1.ClusterVersion{})
+	Scheme.AddKnownTypes(openshiftv1.SchemeGroupVersion,
+		&openshiftv1.ClusterVersion{},
+		&openshiftv1.Proxy{}, &openshiftv1.ProxyList{})
 	Scheme.AddKnownTypes(mcfgv1.SchemeGroupVersion,
 		&mcfgv1.MachineConfigPool{}, &mcfgv1.MachineConfigPoolList{})
 	Scheme.AddKnownTypes(openshiftoperatorv1.SchemeGroupVersion, &openshiftoperatorv1.IngressController{})

--- a/vendor/golang.org/x/net/http/httpproxy/proxy.go
+++ b/vendor/golang.org/x/net/http/httpproxy/proxy.go
@@ -1,0 +1,373 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package httpproxy provides support for HTTP proxy determination
+// based on environment variables, as provided by
+// [net/http.ProxyFromEnvironment] function.
+//
+// The API is not subject to the Go 1 compatibility promise and may change at
+// any time.
+package httpproxy
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"net/url"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/net/idna"
+)
+
+// Config holds configuration for HTTP proxy settings. See
+// FromEnvironment for details.
+type Config struct {
+	// HTTPProxy represents the value of the HTTP_PROXY or
+	// http_proxy environment variable. It will be used as the proxy
+	// URL for HTTP requests unless overridden by NoProxy.
+	HTTPProxy string
+
+	// HTTPSProxy represents the HTTPS_PROXY or https_proxy
+	// environment variable. It will be used as the proxy URL for
+	// HTTPS requests unless overridden by NoProxy.
+	HTTPSProxy string
+
+	// NoProxy represents the NO_PROXY or no_proxy environment
+	// variable. It specifies a string that contains comma-separated values
+	// specifying hosts that should be excluded from proxying. Each value is
+	// represented by an IP address prefix (1.2.3.4), an IP address prefix in
+	// CIDR notation (1.2.3.4/8), a domain name, or a special DNS label (*).
+	// An IP address prefix and domain name can also include a literal port
+	// number (1.2.3.4:80).
+	// A domain name matches that name and all subdomains. A domain name with
+	// a leading "." matches subdomains only. For example "foo.com" matches
+	// "foo.com" and "bar.foo.com"; ".y.com" matches "x.y.com" but not "y.com".
+	// A single asterisk (*) indicates that no proxying should be done.
+	// A best effort is made to parse the string and errors are
+	// ignored.
+	NoProxy string
+
+	// CGI holds whether the current process is running
+	// as a CGI handler (FromEnvironment infers this from the
+	// presence of a REQUEST_METHOD environment variable).
+	// When this is set, ProxyForURL will return an error
+	// when HTTPProxy applies, because a client could be
+	// setting HTTP_PROXY maliciously. See https://go.dev/s/cgihttpproxy.
+	CGI bool
+}
+
+// config holds the parsed configuration for HTTP proxy settings.
+type config struct {
+	// Config represents the original configuration as defined above.
+	Config
+
+	// httpsProxy is the parsed URL of the HTTPSProxy if defined.
+	httpsProxy *url.URL
+
+	// httpProxy is the parsed URL of the HTTPProxy if defined.
+	httpProxy *url.URL
+
+	// ipMatchers represent all values in the NoProxy that are IP address
+	// prefixes or an IP address in CIDR notation.
+	ipMatchers []matcher
+
+	// domainMatchers represent all values in the NoProxy that are a domain
+	// name or hostname & domain name
+	domainMatchers []matcher
+}
+
+// FromEnvironment returns a Config instance populated from the
+// environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the
+// lowercase versions thereof).
+//
+// The environment values may be either a complete URL or a
+// "host[:port]", in which case the "http" scheme is assumed. An error
+// is returned if the value is a different form.
+func FromEnvironment() *Config {
+	return &Config{
+		HTTPProxy:  getEnvAny("HTTP_PROXY", "http_proxy"),
+		HTTPSProxy: getEnvAny("HTTPS_PROXY", "https_proxy"),
+		NoProxy:    getEnvAny("NO_PROXY", "no_proxy"),
+		CGI:        os.Getenv("REQUEST_METHOD") != "",
+	}
+}
+
+func getEnvAny(names ...string) string {
+	for _, n := range names {
+		if val := os.Getenv(n); val != "" {
+			return val
+		}
+	}
+	return ""
+}
+
+// ProxyFunc returns a function that determines the proxy URL to use for
+// a given request URL. Changing the contents of cfg will not affect
+// proxy functions created earlier.
+//
+// A nil URL and nil error are returned if no proxy is defined in the
+// environment, or a proxy should not be used for the given request, as
+// defined by NO_PROXY.
+//
+// As a special case, if reqURL.Host is "localhost" or a loopback address
+// (with or without a port number), then a nil URL and nil error will be returned.
+func (cfg *Config) ProxyFunc() func(reqURL *url.URL) (*url.URL, error) {
+	// Preprocess the Config settings for more efficient evaluation.
+	cfg1 := &config{
+		Config: *cfg,
+	}
+	cfg1.init()
+	return cfg1.proxyForURL
+}
+
+func (cfg *config) proxyForURL(reqURL *url.URL) (*url.URL, error) {
+	var proxy *url.URL
+	if reqURL.Scheme == "https" {
+		proxy = cfg.httpsProxy
+	} else if reqURL.Scheme == "http" {
+		proxy = cfg.httpProxy
+		if proxy != nil && cfg.CGI {
+			return nil, errors.New("refusing to use HTTP_PROXY value in CGI environment; see golang.org/s/cgihttpproxy")
+		}
+	}
+	if proxy == nil {
+		return nil, nil
+	}
+	if !cfg.useProxy(canonicalAddr(reqURL)) {
+		return nil, nil
+	}
+
+	return proxy, nil
+}
+
+func parseProxy(proxy string) (*url.URL, error) {
+	if proxy == "" {
+		return nil, nil
+	}
+
+	proxyURL, err := url.Parse(proxy)
+	if err != nil || proxyURL.Scheme == "" || proxyURL.Host == "" {
+		// proxy was bogus. Try prepending "http://" to it and
+		// see if that parses correctly. If not, we fall
+		// through and complain about the original one.
+		if proxyURL, err := url.Parse("http://" + proxy); err == nil {
+			return proxyURL, nil
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("invalid proxy address %q: %v", proxy, err)
+	}
+	return proxyURL, nil
+}
+
+// useProxy reports whether requests to addr should use a proxy,
+// according to the NO_PROXY or no_proxy environment variable.
+// addr is always a canonicalAddr with a host and port.
+func (cfg *config) useProxy(addr string) bool {
+	if len(addr) == 0 {
+		return true
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return false
+	}
+	nip, err := netip.ParseAddr(host)
+	var ip net.IP
+	if err == nil {
+		ip = net.IP(nip.AsSlice())
+		if ip.IsLoopback() {
+			return false
+		}
+	}
+
+	addr = strings.ToLower(strings.TrimSpace(host))
+
+	if ip != nil {
+		for _, m := range cfg.ipMatchers {
+			if m.match(addr, port, ip) {
+				return false
+			}
+		}
+	}
+	for _, m := range cfg.domainMatchers {
+		if m.match(addr, port, ip) {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *config) init() {
+	if parsed, err := parseProxy(c.HTTPProxy); err == nil {
+		c.httpProxy = parsed
+	}
+	if parsed, err := parseProxy(c.HTTPSProxy); err == nil {
+		c.httpsProxy = parsed
+	}
+
+	for _, p := range strings.Split(c.NoProxy, ",") {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if len(p) == 0 {
+			continue
+		}
+
+		if p == "*" {
+			c.ipMatchers = []matcher{allMatch{}}
+			c.domainMatchers = []matcher{allMatch{}}
+			return
+		}
+
+		// IPv4/CIDR, IPv6/CIDR
+		if _, pnet, err := net.ParseCIDR(p); err == nil {
+			c.ipMatchers = append(c.ipMatchers, cidrMatch{cidr: pnet})
+			continue
+		}
+
+		// IPv4:port, [IPv6]:port
+		phost, pport, err := net.SplitHostPort(p)
+		if err == nil {
+			if len(phost) == 0 {
+				// There is no host part, likely the entry is malformed; ignore.
+				continue
+			}
+			if phost[0] == '[' && phost[len(phost)-1] == ']' {
+				phost = phost[1 : len(phost)-1]
+			}
+		} else {
+			phost = p
+		}
+		// IPv4, IPv6
+		if pip := net.ParseIP(phost); pip != nil {
+			c.ipMatchers = append(c.ipMatchers, ipMatch{ip: pip, port: pport})
+			continue
+		}
+
+		if len(phost) == 0 {
+			// There is no host part, likely the entry is malformed; ignore.
+			continue
+		}
+
+		// domain.com or domain.com:80
+		// foo.com matches bar.foo.com
+		// .domain.com or .domain.com:port
+		// *.domain.com or *.domain.com:port
+		if strings.HasPrefix(phost, "*.") {
+			phost = phost[1:]
+		}
+		matchHost := false
+		if phost[0] != '.' {
+			matchHost = true
+			phost = "." + phost
+		}
+		if v, err := idnaASCII(phost); err == nil {
+			phost = v
+		}
+		c.domainMatchers = append(c.domainMatchers, domainMatch{host: phost, port: pport, matchHost: matchHost})
+	}
+}
+
+var portMap = map[string]string{
+	"http":   "80",
+	"https":  "443",
+	"socks5": "1080",
+}
+
+// canonicalAddr returns url.Host but always with a ":port" suffix
+func canonicalAddr(url *url.URL) string {
+	addr := url.Hostname()
+	if v, err := idnaASCII(addr); err == nil {
+		addr = v
+	}
+	port := url.Port()
+	if port == "" {
+		port = portMap[url.Scheme]
+	}
+	return net.JoinHostPort(addr, port)
+}
+
+// Given a string of the form "host", "host:port", or "[ipv6::address]:port",
+// return true if the string includes a port.
+func hasPort(s string) bool { return strings.LastIndex(s, ":") > strings.LastIndex(s, "]") }
+
+func idnaASCII(v string) (string, error) {
+	// TODO: Consider removing this check after verifying performance is okay.
+	// Right now punycode verification, length checks, context checks, and the
+	// permissible character tests are all omitted. It also prevents the ToASCII
+	// call from salvaging an invalid IDN, when possible. As a result it may be
+	// possible to have two IDNs that appear identical to the user where the
+	// ASCII-only version causes an error downstream whereas the non-ASCII
+	// version does not.
+	// Note that for correct ASCII IDNs ToASCII will only do considerably more
+	// work, but it will not cause an allocation.
+	if isASCII(v) {
+		return v, nil
+	}
+	return idna.Lookup.ToASCII(v)
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
+// matcher represents the matching rule for a given value in the NO_PROXY list
+type matcher interface {
+	// match returns true if the host and optional port or ip and optional port
+	// are allowed
+	match(host, port string, ip net.IP) bool
+}
+
+// allMatch matches on all possible inputs
+type allMatch struct{}
+
+func (a allMatch) match(host, port string, ip net.IP) bool {
+	return true
+}
+
+type cidrMatch struct {
+	cidr *net.IPNet
+}
+
+func (m cidrMatch) match(host, port string, ip net.IP) bool {
+	return m.cidr.Contains(ip)
+}
+
+type ipMatch struct {
+	ip   net.IP
+	port string
+}
+
+func (m ipMatch) match(host, port string, ip net.IP) bool {
+	if m.ip.Equal(ip) {
+		return m.port == "" || m.port == port
+	}
+	return false
+}
+
+type domainMatch struct {
+	host string
+	port string
+
+	matchHost bool
+}
+
+func (m domainMatch) match(host, port string, ip net.IP) bool {
+	if ip != nil {
+		return false
+	}
+	if strings.HasSuffix(host, m.host) || (m.matchHost && host == m.host[1:]) {
+		return m.port == "" || m.port == port
+	}
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -665,6 +665,7 @@ golang.org/x/net/html
 golang.org/x/net/html/atom
 golang.org/x/net/html/charset
 golang.org/x/net/http/httpguts
+golang.org/x/net/http/httpproxy
 golang.org/x/net/http2
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna


### PR DESCRIPTION
## Summary

Auto-select the EUS intermediate version from the Cincinnati update graph when `intermediateVersion` is not explicitly configured, making the field truly optional for EUS-to-EUS upgrades.

**Jira**: [CNF-24434](https://redhat.atlassian.net/browse/CNF-24434) — Cincinnati graph API auto-selection for EUS intermediate version

## Changes

- Add Cincinnati graph client (`internal/controllers/utils/cincinnati/`) that fetches the update graph and selects the best intermediate version. The HTTP client loads trusted CAs from the `openshift-config-managed/trusted-ca-bundle` ConfigMap (maintained by the Cluster Network Operator with merged system + custom CAs) and reads proxy settings from the cluster `Proxy` CR
- Integrate auto-selection into `prepareCVSpec` for the EUS intermediate hop — resolves intermediate from user config or Cincinnati, persists the result on `ClusterUpgradeStatus.IntermediateVersion` for use in subsequent reconciliations
- Set `PreconditionChecksFailed` when channel is not configured for auto-selection, when the current or target version is not found in the graph, or when no valid upgrade path exists
- Requeue with `Pending` on Cincinnati connectivity/query failures, consistent with how CVO graph retrieval failures are handled
- Consolidate `ValidateEUSIntermediate` into the `internal/validation` package, removing the duplicate from `internal/controllers/utils`
- Add error/info logging in `updateUpgradeStatus` for all upgrade state transitions
- Handle missing `Proxy` CR gracefully (`meta.IsNoMatchError`) for environments where `config.openshift.io` types are not served
- Register `configv1` in the e2e test scheme and add Cincinnati coverage threshold

## Acceptance Criteria

- [x] EUS upgrade without `intermediateVersion` auto-selects the latest valid intermediate from the Cincinnati graph
- [x] EUS upgrade with explicit `intermediateVersion` uses it directly (unchanged behavior)
- [x] Auto-selection fails with `PreconditionChecksFailed` when no valid path exists
- [x] Cincinnati connectivity failures result in `Pending` with requeue, not terminal failure
- [x] Auto-selected version is logged in the condition message for transparency

## Test Plan

**Unit tests:**
- Cincinnati graph client: graph parsing, intermediate version selection, missing nodes, no valid path, server unavailable, full `SelectIntermediateVersion` integration with fake k8s client (72% coverage)
- `resolveEUSIntermediateVersion`: successful selection, Cincinnati unavailable, empty channel, no valid path
- `prepareCVSpec`: configured intermediate, auto-selected intermediate
- `ValidateEUSIntermediate`: valid/invalid semver, major/minor mismatch

**E2e tests:**
- Auto-selection with local httptest Cincinnati server in the EUS upgrade sequence

**Real cluster:**
- Verified 4.18.25 to 4.20.22 auto-selects 4.19.31 via the default update graph (https://api.openshift.com/api/upgrades_info/v1/graph)
- Verified 4.18.25 to 4.20.15 fails with no valid path:
  `failed to auto-select intermediateVersion: unable to select intermediate version for 4.18.25 to 4.20.15 upgrade: no valid upgrade path found in the update graph https://api.openshift.com/api/upgrades_info/v1/graph with channel eus-4.20`
- Verified non-existent upstream host fails with PreconditionChecksFailed
  `unable to auto-select intermediateVersion: unable to retrieve update graph: Get "https://test.com?arch=amd64&channel=eus-4.22": dial tcp: lookup test.com on 172.30.0.10:53: no such host`
  `unable to auto-select intermediateVersion: unable to retrieve update graph: unexpected HTTP status: 404 from https://angie-test.com/graph`

## Notes
- UpgradeConfig.IntermediateVersion field was removed — parseUpgradeConfig no longer extracts it since prepareCVSpec reads it directly from the merged upgrade data
- Moved `ValidateEUSIntermediate` to `internal/validation` as a shared helper so it can be reused across the PR webhook, ClusterTemplate controller, and PR controller