### PR TITLE
Fix hardware-manager TLS and metrics

### DIFF
--- a/bundle/manifests/oran-o2ims-hardwaremanager-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/oran-o2ims-hardwaremanager-server-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/part-of: oran-o2ims
+  name: oran-o2ims-hardwaremanager-server-metrics-monitor
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: api
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: hardwaremanager-server.oran-o2ims.svc
+  selector:
+    matchLabels:
+      app: hardwaremanager-server

--- a/config/prometheus/services-monitor.yaml
+++ b/config/prometheus/services-monitor.yaml
@@ -116,3 +116,26 @@ spec:
   selector:
     matchLabels:
       app: resource-server
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: oran-o2ims
+    app.kubernetes.io/part-of: oran-o2ims
+    app.kubernetes.io/managed-by: kustomize
+  name: hardwaremanager-server-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: api
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        serverName: hardwaremanager-server.oran-o2ims.svc
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+  selector:
+    matchLabels:
+      app: hardwaremanager-server

--- a/docs/dev/prometheus-metrics.md
+++ b/docs/dev/prometheus-metrics.md
@@ -28,6 +28,8 @@ The O-Cloud Manager exposes Prometheus metrics at two layers:
    `cluster-server`, `provisioning-server`, `resource-server`,
    `artifacts-server`) exposes application-level metrics on its existing TLS
    port 8443 at `/metrics`.
+3. **Hardware manager layer** — The `hardwaremanager-server` exposes
+   controller-runtime reconciliation metrics on port 8443 at `/metrics`.
 
 Both layers are scraped by the OpenShift platform Prometheus via dedicated
 `ServiceMonitor` resources.
@@ -41,8 +43,10 @@ flowchart LR
         AS[alarms-server :8443 /metrics]
         PS[provisioning-server :8443 /metrics]
         ARS[artifacts-server :8443 /metrics]
+        HW[hardwaremanager-server :8443 /metrics]
         SM1[ServiceMonitor operator]
         SM2[ServiceMonitors per-service]
+        SM3[ServiceMonitor hardware-manager]
     end
 
     subgraph monitoring [openshift-monitoring]
@@ -51,12 +55,14 @@ flowchart LR
 
     Prom -->|scrapes| SM1
     Prom -->|scrapes| SM2
+    Prom -->|scrapes| SM3
     SM1 --> CM
     SM2 --> RS
     SM2 --> CS
     SM2 --> AS
     SM2 --> PS
     SM2 --> ARS
+    SM3 --> HW
 ```
 
 For the platform Prometheus instance (in `openshift-monitoring`) to discover
@@ -222,6 +228,7 @@ will be blocked.
 | Server | Ingress allowed from |
 |--------|---------------------|
 | API servers (resource, cluster, alarms, artifacts, provisioning) | OpenShift ingress controller, OpenShift monitoring, same namespace |
+| Hardware manager (hardwaremanager-server) | OpenShift ingress controller, OpenShift monitoring, same namespace |
 | Alarms server (additional) | ACM alertmanager (`open-cluster-management-observability`) |
 | Database (postgres) | Same namespace only |
 
@@ -327,12 +334,10 @@ Key design choices:
   authorized by the `metrics-reader` ClusterRole.
 - **Shared metrics package** — All metric definitions live in
   `internal/service/common/metrics/metrics.go` to avoid duplication.
-- **Per-service ServiceMonitors** — Each API service gets its own
-  ServiceMonitor (in `config/prometheus/services-monitor.yaml`) so that
-  `tlsConfig.serverName` matches the serving certificate SAN. The database
-  (`postgres-server`) is excluded. The hardware manager uses the
-  controller-runtime metrics server pattern and is not selected by these
-  monitors.
+- **Per-service ServiceMonitors** — Each API service and the hardware manager
+  gets its own ServiceMonitor (in `config/prometheus/services-monitor.yaml`)
+  so that `tlsConfig.serverName` matches the serving certificate SAN. The
+  database (`postgres-server`) is excluded.
 
 ### Metrics Exposed
 
@@ -584,13 +589,14 @@ oc get servicemonitor -n oran-o2ims
 Expected output:
 
 ```text
