### PR TITLE
chore: fix crd-watcher screen overflow and add truncation message

### DIFF
--- a/dev-tools/crd-watcher/tui.go
+++ b/dev-tools/crd-watcher/tui.go
@@ -540,7 +540,10 @@ func (t *TUIFormatter) redrawScreen() error {
 	lineCount := 2 // Account for header lines (now just 2 lines)
 	for _, crdType := range orderedTypes {
 		events := eventsByCRD[crdType]
-		if lineCount >= t.termHeight-3 {
+		// Each section needs at minimum 3 lines: section header, table header,
+		// and at least one data row (or "No resources found"). Check if there's
+		// room before starting a new section.
+		if lineCount+3 >= t.termHeight-1 {
 			truncated = true
 			break // Don't exceed terminal height, leave room for status line
 		}

--- a/dev-tools/crd-watcher/tui.go
+++ b/dev-tools/crd-watcher/tui.go
@@ -536,11 +536,13 @@ func (t *TUIFormatter) redrawScreen() error {
 	eventsByCRD := t.groupEventsByType()
 	orderedTypes := t.getOrderedCRDTypes(eventsByCRD)
 
+	truncated := false
 	lineCount := 2 // Account for header lines (now just 2 lines)
 	for _, crdType := range orderedTypes {
 		events := eventsByCRD[crdType]
-		if lineCount >= t.termHeight-2 {
-			break // Don't exceed terminal height
+		if lineCount >= t.termHeight-3 {
+			truncated = true
+			break // Don't exceed terminal height, leave room for status line
 		}
 
 		// Build CRD type header
@@ -561,7 +563,8 @@ func (t *TUIFormatter) redrawScreen() error {
 			lineCount++
 		} else {
 			for i, event := range events {
-				if lineCount >= t.termHeight-1 {
+				if lineCount >= t.termHeight-2 {
+					truncated = true
 					break
 				}
 				t.buildEventLine(event, widths, &screenContent)
@@ -574,14 +577,14 @@ func (t *TUIFormatter) redrawScreen() error {
 			}
 		}
 
-		if lineCount < t.termHeight-1 {
+		if lineCount < t.termHeight-2 {
 			screenContent.WriteString("\n") // Add spacing between CRD types
 			lineCount++
 		}
 	}
 
 	// Build status line
-	t.buildStatusLine(&screenContent)
+	t.buildStatusLine(&screenContent, truncated)
 
 	newContent := screenContent.String()
 
@@ -2051,8 +2054,11 @@ func truncateToWidth(s string, width int) string {
 	return s[:width-3] + "..."
 }
 
-func (t *TUIFormatter) buildStatusLine(sb *strings.Builder) {
+func (t *TUIFormatter) buildStatusLine(sb *strings.Builder, truncated bool) {
 	status := "Press Ctrl+C to exit"
+	if truncated {
+		status = "Screen output truncated │ " + status
+	}
 	sb.WriteString(fmt.Sprintf("\n%s%s%s", ansiBold+ansiBlue, status, ansiReset))
 }
 


### PR DESCRIPTION
When the terminal is too small to display all CRD sections, the differential screen update could get confused by content shifting past the terminal boundary, causing duplicate header rows and garbled output.

Fix the height checks to leave room for the status line and stop rendering before exceeding the terminal height. When output is truncated, show "Screen output truncated" in the footer alongside the existing "Press Ctrl+C to exit" message.