### PR TITLE
CNF-24435: MNO upgrade documentation and sample templates

### DIFF
--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/3node-ran-du-v4-Y-Z+1-1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/3node-ran-du-v4-Y-Z+1-1.yaml
@@ -1,0 +1,213 @@
+apiVersion: clcm.openshift.io/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: 3node-ran-du.v4-Y-Z+1-1
+  namespace: 3node-ran-du-v4-Y-Z+1
+spec:
+  name: 3node-ran-du
+  version: v4-Y-Z+1-1
+  release: 4.Y.Z+1
+  templateDefaults:
+    hwMgmtDefaults:
+      hardwareProvisioningTimeout: "120m"
+      nodeGroupData:
+        - name: master
+          role: master
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "XR8620t"
+            "resourceselector.clcm.openshift.io/server-colour": "purple"
+            "hardwaredata/cpu_arch": "x86_64"
+            "hardwaredata/num_threads;>=": "128"
+    clusterInstanceDefaults: clusterinstance-defaults-v1
+    policyTemplateDefaults: policytemplate-defaults-v1
+    upgradeDefaults:
+      clusterVersion:
+        channel: "stable-4.Y.Z+1"
+        desiredUpdate:
+          version: "4.Y.Z+1"
+  templateParameterSchema:
+    properties:
+      nodeClusterName:
+        type: string
+      oCloudSiteId:
+        type: string
+      hwMgmtParameters:
+        description: >
+          hwMgmtParameters allows overriding hardware management defaults.
+        properties:
+          hardwareProvisioningTimeout:
+            type: string
+          nodeGroupData:
+            type: array
+            items:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                role:
+                  type: string
+                  enum:
+                    - master
+                    - worker
+                hwProfile:
+                  type: string
+                resourcePoolId:
+                  type: string
+                resourceSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+        type: object
+      policyTemplateParameters:
+        description: policyTemplateSchema defines the available parameters for cluster configuration
+        properties:
+          sriov-network-vlan-1:
+            type: string
+          sriov-network-pfNames-1:
+            type: string
+          sriov-network-vlan-2:
+            type: string
+          sriov-network-pfNames-2:
+            type: string
+          cpu-isolated:
+            type: string
+          cpu-reserved:
+            type: string
+          hugepages-default:
+            type: string
+          hugepages-size:
+            type: string
+          hugepages-count:
+            type: string
+          install-plan-approval:
+            type: string
+        type: object
+      clusterInstanceParameters:
+        description: clusterInstanceParameters defines the available parameters for cluster installation
+        properties:
+          additionalNTPSources:
+            items:
+              type: string
+            type: array
+          apiVIPs:
+            items:
+              type: string
+            maxItems: 2
+            type: array
+          baseDomain:
+            type: string
+          clusterName:
+            type: string
+          extraAnnotations:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            type: object
+          extraLabels:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            type: object
+          ingressVIPs:
+            items:
+              type: string
+            maxItems: 2
+            type: array
+          machineNetwork:
+            items:
+              properties:
+                cidr:
+                  type: string
+              required:
+              - cidr
+              type: object
+            type: array
+          nodes:
+            items:
+              properties:
+                extraAnnotations:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  type: object
+                extraLabels:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  type: object
+                hostName:
+                  type: string
+                nodeLabels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                nodeNetwork:
+                  properties:
+                    config:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+              required:
+              - hostName
+              type: object
+            type: array
+          serviceNetwork:
+            items:
+              properties:
+                cidr:
+                  type: string
+              required:
+              - cidr
+              type: object
+            type: array
+          sshPublicKey:
+            type: string
+        required:
+        - clusterName
+        - nodes
+        type: object
+      upgradeParameters:
+        description: upgradeParameters defines the available upgrade parameters for the cluster upgrade
+        properties:
+          clusterUpgradeTimeout:
+            description: defines the timeout for the cluster upgrade
+            type: string
+          intermediateVersion:
+            description: defines the intermediate version for the cluster EUS upgrade
+            type: string
+          clusterVersion:
+            type: object
+            description: defines the ClusterVersion parameters for the upgrade
+            properties:
+              channel:
+                type: string
+              upstream:
+                type: string
+              desiredUpdate:
+                type: object
+                properties:
+                  version:
+                    type: string
+                  image:
+                    type: string
+                  force:
+                    type: boolean
+                  architecture:
+                    type: string
+                    enum:
+                    - "Multi"
+                    - ""
+        type: object
+    required:
+      - nodeClusterName
+      - oCloudSiteId
+      - policyTemplateParameters
+      - clusterInstanceParameters
+    type: object

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/clusterinstance-defaults-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/clusterinstance-defaults-v1.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clusterinstance-defaults-v1
+  namespace: 3node-ran-du-v4-Y-Z+1
+data:
+  # clusterInstallationTimeout is optional.
+  # The value should be a duration string
+  # (e.g., "120m" for 120 minutes)
+  # clusterInstallationTimeout: "120m"
+  clusterinstance-defaults: |
+    baseDomain: example.com
+    extraLabels:
+      ManagedCluster:
+        cluster-version: "v4-Y-Z+1"
+        3node-ran-du-policy: "v1"
+    clusterType: HighlyAvailable
+    clusterImageSetNameRef: "4.Y.Z+1"
+    pullSecretRef:
+      name: pull-secret
+    networkType: OVNKubernetes
+    sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTca4Qyu5AYBmZbSl74cNTKuNINJ7d+ceBRzKUrhHcQpMbl8UnAYhjh/ffTyVCsgwzm1RjTAm6/tPj9euEa+YX4U78Sx+ioLHmjDvACYsti4DekIR+opFwfIw+JTDXoyVv06lOPaTOa/vtgpe+gDEL364j47f3p9H/tGhsLmpjeG3DVAhbqSh3s0IHpd4OzF/r6g6mbPyHadvedkBZp/qeUX054Gc2QqJeg/s/eddPlQDJbmL8yRVkZu+SsFTOEOAtrdA3czeaEaA8s+aWP9PN3X539Ddw3qahyOSCXpCE2eJXPh8DJCBWVEcFFYgmIFVvCQ+o9cjEmIYg6drGGvRV
+    installConfigOverrides: '{"capabilities": {"baselineCapabilitySet": "None", "additionalEnabledCapabilities": ["NodeTuning", "OperatorLifecycleManager", "Ingress", "baremetal", "MachineAPI"]}}'
+    clusterNetwork:
+      - cidr: 203.0.113.0/24
+        hostPrefix: 25
+    serviceNetwork:
+      - cidr: 198.51.100.0/24
+    additionalNTPSources:
+      - 1.pool.ntp.org
+    templateRefs:
+      - name: ai-cluster-templates-v1
+        namespace: open-cluster-management
+    cpuPartitioningMode: AllNodes
+    holdInstallation: false
+    # extraManifestsRefs must use the same name as the original provisioning version
+    extraManifestsRefs:
+      - name: 3node-ran-du-extra-manifest-1
+    nodes:
+      - role: master
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: ens3f0
+              label: boot-interface
+            - name: ens3f1
+              label: data-interface
+            - name: ens2f0
+              label: sriov-1
+            - name: ens2f1
+              label: sriov-2
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens3f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens3f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: master
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: ens3f0
+              label: boot-interface
+            - name: ens3f1
+              label: data-interface
+            - name: ens2f0
+              label: sriov-1
+            - name: ens2f1
+              label: sriov-2
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens3f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens3f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: master
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: ens3f0
+              label: boot-interface
+            - name: ens3f1
+              label: data-interface
+            - name: ens2f0
+              label: sriov-1
+            - name: ens2f1
+              label: sriov-2
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens3f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens3f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/ns.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 3node-ran-du-v4-Y-Z+1

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/policytemplates-defaults-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/policytemplates-defaults-v1.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: policytemplate-defaults-v1
+  namespace: 3node-ran-du-v4-Y-Z+1
+data:
+  # clusterConfigurationTimeout is optional.
+  # The value should be a duration string
+  # (e.g., "40m" for 40 minutes)
+  # clusterConfigurationTimeout: "40m"
+  policytemplate-defaults: |
+    sriov-network-vlan-1: "140"
+    sriov-network-pfNames-1: '["ens2f0"]'
+    sriov-network-vlan-2: "150"
+    sriov-network-pfNames-2: '["ens2f1"]'
+    cpu-isolated: "0-1,126-127"
+    cpu-reserved: "2-10"
+    hugepages-default: "1G"
+    hugepages-size: "1G"
+    hugepages-count: "32"
+    install-plan-approval: "Automatic"

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/pull-secret.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/pull-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pull-secret
+  namespace: 3node-ran-du-v4-Y-Z+1
+stringData:
+  # Replace with real registry auth JSON before applying.
+  .dockerconfigjson: '{"auths":{}}'
+type: kubernetes.io/dockerconfigjson

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/kustomization.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/kustomization.yaml
@@ -23,3 +23,15 @@ resources:
 - sno-ran-du/clusterinstance-defaults-v1.yaml
 # sno-ran-du.v4-Y-Z+1-2 ClusterTemplate:
 - sno-ran-du/sno-ran-du-v4-Y-Z+1-2.yaml
