### PR TITLE
CNF-25887: add MNO worker node scale-in support (Phase 2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -136,7 +136,7 @@ linters:
         - .WrapPrefixf(
     goconst:
       min-occurrences: 5
-      ignore-string-values: '^(get|list|watch|create|update|patch|delete|app|name|namespace|master|worker|role|macAddress|nodes|interfaces|label|extraAnnotations|extraLabels|nodeNetwork|apiextensions\.k8s\.io|CustomResourceDefinition|default|true|agent-install\.openshift\.io/clusterdeployment-namespace)$'
+      ignore-string-values: '^(get|list|watch|create|update|patch|delete|app|name|namespace|master|worker|role|macAddress|nodes|interfaces|label|extraAnnotations|extraLabels|nodeNetwork|apiextensions\.k8s\.io|CustomResourceDefinition|default|true|agent-install\.openshift\.io/clusterdeployment-namespace|apiVersion|kind)$'
   exclusions:
     generated: lax
     presets:

--- a/api/hardwaremanagement/v1alpha1/conditions.go
+++ b/api/hardwaremanagement/v1alpha1/conditions.go
@@ -13,10 +13,11 @@ type ConditionType string
 
 // The following constants define the different types of conditions that will be set
 const (
-	Provisioned ConditionType = "Provisioned"
-	Configured  ConditionType = "Configured"
-	Validation  ConditionType = "Validation"
-	Unknown     ConditionType = "Unknown" // Indicates the condition has not been evaluated
+	Provisioned   ConditionType = "Provisioned"
+	Configured    ConditionType = "Configured"
+	Deprovisioned ConditionType = "Deprovisioned"
+	Validation    ConditionType = "Validation"
+	Unknown       ConditionType = "Unknown" // Indicates the condition has not been evaluated
 )
 
 // ConditionReason describes the reasons for a condition's status.

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -1803,10 +1803,20 @@ spec:
           resources:
           - agents
           verbs:
+          - delete
           - get
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - agent-install.openshift.io
+          resources:
+          - infraenvs
+          - nmstateconfigs
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - apiextensions.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,10 +50,20 @@ rules:
   resources:
   - agents
   verbs:
+  - delete
   - get
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - infraenvs
+  - nmstateconfigs
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/docs/dev/e2e-test-overview.md
+++ b/docs/dev/e2e-test-overview.md
@@ -28,6 +28,7 @@ feature, which parses test structure without executing tests.
   - [Handles mid-flight profile change by abandoning stale updates](#handles-mid-flight-profile-change-by-abandoning-stale-updates)
 - [MNO Scale-Out test [mno-scale-out]](#mno-scale-out-test-mno-scale-out)
   - [Scale-out: add a worker node](#scale-out-add-a-worker-node)
+  - [Scale-in: remove a worker node](#scale-in-remove-a-worker-node)
 - [SNO End-to-end ProvisioningRequestReconcile with hardware manager [sno-provisioning]](#sno-end-to-end-provisioningrequestreconcile-with-hardware-manager-sno-provisioning)
 
 ## MNO Standard ClusterVersion Upgrade [mno-cv-upgrade]
@@ -169,6 +170,12 @@ File: `test/e2e/mno_scale_test.go`
 1. should create a new AllocatedNode for the added worker
    - Waiting for 6 AllocatedNodes (3 masters + 3 workers)
    - Verifying original nodes are preserved and new node is a worker
+
+### Scale-in: remove a worker node
+
+1. should decrease NAR worker NodeGroup Size after removing a worker
+   - Updating PR to remove worker-3 (revert to v1 CT with 2 workers)
+   - Verifying NAR NodeGroup sizes after scale-in
 
 ## SNO End-to-end ProvisioningRequestReconcile with hardware manager [sno-provisioning]
 

--- a/docs/user-guide/cluster-configuration.md
+++ b/docs/user-guide/cluster-configuration.md
@@ -790,8 +790,26 @@ nodes) is planned for a future release.
 
 #### Removing a worker node (scale-in)
 
-> [!IMPORTANT]
-> Scale-in is not yet supported. Do not remove worker nodes from the
-> ProvisioningRequest nodes array. When scale-in support is added in a
-> future release, the controller will drain nodes before removal to
-> minimize workload disruption.
+To remove a worker node, remove its entry from the
+`clusterInstanceParameters.nodes` array in the ProvisioningRequest and
+update the `templateName` to reference a ClusterTemplate with matching
+CI defaults (one fewer worker node template).
+
+The controller automatically:
+
+1. Cordons and drains the removed node on the spoke cluster
+2. Applies an intermediate ClusterInstance with `pruneManifests` to
+   instruct siteconfig to delete per-node resources (InfraEnv,
+   NMStateConfig) while the node entry is still present
+3. Waits for siteconfig to process the pruning, then deletes the
+   Agent CR
+4. Applies the reduced ClusterInstance via Server-Side Apply
+   (removing the node entry)
+5. Waits for the removed node to leave the spoke cluster
+6. Deletes the AllocatedNode CR (triggering BMH deallocation)
+7. Cleans up the AllocatedNodeHostMap
+
+> [!NOTE]
+> Only worker nodes can be removed. Attempting to remove a control-plane
+> node is rejected. Scale-in and upgrade operations cannot run
+> concurrently.

--- a/docs/user-guide/cluster-configuration.md
+++ b/docs/user-guide/cluster-configuration.md
@@ -724,10 +724,9 @@ The following steps are required:
 
 ### Scaling Worker Nodes
 
-After a multi-node (MNO) cluster is provisioned, you can add worker
-nodes by updating the ProvisioningRequest's
-`clusterInstanceParameters.nodes` array. Scale-in (removing worker
-nodes) is planned for a future release.
+After a multi-node (MNO) cluster is provisioned, you can add or remove
+worker nodes by updating the ProvisioningRequest's
+`clusterInstanceParameters.nodes` array.
 
 > [!NOTE]
 > Scaling is only supported for worker nodes. Control plane (master)

--- a/docs/user-guide/cluster-configuration.md
+++ b/docs/user-guide/cluster-configuration.md
@@ -796,17 +796,19 @@ CI defaults (one fewer worker node template).
 
 The controller automatically:
 
-1. Cordons and drains the removed node on the spoke cluster
-2. Applies an intermediate ClusterInstance with `pruneManifests` to
+1. Signals the hardware manager to drain and decommission the
+   removed node (via a NAR annotation)
+2. The hardware manager cordons and drains the node on the spoke,
+   deletes the Node object, deletes the AllocatedNode CR
+   (triggering BMH deallocation), and cleans up node tracking
+3. Applies an intermediate ClusterInstance with `pruneManifests` to
    instruct siteconfig to delete per-node resources (InfraEnv,
    NMStateConfig) while the node entry is still present
-3. Waits for siteconfig to process the pruning, then deletes the
+4. Waits for siteconfig to process the pruning, then deletes the
    Agent CR
-4. Applies the reduced ClusterInstance via Server-Side Apply
+5. Applies the reduced ClusterInstance via Server-Side Apply
    (removing the node entry)
-5. Waits for the removed node to leave the spoke cluster
-6. Deletes the AllocatedNode CR (triggering BMH deallocation)
-7. Cleans up the AllocatedNodeHostMap
+6. Cleans up the AllocatedNodeHostMap
 
 > [!NOTE]
 > Only worker nodes can be removed. Attempting to remove a control-plane

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -29,8 +31,11 @@ import (
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils/spokeclient"
+	hwmgrcontroller "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/controller"
+	k8sclients "github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
 	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -204,6 +209,391 @@ func (t *provisioningRequestReconcilerTask) buildClusterInstanceUnstructured() (
 	return renderedClusterInstanceUnstructured, nil
 }
 
+// handleScaleInDrain detects nodes being removed from the ClusterInstance and
+// cordons/drains them on the spoke cluster before the CI is updated. This must
+// run before handleClusterInstallation so nodes are drained before being removed
+// from the cluster topology.
+func (t *provisioningRequestReconcilerTask) handleScaleInDrain(
+	ctx context.Context, renderedCI *unstructured.Unstructured) (bool, error) {
+
+	if !ctlrutils.IsClusterProvisionCompleted(t.object) {
+		return false, nil
+	}
+
+	// Fetch the existing CI to compare
+	ciName := renderedCI.GetName()
+	existingCI := &unstructured.Unstructured{}
+	existingCI.SetGroupVersionKind(renderedCI.GroupVersionKind())
+	exists, err := ctlrutils.DoesK8SResourceExist(ctx, t.client, ciName, ciName, existingCI)
+	if err != nil {
+		return false, fmt.Errorf("failed to get existing ClusterInstance (%s): %w", ciName, err)
+	}
+	if !exists {
+		return false, nil
+	}
+
+	// Identify removed nodes (in existing but not in rendered)
+	existingNodes := getNodeRolesByHostname(existingCI)
+	renderedNodes := getNodeRolesByHostname(renderedCI)
+
+	var removedHostnames []string
+	for hostname := range existingNodes {
+		if _, exists := renderedNodes[hostname]; !exists {
+			removedHostnames = append(removedHostnames, hostname)
+		}
+	}
+
+	if len(removedHostnames) == 0 {
+		return false, nil
+	}
+
+	t.logger.InfoContext(ctx, "Scale-in detected, processing removed nodes",
+		slog.Int("removedCount", len(removedHostnames)),
+		slog.Any("removedNodes", removedHostnames))
+
+	message := fmt.Sprintf("Scale-in: processing %d removed node(s)", len(removedHostnames))
+	ctlrutils.SetProvisioningStateInProgress(t.object, message)
+	if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
+		return false, fmt.Errorf("failed to update scale-in status: %w", updateErr)
+	}
+
+	// Step 1: Drain nodes that are still on the spoke.
+	// If no kubeconfig secret exists (e.g., e2e test environment), skip drain.
+	clusterName := t.object.Status.Extensions.ClusterDetails.Name
+	spokeClient, err := k8sclients.NewClientForCluster(ctx, t.client, clusterName)
+	if err != nil {
+		if strings.Contains(err.Error(), "no kubeconfig secret found") {
+			t.logger.WarnContext(ctx, "No spoke kubeconfig secret found, skipping drain",
+				slog.String("clusterName", clusterName))
+		} else {
+			return false, fmt.Errorf("failed to create spoke client for drain: %w", err)
+		}
+	}
+
+	if spokeClient != nil {
+		if err := t.drainRemovedNodesFromSpoke(ctx, spokeClient, clusterName, removedHostnames); err != nil {
+			return false, err
+		}
+	}
+
+	// Step 2: Apply intermediate CI with pruneManifests on removed node entries.
+	// This tells siteconfig to delete InfraEnv and NMStateConfig for those nodes
+	// while the node entries remain in spec.nodes.
+	intermediateCI := buildIntermediateCIWithPruneManifests(renderedCI, existingCI, removedHostnames)
+	if err := t.applyClusterInstance(ctx, intermediateCI, false); err != nil {
+		return false, fmt.Errorf("failed to apply intermediate CI with pruneManifests: %w", err)
+	}
+
+	// Build a map of removed hostname → BMH identity (name + namespace).
+	// InfraEnv and NMStateConfig are named after the BMH, not the hostname.
+	removedNodeBMHs, err := t.lookupRemovedNodeBMHs(ctx, removedHostnames)
+	if err != nil {
+		return false, fmt.Errorf("failed to look up BMH info for removed nodes: %w", err)
+	}
+
+	// Step 3: Wait for siteconfig to delete the pruned resources
+	allPruned, err := t.checkScaleInPrunedResourcesGone(ctx, removedNodeBMHs)
+	if err != nil {
+		return false, fmt.Errorf("failed to check pruned resources: %w", err)
+	}
+
+	if !allPruned {
+		t.logger.InfoContext(ctx, "Waiting for siteconfig to process pruneManifests")
+		return true, nil
+	}
+
+	// Step 4: Delete Agent CRs (not managed by siteconfig)
+	if err := t.deleteScaleInAgentCRs(ctx, removedHostnames, removedNodeBMHs); err != nil {
+		return false, fmt.Errorf("failed to delete Agent CRs: %w", err)
+	}
+
+	t.logger.InfoContext(ctx, "Scale-in pre-processing complete, proceeding to CI update")
+	return false, nil
+}
+
+// drainRemovedNodesFromSpoke drains and deletes removed nodes that still exist
+// on the spoke cluster. Nodes already absent from the spoke are skipped.
+func (t *provisioningRequestReconcilerTask) drainRemovedNodesFromSpoke(
+	ctx context.Context, spokeClient client.Client, clusterName string,
+	removedHostnames []string) error {
+
+	nodeList := &corev1.NodeList{}
+	if err := spokeClient.List(ctx, nodeList); err != nil {
+		return fmt.Errorf("failed to list nodes on spoke cluster: %w", err)
+	}
+
+	spokeNodeSet := make(map[string]bool, len(nodeList.Items))
+	for _, node := range nodeList.Items {
+		spokeNodeSet[node.Name] = true
+	}
+
+	var nodesToDrain []string
+	for _, hostname := range removedHostnames {
+		if spokeNodeSet[hostname] {
+			nodesToDrain = append(nodesToDrain, hostname)
+		}
+	}
+
+	if len(nodesToDrain) == 0 {
+		return nil
+	}
+
+	clientset, err := k8sclients.NewClientsetForCluster(ctx, t.client, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to create spoke clientset for drain: %w", err)
+	}
+	nodeOps := hwmgrcontroller.NewNodeOps(spokeClient, clientset, t.logger, false)
+
+	for i, hostname := range nodesToDrain {
+		drainMsg := fmt.Sprintf("Scale-in: draining node %s (%d/%d)", hostname, i+1, len(nodesToDrain))
+		t.logger.InfoContext(ctx, drainMsg)
+		ctlrutils.SetProvisioningStateInProgress(t.object, drainMsg)
+		if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
+			t.logger.WarnContext(ctx, "Failed to update drain progress status",
+				slog.Any("error", updateErr))
+		}
+
+		if err := nodeOps.DrainNode(ctx, hostname); err != nil {
+			return fmt.Errorf("failed to drain node %s: %w", hostname, err)
+		}
+
+		// Delete the Node object from the spoke cluster
+		spokeNode := &corev1.Node{}
+		spokeNode.Name = hostname
+		if err := spokeClient.Delete(ctx, spokeNode); err != nil {
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("failed to delete node %s from spoke cluster: %w", hostname, err)
+			}
+		}
+		t.logger.InfoContext(ctx, "Drained and deleted node from spoke cluster",
+			slog.String("hostname", hostname))
+	}
+
+	return nil
+}
+
+// buildIntermediateCIWithPruneManifests constructs a CI that includes the
+// rendered nodes plus the removed nodes with pruneManifests set for InfraEnv
+// and NMStateConfig. This intermediate CI is SSA-applied so that siteconfig
+// deletes those per-node resources before the node entries are removed.
+func buildIntermediateCIWithPruneManifests(
+	renderedCI, existingCI *unstructured.Unstructured,
+	removedHostnames []string) *unstructured.Unstructured {
+
+	intermediateCI := renderedCI.DeepCopy()
+
+	removedSet := make(map[string]bool, len(removedHostnames))
+	for _, h := range removedHostnames {
+		removedSet[h] = true
+	}
+
+	existingSpec, _ := existingCI.Object["spec"].(map[string]any)
+	existingNodes, _ := existingSpec["nodes"].([]any)
+
+	pruneManifests := []any{
+		map[string]any{
+			"apiVersion": "agent-install.openshift.io/v1beta1",
+			"kind":       "InfraEnv",
+		},
+		map[string]any{
+			"apiVersion": "agent-install.openshift.io/v1beta1",
+			"kind":       "NMStateConfig",
+		},
+	}
+
+	var removedNodeEntries []any
+	for _, node := range existingNodes {
+		nodeMap, ok := node.(map[string]any)
+		if !ok {
+			continue
+		}
+		hostname, _ := nodeMap["hostName"].(string)
+		if !removedSet[hostname] {
+			continue
+		}
+		nodeCopy := runtime.DeepCopyJSONValue(nodeMap).(map[string]any)
+		nodeCopy["pruneManifests"] = pruneManifests
+		removedNodeEntries = append(removedNodeEntries, nodeCopy)
+	}
+
+	intermediateSpec := intermediateCI.Object["spec"].(map[string]any)
+	intermediateNodes, _ := intermediateSpec["nodes"].([]any)
+	intermediateNodes = append(intermediateNodes, removedNodeEntries...)
+	intermediateSpec["nodes"] = intermediateNodes
+
+	return intermediateCI
+}
+
+// bmhIdentity holds the BMH name and namespace for a node being removed.
+type bmhIdentity struct {
+	name      string
+	namespace string
+}
+
+// lookupRemovedNodeBMHs maps removed hostnames to their BMH name and namespace
+// via AllocatedNodeHostMap and AllocatedNode CRs.
+func (t *provisioningRequestReconcilerTask) lookupRemovedNodeBMHs(
+	ctx context.Context, removedHostnames []string) ([]bmhIdentity, error) {
+
+	// Build reverse map: hostname → AllocatedNode ID
+	hostnameToNodeID := make(map[string]string)
+	for nodeID, hostname := range t.object.Status.Extensions.AllocatedNodeHostMap {
+		hostnameToNodeID[hostname] = nodeID
+	}
+
+	narNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
+	var result []bmhIdentity
+
+	for _, hostname := range removedHostnames {
+		nodeID, ok := hostnameToNodeID[hostname]
+		if !ok {
+			t.logger.WarnContext(ctx, "No AllocatedNode found in host map for removed hostname",
+				slog.String("hostname", hostname))
+			continue
+		}
+
+		an := &hwmgmtv1alpha1.AllocatedNode{}
+		if err := t.client.Get(ctx, types.NamespacedName{Name: nodeID, Namespace: narNS}, an); err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to get AllocatedNode %s: %w", nodeID, err)
+		}
+
+		result = append(result, bmhIdentity{
+			name:      an.Spec.HwMgrNodeId,
+			namespace: an.Spec.HwMgrNodeNs,
+		})
+	}
+
+	return result, nil
+}
+
+// checkScaleInPrunedResourcesGone checks whether InfraEnv and NMStateConfig
+// resources for the removed nodes have been deleted by siteconfig.
+func (t *provisioningRequestReconcilerTask) checkScaleInPrunedResourcesGone(
+	ctx context.Context, removedBMHs []bmhIdentity) (bool, error) {
+
+	for _, bmh := range removedBMHs {
+		infraEnv := &unstructured.Unstructured{}
+		infraEnv.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "agent-install.openshift.io",
+			Version: "v1beta1",
+			Kind:    "InfraEnv",
+		})
+		if exists, err := resourceStillExists(ctx, t.client, bmh.name, bmh.namespace, infraEnv); err != nil {
+			return false, fmt.Errorf("failed to check InfraEnv %s/%s: %w", bmh.namespace, bmh.name, err)
+		} else if exists {
+			t.logger.InfoContext(ctx, "InfraEnv still exists, waiting for prune",
+				slog.String("name", bmh.name),
+				slog.String("namespace", bmh.namespace))
+			return false, nil
+		}
+
+		nmsc := &unstructured.Unstructured{}
+		nmsc.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "agent-install.openshift.io",
+			Version: "v1beta1",
+			Kind:    "NMStateConfig",
+		})
+		if exists, err := resourceStillExists(ctx, t.client, bmh.name, bmh.namespace, nmsc); err != nil {
+			return false, fmt.Errorf("failed to check NMStateConfig %s/%s: %w", bmh.namespace, bmh.name, err)
+		} else if exists {
+			t.logger.InfoContext(ctx, "NMStateConfig still exists, waiting for prune",
+				slog.String("name", bmh.name),
+				slog.String("namespace", bmh.namespace))
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// resourceStillExists checks if a resource exists. Returns false (not an error)
+// when the resource is not found or when the CRD for the resource type is not
+// installed on the cluster.
+func resourceStillExists(ctx context.Context, c client.Client, name, namespace string,
+	obj client.Object) (bool, error) {
+
+	exists, err := ctlrutils.DoesK8SResourceExist(ctx, c, name, namespace, obj)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check resource existence: %w", err)
+	}
+	return exists, nil
+}
+
+// deleteScaleInAgentCRs deletes Agent CRs for removed nodes. Agent CRs are
+// created by the Assisted Service (not siteconfig), so they must be deleted
+// explicitly during scale-in.
+func (t *provisioningRequestReconcilerTask) deleteScaleInAgentCRs(
+	ctx context.Context, removedHostnames []string, removedBMHs []bmhIdentity) error {
+
+	removedSet := make(map[string]bool, len(removedHostnames))
+	for _, h := range removedHostnames {
+		removedSet[h] = true
+	}
+
+	// Collect unique namespaces to search for Agent CRs
+	namespaces := make(map[string]bool)
+	for _, bmh := range removedBMHs {
+		namespaces[bmh.namespace] = true
+	}
+
+	for ns := range namespaces {
+		agentList := &unstructured.UnstructuredList{}
+		agentList.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "agent-install.openshift.io",
+			Version: "v1beta1",
+			Kind:    "AgentList",
+		})
+		if err := t.client.List(ctx, agentList, client.InNamespace(ns)); err != nil {
+			if meta.IsNoMatchError(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to list Agents in namespace %s: %w", ns, err)
+		}
+
+		for i := range agentList.Items {
+			agent := &agentList.Items[i]
+			hostname := getAgentHostname(agent)
+			if !removedSet[hostname] {
+				continue
+			}
+			if err := t.client.Delete(ctx, agent); err != nil {
+				if !errors.IsNotFound(err) {
+					return fmt.Errorf("failed to delete Agent %s/%s: %w", ns, agent.GetName(), err)
+				}
+			}
+			t.logger.InfoContext(ctx, "Deleted Agent CR for removed node",
+				slog.String("agent", agent.GetName()),
+				slog.String("hostname", hostname))
+		}
+	}
+
+	return nil
+}
+
+// getAgentHostname extracts the hostname from an Agent CR by checking
+// spec.hostname first, then falling back to status.inventory.hostname.
+func getAgentHostname(agent *unstructured.Unstructured) string {
+	if spec, ok := agent.Object["spec"].(map[string]any); ok {
+		if hostname, ok := spec["hostname"].(string); ok && hostname != "" {
+			return hostname
+		}
+	}
+	if status, ok := agent.Object["status"].(map[string]any); ok {
+		if inventory, ok := status["inventory"].(map[string]any); ok {
+			if hostname, ok := inventory["hostname"].(string); ok {
+				return hostname
+			}
+		}
+	}
+	return ""
+}
+
 // handleClusterInstallation creates/updates the ClusterInstance to handle the cluster provisioning.
 func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx context.Context, clusterInstance *unstructured.Unstructured) error {
 	isDryRun := false
@@ -298,6 +688,71 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx contex
 			// condition for scale-out, so checkClusterProvisionStatus would
 			// overwrite our InProgress status back to Completed, causing
 			// premature finalization.
+			return nil
+		}
+	}
+
+	// Detect scale-in: if the rendered CI has fewer nodes than the last fulfilled
+	// count, wait for removed nodes to leave the spoke, then perform cleanup.
+	if fulfilledCount > 0 && renderedNodeCount < fulfilledCount {
+		t.logger.InfoContext(ctx, "Scale-in in progress",
+			slog.Int("fulfilledNodeCount", fulfilledCount),
+			slog.Int("renderedNodeCount", renderedNodeCount))
+
+		// Only set InProgress on the first detection
+		if ctlrutils.IsClusterProvisionCompleted(t.object) {
+			message := fmt.Sprintf("Scale-in: waiting for removed node(s) to leave the cluster (%d → %d nodes)",
+				fulfilledCount, renderedNodeCount)
+			t.logger.InfoContext(ctx, message)
+			ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
+				provisioningv1alpha1.PRconditionTypes.ClusterProvisioned,
+				provisioningv1alpha1.CRconditionReasons.InProgress,
+				metav1.ConditionFalse,
+				message,
+			)
+			ctlrutils.SetProvisioningStateInProgress(t.object, message)
+			currentTime := metav1.Now()
+			t.object.Status.Extensions.ClusterDetails.ClusterProvisionStartedAt = &currentTime
+			if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
+				return fmt.Errorf("failed to update scale-in status: %w", updateErr)
+			}
+		}
+
+		// Check if all removed nodes have left the spoke cluster.
+		// AllocatedNode deletion and cleanup must wait until the node is
+		// actually gone — deleting the AllocatedNode triggers BMH
+		// deallocation, which must not happen while the node is still
+		// part of the spoke cluster.
+		allGone, checkErr := t.checkRemovedNodesGone(ctx, clusterInstance)
+		if checkErr != nil {
+			t.logger.WarnContext(ctx, "Failed to check spoke node status for scale-in, will retry",
+				slog.Any("error", checkErr))
+		}
+		t.logger.InfoContext(ctx, "Scale-in node removal check",
+			slog.Bool("allGone", allGone))
+
+		if allGone {
+			t.logger.InfoContext(ctx, "All removed nodes have left the cluster, performing cleanup")
+
+			// Now it's safe to delete AllocatedNodes and clean up the host map
+			if err := t.handleScaleInCleanup(ctx, clusterInstance); err != nil {
+				return fmt.Errorf("failed to perform scale-in cleanup: %w", err)
+			}
+
+			t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount = renderedNodeCount
+			ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
+				provisioningv1alpha1.PRconditionTypes.ClusterProvisioned,
+				provisioningv1alpha1.CRconditionReasons.Completed,
+				metav1.ConditionTrue,
+				"Provisioning completed",
+			)
+			if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
+				return fmt.Errorf("failed to update scale-in completion status: %w", updateErr)
+			}
+			// Fall through to normal finalization
+		} else {
+			// Don't fall through to checkClusterProvisionStatus while scale-in
+			// is in progress — same pattern as scale-out
 			return nil
 		}
 	}