-NAME                                           AGE
-oran-o2ims-alarms-server-metrics-monitor       ...
-oran-o2ims-artifacts-server-metrics-monitor    ...
-oran-o2ims-cluster-server-metrics-monitor      ...
-oran-o2ims-controller-manager-metrics-monitor  ...
-oran-o2ims-provisioning-server-metrics-monitor ...
-oran-o2ims-resource-server-metrics-monitor     ...
+NAME                                                  AGE
+oran-o2ims-alarms-server-metrics-monitor              ...
+oran-o2ims-artifacts-server-metrics-monitor            ...
+oran-o2ims-cluster-server-metrics-monitor              ...
+oran-o2ims-controller-manager-metrics-monitor          ...
+oran-o2ims-hardwaremanager-server-metrics-monitor      ...
+oran-o2ims-provisioning-server-metrics-monitor         ...
+oran-o2ims-resource-server-metrics-monitor             ...
 ```
 
 #### Verify Prometheus discovered the targets

--- a/docs/dev/tls-configuration.md
+++ b/docs/dev/tls-configuration.md
@@ -102,11 +102,18 @@ flowchart TB
         Serve["serve.go (GetServerTLSConfig)"]
     end
 
+    subgraph hw_mgr_pod["Hardware Manager Pod"]
+        HWEnvRead["reads TLS_PROFILE_* env vars"]
+        HWMgr["controller-runtime metrics server (TLSOpts)"]
+    end
+
     APIServerRes -->|"watch"| Watcher
     Watcher -->|"OnProfileChange: cancel()"| MgrTLS
     Watcher -->|"OnProfileChange: patch annotation"| Reconciler
     Reconciler -->|"rolling restart + env var injection"| http_pods
+    Reconciler -->|"rolling restart + env var injection"| hw_mgr_pod
     EnvRead -->|"builds tls.Config"| Serve
+    HWEnvRead -->|"builds tls.Config"| HWMgr
 ```
 
 Key design decisions:
@@ -164,7 +171,8 @@ oc get pods -n oran-o2ims
 ```
 
 All HTTP server pods (`resource-server`, `cluster-server`,
-`provisioning-server`, `artifacts-server`) should be in `Running` state.
+`provisioning-server`, `artifacts-server`) and the `hardwaremanager-server`
+should be in `Running` state.
 
 ### Test 1: Default Profile Verification
 
@@ -385,10 +393,11 @@ With the cluster running the default Intermediate profile
 
 | Pod | Port | TLS Versions | PQC Ready | API MinVersion Compliance | API Cipher Compliance |
 |-----|------|-------------|-----------|---------------------------|----------------------|
+| artifacts-server | 8443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
 | cluster-server | 8443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
+| hardwaremanager-server | 8443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
 | oran-o2ims-controller-manager | 6443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
 | oran-o2ims-controller-manager | 9443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
-| artifacts-server | 8443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
 | provisioning-server | 8443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
 | resource-server | 8443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
 

--- a/internal/controllers/inventory_controller.go
+++ b/internal/controllers/inventory_controller.go
@@ -1131,9 +1131,6 @@ func (t *reconcilerTask) createService(ctx context.Context, resourceName string,
 	labels := map[string]string{
 		"app": resourceName,
 	}
-	if resourceName != ctlrutils.InventoryDatabaseServerName && resourceName != ctlrutils.HardwareManagerServerName {
-		labels["oran-o2ims/metrics"] = "true"
-	}
 	serviceMeta := metav1.ObjectMeta{
 		Name:      resourceName,
 		Namespace: t.object.Namespace,

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -126,7 +126,7 @@ var (
 		constants.HardwareManagerCmd,
 		constants.StartSubcommand,
 		constants.HealthProbeFlag + "=" + constants.HealthProbePort,
-		constants.MetricsFlag + "=" + constants.MetricsPort,
+		fmt.Sprintf("%s=:%d", constants.MetricsFlag, constants.DefaultContainerPort),
 		fmt.Sprintf("--metrics-tls-cert-dir=%s", constants.TLSServerMountPath),
 		constants.LeaderElectFlag,
 	}

--- a/internal/controllers/utils/tls_profile.go
+++ b/internal/controllers/utils/tls_profile.go
@@ -130,8 +130,8 @@ func TLSProfileHash(profile configv1.TLSProfileSpec) string {
 	return hex.EncodeToString(sum[:])[:16]
 }
 
-// newTLSProfileFromEnv reconstructs a TLSProfileSpec from operator-injected environment variables.
-func newTLSProfileFromEnv() configv1.TLSProfileSpec {
+// NewTLSProfileFromEnv reconstructs a TLSProfileSpec from operator-injected environment variables.
+func NewTLSProfileFromEnv() configv1.TLSProfileSpec {
 	minVersion := os.Getenv(TLSProfileMinVersionEnvName)
 	ciphersStr := os.Getenv(TLSProfileCiphersEnvName)
 

--- a/internal/controllers/utils/tls_profile_test.go
+++ b/internal/controllers/utils/tls_profile_test.go
@@ -160,14 +160,14 @@ var _ = Describe("TLS Profile", func() {
 		})
 	})
 
-	Describe("newTLSProfileFromEnv", func() {
+	Describe("NewTLSProfileFromEnv", func() {
 		AfterEach(func() {
 			os.Unsetenv(TLSProfileMinVersionEnvName)
 			os.Unsetenv(TLSProfileCiphersEnvName)
 		})
 
 		It("should fall back to Intermediate when env vars are not set", func() {
-			profile := newTLSProfileFromEnv()
+			profile := NewTLSProfileFromEnv()
 			Expect(profile.MinTLSVersion).To(Equal(configv1.VersionTLS12))
 			Expect(profile.Ciphers).ToNot(BeEmpty())
 		})
@@ -176,7 +176,7 @@ var _ = Describe("TLS Profile", func() {
 			os.Setenv(TLSProfileMinVersionEnvName, string(configv1.VersionTLS13))
 			os.Setenv(TLSProfileCiphersEnvName, "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384")
 
-			profile := newTLSProfileFromEnv()
+			profile := NewTLSProfileFromEnv()
 			Expect(profile.MinTLSVersion).To(Equal(configv1.VersionTLS13))
 			Expect(profile.Ciphers).To(Equal([]string{
 				"TLS_AES_128_GCM_SHA256",
@@ -188,7 +188,7 @@ var _ = Describe("TLS Profile", func() {
 			os.Setenv(TLSProfileMinVersionEnvName, string(configv1.VersionTLS13))
 			os.Setenv(TLSProfileCiphersEnvName, "")
 
-			profile := newTLSProfileFromEnv()
+			profile := NewTLSProfileFromEnv()
 			Expect(profile.MinTLSVersion).To(Equal(configv1.VersionTLS13))
 			Expect(profile.Ciphers).To(BeEmpty())
 		})
@@ -197,7 +197,7 @@ var _ = Describe("TLS Profile", func() {
 			os.Setenv(TLSProfileMinVersionEnvName, "TLS1.2") // invalid format
 			os.Setenv(TLSProfileCiphersEnvName, "ECDHE-RSA-AES128-GCM-SHA256")
 
-			profile := newTLSProfileFromEnv()
+			profile := NewTLSProfileFromEnv()
 			Expect(profile.MinTLSVersion).To(Equal(configv1.VersionTLS12))
 			Expect(profile.Ciphers).ToNot(BeEmpty())
 		})

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -869,7 +869,7 @@ func loadDefaultCABundles(config *tls.Config) error {
 // When loadCAs is true, default in-cluster CA bundles are loaded.
 // Pass loadCAs=false when the caller provides its own trust anchors (e.g., a pinned service CA).
 func GetDefaultTLSConfig(config *tls.Config, loadCAs bool) (*tls.Config, error) {
-	profile := newTLSProfileFromEnv()
+	profile := NewTLSProfileFromEnv()
 	tlsConfig, err := NewOutboundTLSConfig(profile, config)
 	if err != nil {
 		return nil, err
@@ -903,7 +903,7 @@ func AddCABundle(config *tls.Config, caBundle string) error {
 // TLS version and cipher suites are inherited from the cluster TLS security profile
 // (via operator-injected environment variables).
 func GetClientTLSConfig(ctx context.Context, certFile, keyFile, caFile string) (*tls.Config, error) {
-	profile := newTLSProfileFromEnv()
+	profile := NewTLSProfileFromEnv()
 	return NewOutboundMTLSConfig(ctx, profile, certFile, keyFile, caFile)
 }
 
@@ -911,7 +911,7 @@ func GetClientTLSConfig(ctx context.Context, certFile, keyFile, caFile string) (
 // TLS version and cipher suites are inherited from the cluster TLS security profile
 // (via operator-injected environment variables).
 func GetServerTLSConfig(ctx context.Context, certFile, keyFile string) (*tls.Config, error) {
-	profile := newTLSProfileFromEnv()
+	profile := NewTLSProfileFromEnv()
 	return NewInboundTLSConfig(ctx, profile, certFile, keyFile)
 }
 

--- a/internal/hardwaremanager/cmd/start_hardwaremanager.go
+++ b/internal/hardwaremanager/cmd/start_hardwaremanager.go
@@ -139,6 +139,8 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 			c.NextProtos = []string{"http/1.1"}
 		})
 	}
+	tlsProfile := ctlrutils.NewTLSProfileFromEnv()
+	tlsOpts = append(tlsOpts, ctlrutils.NewTLSConfiguratorFromProfile(tlsProfile))
 
 	if err := hwmgrutils.InitNodeAllocationRequestUtils(scheme); err != nil {
 		logger.ErrorContext(ctx, "failed InitNodeAllocationRequestUtils", slog.Any("error", err))


### PR DESCRIPTION
**Why these changes ?** 

These changes are a follow-up to https://github.com/openshift-kni/oran-o2ims/pull/2693 : the implementation for the hardware-manager TLS was partially done there. That development included the generic env var passing mechanism for TLS enforcement in the hardware-manager but those variables were never applied and the TLS configuration was never enforced on that pod.

Unfortunately, neither Claude nor CodeRabbit detected those variables were never applied.

Similarly, the metrics development was partially done: the hardware-manager configured metrics but they were never correctly exposed.

**Backport ?** 

Yes, we will need to fix this present already in 4.22 too.