+# 3-node cluster:
+- 3node-ran-du/ns.yaml
+- 3node-ran-du/pull-secret.yaml
+- 3node-ran-du/policytemplates-defaults-v1.yaml
+- 3node-ran-du/3node-ran-du-v4-Y-Z+1-1.yaml
+- 3node-ran-du/clusterinstance-defaults-v1.yaml
+# Standard cluster:
+- std-ran-du/ns.yaml
+- std-ran-du/pull-secret.yaml
+- std-ran-du/policytemplates-defaults-v1.yaml
+- std-ran-du/std-ran-du-v4-Y-Z+1-1.yaml
+- std-ran-du/clusterinstance-defaults-v1.yaml

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/clusterinstance-defaults-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/clusterinstance-defaults-v1.yaml
@@ -1,0 +1,192 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clusterinstance-defaults-v1
+  namespace: std-ran-du-v4-Y-Z+1
+data:
+  # clusterInstallationTimeout is optional.
+  # The value should be a duration string
+  # (e.g., "180m" for 180 minutes)
+  # clusterInstallationTimeout: "180m"
+  clusterinstance-defaults: |
+    baseDomain: example.com
+    extraLabels:
+      ManagedCluster:
+        cluster-version: "v4-Y-Z+1"
+        std-ran-du-policy: "v1"
+    clusterType: HighlyAvailable
+    clusterImageSetNameRef: "4.Y.Z+1"
+    pullSecretRef:
+      name: pull-secret
+    networkType: OVNKubernetes
+    sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTca4Qyu5AYBmZbSl74cNTKuNINJ7d+ceBRzKUrhHcQpMbl8UnAYhjh/ffTyVCsgwzm1RjTAm6/tPj9euEa+YX4U78Sx+ioLHmjDvACYsti4DekIR+opFwfIw+JTDXoyVv06lOPaTOa/vtgpe+gDEL364j47f3p9H/tGhsLmpjeG3DVAhbqSh3s0IHpd4OzF/r6g6mbPyHadvedkBZp/qeUX054Gc2QqJeg/s/eddPlQDJbmL8yRVkZu+SsFTOEOAtrdA3czeaEaA8s+aWP9PN3X539Ddw3qahyOSCXpCE2eJXPh8DJCBWVEcFFYgmIFVvCQ+o9cjEmIYg6drGGvRV
+    installConfigOverrides: '{"capabilities": {"baselineCapabilitySet": "None", "additionalEnabledCapabilities": ["NodeTuning", "OperatorLifecycleManager", "Ingress", "baremetal", "MachineAPI"]}}'
+    clusterNetwork:
+      - cidr: 203.0.113.0/24
+        hostPrefix: 25
+    serviceNetwork:
+      - cidr: 198.51.100.0/24
+    additionalNTPSources:
+      - 1.pool.ntp.org
+    templateRefs:
+      - name: ai-cluster-templates-v1
+        namespace: open-cluster-management
+    cpuPartitioningMode: AllNodes
+    holdInstallation: false
+    # extraManifestsRefs must use the same name as the original provisioning version
+    extraManifestsRefs:
+      - name: std-ran-du-extra-manifest-1
+    nodes:
+      - role: master
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: ens1f0
+              label: boot-interface
+            - name: ens1f1
+              label: data-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens1f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens1f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: master
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: ens1f0
+              label: boot-interface
+            - name: ens1f1
+              label: data-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens1f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens1f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: master
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: ens1f0
+              label: boot-interface
+            - name: ens1f1
+              label: data-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens1f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens1f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: worker
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: ens3f0
+              label: boot-interface
+            - name: ens3f1
+              label: data-interface
+            - name: ens2f0
+              label: sriov-1
+            - name: ens2f1
+              label: sriov-2
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens3f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens3f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - role: worker
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: ens3f0
+              label: boot-interface
+            - name: ens3f1
+              label: data-interface
+            - name: ens2f0
+              label: sriov-1
+            - name: ens2f1
+              label: sriov-2
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens3f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens3f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/ns.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: std-ran-du-v4-Y-Z+1

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/policytemplates-defaults-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/policytemplates-defaults-v1.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: policytemplate-defaults-v1
+  namespace: std-ran-du-v4-Y-Z+1
+data:
+  # clusterConfigurationTimeout is optional.
+  # The value should be a duration string
+  # (e.g., "60m" for 60 minutes)
+  # clusterConfigurationTimeout: "60m"
+  policytemplate-defaults: |
+    sriov-network-vlan-1: "140"
+    sriov-network-pfNames-1: '["ens2f0"]'
+    sriov-network-vlan-2: "150"
+    sriov-network-pfNames-2: '["ens2f1"]'
+    cpu-isolated: "0-1,64-65"
+    cpu-reserved: "2-10"
+    hugepages-default: "1G"
+    hugepages-size: "1G"
+    hugepages-count: "32"
+    install-plan-approval: "Automatic"

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/pull-secret.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/pull-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pull-secret
+  namespace: std-ran-du-v4-Y-Z+1
+stringData:
+  # Replace with real registry auth JSON before applying.
+  .dockerconfigjson: '{"auths":{}}'
+type: kubernetes.io/dockerconfigjson

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/std-ran-du-v4-Y-Z+1-1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/std-ran-du-v4-Y-Z+1-1.yaml
@@ -1,0 +1,271 @@
+apiVersion: clcm.openshift.io/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: std-ran-du.v4-Y-Z+1-1
+  namespace: std-ran-du-v4-Y-Z+1
+spec:
+  name: std-ran-du
+  version: v4-Y-Z+1-1
+  release: 4.Y.Z+1
+  templateDefaults:
+    hwMgmtDefaults:
+      hardwareProvisioningTimeout: "4h"
+      nodeGroupData:
+        - name: master
+          role: master
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "R740"
+            "resourceselector.clcm.openshift.io/server-colour": "green"
+            "hardwaredata/cpu_arch": "x86_64"
+        - name: worker
+          role: worker
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "XR8620t"
+            "resourceselector.clcm.openshift.io/server-colour": "blue"
+            "hardwaredata/cpu_arch": "x86_64"
+    clusterInstanceDefaults: clusterinstance-defaults-v1
+    policyTemplateDefaults: policytemplate-defaults-v1
+    upgradeDefaults:
+      clusterVersion:
+        channel: "stable-4.Y.Z+1"
+        desiredUpdate:
+          version: "4.Y.Z+1"
+  templateParameterSchema:
+    properties:
+      nodeClusterName:
+        type: string
+      oCloudSiteId:
+        type: string
+      hwMgmtParameters:
+        description: >
+          hwMgmtParameters allows overriding hardware management defaults.
+        properties:
+          hardwareProvisioningTimeout:
+            type: string
+          nodeGroupData:
+            type: array
+            items:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                role:
+                  type: string
+                  enum:
+                    - master
+                    - worker
+                hwProfile:
+                  type: string
+                resourcePoolId:
+                  type: string
+                resourceSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+        type: object
+      policyTemplateParameters:
+        description: policyTemplateSchema defines the available parameters for cluster configuration
+        properties:
+          sriov-network-vlan-1:
+            type: string
+          sriov-network-pfNames-1:
+            type: string
+          sriov-network-vlan-2:
+            type: string
+          sriov-network-pfNames-2:
+            type: string
+          cpu-isolated:
+            type: string
+          cpu-reserved:
+            type: string
+          hugepages-default:
+            type: string
+          hugepages-size:
+            type: string
+          hugepages-count:
+            type: string
+          install-plan-approval:
+            type: string
+        type: object
+      clusterInstanceParameters:
+        description: clusterInstanceParameters defines the available parameters for cluster installation
+        properties:
+          additionalNTPSources:
+            description: AdditionalNTPSources is a list of NTP sources (hostname
+              or IP) to be added to all cluster hosts. They are added to any NTP
+              sources that were configured through other means.
+            items:
+              type: string
+            type: array
+          apiVIPs:
+            description: APIVIPs are the virtual IPs used to reach the OpenShift
+              cluster's API. Enter one IP address for single-stack clusters, or
+              up to two for dual-stack clusters (at most one IP address per IP
+              stack used). The order of stacks should be the same as order of
+              subnets in Cluster Networks, Service Networks, and Machine Networks.
+            items:
+              type: string
+            maxItems: 2
+            type: array
+          baseDomain:
+            description: BaseDomain is the base domain to use for the deployed
+              cluster.
+            type: string
+          clusterName:
+            description: ClusterName is the name of the cluster.
+            type: string
+          extraAnnotations:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            description: Additional cluster-wide annotations to be applied to
+              the rendered templates
+            type: object
+          extraLabels:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            description: Additional cluster-wide labels to be applied to the rendered
+              templates
+            type: object
+          ingressVIPs:
+            description: IngressVIPs are the virtual IPs used for cluster ingress
+              traffic. Enter one IP address for single-stack clusters, or up to
+              two for dual-stack clusters (at most one IP address per IP stack
+              used). The order of stacks should be the same as order of subnets
+              in Cluster Networks, Service Networks, and Machine Networks.
+            items:
+              type: string
+            maxItems: 2
+            type: array
+          machineNetwork:
+            description: MachineNetwork is the list of IP address pools for machines.
+            items:
+              description: MachineNetworkEntry is a single IP address block for
+                node IP blocks.
+              properties:
+                cidr:
+                  description: CIDR is the IP block address pool for machines
+                    within the cluster.
+                  type: string
+              required:
+              - cidr
+              type: object
+            type: array
+          nodes:
+            items:
+              description: NodeSpec
+              properties:
+                extraAnnotations:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Additional node-level annotations to be applied
+                    to the rendered templates
+                  type: object
+                extraLabels:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Additional node-level labels to be applied to the
+                    rendered templates
+                  type: object
+                hostName:
+                  description: Hostname is the desired hostname for the host
+                  type: string
+                nodeLabels:
+                  additionalProperties:
+                    type: string
+                  description: NodeLabels allows the specification of custom roles
+                    for your nodes in your managed clusters. These are additional
+                    roles are not used by any OpenShift Container Platform components,
+                    only by the user. When you add a custom role, it can be associated
+                    with a custom machine config pool that references a specific
+                    configuration for that role. Adding custom labels or roles
+                    during installation makes the deployment process more effective
+                    and prevents the need for additional reboots after the installation
+                    is complete.
+                  type: object
+                nodeNetwork:
+                  description: NodeNetwork is a set of configurations pertaining
+                    to the network settings for the node.
+                  properties:
+                    config:
+                      description: yaml that can be processed by nmstate, using
+                        custom marshaling/unmarshaling that will allow to populate
+                        nmstate config as plain yaml.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+              required:
+              - hostName
+              type: object
+            type: array
+          serviceNetwork:
+            description: ServiceNetwork is the list of IP address pools for services.
+            items:
+              description: ServiceNetworkEntry is a single IP address block for
+                node IP blocks.
+              properties:
+                cidr:
+                  description: CIDR is the IP block address pool for machines
+                    within the cluster.
+                  type: string
+              required:
+              - cidr
+              type: object
+            type: array
+          sshPublicKey:
+            description: SSHPublicKey is the public Secure Shell (SSH) key to
+              provide access to instances. This key will be added to the host
+              to allow ssh access
+            type: string
+        required:
+        - clusterName
+        - nodes
+        type: object
+      upgradeParameters:
+        description: upgradeParameters defines the available upgrade parameters for the cluster upgrade
+        properties:
+          clusterUpgradeTimeout:
+            description: defines the timeout for the cluster upgrade
+            type: string
+          intermediateVersion:
+            description: defines the intermediate version for the cluster EUS upgrade
+            type: string
+          clusterVersion:
+            type: object
+            description: defines the ClusterVersion parameters for the upgrade
+            properties:
+              channel:
+                type: string
+              upstream:
+                type: string
+              desiredUpdate:
+                type: object
+                properties:
+                  version:
+                    type: string
+                  image:
+                    type: string
+                  force:
+                    type: boolean
+                  architecture:
+                    type: string
+                    enum:
+                    - "Multi"
+                    - ""
+        type: object
+    required:
+      - nodeClusterName
+      - oCloudSiteId
+      - policyTemplateParameters
+      - clusterInstanceParameters
+    type: object

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/3node-ran-du/3node-ran-du-pg-v4-Y-Z+1-v1.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/3node-ran-du/3node-ran-du-pg-v4-Y-Z+1-v1.yaml
@@ -1,0 +1,170 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: 3node-ran-du-pg-v4-Y-Z+1-v1
+policyDefaults:
+  namespace: ztp-3node-ran-du-v4-Y-Z+1
+  # Use an existing placement rule so that placement bindings can be consolidated
+  placement:
+    # These labels must match the labels set for the ManagedCluster either through the ProvisioningRequest
+    # or the ClusterInstance ConfigMap.
+    labelSelector:
+      cluster-version: "v4-Y-Z+1"
+      3node-ran-du-policy: "v1"
+  policyAnnotations:
+    # This annotation contains a comma-separated list of ClusterTemplates (metadata.name) this PG is associated with.
+    # This is used for linking the generated root policies to the ClusterTemplate used by the ProvisioningRequest.
+    clustertemplates.clcm.openshift.io/templates: "3node-ran-du.v4-Y-Z+1-1"
+  remediationAction: enforce
+  severity: low
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+    compliant: 5m
+    noncompliant: 10s
+  orderPolicies: true
+policies:
+# CATALOG SOURCE - DISCONNECTED REGISTRY
+- name: v1-catalog-source-policy
+  manifests:
+    - path: source-crs/disconnected-registry/DefaultCatsrc.yaml
+      patches:
+      - metadata:
+          name: redhat-operators-disconnected
+        spec:
+          displayName: disconnected-redhat-operators
+          image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.Y.Z+1
+# SUBSCRIPTIONS
+- name: v1-subscriptions-policy
+  manifests:
+    # Cluster Logging operator
+    - path: source-crs/cluster-logging/ClusterLogNS.yaml
+    - path: source-crs/cluster-logging/ClusterLogOperGroup.yaml
+    - path: source-crs/cluster-logging/ClusterLogSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/cluster-logging/ClusterLogOperatorStatus.yaml
+    - path: source-crs/cluster-logging/ClusterLogServiceAccount.yaml
+    - path: source-crs/cluster-logging/ClusterLogServiceAccountAuditBinding.yaml
+    - path: source-crs/cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml
+    # Ptp operator
+    - path: source-crs/ptp-operator/PtpSubscriptionNS.yaml
+    - path: source-crs/ptp-operator/PtpSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/ptp-operator/PtpSubscriptionOperGroup.yaml
+    - path: source-crs/ptp-operator/PtpOperatorStatus.yaml
+    # SRIOV operator
+    - path: source-crs/sriov-operator/SriovSubscriptionNS.yaml
+    - path: source-crs/sriov-operator/SriovSubscriptionOperGroup.yaml
+    - path: source-crs/sriov-operator/SriovSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/sriov-operator/SriovOperatorStatus.yaml
+    # Storage operator
+    - path: source-crs/storage-lso/StorageNS.yaml
+    - path: source-crs/storage-lso/StorageOperGroup.yaml
+    - path: source-crs/storage-lso/StorageSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/storage-lso/StorageOperatorStatus.yaml
+- name: v1-config-policy
+  manifests:
+    - path: source-crs/sriov-operator/SriovOperatorConfig-SetSelector.yaml
+      complianceType: musthave
+      patches:
+      - spec:
+          configDaemonNodeSelector:
+            node-role.kubernetes.io/master: ""
+    - path: source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
+      patches:
+      - metadata:
+          name: openshift-node-performance-profile
+        spec:
+          cpu:
+            # These must be tailored for the specific hardware platform
+            isolated: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "cpu-isolated" hub}}'
+            reserved: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "cpu-reserved" hub}}'
+          hugepages:
+            defaultHugepagesSize: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-default" hub}}'
+            pages:
+              - size: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-size" hub}}'
+                count: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-count" | toInt hub}}'
+          machineConfigPoolSelector:
+            pools.operator.machineconfiguration.openshift.io/master: ""
+          nodeSelector:
+            node-role.kubernetes.io/master: ''
+    - path: source-crs/node-tuning-operator/TunedPerformancePatch.yaml
+      patches:
+      - spec:
+          recommend:
+          - machineConfigLabels:
+              machineconfiguration.openshift.io/role: "master"
+            priority: 18
+            profile: ran-du-performance
+    - path: source-crs/sriov-operator/SriovNetwork.yaml
+      patches:
+      - metadata:
+          name: sriov-nw-du-fh
+        spec:
+          resourceName: du_fh
+          vlan: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-vlan-1" | toInt hub}}'
+    - path: source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml
+      patches:
+      - metadata:
+          name: sriov-nnp-du-fh
+        spec:
+          deviceType: netdevice
+          isRdma: false
+          nicSelector:
+            pfNames: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-pfNames-1" | toLiteral hub}}'
+          nodeSelector:
+            node-role.kubernetes.io/master: ""
+          numVfs: 8
+          priority: 10
+          resourceName: du_fh
+    - path: source-crs/sriov-operator/SriovNetwork.yaml
+      patches:
+      - metadata:
+          name: sriov-nw-du-mh
+        spec:
+          resourceName: du_mh
+          vlan: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-vlan-2" | toInt hub}}'
+    - path: source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml
+      patches:
+      - metadata:
+          name: sriov-nnp-du-mh
+        spec:
+          deviceType: vfio-pci
+          isRdma: false
+          nicSelector:
+            pfNames: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-pfNames-2" | toLiteral hub}}'
+          nodeSelector:
+            node-role.kubernetes.io/master: ""
+          numVfs: 8
+          priority: 10
+          resourceName: du_mh
+- name: v1-du-validator-policy
+  remediationAction: inform
+  # This policy is not re-evaluated after it becomes
+  # compliant to reduce resource usage.
+  evaluationInterval:
+    compliant: never
+    noncompliant: 10s
+  manifests:
+    - path: source-crs/validatorCRs/informDuValidatorMaster.yaml

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/3node-ran-du/msc-binding.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/3node-ran-du/msc-binding.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: ztp-3node-ran-du-v4-Y-Z+1
+spec:
+  clusterSet: global

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/3node-ran-du/ns.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/3node-ran-du/ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ztp-3node-ran-du-v4-Y-Z+1

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/std-ran-du/msc-binding.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/std-ran-du/msc-binding.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: ztp-std-ran-du-v4-Y-Z+1
+spec:
+  clusterSet: global

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/std-ran-du/ns.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/std-ran-du/ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ztp-std-ran-du-v4-Y-Z+1

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/std-ran-du/std-ran-du-pg-v4-Y-Z+1-v1.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z+1/std-ran-du/std-ran-du-pg-v4-Y-Z+1-v1.yaml
@@ -1,0 +1,170 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: std-ran-du-pg-v4-Y-Z+1-v1
+policyDefaults:
+  namespace: ztp-std-ran-du-v4-Y-Z+1
+  # Use an existing placement rule so that placement bindings can be consolidated
+  placement:
+    # These labels must match the labels set for the ManagedCluster either through the ProvisioningRequest
+    # or the ClusterInstance ConfigMap.
+    labelSelector:
+      cluster-version: "v4-Y-Z+1"
+      std-ran-du-policy: "v1"
+  policyAnnotations:
+    # This annotation contains a comma-separated list of ClusterTemplates (metadata.name) this PG is associated with.
+    # This is used for linking the generated root policies to the ClusterTemplate used by the ProvisioningRequest.
+    clustertemplates.clcm.openshift.io/templates: "std-ran-du.v4-Y-Z+1-1"
+  remediationAction: enforce
+  severity: low
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+    compliant: 5m
+    noncompliant: 10s
+  orderPolicies: true
+policies:
+# CATALOG SOURCE - DISCONNECTED REGISTRY
+- name: v1-catalog-source-policy
+  manifests:
+    - path: source-crs/disconnected-registry/DefaultCatsrc.yaml
+      patches:
+      - metadata:
+          name: redhat-operators-disconnected
+        spec:
+          displayName: disconnected-redhat-operators
+          image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.Y.Z+1
+# SUBSCRIPTIONS
+- name: v1-subscriptions-policy
+  manifests:
+    # Cluster Logging operator
+    - path: source-crs/cluster-logging/ClusterLogNS.yaml
+    - path: source-crs/cluster-logging/ClusterLogOperGroup.yaml
+    - path: source-crs/cluster-logging/ClusterLogSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/cluster-logging/ClusterLogOperatorStatus.yaml
+    - path: source-crs/cluster-logging/ClusterLogServiceAccount.yaml
+    - path: source-crs/cluster-logging/ClusterLogServiceAccountAuditBinding.yaml
+    - path: source-crs/cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml
+    # Ptp operator
+    - path: source-crs/ptp-operator/PtpSubscriptionNS.yaml
+    - path: source-crs/ptp-operator/PtpSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/ptp-operator/PtpSubscriptionOperGroup.yaml
+    - path: source-crs/ptp-operator/PtpOperatorStatus.yaml
+    # SRIOV operator
+    - path: source-crs/sriov-operator/SriovSubscriptionNS.yaml
+    - path: source-crs/sriov-operator/SriovSubscriptionOperGroup.yaml
+    - path: source-crs/sriov-operator/SriovSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/sriov-operator/SriovOperatorStatus.yaml
+    # Storage operator
+    - path: source-crs/storage-lso/StorageNS.yaml
+    - path: source-crs/storage-lso/StorageOperGroup.yaml
+    - path: source-crs/storage-lso/StorageSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/storage-lso/StorageOperatorStatus.yaml
+- name: v1-config-policy
+  manifests:
+    - path: source-crs/sriov-operator/SriovOperatorConfig-SetSelector.yaml
+      complianceType: musthave
+      patches:
+      - spec:
+          configDaemonNodeSelector:
+            node-role.kubernetes.io/worker: ""
+    - path: source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
+      patches:
+      - metadata:
+          name: openshift-node-performance-profile
+        spec:
+          cpu:
+            # These must be tailored for the specific hardware platform
+            isolated: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "cpu-isolated" hub}}'
+            reserved: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "cpu-reserved" hub}}'
+          hugepages:
+            defaultHugepagesSize: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-default" hub}}'
+            pages:
+              - size: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-size" hub}}'
+                count: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-count" | toInt hub}}'
+          machineConfigPoolSelector:
+            pools.operator.machineconfiguration.openshift.io/worker: ""
+          nodeSelector:
+            node-role.kubernetes.io/worker: ''
+    - path: source-crs/node-tuning-operator/TunedPerformancePatch.yaml
+      patches:
+      - spec:
+          recommend:
+          - machineConfigLabels:
+              machineconfiguration.openshift.io/role: "worker"
+            priority: 18
+            profile: ran-du-performance
+    - path: source-crs/sriov-operator/SriovNetwork.yaml
+      patches:
+      - metadata:
+          name: sriov-nw-du-fh
+        spec:
+          resourceName: du_fh
+          vlan: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-vlan-1" | toInt hub}}'
+    - path: source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml
+      patches:
+      - metadata:
+          name: sriov-nnp-du-fh
+        spec:
+          deviceType: netdevice
+          isRdma: false
+          nicSelector:
+            pfNames: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-pfNames-1" | toLiteral hub}}'
+          nodeSelector:
+            node-role.kubernetes.io/worker: ""
+          numVfs: 8
+          priority: 10
+          resourceName: du_fh
+    - path: source-crs/sriov-operator/SriovNetwork.yaml
+      patches:
+      - metadata:
+          name: sriov-nw-du-mh
+        spec:
+          resourceName: du_mh
+          vlan: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-vlan-2" | toInt hub}}'
+    - path: source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml
+      patches:
+      - metadata:
+          name: sriov-nnp-du-mh
+        spec:
+          deviceType: vfio-pci
+          isRdma: false
+          nicSelector:
+            pfNames: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-pfNames-2" | toLiteral hub}}'
+          nodeSelector:
+            node-role.kubernetes.io/worker: ""
+          numVfs: 8
+          priority: 10
+          resourceName: du_mh
+- name: v1-du-validator-policy
+  remediationAction: inform
+  # This policy is not re-evaluated after it becomes
+  # compliant to reduce resource usage.
+  evaluationInterval:
+    compliant: never
+    noncompliant: 10s
+  manifests:
+    - path: source-crs/validatorCRs/informDuValidatorWorker.yaml

