### PR TITLE
chore: separate test-e2e from ci-job and fix git-diff pager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ O-Cloud Manager operator built on OpenShift and ACM (Red Hat Advanced Cluster Ma
 
 Use `make help` to list all available targets. Key commands:
 
-- `make ci-job` - Full CI pipeline locally (format, vet, lint, test, e2e, envtest, coverage, bundle-check). Run before submitting PRs. Includes `bundle-check`, which verifies the git tree is clean after code generation — a common CI failure when API or manifest changes aren't regenerated.
+- `make ci-job` - Full CI pipeline locally (format, vet, lint, test, envtest, coverage, bundle-check). Run before submitting PRs. Includes `bundle-check`, which verifies the git tree is clean after code generation — a common CI failure when API or manifest changes aren't regenerated.
+- `make test-e2e` - Run e2e tests separately (not included in `ci-job`). Run before submitting PRs that affect controller logic, hardware manager code, or provisioning workflows.
 - `make generate && make manifests && make bundle` - Regenerate code after API changes.
 
 ### Lint by File Type
@@ -161,7 +162,7 @@ issues during code review.
 ## Contributing Requirements
 
 - All commits must be signed off with DCO: `git commit -s`
-- Commit all files and run `make ci-job` before submitting PRs
+- Commit all files and run `make ci-job` and `make test-e2e` before submitting PRs
 - After API changes: `make generate && make manifests && make bundle`
 - AI-generated code must use `Co-Authored-By` or `Assisted-By` trailer
 - Run lint checks before committing (see [Lint by File Type](#lint-by-file-type))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,20 @@ Before submitting a pull request, run the CI validation suite locally:
 make ci-job
 ```
 
-This runs formatting, vetting, linting, unit tests, e2e tests, and bundle
-validation — the same checks that CI runs on each pull request. Running this
-locally allows you to find and fix issues before the CI runs.
+This runs formatting, vetting, linting, unit tests, envtest tests, coverage
+checks, and bundle validation. Running this locally allows you to find and
+fix issues before the CI runs.
+
+Additionally, run the e2e tests separately:
+
+```bash
+make test-e2e
+```
+
+The e2e tests are not included in `ci-job` because they take ~20 minutes
+and do not contribute to code coverage. They should be run before submitting
+PRs that affect controller logic, hardware manager code, or provisioning
+workflows.
 
 Additional checks to run depending on the type of change:
 
@@ -101,8 +112,9 @@ All code changes must include appropriate unit tests:
 
 1. Write unit tests that cover new code paths.
 2. Ensure existing tests still pass.
-3. `make ci-job` runs both unit tests (`make test`) and e2e tests
-   (`make test-e2e`).
+3. `make ci-job` runs unit tests (`make test`), envtest tests
+   (`make test-envtest`), and coverage checks.
+4. `make test-e2e` runs the e2e tests separately.
 
 ## API and CRD Changes
 
@@ -132,7 +144,8 @@ structure.
 
 - All pull requests must be opened against the `main` branch.
 - Ensure all commits are signed off with DCO (`git commit -s`).
-- Run `make ci-job` locally and ensure all checks pass before submitting.
+- Run `make ci-job` and `make test-e2e` locally and ensure all checks pass
+  before submitting.
 - If updating documentation, also run `make markdownlint`.
 - If updating bundle metadata (e.g., adding new CRDs, updating fields), also
   run `make scorecard-test`.

--- a/Makefile
+++ b/Makefile
@@ -709,10 +709,10 @@ deps-update: mock-gen golangci-lint-download
 	$(PROJECT_DIR)/hack/update_deps.sh
 	$(PROJECT_DIR)/hack/install_test_deps.sh
 
-# TODO: add back `test-e2e` to ci-job
 # NOTE: `bundle-check` should be the last job in the list for `ci-job`
+# test-e2e is run separately as it takes ~20 minutes and does not contribute to coverage
 .PHONY: ci-job
-ci-job: deps-update go-generate generate fmt vet lint test test-e2e test-envtest test-crd-watcher test-coverage-check e2e-outline bundle-check
+ci-job: deps-update go-generate generate fmt vet lint test test-envtest test-crd-watcher test-coverage-check e2e-outline bundle-check
 
 .PHONY: clean
 clean:

--- a/hack/check-git-tree.sh
+++ b/hack/check-git-tree.sh
@@ -9,7 +9,7 @@ RC=0
 if [ -n "$(git status --porcelain)" ]; then
     echo "Unstaged or untracked changes exist:"
     git status --porcelain
-    git diff
+    git --no-pager diff
     RC=1
 else
     echo "git tree is clean"


### PR DESCRIPTION
Remove test-e2e from the ci-job target. The e2e tests take ~20 minutes, do not contribute to code coverage, and can be run independently via make test-e2e. This reduces the ci-job execution time significantly.

Also fix hack/check-git-tree.sh to use git --no-pager diff so the script does not block on a pager when the diff output is large.