@@ -710,12 +1165,14 @@ func validateScaleWorkerOnly(existingCI, renderedCI *unstructured.Unstructured) 
 		return typederrors.NewInputError("node scaling is not supported on single-node clusters")
 	}
 
-	// Reject any node removals — scale-in is not yet supported
+	// Reject removal of non-worker nodes
 	for hostname, role := range existingNodes {
 		if _, exists := renderedNodes[hostname]; !exists {
-			return typederrors.NewInputError(
-				"node removal is not yet supported: cannot remove %s node %q",
-				role, hostname)
+			if role != "worker" {
+				return typederrors.NewInputError(
+					"node scaling is restricted to worker nodes: cannot remove %s node %q",
+					role, hostname)
+			}
 		}
 	}
 
@@ -936,6 +1393,98 @@ func isNodeReady(node *corev1.Node) bool {
 
 // cleanupScaleOutSpokeAccess removes the spoke client resources created for
 // scale-out CSR approval.
+// handleScaleInCleanup performs post-drain cleanup for scale-in operations:
+// deletes AllocatedNode CRs for removed nodes and cleans up AllocatedNodeHostMap.
+func (t *provisioningRequestReconcilerTask) handleScaleInCleanup(
+	ctx context.Context, renderedCI *unstructured.Unstructured) error {
+
+	renderedNodes := getNodeRolesByHostname(renderedCI)
+
+	// Build a reverse map: hostname → AllocatedNode ID
+	hostnameToNodeID := make(map[string]string)
+	for nodeID, hostname := range t.object.Status.Extensions.AllocatedNodeHostMap {
+		hostnameToNodeID[hostname] = nodeID
+	}
+
+	// Identify AllocatedNodes to delete (those whose hostname is not in the rendered CI)
+	var nodesToDelete []string
+	for hostname, nodeID := range hostnameToNodeID {
+		if _, exists := renderedNodes[hostname]; !exists {
+			nodesToDelete = append(nodesToDelete, nodeID)
+			t.logger.InfoContext(ctx, "Marking AllocatedNode for deletion",
+				slog.String("allocatedNode", nodeID),
+				slog.String("hostname", hostname))
+		}
+	}
+
+	if len(nodesToDelete) == 0 {
+		return nil
+	}
+
+	// Delete AllocatedNode CRs — the AllocatedNode controller handles BMH deallocation
+	narNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
+	for _, nodeID := range nodesToDelete {
+		an := &hwmgmtv1alpha1.AllocatedNode{}
+		an.Name = nodeID
+		an.Namespace = narNS
+		if err := t.client.Delete(ctx, an); err != nil {
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("failed to delete AllocatedNode %s: %w", nodeID, err)
+			}
+		}
+		t.logger.InfoContext(ctx, "Deleted AllocatedNode",
+			slog.String("allocatedNode", nodeID))
+	}
+
+	// Clean up AllocatedNodeHostMap — remove entries for deleted nodes
+	for _, nodeID := range nodesToDelete {
+		delete(t.object.Status.Extensions.AllocatedNodeHostMap, nodeID)
+	}
+
+	ctlrutils.SetProvisioningStateInProgress(t.object,
+		fmt.Sprintf("Scale-in: removed %d node(s), cleaning up", len(nodesToDelete)))
+
+	return nil
+}
+
+// checkRemovedNodesGone verifies that no spoke node exists for hostnames that
+// are NOT in the rendered ClusterInstance. Returns true only when all removed
+// nodes have left the spoke cluster.
+func (t *provisioningRequestReconcilerTask) checkRemovedNodesGone(
+	ctx context.Context, renderedCI *unstructured.Unstructured) (bool, error) {
+
+	clusterName := t.object.Status.Extensions.ClusterDetails.Name
+
+	// Use the admin kubeconfig spoke client (same as drain) for node listing
+	spokeClient, err := k8sclients.NewClientForCluster(ctx, t.client, clusterName)
+	if err != nil {
+		return false, fmt.Errorf("failed to create spoke client for node check: %w", err)
+	}
+
+	// List nodes on the spoke
+	nodeList := &corev1.NodeList{}
+	if err := spokeClient.List(ctx, nodeList); err != nil {
+		return false, fmt.Errorf("failed to list nodes on spoke cluster: %w", err)
+	}
+
+	spokeNodes := make(map[string]bool, len(nodeList.Items))
+	for _, node := range nodeList.Items {
+		spokeNodes[node.Name] = true
+	}
+
+	// Check that no spoke node exists for hostnames not in the rendered CI
+	renderedHostnames := getNodeRolesByHostname(renderedCI)
+	for hostname := range spokeNodes {
+		if _, inRendered := renderedHostnames[hostname]; !inRendered {
+			t.logger.InfoContext(ctx, "Removed node still present on spoke",
+				slog.String("hostname", hostname))
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
 func (t *provisioningRequestReconcilerTask) cleanupScaleOutSpokeAccess(ctx context.Context, clusterName string) {
 	msaName := t.object.Name + "-scaleout"
 	mwName := t.object.Name + "-scaleout-rbac"

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -257,22 +257,24 @@ func (t *provisioningRequestReconcilerTask) handleScaleInDrain(
 		return false, fmt.Errorf("failed to update scale-in status: %w", updateErr)
 	}
 
-	// Step 1: Drain nodes that are still on the spoke.
-	// If no kubeconfig secret exists (e.g., e2e test environment), skip drain.
-	clusterName := t.object.Status.Extensions.ClusterDetails.Name
-	spokeClient, err := k8sclients.NewClientForCluster(ctx, t.client, clusterName)
+	// Resolve BMH identities before requesting drain. The NAR controller
+	// deletes AllocatedNodes during scale-in processing, so lookups must
+	// happen while the CRs still exist.
+	removedNodeIDs := t.hostnameToAllocatedNodeIDs(removedHostnames)
+	removedNodeBMHs, err := t.lookupRemovedNodeBMHs(ctx, removedHostnames)
 	if err != nil {
-		if strings.Contains(err.Error(), "no kubeconfig secret found") {
-			t.logger.WarnContext(ctx, "No spoke kubeconfig secret found, skipping drain",
-				slog.String("clusterName", clusterName))
-		} else {
-			return false, fmt.Errorf("failed to create spoke client for drain: %w", err)
-		}
+		return false, fmt.Errorf("failed to look up BMH info for removed nodes: %w", err)
 	}
 
-	if spokeClient != nil {
-		if err := t.drainRemovedNodesFromSpoke(ctx, spokeClient, clusterName, removedHostnames); err != nil {
-			return false, err
+	// Step 1: Request drain via NAR annotation. The NAR controller handles
+	// the actual drain, deallocation, and AllocatedNode deletion.
+	if len(removedNodeIDs) > 0 {
+		allDrained, drainErr := t.requestAndWaitForDrain(ctx, removedNodeIDs)
+		if drainErr != nil {
+			return false, fmt.Errorf("failed to request drain: %w", drainErr)
+		}
+		if !allDrained {
+			return true, nil
 		}
 	}
 
@@ -282,13 +284,6 @@ func (t *provisioningRequestReconcilerTask) handleScaleInDrain(
 	intermediateCI := buildIntermediateCIWithPruneManifests(renderedCI, existingCI, removedHostnames)
 	if err := t.applyClusterInstance(ctx, intermediateCI, false); err != nil {
 		return false, fmt.Errorf("failed to apply intermediate CI with pruneManifests: %w", err)
-	}
-
-	// Build a map of removed hostname → BMH identity (name + namespace).
-	// InfraEnv and NMStateConfig are named after the BMH, not the hostname.
-	removedNodeBMHs, err := t.lookupRemovedNodeBMHs(ctx, removedHostnames)
-	if err != nil {
-		return false, fmt.Errorf("failed to look up BMH info for removed nodes: %w", err)
 	}
 
 	// Step 3: Wait for siteconfig to delete the pruned resources
@@ -311,65 +306,74 @@ func (t *provisioningRequestReconcilerTask) handleScaleInDrain(
 	return false, nil
 }
 
-// drainRemovedNodesFromSpoke drains and deletes removed nodes that still exist
-// on the spoke cluster. Nodes already absent from the spoke are skipped.
-func (t *provisioningRequestReconcilerTask) drainRemovedNodesFromSpoke(
-	ctx context.Context, spokeClient client.Client, clusterName string,
-	removedHostnames []string) error {
+// hostnameToAllocatedNodeIDs maps removed hostnames to AllocatedNode names
+// using the AllocatedNodeHostMap.
+func (t *provisioningRequestReconcilerTask) hostnameToAllocatedNodeIDs(
+	hostnames []string) []string {
 
-	nodeList := &corev1.NodeList{}
-	if err := spokeClient.List(ctx, nodeList); err != nil {
-		return fmt.Errorf("failed to list nodes on spoke cluster: %w", err)
+	hostnameToID := make(map[string]string)
+	for nodeID, hostname := range t.object.Status.Extensions.AllocatedNodeHostMap {
+		hostnameToID[hostname] = nodeID
 	}
 
-	spokeNodeSet := make(map[string]bool, len(nodeList.Items))
-	for _, node := range nodeList.Items {
-		spokeNodeSet[node.Name] = true
-	}
-
-	var nodesToDrain []string
-	for _, hostname := range removedHostnames {
-		if spokeNodeSet[hostname] {
-			nodesToDrain = append(nodesToDrain, hostname)
+	var nodeIDs []string
+	for _, hostname := range hostnames {
+		if id, ok := hostnameToID[hostname]; ok {
+			nodeIDs = append(nodeIDs, id)
 		}
 	}
+	return nodeIDs
+}
 
-	if len(nodesToDrain) == 0 {
-		return nil
-	}
+// requestAndWaitForDrain sets the drain-nodes annotation on the NAR if not
+// already set, then checks if all listed AllocatedNodes have Drained=Completed.
+func (t *provisioningRequestReconcilerTask) requestAndWaitForDrain(
+	ctx context.Context, nodeIDs []string) (bool, error) {
 
-	clientset, err := k8sclients.NewClientsetForCluster(ctx, t.client, clusterName)
+	nar, err := t.getNAR(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to create spoke clientset for drain: %w", err)
+		return false, fmt.Errorf("failed to get NAR for drain request: %w", err)
 	}
-	nodeOps := hwmgrcontroller.NewNodeOps(spokeClient, clientset, t.logger, false)
 
-	for i, hostname := range nodesToDrain {
-		drainMsg := fmt.Sprintf("Scale-in: draining node %s (%d/%d)", hostname, i+1, len(nodesToDrain))
-		t.logger.InfoContext(ctx, drainMsg)
-		ctlrutils.SetProvisioningStateInProgress(t.object, drainMsg)
-		if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
-			t.logger.WarnContext(ctx, "Failed to update drain progress status",
-				slog.Any("error", updateErr))
+	// Set the drain annotation if not already present
+	annotations := nar.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if _, ok := annotations[hwmgrcontroller.ScaleInNodesAnnotation]; !ok {
+		nodeList := strings.Join(nodeIDs, ",")
+		annotations[hwmgrcontroller.ScaleInNodesAnnotation] = nodeList
+		patch := client.MergeFrom(nar.DeepCopy())
+		nar.SetAnnotations(annotations)
+		if err := t.client.Patch(ctx, nar, patch); err != nil {
+			return false, fmt.Errorf("failed to set drain-nodes annotation: %w", err)
 		}
+		t.logger.InfoContext(ctx, "Set drain-nodes annotation on NAR",
+			slog.String("nodes", nodeList))
+	}
 
-		if err := nodeOps.DrainNode(ctx, hostname); err != nil {
-			return fmt.Errorf("failed to drain node %s: %w", hostname, err)
-		}
-
-		// Delete the Node object from the spoke cluster
-		spokeNode := &corev1.Node{}
-		spokeNode.Name = hostname
-		if err := spokeClient.Delete(ctx, spokeNode); err != nil {
-			if !errors.IsNotFound(err) {
-				return fmt.Errorf("failed to delete node %s from spoke cluster: %w", hostname, err)
+	// Check if all nodes have Drained=Completed
+	narNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
+	for _, nodeID := range nodeIDs {
+		an := &hwmgmtv1alpha1.AllocatedNode{}
+		if err := t.client.Get(ctx, types.NamespacedName{
+			Name: nodeID, Namespace: narNS,
+		}, an); err != nil {
+			if errors.IsNotFound(err) {
+				continue
 			}
+			return false, fmt.Errorf("failed to get AllocatedNode %s: %w", nodeID, err)
 		}
-		t.logger.InfoContext(ctx, "Drained and deleted node from spoke cluster",
-			slog.String("hostname", hostname))
+
+		drainCond := meta.FindStatusCondition(an.Status.Conditions, string(hwmgmtv1alpha1.Deprovisioned))
+		if drainCond == nil || drainCond.Reason != string(hwmgmtv1alpha1.Completed) {
+			t.logger.InfoContext(ctx, "Waiting for node drain to complete",
+				slog.String("allocatedNode", nodeID))
+			return false, nil
+		}
 	}
 
-	return nil
+	return true, nil
 }
 
 // buildIntermediateCIWithPruneManifests constructs a CI that includes the
@@ -416,7 +420,10 @@ func buildIntermediateCIWithPruneManifests(
 		removedNodeEntries = append(removedNodeEntries, nodeCopy)
 	}
 
-	intermediateSpec := intermediateCI.Object["spec"].(map[string]any)
+	intermediateSpec, ok := intermediateCI.Object["spec"].(map[string]any)
+	if !ok {
+		return intermediateCI
+	}
 	intermediateNodes, _ := intermediateSpec["nodes"].([]any)
 	intermediateNodes = append(intermediateNodes, removedNodeEntries...)
 	intermediateSpec["nodes"] = intermediateNodes
@@ -559,13 +566,14 @@ func (t *provisioningRequestReconcilerTask) deleteScaleInAgentCRs(
 		for i := range agentList.Items {
 			agent := &agentList.Items[i]
 			hostname := getAgentHostname(agent)
-			if !removedSet[hostname] {
+			if hostname == "" || !removedSet[hostname] {
 				continue
 			}
 			if err := t.client.Delete(ctx, agent); err != nil {
 				if !errors.IsNotFound(err) {
 					return fmt.Errorf("failed to delete Agent %s/%s: %w", ns, agent.GetName(), err)
 				}
+				continue
 			}
 			t.logger.InfoContext(ctx, "Deleted Agent CR for removed node",
 				slog.String("agent", agent.GetName()),
@@ -734,9 +742,13 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx contex
 		if allGone {
 			t.logger.InfoContext(ctx, "All removed nodes have left the cluster, performing cleanup")
 
-			// Now it's safe to delete AllocatedNodes and clean up the host map
-			if err := t.handleScaleInCleanup(ctx, clusterInstance); err != nil {
+			// Wait for NAR controller to complete deallocation, then clean up host map
+			done, err := t.handleScaleInCleanup(ctx, clusterInstance)
+			if err != nil {
 				return fmt.Errorf("failed to perform scale-in cleanup: %w", err)
+			}
+			if !done {
+				return nil
 			}
 
 			t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount = renderedNodeCount
@@ -1393,10 +1405,11 @@ func isNodeReady(node *corev1.Node) bool {
 
 // cleanupScaleOutSpokeAccess removes the spoke client resources created for
 // scale-out CSR approval.
-// handleScaleInCleanup performs post-drain cleanup for scale-in operations:
-// deletes AllocatedNode CRs for removed nodes and cleans up AllocatedNodeHostMap.
+// handleScaleInCleanup waits for the NAR controller to complete scale-in
+// processing (annotation removed) and then cleans up AllocatedNodeHostMap.
+// Returns done=false if the NAR controller is still processing.
 func (t *provisioningRequestReconcilerTask) handleScaleInCleanup(
-	ctx context.Context, renderedCI *unstructured.Unstructured) error {
+	ctx context.Context, renderedCI *unstructured.Unstructured) (bool, error) {
 
 	renderedNodes := getNodeRolesByHostname(renderedCI)
 
@@ -1406,37 +1419,31 @@ func (t *provisioningRequestReconcilerTask) handleScaleInCleanup(
 		hostnameToNodeID[hostname] = nodeID
 	}
 
-	// Identify AllocatedNodes to delete (those whose hostname is not in the rendered CI)
+	// Identify AllocatedNodes to remove (those whose hostname is not in the rendered CI)
 	var nodesToDelete []string
 	for hostname, nodeID := range hostnameToNodeID {
 		if _, exists := renderedNodes[hostname]; !exists {
 			nodesToDelete = append(nodesToDelete, nodeID)
-			t.logger.InfoContext(ctx, "Marking AllocatedNode for deletion",
-				slog.String("allocatedNode", nodeID),
-				slog.String("hostname", hostname))
 		}
 	}
 
 	if len(nodesToDelete) == 0 {
-		return nil
+		return true, nil
 	}
 
-	// Delete AllocatedNode CRs — the AllocatedNode controller handles BMH deallocation
-	narNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
-	for _, nodeID := range nodesToDelete {
-		an := &hwmgmtv1alpha1.AllocatedNode{}
-		an.Name = nodeID
-		an.Namespace = narNS
-		if err := t.client.Delete(ctx, an); err != nil {
-			if !errors.IsNotFound(err) {
-				return fmt.Errorf("failed to delete AllocatedNode %s: %w", nodeID, err)
-			}
-		}
-		t.logger.InfoContext(ctx, "Deleted AllocatedNode",
-			slog.String("allocatedNode", nodeID))
+	// The scale-in-nodes annotation was set by handleScaleInDrain. The NAR
+	// controller handles drain, Node deletion from spoke, AllocatedNode
+	// deletion, and nodeNames cleanup. Wait for it to finish.
+	nar, err := t.getNAR(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get NAR for scale-in cleanup: %w", err)
+	}
+	if _, ok := nar.GetAnnotations()[hwmgrcontroller.ScaleInNodesAnnotation]; ok {
+		t.logger.InfoContext(ctx, "Waiting for NAR controller to complete scale-in")
+		return false, nil
 	}
 
-	// Clean up AllocatedNodeHostMap — remove entries for deleted nodes
+	// Clean up AllocatedNodeHostMap — remove entries for deallocated nodes
 	for _, nodeID := range nodesToDelete {
 		delete(t.object.Status.Extensions.AllocatedNodeHostMap, nodeID)
 	}
@@ -1444,7 +1451,7 @@ func (t *provisioningRequestReconcilerTask) handleScaleInCleanup(
 	ctlrutils.SetProvisioningStateInProgress(t.object,
 		fmt.Sprintf("Scale-in: removed %d node(s), cleaning up", len(nodesToDelete)))
 
-	return nil
+	return true, nil
 }
 
 // checkRemovedNodesGone verifies that no spoke node exists for hostnames that
@@ -1472,10 +1479,14 @@ func (t *provisioningRequestReconcilerTask) checkRemovedNodesGone(
 		spokeNodes[node.Name] = true
 	}
 
-	// Check that no spoke node exists for hostnames not in the rendered CI
+	// Derive the set of removed hostnames from AllocatedNodeHostMap.
+	// Only check these specific hostnames on the spoke, not all spoke nodes.
 	renderedHostnames := getNodeRolesByHostname(renderedCI)
-	for hostname := range spokeNodes {
-		if _, inRendered := renderedHostnames[hostname]; !inRendered {
+	for _, hostname := range t.object.Status.Extensions.AllocatedNodeHostMap {
+		if _, inRendered := renderedHostnames[hostname]; inRendered {
+			continue
+		}
+		if spokeNodes[hostname] {
 			t.logger.InfoContext(ctx, "Removed node still present on spoke",
 				slog.String("hostname", hostname))
 			return false, nil

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -257,13 +257,14 @@ func (t *provisioningRequestReconcilerTask) handleScaleInDrain(
 		return false, fmt.Errorf("failed to update scale-in status: %w", updateErr)
 	}
 
-	// Resolve BMH identities before requesting drain. The NAR controller
-	// deletes AllocatedNodes during scale-in processing, so lookups must
-	// happen while the CRs still exist.
+	// Resolve BMH identities while AllocatedNodes still exist. The NAR
+	// controller deletes them during scale-in processing, so these lookups
+	// must happen before or concurrently with the drain request.
 	removedNodeIDs := t.hostnameToAllocatedNodeIDs(removedHostnames)
 	removedNodeBMHs, err := t.lookupRemovedNodeBMHs(ctx, removedHostnames)
 	if err != nil {
-		return false, fmt.Errorf("failed to look up BMH info for removed nodes: %w", err)
+		t.logger.WarnContext(ctx, "Failed to look up BMH info for removed nodes",
+			slog.Any("error", err))
 	}
 
 	// Step 1: Request drain via NAR annotation. The NAR controller handles

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -775,7 +775,7 @@ var _ = Describe("validateScaleWorkerOnly", func() {
 		Expect(validateScaleWorkerOnly(existingCI, renderedCI)).To(Succeed())
 	})
 
-	It("should reject removing worker nodes (scale-in not yet supported)", func() {
+	It("should allow removing worker nodes", func() {
 		existingCI := makeCI([]map[string]any{
 			{"hostName": "master1", "role": "master"},
 			{"hostName": "worker1", "role": "worker"},
@@ -785,12 +785,10 @@ var _ = Describe("validateScaleWorkerOnly", func() {
 			{"hostName": "master1", "role": "master"},
 			{"hostName": "worker1", "role": "worker"},
 		})
-		err := validateScaleWorkerOnly(existingCI, renderedCI)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("node removal is not yet supported"))
+		Expect(validateScaleWorkerOnly(existingCI, renderedCI)).To(Succeed())
 	})
 
-	It("should reject replacing a worker node (simultaneous add and remove)", func() {
+	It("should allow replacing a worker node (simultaneous add and remove)", func() {
 		existingCI := makeCI([]map[string]any{
 			{"hostName": "master1", "role": "master"},
 			{"hostName": "worker1", "role": "worker"},
@@ -799,9 +797,7 @@ var _ = Describe("validateScaleWorkerOnly", func() {
 			{"hostName": "master1", "role": "master"},
 			{"hostName": "worker2", "role": "worker"},
 		})
-		err := validateScaleWorkerOnly(existingCI, renderedCI)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("node removal is not yet supported"))
+		Expect(validateScaleWorkerOnly(existingCI, renderedCI)).To(Succeed())
 	})
 
 	It("should reject adding master nodes", func() {
@@ -833,7 +829,7 @@ var _ = Describe("validateScaleWorkerOnly", func() {
 		})
 		err := validateScaleWorkerOnly(existingCI, renderedCI)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("node removal is not yet supported"))
+		Expect(err.Error()).To(ContainSubstring("cannot remove master node"))
 		Expect(err.Error()).To(ContainSubstring("master3"))
 	})
 
@@ -941,5 +937,172 @@ var _ = Describe("scale-out detection via getNodeRolesByHostname", func() {
 		existingCount := len(getNodeRolesByHostname(existingCI))
 		renderedCount := len(getNodeRolesByHostname(renderedCI))
 		Expect(renderedCount).To(Equal(existingCount))
+	})
+})
+
+var _ = Describe("buildIntermediateCIWithPruneManifests", func() {
+	makeCI := func(nodes []map[string]any) *unstructured.Unstructured {
+		ci := &unstructured.Unstructured{}
+		ci.Object = map[string]any{
+			"spec": map[string]any{
+				"nodes": func() []any {
+					result := make([]any, len(nodes))
+					for i, n := range nodes {
+						result[i] = n
+					}
+					return result
+				}(),
+			},
+		}
+		return ci
+	}
+
+	It("should add removed node entries with pruneManifests", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master", "bmcAddress": "redfish://1.2.3.4"},
+			{"hostName": "worker1", "role": "worker", "bmcAddress": "redfish://1.2.3.5"},
+			{"hostName": "worker2", "role": "worker", "bmcAddress": "redfish://1.2.3.6"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master", "bmcAddress": "redfish://1.2.3.4"},
+			{"hostName": "worker1", "role": "worker", "bmcAddress": "redfish://1.2.3.5"},
+		})
+
+		result := buildIntermediateCIWithPruneManifests(renderedCI, existingCI, []string{"worker2"})
+
+		spec := result.Object["spec"].(map[string]any)
+		nodes := spec["nodes"].([]any)
+		Expect(nodes).To(HaveLen(3))
+
+		// The third node (worker2) should have pruneManifests
+		worker2 := nodes[2].(map[string]any)
+		Expect(worker2["hostName"]).To(Equal("worker2"))
+		Expect(worker2["pruneManifests"]).ToNot(BeNil())
+
+		prune := worker2["pruneManifests"].([]any)
+		Expect(prune).To(HaveLen(2))
+		Expect(prune[0].(map[string]any)["kind"]).To(Equal("InfraEnv"))
+		Expect(prune[1].(map[string]any)["kind"]).To(Equal("NMStateConfig"))
+	})
+
+	It("should not modify the original rendered CI", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+		})
+
+		result := buildIntermediateCIWithPruneManifests(renderedCI, existingCI, []string{"worker1"})
+
+		// Original rendered CI should still have 1 node
+		origSpec := renderedCI.Object["spec"].(map[string]any)
+		origNodes := origSpec["nodes"].([]any)
+		Expect(origNodes).To(HaveLen(1))
+
+		// Result should have 2 nodes
+		resultSpec := result.Object["spec"].(map[string]any)
+		resultNodes := resultSpec["nodes"].([]any)
+		Expect(resultNodes).To(HaveLen(2))
+	})
+
+	It("should handle multiple removed nodes", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+			{"hostName": "worker2", "role": "worker"},
+			{"hostName": "worker3", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+
+		result := buildIntermediateCIWithPruneManifests(renderedCI, existingCI, []string{"worker2", "worker3"})
+
+		spec := result.Object["spec"].(map[string]any)
+		nodes := spec["nodes"].([]any)
+		Expect(nodes).To(HaveLen(4))
+
+		// Both removed nodes should have pruneManifests
+		for _, node := range nodes[2:] {
+			nodeMap := node.(map[string]any)
+			Expect(nodeMap["pruneManifests"]).ToNot(BeNil())
+		}
+	})
+
+	It("should not include BMH in pruneManifests", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+		})
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+		})
+
+		result := buildIntermediateCIWithPruneManifests(renderedCI, existingCI, []string{"worker1"})
+
+		spec := result.Object["spec"].(map[string]any)
+		nodes := spec["nodes"].([]any)
+		worker1 := nodes[1].(map[string]any)
+		prune := worker1["pruneManifests"].([]any)
+
+		for _, entry := range prune {
+			kind := entry.(map[string]any)["kind"].(string)
+			Expect(kind).ToNot(Equal("BareMetalHost"))
+		}
+	})
+})
+
+var _ = Describe("getAgentHostname", func() {
+	It("should extract hostname from spec.hostname", func() {
+		agent := &unstructured.Unstructured{
+			Object: map[string]any{
+				"spec": map[string]any{
+					"hostname": "worker1.cluster.example.com",
+				},
+			},
+		}
+		Expect(getAgentHostname(agent)).To(Equal("worker1.cluster.example.com"))
+	})
+
+	It("should fall back to status.inventory.hostname", func() {
+		agent := &unstructured.Unstructured{
+			Object: map[string]any{
+				"spec": map[string]any{},
+				"status": map[string]any{
+					"inventory": map[string]any{
+						"hostname": "worker2.cluster.example.com",
+					},
+				},
+			},
+		}
+		Expect(getAgentHostname(agent)).To(Equal("worker2.cluster.example.com"))
+	})
+
+	It("should prefer spec.hostname over status.inventory.hostname", func() {
+		agent := &unstructured.Unstructured{
+			Object: map[string]any{
+				"spec": map[string]any{
+					"hostname": "from-spec",
+				},
+				"status": map[string]any{
+					"inventory": map[string]any{
+						"hostname": "from-status",
+					},
+				},
+			},
+		}
+		Expect(getAgentHostname(agent)).To(Equal("from-spec"))
+	})
+
+	It("should return empty string when no hostname is found", func() {
+		agent := &unstructured.Unstructured{
+			Object: map[string]any{
+				"spec": map[string]any{},
+			},
+		}
+		Expect(getAgentHostname(agent)).To(BeEmpty())
 	})
 })

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -97,7 +97,9 @@ func GetClusterTemplateRefName(name, version string) string {
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=list;watch
 //+kubebuilder:rbac:groups=lcm.openshift.io,resources=imagebasedgroupupgrades,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=lcm.openshift.io,resources=imagebasedgroupupgrades/status,verbs=get
-//+kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;patch;update;watch
+//+kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;patch;update;watch;delete
+//+kubebuilder:rbac:groups=agent-install.openshift.io,resources=infraenvs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=agent-install.openshift.io,resources=nmstateconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;patch;update;watch
 //+kubebuilder:rbac:groups=observability.open-cluster-management.io,resources=observabilityaddons,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch;create;delete
@@ -208,6 +210,20 @@ func (t *provisioningRequestReconcilerTask) executeProvisioningPhases(ctx contex
 	renderedClusterInstance, unstructuredClusterInstance, result, err := t.executePreProvisioningPhase(ctx)
 	if err != nil || renderedClusterInstance == nil {
 		return nil, result, err
+	}
+
+	// Handle scale-in pre-processing before hardware provisioning. Nodes must
+	// be cordoned, drained, and per-node resources (InfraEnv, NMStateConfig)
+	// pruned via siteconfig before the hardware provisioning phase updates
+	// the NAR and CI.
+	scaleInActive, err := t.handleScaleInDrain(ctx, unstructuredClusterInstance)
+	if err != nil {
+		ctlrutils.LogError(ctx, t.logger, "Scale-in pre-processing failed", err)
+		result, _ := requeueWithError(err)
+		return nil, result, err
+	}
+	if scaleInActive {
+		return nil, requeueWithMediumInterval(), nil
 	}
 
 	// Phase 2: Hardware provisioning
@@ -440,6 +456,26 @@ func (t *provisioningRequestReconcilerTask) checkOverallProvisioningTimeout(ctx 
 
 // handleClusterUpgrades handles cluster upgrade logic
 func (t *provisioningRequestReconcilerTask) handleClusterUpgrades(ctx context.Context, clusterName string) (ctrl.Result, error) {
+	// Block upgrades while a scale operation is in progress. Compare the
+	// rendered CI hostname set against the fulfilled node count to detect
+	// active scaling. Use hostname set comparison (not count) because a
+	// mixed add+remove could leave the count unchanged.
+	if t.object.Status.Extensions.ClusterDetails != nil {
+		fulfilledCount := t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount
+		existingCI, err := t.getExistingClusterInstance(ctx)
+		if err == nil && existingCI != nil {
+			if ciUnstructured, convErr := ctlrutils.ConvertToUnstructured(*existingCI); convErr == nil {
+				currentNodeCount := len(getNodeRolesByHostname(ciUnstructured))
+				if fulfilledCount > 0 && currentNodeCount != fulfilledCount {
+					t.logger.InfoContext(ctx, "Skipping upgrade: scale operation in progress",
+						slog.Int("fulfilledNodeCount", fulfilledCount),
+						slog.Int("currentNodeCount", currentNodeCount))
+					return requeueWithMediumInterval(), nil
+				}
+			}
+		}
+	}
+
 	shouldUpgrade, result, err := t.IsUpgradeRequested(ctx, clusterName)
 	if err != nil {
 		return requeueWithError(err)

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -460,13 +460,17 @@ func (t *provisioningRequestReconcilerTask) handleClusterUpgrades(ctx context.Co
 	// rendered CI hostname set against the fulfilled node count to detect
 	// active scaling. Use hostname set comparison (not count) because a
 	// mixed add+remove could leave the count unchanged.
-	if t.object.Status.Extensions.ClusterDetails != nil {
+	if t.object.Status.Extensions.ClusterDetails != nil &&
+		t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount > 0 {
 		fulfilledCount := t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount
 		existingCI, err := t.getExistingClusterInstance(ctx)
-		if err == nil && existingCI != nil {
+		if err != nil {
+			return requeueWithMediumInterval(), fmt.Errorf("failed to get existing ClusterInstance for upgrade check: %w", err)
+		}
+		if existingCI != nil {
 			if ciUnstructured, convErr := ctlrutils.ConvertToUnstructured(*existingCI); convErr == nil {
 				currentNodeCount := len(getNodeRolesByHostname(ciUnstructured))
-				if fulfilledCount > 0 && currentNodeCount != fulfilledCount {
+				if currentNodeCount != fulfilledCount {
 					t.logger.InfoContext(ctx, "Skipping upgrade: scale operation in progress",
 						slog.Int("fulfilledNodeCount", fulfilledCount),
 						slog.Int("currentNodeCount", currentNodeCount))

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -36,6 +36,8 @@ import (
 
 const ConfigAnnotation = "clcm.openshift.io/config-in-progress"
 
+const ScaleInNodesAnnotation = "clcm.openshift.io/scale-in-nodes"
+
 // syncSkipCleanupToAllocatedNodes propagates the SkipCleanup field from the NAR
 // to all child AllocatedNodes, so the AllocatedNode deletion handler can read it
 // directly without looking up the NAR.

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -745,20 +745,6 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestProcessing(
 	if full {
 		r.Logger.InfoContext(ctx, "NodeAllocationRequest is fully allocated")
 
-		// Populate Status.Hostname on each AllocatedNode from the PR's
-		// AllocatedNodeHostMap. This makes the hostname available for
-		// subsequent operations (drain, deallocation) without waiting
-		// for a day-2 config trigger.
-		nodelist, err := hwmgrutils.GetChildNodes(ctx, r.Logger, r.Client, nodeAllocationRequest)
-		if err != nil {
-			return hwmgrutils.RequeueWithShortInterval(),
-				fmt.Errorf("failed to list AllocatedNodes for hostname population: %w", err)
-		}
-		if err := populateNodeHostnames(ctx, r.Client, r.Logger, nodelist, nodeAllocationRequest); err != nil {
-			r.Logger.WarnContext(ctx, "Failed to populate node hostnames, will retry on next reconcile",
-				slog.Any("error", err))
-		}
-
 		if err := hwmgrutils.UpdateNodeAllocationRequestStatusCondition(
 			ctx, r.Client, nodeAllocationRequest,
 			hwmgmtv1alpha1.Provisioned, hwmgmtv1alpha1.Completed,

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -10,8 +10,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,6 +168,23 @@ func (r *NodeAllocationRequestReconciler) SetupWithManager(mgr ctrl.Manager) err
 	return nil
 }
 
+// tryPopulateNodeHostnames attempts to populate Status.Hostname on
+// AllocatedNodes that don't have it yet. Failures are logged but not fatal.
+func (r *NodeAllocationRequestReconciler) tryPopulateNodeHostnames(
+	ctx context.Context, nar *hwmgmtv1alpha1.NodeAllocationRequest) {
+
+	nodelist, err := hwmgrutils.GetChildNodes(ctx, r.Logger, r.Client, nar)
+	if err != nil {
+		r.Logger.DebugContext(ctx, "Failed to list AllocatedNodes for hostname population",
+			slog.Any("error", err))
+		return
+	}
+	if err := populateNodeHostnames(ctx, r.Client, r.Logger, nodelist, nar); err != nil {
+		r.Logger.DebugContext(ctx, "Failed to populate node hostnames, will retry",
+			slog.Any("error", err))
+	}
+}
+
 // HandleNodeAllocationRequest processes the NodeAllocationRequest CR
 func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 	ctx context.Context, nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest) (ctrl.Result, error) {
@@ -254,6 +273,12 @@ func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 		}
 	}
 
+	// Handle scale-in annotations before the FSM. These are set by the PR
+	// controller to request drain and deallocation of specific nodes.
+	if result, handled, err := r.handleScaleInAnnotations(ctx, nodeAllocationRequest); handled || err != nil {
+		return result, err
+	}
+
 	switch hwmgrutils.DetermineAction(ctx, r.Logger, nodeAllocationRequest) {
 	case hwmgrutils.NodeAllocationRequestFSMCreate:
 		return r.handleNewNodeAllocationRequestCreate(ctx, nodeAllocationRequest)
@@ -267,6 +292,203 @@ func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 	}
 
 	return result, nil
+}
+
+// handleScaleInAnnotations checks for the scale-in-nodes annotation and
+// processes it. Returns handled=true if the annotation was found.
+func (r *NodeAllocationRequestReconciler) handleScaleInAnnotations(
+	ctx context.Context,
+	nar *hwmgmtv1alpha1.NodeAllocationRequest) (ctrl.Result, bool, error) {
+
+	annotations := nar.GetAnnotations()
+	if annotations == nil {
+		return ctrl.Result{}, false, nil
+	}
+
+	nodeList, ok := annotations[ScaleInNodesAnnotation]
+	if !ok {
+		return ctrl.Result{}, false, nil
+	}
+
+	result, err := r.handleScaleInNodesAnnotation(ctx, nar, nodeList)
+	return result, true, err
+}
+
+// handleScaleInNodesAnnotation performs the full scale-in lifecycle for the
+// listed AllocatedNodes: drain on the spoke, delete the Node object from
+// the spoke, delete the AllocatedNode CR, and clean up nodeNames. Sets the
+// Deprovisioned condition on each AllocatedNode for observability. Removes
+// the annotation when all nodes are fully processed.
+func (r *NodeAllocationRequestReconciler) handleScaleInNodesAnnotation(
+	ctx context.Context,
+	nar *hwmgmtv1alpha1.NodeAllocationRequest,
+	nodeList string) (ctrl.Result, error) {
+
+	nodeNames := strings.Split(nodeList, ",")
+	r.Logger.InfoContext(ctx, "Processing scale-in-nodes annotation",
+		slog.Any("nodes", nodeNames))
+
+	spokeClient, spokeClientset, err := createSpokeClients(ctx, r.Client, nar)
+	noSpokeKubeconfig := err != nil && strings.Contains(err.Error(), "no kubeconfig secret found")
+	if err != nil && !noSpokeKubeconfig {
+		return hwmgrutils.RequeueWithMediumInterval(),
+			fmt.Errorf("failed to create spoke clients for scale-in: %w", err)
+	}
+
+	var nodeOps NodeOps
+	if !noSpokeKubeconfig {
+		nodeOps = NewNodeOps(spokeClient, spokeClientset, r.Logger, false)
+	}
+
+	var remainingNodeNames []string
+	for _, nn := range nar.Status.Properties.NodeNames {
+		remainingNodeNames = append(remainingNodeNames, nn)
+	}
+
+	r.tryPopulateNodeHostnames(ctx, nar)
+
+	allProcessed := true
+	for _, nodeName := range nodeNames {
+		nodeName = strings.TrimSpace(nodeName)
+		if nodeName == "" {
+			continue
+		}
+
+		an := &hwmgmtv1alpha1.AllocatedNode{}
+		if err := r.Client.Get(ctx, client.ObjectKey{
+			Name: nodeName, Namespace: r.Namespace,
+		}, an); err != nil {
+			if errors.IsNotFound(err) {
+				remainingNodeNames = removeFromSlice(remainingNodeNames, nodeName)
+				continue
+			}
+			return hwmgrutils.RequeueWithShortInterval(),
+				fmt.Errorf("failed to get AllocatedNode %s: %w", nodeName, err)
+		}
+
+		// Phase 1: Drain the node on the spoke
+		deprovCond := meta.FindStatusCondition(an.Status.Conditions, string(hwmgmtv1alpha1.Deprovisioned))
+		if deprovCond == nil || deprovCond.Reason == string(hwmgmtv1alpha1.InProgress) {
+			if nodeOps != nil && an.Status.Hostname == "" {
+				allProcessed = false
+				r.Logger.WarnContext(ctx, "Hostname not yet populated, deferring scale-in for node",
+					slog.String("allocatedNode", nodeName))
+				continue
+			}
+			if nodeOps != nil {
+				hwmgrutils.SetStatusCondition(&an.Status.Conditions,
+					string(hwmgmtv1alpha1.Deprovisioned), string(hwmgmtv1alpha1.InProgress),
+					metav1.ConditionFalse, string(hwmgmtv1alpha1.NodeDraining))
+				if err := r.Client.Status().Update(ctx, an); err != nil {
+					return hwmgrutils.RequeueWithShortInterval(),
+						fmt.Errorf("failed to update Deprovisioned condition on AllocatedNode %s: %w", nodeName, err)
+				}
+
+				r.Logger.InfoContext(ctx, "Draining node for scale-in",
+					slog.String("allocatedNode", nodeName),
+					slog.String("hostname", an.Status.Hostname))
+
+				if err := nodeOps.DrainNode(ctx, an.Status.Hostname); err != nil {
+					allProcessed = false
+					r.Logger.WarnContext(ctx, "Drain failed, will retry",
+						slog.String("hostname", an.Status.Hostname),
+						slog.Any("error", err))
+					continue
+				}
+			}
+
+			hwmgrutils.SetStatusCondition(&an.Status.Conditions,
+				string(hwmgmtv1alpha1.Deprovisioned), string(hwmgmtv1alpha1.Completed),
+				metav1.ConditionTrue, "Node deprovisioned")
+			if err := r.Client.Status().Update(ctx, an); err != nil {
+				return hwmgrutils.RequeueWithShortInterval(),
+					fmt.Errorf("failed to update Deprovisioned condition on AllocatedNode %s: %w", nodeName, err)
+			}
+		}
+
+		// Phase 2: Delete Node from spoke and AllocatedNode CR
+		if spokeClient != nil && an.Status.Hostname != "" {
+			spokeNode := &corev1.Node{}
+			spokeNode.Name = an.Status.Hostname
+			if err := spokeClient.Delete(ctx, spokeNode); err != nil {
+				if !errors.IsNotFound(err) {
+					return hwmgrutils.RequeueWithShortInterval(),
+						fmt.Errorf("failed to delete node %s from spoke: %w", an.Status.Hostname, err)
+				}
+			}
+			r.Logger.InfoContext(ctx, "Deleted node from spoke cluster",
+				slog.String("hostname", an.Status.Hostname))
+		}
+
+		if err := r.Client.Delete(ctx, an); err != nil {
+			if !errors.IsNotFound(err) {
+				return hwmgrutils.RequeueWithShortInterval(),
+					fmt.Errorf("failed to delete AllocatedNode %s: %w", nodeName, err)
+			}
+		}
+		r.Logger.InfoContext(ctx, "Deleted AllocatedNode",
+			slog.String("allocatedNode", nodeName))
+
+		remainingNodeNames = removeFromSlice(remainingNodeNames, nodeName)
+	}
+
+	if !allProcessed {
+		return hwmgrutils.RequeueWithMediumInterval(), nil
+	}
+
+	// Update nodeNames in NAR status. Use a direct status update (not
+	// UpdateNodeAllocationRequestProperties, which does a union merge
+	// and would re-add the removed nodes).
+	freshNAR := &hwmgmtv1alpha1.NodeAllocationRequest{}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(nar), freshNAR); err != nil {
+		return hwmgrutils.RequeueWithShortInterval(),
+			fmt.Errorf("failed to re-fetch NAR for nodeNames update: %w", err)
+	}
+	freshNAR.Status.Properties.NodeNames = remainingNodeNames
+	if err := r.Client.Status().Update(ctx, freshNAR); err != nil {
+		return hwmgrutils.RequeueWithShortInterval(),
+			fmt.Errorf("failed to update nodeNames after scale-in: %w", err)
+	}
+	r.Logger.InfoContext(ctx, "Updated NodeAllocationRequest properties",
+		slog.Int("nodeCount", len(remainingNodeNames)))
+
+	if err := r.removeAnnotation(ctx, nar, ScaleInNodesAnnotation); err != nil {
+		return hwmgrutils.RequeueWithShortInterval(), err
+	}
+
+	r.Logger.InfoContext(ctx, "Scale-in processing complete")
+	return hwmgrutils.DoNotRequeue(), nil
+}
+
+// removeFromSlice removes the first occurrence of val from s.
+func removeFromSlice(s []string, val string) []string {
+	for i, v := range s {
+		if v == val {
+			return append(s[:i], s[i+1:]...)
+		}
+	}
+	return s
+}
+
+// removeAnnotation removes the specified annotation from the NAR.
+// Re-fetches the NAR to ensure the resourceVersion is current.
+func (r *NodeAllocationRequestReconciler) removeAnnotation(
+	ctx context.Context, nar *hwmgmtv1alpha1.NodeAllocationRequest,
+	annotation string) error {
+
+	fresh := &hwmgmtv1alpha1.NodeAllocationRequest{}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(nar), fresh); err != nil {
+		return fmt.Errorf("failed to re-fetch NAR %s: %w", nar.Name, err)
+	}
+	patch := client.MergeFromWithOptions(fresh.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	annotations := fresh.GetAnnotations()
+	delete(annotations, annotation)
+	fresh.SetAnnotations(annotations)
+	if err := r.Client.Patch(ctx, fresh, patch); err != nil {
+		return fmt.Errorf("failed to remove annotation %s from NAR %s: %w",
+			annotation, nar.Name, err)
+	}
+	return nil
 }
 
 func (r *NodeAllocationRequestReconciler) handleNewNodeAllocationRequestCreate(
@@ -340,6 +562,11 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestSpecChanged
 		return hwmgrutils.RequeueWithShortInterval(),
 			fmt.Errorf("failed to sync skipCleanup to AllocatedNodes: %w", err)
 	}
+
+	// Populate Status.Hostname on AllocatedNodes that don't have it yet.
+	// The hostmap may have been updated by the PR controller since the last
+	// reconcile (e.g., after scale-out node allocation).
+	r.tryPopulateNodeHostnames(ctx, nodeAllocationRequest)
 
 	// Handle post-provisioning setup for IBI nodes when ClusterProvisioned is set.
 	// This sets online=true and removes the detached annotation so BMO can manage the nodes.
@@ -517,6 +744,21 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestProcessing(
 	// No explicit requeue requested by the checker: decide based on "full".
 	if full {
 		r.Logger.InfoContext(ctx, "NodeAllocationRequest is fully allocated")
+
+		// Populate Status.Hostname on each AllocatedNode from the PR's
+		// AllocatedNodeHostMap. This makes the hostname available for
+		// subsequent operations (drain, deallocation) without waiting
+		// for a day-2 config trigger.
+		nodelist, err := hwmgrutils.GetChildNodes(ctx, r.Logger, r.Client, nodeAllocationRequest)
+		if err != nil {
+			return hwmgrutils.RequeueWithShortInterval(),
+				fmt.Errorf("failed to list AllocatedNodes for hostname population: %w", err)
+		}
+		if err := populateNodeHostnames(ctx, r.Client, r.Logger, nodelist, nodeAllocationRequest); err != nil {
+			r.Logger.WarnContext(ctx, "Failed to populate node hostnames, will retry on next reconcile",
+				slog.Any("error", err))
+		}
+
 		if err := hwmgrutils.UpdateNodeAllocationRequestStatusCondition(
 			ctx, r.Client, nodeAllocationRequest,
 			hwmgmtv1alpha1.Provisioned, hwmgmtv1alpha1.Completed,

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
@@ -28,6 +28,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
 )
 
@@ -476,5 +479,164 @@ var _ = Describe("handleScaleOut", func() {
 		_, handled, err := reconciler.handleScaleOut(ctx, nar)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(handled).To(BeFalse())
+	})
+})
+
+var _ = Describe("handleScaleInAnnotations", func() {
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+		reconciler *NodeAllocationRequestReconciler
+		logger     *slog.Logger
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		scheme := runtime.NewScheme()
+		Expect(hwmgmtv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(provisioningv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(
+				&hwmgmtv1alpha1.AllocatedNode{},
+				&hwmgmtv1alpha1.NodeAllocationRequest{},
+				&provisioningv1alpha1.ProvisioningRequest{},
+			).
+			WithIndex(&hwmgmtv1alpha1.AllocatedNode{}, "spec.nodeAllocationRequest",
+				func(obj client.Object) []string {
+					an := obj.(*hwmgmtv1alpha1.AllocatedNode)
+					return []string{an.Spec.NodeAllocationRequest}
+				}).
+			Build()
+
+		reconciler = &NodeAllocationRequestReconciler{
+			Client:    fakeClient,
+			Logger:    logger,
+			Namespace: "test-ns",
+		}
+
+		// Create a ProvisioningRequest (looked up by createSpokeClients)
+		pr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-nar",
+			},
+			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
+				Name:            "test",
+				TemplateName:    "test-template",
+				TemplateVersion: "v1",
+			},
+		}
+		Expect(fakeClient.Create(ctx, pr)).To(Succeed())
+		pr.Status.Extensions.ClusterDetails = &provisioningv1alpha1.ClusterDetails{
+			Name: "test-cluster",
+		}
+		Expect(fakeClient.Status().Update(ctx, pr)).To(Succeed())
+	})
+
+	It("should return handled=false when no annotation is present", func() {
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-nar",
+				Namespace: "test-ns",
+			},
+		}
+		Expect(fakeClient.Create(ctx, nar)).To(Succeed())
+
+		_, handled, err := reconciler.handleScaleInAnnotations(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeFalse())
+	})
+
+	It("should return handled=true when scale-in annotation is present", func() {
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-nar",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					ScaleInNodesAnnotation: "node-1",
+				},
+			},
+		}
+		Expect(fakeClient.Create(ctx, nar)).To(Succeed())
+
+		_, handled, err := reconciler.handleScaleInAnnotations(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeTrue())
+	})
+
+	It("should set Deprovisioned condition and delete AllocatedNode when no spoke", func() {
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-nar",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					ScaleInNodesAnnotation: "node-1",
+				},
+			},
+		}
+		Expect(fakeClient.Create(ctx, nar)).To(Succeed())
+		nar.Status.Properties.NodeNames = []string{"node-1", "node-2"}
+		Expect(fakeClient.Status().Update(ctx, nar)).To(Succeed())
+
+		node := &hwmgmtv1alpha1.AllocatedNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node-1",
+				Namespace: "test-ns",
+			},
+			Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
+				NodeAllocationRequest: "test-nar",
+			},
+		}
+		Expect(fakeClient.Create(ctx, node)).To(Succeed())
+		node.Status.Hostname = "worker1.example.com"
+		Expect(fakeClient.Status().Update(ctx, node)).To(Succeed())
+
+		_, handled, err := reconciler.handleScaleInAnnotations(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeTrue())
+
+		// Verify annotation was removed
+		updatedNAR := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nar), updatedNAR)).To(Succeed())
+		Expect(updatedNAR.GetAnnotations()).ToNot(HaveKey(ScaleInNodesAnnotation))
+
+		// Verify nodeNames was pruned
+		Expect(updatedNAR.Status.Properties.NodeNames).To(ConsistOf("node-2"))
+
+		// Verify AllocatedNode was deleted
+		deletedNode := &hwmgmtv1alpha1.AllocatedNode{}
+		err = fakeClient.Get(ctx, client.ObjectKeyFromObject(node), deletedNode)
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should skip AllocatedNodes that are not found and prune nodeNames", func() {
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-nar",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					ScaleInNodesAnnotation: "nonexistent-node",
+				},
+			},
+		}
+		Expect(fakeClient.Create(ctx, nar)).To(Succeed())
+		nar.Status.Properties.NodeNames = []string{"nonexistent-node", "other-node"}
+		Expect(fakeClient.Status().Update(ctx, nar)).To(Succeed())
+
+		_, handled, err := reconciler.handleScaleInAnnotations(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeTrue())
+
+		// Verify annotation was removed
+		updatedNAR := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nar), updatedNAR)).To(Succeed())
+		Expect(updatedNAR.GetAnnotations()).ToNot(HaveKey(ScaleInNodesAnnotation))
+
+		// Verify nodeNames was pruned even for NotFound nodes
+		Expect(updatedNAR.Status.Properties.NodeNames).To(ConsistOf("other-node"))
 	})
 })

--- a/test/e2e/mno_scale_test.go
+++ b/test/e2e/mno_scale_test.go
@@ -449,6 +449,44 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 			Expect(newWorkerCount).To(Equal(1), "Exactly one new worker should be allocated")
 		})
 	})
+
+	Describe("Scale-in: remove a worker node", func() {
+		It("should decrease NAR worker NodeGroup Size after removing a worker", func() {
+			By("Updating PR to remove worker-3 (revert to v1 CT with 2 workers)")
+			Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
+			pr.Spec.TemplateVersion = "v4-20-16-v1"
+
+			var templateParams map[string]any
+			Expect(json.Unmarshal(pr.Spec.TemplateParameters.Raw, &templateParams)).To(Succeed())
+			ciParams := templateParams["clusterInstanceParameters"].(map[string]any)
+			nodes := ciParams["nodes"].([]any)
+
+			// Remove the last node (worker-3)
+			Expect(len(nodes)).To(BeNumerically(">=", masterCount+workerCount+1),
+				"Should have at least %d nodes before scale-in", masterCount+workerCount+1)
+			nodes = nodes[:masterCount+workerCount]
+			ciParams["nodes"] = nodes
+			templateParams["clusterInstanceParameters"] = ciParams
+
+			updatedParams, err := json.Marshal(templateParams)
+			Expect(err).ToNot(HaveOccurred())
+			pr.Spec.TemplateParameters.Raw = updatedParams
+			Expect(K8SClient.Update(testCtx, pr)).To(Succeed())
+
+			By("Verifying NAR NodeGroup sizes after scale-in")
+			Eventually(func() bool {
+				Expect(K8SClient.Get(testCtx, client.ObjectKeyFromObject(nar), nar)).To(Succeed())
+				sizes := nodeGroupSizeMap(nar)
+				return sizes[worker] == workerCount && sizes[master] == masterCount
+			}, timeout, interval).Should(BeTrue(),
+				"Worker Size should be %d and master Size should remain %d", workerCount, masterCount)
+		})
+
+		// NOTE: AllocatedNode deletion is gated on spoke node removal
+		// (checkRemovedNodesGone), which requires a real spoke cluster.
+		// This cannot be verified in the e2e test environment. Lab testing
+		// validates the full flow including AllocatedNode cleanup.
+	})
 })
 
 func scaleBMHs(masterCount, workerCount int) []testutils.BMHData {


### PR DESCRIPTION
Add scale-in support for removing worker nodes from a provisioned MNO cluster. When a user removes worker node entries from the ProvisioningRequest, the controller:

1. Cordons and drains the removed nodes on the spoke cluster
2. SSA-applies an intermediate ClusterInstance with pruneManifests to instruct siteconfig to delete per-node resources (InfraEnv, NMStateConfig) while the node entries are still present
3. Waits for siteconfig to process the pruning, then deletes the Agent CRs (not managed by siteconfig)
4. SSA-applies the reduced ClusterInstance (removing node entries)
5. Waits for the removed nodes to leave the spoke cluster
6. Deletes AllocatedNode CRs (triggering BMH deallocation) and cleans up AllocatedNodeHostMap

Includes RBAC for infraenvs/nmstateconfigs (get/list/watch) and agents (delete), scale-in e2e test, and documentation updates.