--- a/docs/user-guide/upgrade.md
+++ b/docs/user-guide/upgrade.md
@@ -4,9 +4,40 @@ SPDX-FileCopyrightText: Red Hat
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Example upgrade from 4.Y.Z to 4.Y.Z+1
+# Cluster Upgrade
 
-This guide describes how to perform an Image-Based Upgrade (IBU) of a spoke cluster
+- [Cluster Upgrade](#cluster-upgrade)
+  - [Overview](#overview)
+  - [SNO Image-Based Upgrade (IBU)](#sno-image-based-upgrade-ibu)
+    - [Prerequisites](#prerequisites)
+    - [Steps](#steps)
+    - [Example ClusterTemplate and upgrade defaults for the new release](#example-clustertemplate-and-upgrade-defaults-for-the-new-release)
+    - [Overriding Upgrade Parameters per ProvisioningRequest](#overriding-upgrade-parameters-per-provisioningrequest)
+    - [Monitoring Upgrade Progress](#monitoring-upgrade-progress)
+    - [Retry After Failure](#retry-after-failure)
+  - [MNO ClusterVersion Upgrade](#mno-clusterversion-upgrade)
+    - [MNO Prerequisites](#mno-prerequisites)
+    - [Preparing the Upgrade ClusterTemplate](#preparing-the-upgrade-clustertemplate)
+    - [Triggering the Upgrade](#triggering-the-upgrade)
+    - [Timeout Configuration](#timeout-configuration)
+    - [How It Works](#how-it-works)
+    - [MNO Monitoring Upgrade Progress](#mno-monitoring-upgrade-progress)
+    - [MNO Retry After Failure](#mno-retry-after-failure)
+
+## Overview
+
+The O-Cloud Manager supports two cluster upgrade methods:
+
+- **SNO Image-Based Upgrade** — upgrades Single-Node OpenShift clusters via ImageBasedGroupUpgrade (IBGU).
+- **MNO ClusterVersion upgrade** — upgrades Multi-Node OpenShift clusters via the ClusterVersion CR on the spoke cluster.
+
+The upgrade type is determined by the upgrade configuration in the ClusterTemplate's `upgradeDefaults` and
+the ProvisioningRequest's `upgradeParameters`: `clusterVersion` for MNO or `imageBasedGroupUpgrade` for SNO.
+Only one upgrade type can be configured per ClusterTemplate.
+
+## SNO Image-Based Upgrade (IBU)
+
+This section describes how to perform an Image-Based Upgrade (IBU) of a spoke cluster
 from one OCP version to a newer version using the O-Cloud Manager. IBU uses a seed
 image containing a pre-installed OCP version to perform a fast, image-based upgrade with
 automatic rollback on failure.
@@ -18,7 +49,7 @@ defined inline in the ClusterTemplate's `spec.templateDefaults.upgradeDefaults` 
 Individual ProvisioningRequests can override specific upgrade parameters via
 `spec.templateParameters.upgradeParameters`.
 
-## Prerequisites
+### Prerequisites
 
 - The OpenShift API for Data Protection (OADP) operator and the Lifecycle Agent (LCA)
   operator are installed on the spoke cluster, and the OADP backend is configured.
@@ -66,7 +97,7 @@ policies:
             <FILL>
 ```
 
-## Steps
+### Steps
 
 1. Create new [clustertemplates](../samples/git-setup/clustertemplates/version_4.Y.Z+1/)
    and [policytemplates](../samples/git-setup/policytemplates/version_4.Y.Z+1/) directories
@@ -167,7 +198,7 @@ spec:
     type: object
 ```
 
-## Overriding Upgrade Parameters per ProvisioningRequest
+### Overriding Upgrade Parameters per ProvisioningRequest
 
 ProvisioningRequests can override specific upgrade defaults by providing
 `upgradeParameters` in `spec.templateParameters`. The values are deep-merged on
@@ -182,7 +213,7 @@ Note that `plan` is an array and is merged by index position — element 0 of
 the override merges with element 0 of the defaults, element 1 with element 1,
 and so on. If the override array is longer, extra elements are appended.
 
-### Example: Override the seed image and increase the Upgrade timeout
+#### Example: Override the seed image and increase the Upgrade timeout
 
 ```yaml
 apiVersion: clcm.openshift.io/v1alpha1
@@ -220,7 +251,7 @@ In this example:
   `autoRollbackOnFailure`, and remaining plan steps) are inherited from the
   ClusterTemplate's `upgradeDefaults`.
 
-## Monitoring Upgrade Progress
+### Monitoring Upgrade Progress
 
 Monitor the `UpgradeCompleted` condition on the ProvisioningRequest:
 
@@ -250,7 +281,7 @@ status:
     provisioningPhase: fulfilled
 ```
 
-## Retry After Failure
+### Retry After Failure
 
 If the upgrade fails, the spoke cluster may be automatically rolled back depending on
 how far the upgrade progressed. The IBGU plan includes `AbortOnFailure` actions to
@@ -273,3 +304,333 @@ handle rollback and cleanup. To retry after the rollback or abort completes:
    oc patch provisioningrequests.clcm.openshift.io <name> --type merge \
      -p '{"spec":{"templateName":"sno-ran-du","templateVersion":"v4-Y-Z+1-1"}}'
    ```
+
+## MNO ClusterVersion Upgrade
+
+This section describes how to upgrade Multi-Node OpenShift (MNO) clusters
+using the O-Cloud Manager. The upgrade is performed by patching the
+ClusterVersion CR on the spoke cluster, where the Cluster Version Operator
+(CVO) orchestrates the component-by-component update of the control plane
+and worker nodes.
+
+### MNO Prerequisites
+
+- The [ManagedServiceAccount](https://github.com/open-cluster-management-io/managed-serviceaccount)
+  addon is enabled on the hub cluster. This addon is enabled by default in
+  ACM/MCE. To verify, check the MultiClusterEngine CR:
+
+  ```console
+  oc get multiclusterengines.multicluster.openshift.io multiclusterengine \
+    -o jsonpath='{.spec.overrides.components[?(@.name=="managedserviceaccount")].enabled}'
+  ```
+
+  If it returns `false` or is not present, enable it using
+  `oc edit` to add or update the entry while preserving existing
+  component overrides:
+
+  ```console
+  oc edit multiclusterengines.multicluster.openshift.io multiclusterengine
+  ```
+
+  Ensure the `managedserviceaccount` component is listed and enabled:
+
+  ```yaml
+  spec:
+    overrides:
+      components:
+      - name: managedserviceaccount
+        enabled: true
+      # ... other existing components ...
+  ```
+
+- Administrator pre-upgrade tasks are completed before triggering the upgrade.
+  These are the administrator's responsibility and must be done before updating
+  the ProvisioningRequest. See [Preparing to update a cluster](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/updating_clusters/preparing-to-update-a-cluster) for details including:
+  - etcd backup
+  - Reviewing deprecated APIs
+  - Administrator acknowledgement for minor version upgrades
+    This can be done by updating a ConfigMap on the spoke cluster via an ACM policy. Follow the pattern described in
+    [Adding a new manifest to an existing ACM PolicyGenerator](./cluster-configuration.md#adding-a-new-manifest-to-an-existing-acm-policygenerator)
+    to add the acknowledgement ConfigMap:
+
+    ```yaml
+    - name: v2-admin-acks-policy
+      manifests:
+        - path: source-crs/ConfigMapGeneric.yaml
+          patches:
+          - metadata:
+              name: admin-acks
+              namespace: openshift-config
+            data:
+              ack-4.18-kube-1.32-api-removals-in-4.19: "true"
+    ```
+
+    For EUS-to-EUS upgrades where both the intermediate and target versions require acknowledgement, include entries for both:
+
+    ```yaml
+            data:
+              ack-4.18-kube-1.32-api-removals-in-4.19: "true"
+              ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20: "true"
+    ```
+
+  - The spoke cluster is successfully deployed via ProvisioningRequest.
+
+### Preparing the Upgrade ClusterTemplate
+
+Create a new ClusterTemplate version for the target OCP release. See the complete sample upgrade templates
+for [std-ran-du](../samples/git-setup/clustertemplates/version_4.Y.Z+1/std-ran-du/)
+and [3node-ran-du](../samples/git-setup/clustertemplates/version_4.Y.Z+1/3node-ran-du/).
+This involves updating the sub-templates and creating the ClusterTemplate CR.
+
+1. **Create a ClusterInstance defaults ConfigMap** in the target version namespace.
+   Update `clusterImageSetNameRef` to the new OCP image version and update `extraLabels`
+   to bind the cluster to the new version's policies:
+
+   ```yaml
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: clusterinstance-defaults-v1
+     namespace: std-ran-du-v4-22-0
+   data:
+     clusterinstance-defaults: |
+       clusterImageSetNameRef: "4.22.0"
+       extraLabels:
+         ManagedCluster:
+           cluster-version: "v4-22-0"
+           std-ran-du-policy: "v1"
+   ```
+
+   > [!NOTE]
+   > The SiteConfig operator only permits updates to a limited
+   > subset of ClusterInstance fields after initial installation. The rest
+   > of the configuration must remain identical to the original ConfigMap
+   > used for provisioning. In particular, `extraManifestsRefs` must
+   > reference the same ConfigMap names as the original version — for
+   > example, if the original used `std-ran-extra-manifest-v1`, the new
+   > ConfigMap must also use `std-ran-extra-manifest-v1`.
+
+2. **Create policy templates** for the new OpenShift version. Create a new PolicyGenerator
+   and policy template defaults ConfigMap in the target version namespace with the updated
+   operator index image referencing the new release.
+
+3. **Create the ClusterTemplate CR** referencing the new default configurations. Set `spec.release`
+   to the target version, configure `upgradeDefaults` with the `clusterVersion` upgrade settings,
+   and define `templateParameterSchema` to expose overridable upgrade fields. Hardware configuration
+   parameters `hwMgmtDefaults` should remain the same as the original provisioning version.
+
+```yaml
+apiVersion: clcm.openshift.io/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: std-ran-du.v4-22-0-v1
+  namespace: std-ran-du-v4-22-0
+spec:
+  name: std-ran-du
+  version: v4-22-0-v1
+  release: "4.22.0"
+  templateDefaults:
+    # ... other default configurations ...
+    upgradeDefaults:
+      # clusterUpgradeTimeout: "6h"            # optional; defaults to 4h (standard upgrades) or 8h (EUS upgrades)
+      # intermediateVersion: "4.21.5"          # optional; for EUS upgrades (auto-selected if omitted)
+      clusterVersion:
+        channel: "stable-4.22"                 # required for minior version and EUS upgrades
+        # upstream: "https://api.openshift.com/api/upgrades_info/v1/graph"  # optional
+        desiredUpdate:
+          version: "4.22.0"                    # must match spec.release 
+  templateParameterSchema:
+    type: object
+    properties:
+      # ... other parameters ...
+      upgradeParameters:
+        type: object
+        properties:
+          clusterUpgradeTimeout:
+            type: string
+          intermediateVersion:
+            type: string
+          clusterVersion:
+            type: object
+            properties:
+              channel:
+                type: string
+              upstream:
+                type: string
+              desiredUpdate:
+                type: object
+                properties:
+                  version:
+                    type: string
+                  image:
+                    type: string
+                  force:
+                    type: boolean
+                  architecture:
+                    type: string
+                    enum:
+                    - Multi
+                    - ""
+```
+
+**Notes:**
+
+- `upgradeDefaults` must contain either `clusterVersion` or `imageBasedGroupUpgrade`, not both.
+- `desiredUpdate.version` must match the ClusterTemplate's `spec.release`.
+- An EUS-to-EUS upgrade is detected when both the current and target cluster versions are even-numbered minor releases exactly 2 minor
+  versions apart (e.g., 4.20 to 4.22). The upgrade proceeds through an intermediate version (e.g., 4.21.x) before reaching the target.
+  If `intermediateVersion` is specified, it is used directly and must be valid semver with the same major version and exactly one minor
+  version below `desiredUpdate.version`. If `intermediateVersion` is not specified, the controller auto-selects the highest valid
+  intermediate version from the configured `upstream` and `channel`, where the selected version has a valid upgrade path from the current
+  version and to the target version. `channel` is required for auto-selection.
+
+### Triggering the Upgrade
+
+Update the ProvisioningRequest to reference the new ClusterTemplate to trigger the upgrade. The ProvisioningRequest can be updated via the
+CLI or the [Provisioning REST API](./cluster-provisioning.md#provisioning-rest-apis).
+
+ProvisioningRequests can also override specific upgrade defaults by providing `upgradeParameters` in `spec.templateParameters`. The values
+are deep-merged on top of the ClusterTemplate's `upgradeDefaults`, with ProvisioningRequest values taking precedence:
+
+```yaml
+spec:
+  templateParameters:
+    upgradeParameters:
+      clusterUpgradeTimeout: "6h"
+      clusterVersion:
+        channel: "eus-4.22"
+        upstream: "https://example.com/graph"
+```
+
+### Timeout Configuration
+
+The `clusterUpgradeTimeout` controls how long the controller waits for the upgrade to complete before marking it as `TimedOut`.
+
+| Upgrade Type | Default Timeout |
+|---|---|
+| Standard (z-stream / y-stream) | 4 hours |
+| EUS-to-EUS | 8 hours |
+
+A single timeout covers the entire upgrade process, including both hops for EUS upgrades. The timeout is tracked from
+`status.clusterDetails.clusterUpgradeStatus.startedAt`.
+
+The timeout can be configured via `upgradeDefaults` or overridden per ProvisioningRequest via `upgradeParameters`.
+`clusterUpgradeTimeout` is the only parameter update recognized during an in-progress upgrade. Other parameter changes are
+ignored until the upgrade completes or fails.
+
+### How It Works
+
+The MNO ClusterVersion upgrade follows these steps:
+
+1. **Create spoke client** — the controller creates a ManagedServiceAccount
+   and RBAC ManifestWork for scoped access to the managed cluster's
+   ClusterVersion and MachineConfigPool resources.
+
+2. **Pre-upgrade checks** — for minor version upgrades, verifies the
+   `Upgradeable` condition on the spoke ClusterVersion. For standard
+   upgrades, requires all MachineConfigPools are unpaused. For EUS
+   upgrades, requires all MachineConfigPools show `Updated=True`.
+
+3. **Set channel and upstream** — patches the spoke ClusterVersion with
+   the configured channel and upstream if provided, then waits for the CVO
+   to retrieve the update graph (`RetrievedUpdates=True`).
+
+4. **Verify target available** — for version-based upgrades (no
+   `desiredUpdate.image`), confirms the target version is listed in the
+   spoke ClusterVersion's `status.availableUpdates`.
+
+5. **Trigger upgrade and monitor** — patches `spec.desiredUpdate` on
+   the spoke ClusterVersion and monitors CVO progress via ClusterVersion
+   history and conditions.
+
+6. **For EUS** — resolves the intermediate version (from configuration
+   or the Cincinnati update graph), pauses non-master worker MCPs,
+   triggers the intermediate version upgrade first, then the target
+   version upgrade, and finally unpauses MCPs and waits for workers to
+   update.
+
+### MNO Monitoring Upgrade Progress
+
+Monitor the `UpgradeCompleted` condition on the ProvisioningRequest:
+
+```console
+oc get provisioningrequests.clcm.openshift.io <name> \
+  -o jsonpath='{.status.conditions[?(@.type=="UpgradeCompleted")]}'
+```
+
+| Status | Reason | Meaning | Common Causes |
+|---|---|---|---|
+| False | Pending | Upgrade not yet started or waiting | Spoke client setup in progress, waiting for CVO to retrieve update graph or image payload, `Upgradeable=False` on spoke (minor version upgrade) |
+| False | InProgress | Upgrade is running | CVO updating control plane and worker nodes |
+| False | Unknown | Upgrade stalled | CVO not progressing, possible `Failing` condition on spoke |
+| False | PreconditionChecksFailed | Cannot proceed with upgrade | MCPs not unpaused (standard) or not updated (EUS), spoke client setup issue, invalid upgrade configuration |
+| True | Completed | Upgrade finished successfully | — |
+| False | TimedOut | Upgrade exceeded the configured timeout | Timeout too short for cluster size, spoke connectivity issues, upgrade stalled |
+
+The condition message provides details about the current phase:
+
+- Spoke client setup: `"Preparing upgrade resources"`
+- Upgrade triggered, waiting for CVO to begin: `"Upgrade to [intermediate/target] version X.Y.Z triggered. Waiting for upgrade to start"`
+- Upgrade is in progress with CVO Progressing details: `"Upgrading to [intermediate/target] version X.Y.Z: ..."`
+- EUS: MCPs unpaused, workers updating: `"Cluster version upgrade completed. Waiting for worker MachineConfigPools to finish updating"`
+- Upgrade completed: `"Upgrade to version X.Y.Z completed"`
+- Timeout with optional CVO Failing details: `"Upgrade timed out"` or `"Upgrade timed out: ..."`
+
+The `ClusterUpgradeStatus` in the ProvisioningRequest status provides
+additional upgrade state:
+
+```yaml
+status:
+  extensions:
+    clusterDetails:
+      clusterUpgradeStatus:
+        startedAt: "2026-07-20T15:30:00Z"
+        startVersion: "4.18.25"
+        intermediateVersion: "4.19.31"  # present for EUS upgrades
+```
+
+The upgrade status is also reflected in the ProvisioningRequest's `provisioningPhase` and `provisioningDetails`. The message from the
+`UpgradeCompleted` condition is propagated to `provisioningDetails`:
+
+```console
+oc get provisioningrequests.clcm.openshift.io
+```
+
+| UpgradeCompleted Reason | provisioningPhase |
+|---|---|
+| Pending, InProgress, Unknown | progressing |
+| PreconditionChecksFailed, TimedOut | failed |
+| Completed | fulfilled |
+
+### MNO Retry After Failure
+
+**Pending (requires attention):** Some `Pending` states indicate issues that may require
+investigation. The controller continues to requeue in ase the issue is temporaray
+(e.g., network connectivity), but if the condition persists, user action may be needed:
+
+  The `UpgradeCompleted` condition message includes the relevant spoke
+  ClusterVersion condition details (e.g., `Upgradeable`, `RetrievedUpdates`,
+  `ReleaseAccepted`). Check the message to determine the root cause —
+  for example, it may indicate a required administrator acknowledgement,
+  a degraded cluster operator, a channel/upstream misconfiguration, or
+  a payload verification failure.
+
+The controller will automatically proceed once the issue is resolved.
+
+**PreconditionChecksFailed:** The upgrade is stopped. Check the
+`UpgradeCompleted` condition message for details, fix the underlying
+cause, and update the ProvisioningRequest to retry.
+
+**TimedOut:** The upgrade exceeded its timeout. The administrator should
+investigate the spoke cluster to determine the root cause and resolve it.
+
+- If the cluster is still on the original version and ready to retry:
+  revert the ProvisioningRequest to the original ClusterTemplate, wait
+  for `fulfilled`, then update it again to the upgrade ClusterTemplate
+  to reattempt the upgrade.
+
+- If the administrator managed to complete the upgrade to the target
+  version outside of the O-Cloud Manager: add or update a ManagedCluster
+  label through the ProvisioningRequest's `clusterInstanceParameters` to
+  trigger reconciliation, and the ProvisioningRequest will detect the
+  new version and transition to `fulfilled`.

--- a/internal/controllers/provisioningrequest_upgrade.go
+++ b/internal/controllers/provisioningrequest_upgrade.go
@@ -693,7 +693,7 @@ func (t *provisioningRequestReconcilerTask) handleCVUpgradeCompleted(
 		// MCPs were already unpaused — the list is fresh at that point.
 		if unpaused || len(ctlrutils.GetNonUpdatedMCPs(mcps)) > 0 {
 			if err := t.updateUpgradeStatus(ctx,
-				provisioningv1alpha1.CRconditionReasons.Pending,
+				provisioningv1alpha1.CRconditionReasons.InProgress,
 				"Cluster version upgrade completed. Waiting for worker MachineConfigPools to finish updating",
 			); err != nil {
 				return ctrl.Result{}, err

--- a/internal/controllers/provisioningrequest_upgrade_test.go
+++ b/internal/controllers/provisioningrequest_upgrade_test.go
@@ -1815,7 +1815,7 @@ var _ = Describe("handleClusterVersionUpgrade", func() {
 			Expect(proceed).To(BeFalse())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 
-			assertUpgradeCondition(string(provisioningv1alpha1.CRconditionReasons.Pending),
+			assertUpgradeCondition(string(provisioningv1alpha1.CRconditionReasons.InProgress),
 				"Waiting for worker MachineConfigPools to finish updating")
 			assertMCPPaused("worker", false)
 		})

--- a/test/e2e/mno_cv_upgrade_test.go
+++ b/test/e2e/mno_cv_upgrade_test.go
@@ -775,7 +775,7 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 			})
 
 			waitForPRUpgradeCondition(testCtx, K8SClient,
-				string(provisioningv1alpha1.CRconditionReasons.Pending),
+				string(provisioningv1alpha1.CRconditionReasons.InProgress),
 				"Waiting for worker MachineConfigPools to finish updating",
 				provisioningv1alpha1.StateProgressing,
 			)


### PR DESCRIPTION
Add MNO ClusterVersion upgrade documentation to the existing upgrade guide and provide sample GitOps templates for std-ran-du and 3node-ran-du upgrade ClusterTemplates.

Documentation:
- Restructure upgrade.md with Overview, SNO IBU, and MNO sections
- Add MNO prerequisites including ManagedServiceAccount addon verification, administrator pre-upgrade tasks, and admin acknowledgement via ACM policy
- Document ClusterTemplate preparation: ClusterInstance defaults ConfigMap updates, policy template creation, and ClusterTemplate CR with upgradeDefaults and upgradeParameters schema
- Cover standard (z-stream/y-stream) and EUS-to-EUS upgrade types including intermediateVersion auto-selection from Cincinnati graph
- Add timeout configuration section with defaults (4h standard, 8h EUS)
- Document upgrade flow (How It Works) with 6-step walkthrough
- Add monitoring section with UpgradeCompleted condition states table, condition messages, and provisioningPhase mapping
- Add retry guidance for Pending, PreconditionChecksFailed, and TimedOut states

Sample templates (version_4.Y.Z+1):
- std-ran-du and 3node-ran-du ClusterTemplates with clusterVersion upgradeDefaults and upgradeParameters schema
- ClusterInstance defaults ConfigMaps with updated clusterImageSetNameRef and extraLabels
- PolicyGenerators with updated operator index images and label selectors

Also changes UpgradeCompleted condition from Pending to InProgress when waiting for worker MachineConfigPools to finish updating for EUS upgrade.