### PR TITLE
Fix OAuth audience tests to not depend on in-cluster CA files

### DIFF
--- a/internal/controllers/utils/oauth.go
+++ b/internal/controllers/utils/oauth.go
@@ -113,29 +113,33 @@ func SetupOAuthClient(ctx context.Context, logger *slog.Logger, config *OAuthCli
 	}
 
 	if config.OAuthConfig != nil && config.OAuthConfig.ClientID != "" {
-		var endpointParams url.Values
-		if config.OAuthConfig.Audience != "" {
-			endpointParams = url.Values{"audience": {config.OAuthConfig.Audience}}
-		}
-
-		oauthConfig := clientcredentials.Config{
-			ClientID:       config.OAuthConfig.ClientID,
-			ClientSecret:   config.OAuthConfig.ClientSecret,
-			TokenURL:       config.OAuthConfig.TokenURL,
-			Scopes:         config.OAuthConfig.Scopes,
-			EndpointParams: endpointParams,
-			AuthStyle:      oauth2.AuthStyleInParams,
-		}
-
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, baseClient)
-		oauthClient := oauthConfig.Client(ctx)
-
+		oauthClient := newOAuthClient(ctx, baseClient, config.OAuthConfig)
 		logger.InfoContext(ctx, "Successfully created oauth client")
 		return oauthClient, nil
 	}
 
 	logger.InfoContext(ctx, "Successfully created base client")
 	return baseClient, nil
+}
+
+// newOAuthClient wraps the given base HTTP client with OAuth client credentials token acquisition.
+func newOAuthClient(ctx context.Context, baseClient *http.Client, config *OAuthConfig) *http.Client {
+	var endpointParams url.Values
+	if config.Audience != "" {
+		endpointParams = url.Values{"audience": {config.Audience}}
+	}
+
+	oauthConfig := clientcredentials.Config{
+		ClientID:       config.ClientID,
+		ClientSecret:   config.ClientSecret,
+		TokenURL:       config.TokenURL,
+		Scopes:         config.Scopes,
+		EndpointParams: endpointParams,
+		AuthStyle:      oauth2.AuthStyleInParams,
+	}
+
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, baseClient)
+	return oauthConfig.Client(ctx)
 }
 
 // setupTLSConfig updates the TLS config with the related options from the OAuth configuration

--- a/internal/controllers/utils/oauth_test.go
+++ b/internal/controllers/utils/oauth_test.go
@@ -32,16 +32,13 @@ var _ = Describe("OAuth audience configuration", func() {
 		}))
 		defer resourceServer.Close()
 
-		client, err := SetupOAuthClient(context.Background(), nil, &OAuthClientConfig{
-			OAuthConfig: &OAuthConfig{
-				ClientID:     "test-client",
-				ClientSecret: "test-secret",
-				TokenURL:     tokenServer.URL,
-				Scopes:       []string{"openid"},
-				Audience:     "https://api.example.com",
-			},
+		client := newOAuthClient(context.Background(), http.DefaultClient, &OAuthConfig{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			TokenURL:     tokenServer.URL,
+			Scopes:       []string{"openid"},
+			Audience:     "https://api.example.com",
 		})
-		Expect(err).ToNot(HaveOccurred())
 
 		resp, err := client.Get(resourceServer.URL)
 		Expect(err).ToNot(HaveOccurred())
@@ -66,15 +63,12 @@ var _ = Describe("OAuth audience configuration", func() {
 		}))
 		defer resourceServer.Close()
 
-		client, err := SetupOAuthClient(context.Background(), nil, &OAuthClientConfig{
-			OAuthConfig: &OAuthConfig{
-				ClientID:     "test-client",
-				ClientSecret: "test-secret",
-				TokenURL:     tokenServer.URL,
-				Scopes:       []string{"openid"},
-			},
+		client := newOAuthClient(context.Background(), http.DefaultClient, &OAuthConfig{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			TokenURL:     tokenServer.URL,
+			Scopes:       []string{"openid"},
 		})
-		Expect(err).ToNot(HaveOccurred())
 
 		resp, err := client.Get(resourceServer.URL)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The audience tests called SetupOAuthClient which unconditionally loads CA bundles from /var/run/secrets/kubernetes.io/serviceaccount/ca.crt. This passed in Prow (runs in a k8s pod) but fails locally.

Extract newOAuthClient helper from SetupOAuthClient so the tests can exercise the audience forwarding logic directly without TLS setup.