### PR TITLE
CNF-26210: add MNO cluster node swap support (Phase 4)

### DIFF
--- a/api/provisioning/v1alpha1/provisioningrequest_validation.go
+++ b/api/provisioning/v1alpha1/provisioningrequest_validation.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"os"
@@ -297,6 +298,17 @@ func FindClusterInstanceImmutableFieldUpdates(
 			"and new ClusterInstance input: %w", err)
 	}
 
+	// First pass: identify node indices where hostName changed (swap).
+	// When a node's hostName is updated in-place, the diff library reports
+	// field-level changes (e.g., nodes.3.hostName) rather than a whole-node
+	// add/remove. We treat all changes under such a node index as scaling.
+	swappedNodeIndices := make(map[string]bool)
+	for _, d := range diffs {
+		if len(d.Path) >= 3 && d.Path[0] == "nodes" && d.Path[2] == "hostName" && d.Type == "update" {
+			swappedNodeIndices[d.Path[1]] = true
+		}
+	}
+
 	var updatedFields []string
 	var scalingNodes []string
 	for _, diff := range diffs {
@@ -338,6 +350,9 @@ func FindClusterInstanceImmutableFieldUpdates(
 
 		Field updated at the node-level
 		  {"type": "update", "path": ["nodes", "0", "nodeNetwork", "config", "dns-resolver", "config", "server", "0"], "from": "192.10.1.2", "to": "192.10.1.3"}
+
+		Node swap (hostName changed in-place)
+		  {"type": "update", "path": ["nodes", "3", "hostName"], "from": "worker1", "to": "worker2"}
 		*/
 
 		// Check if the path matches any ignored fields
@@ -365,6 +380,18 @@ func FindClusterInstanceImmutableFieldUpdates(
 			scalingNodes = append(scalingNodes, strings.Join(diff.Path, "."))
 			continue
 		}
+
+		// Check if this change is under a node whose hostName changed
+		// (swap). Treat all such changes as scaling, not immutable
+		// field violations.
+		if len(diff.Path) >= 2 && diff.Path[0] == "nodes" && swappedNodeIndices[diff.Path[1]] {
+			nodeKey := "nodes." + diff.Path[1]
+			if !slices.Contains(scalingNodes, nodeKey) {
+				scalingNodes = append(scalingNodes, nodeKey)
+			}
+			continue
+		}
+
 		updatedFields = append(updatedFields, strings.Join(diff.Path, "."))
 	}
 

--- a/docs/user-guide/cluster-configuration.md
+++ b/docs/user-guide/cluster-configuration.md
@@ -830,3 +830,28 @@ returns to normal operation.
 > window has closed. Re-adding the node at that point triggers a new
 > scale-out operation, which waits for the BMH to finish
 > deprovisioning before re-provisioning the node.
+
+#### Replacing a worker node (swap)
+
+A swap operation replaces one or more worker nodes in a single
+ProvisioningRequest update. Remove the old node entries and add the new
+node entries in the `clusterInstanceParameters.nodes` array at the same
+time.
+
+The controller processes the swap sequentially:
+
+1. **Scale-in phase**: The removed nodes are drained, their per-node
+   resources (InfraEnv, NMStateConfig) are pruned, and the hardware
+   manager deallocates the old nodes.
+2. **Scale-out phase**: Once scale-in is complete, the new nodes are
+   provisioned through the hardware manager, added to the cluster, and
+   the controller waits for them to join and become Ready.
+
+The ProvisioningRequest status shows `ClusterProvisioned=InProgress`
+throughout the swap, with the message reflecting which phase is active.
+
+Aborting a swap follows the same rules as aborting a standalone
+scale-in: re-add the removed nodes to the ProvisioningRequest before
+deallocation completes. The newly added nodes that have not yet been
+provisioned are treated as a separate scale-out if the removed nodes are
+restored.

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -788,6 +788,9 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx contex
 			// Already InProgress (e.g. from scale-in portion of a swap).
 			// Update the message to reflect scale-out phase.
 			ctlrutils.SetProvisioningStateInProgress(t.object, message)
+			if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
+				return fmt.Errorf("failed to update scale-out status for ProvisioningRequest %s: %w", t.object.Name, updateErr)
+			}
 		}
 
 		// WORKAROUND: Approve pending CSRs for scale-out worker nodes.

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -232,14 +232,23 @@ func (t *provisioningRequestReconcilerTask) handleScaleInDrain(
 		return false, nil
 	}
 
-	// Identify removed nodes (in existing but not in rendered)
+	// Identify removed nodes (in existing but not in rendered). Only consider
+	// nodes that are still tracked in AllocatedNodeHostMap — nodes already
+	// cleaned up by a prior scale-in pass (e.g., during a swap) are skipped.
 	existingNodes := getNodeRolesByHostname(existingCI)
 	renderedNodes := getNodeRolesByHostname(renderedCI)
+
+	hostMapHostnames := make(map[string]bool)
+	for _, h := range t.object.Status.Extensions.AllocatedNodeHostMap {
+		hostMapHostnames[h] = true
+	}
 
 	var removedHostnames []string
 	for hostname := range existingNodes {
 		if _, exists := renderedNodes[hostname]; !exists {
-			removedHostnames = append(removedHostnames, hostname)
+			if hostMapHostnames[hostname] {
+				removedHostnames = append(removedHostnames, hostname)
+			}
 		}
 	}
 
@@ -486,6 +495,19 @@ func buildIntermediateCIWithPruneManifests(
 	existingSpec, _ := existingCI.Object["spec"].(map[string]any)
 	existingNodes, _ := existingSpec["nodes"].([]any)
 
+	// Build set of existing hostnames to identify new nodes being added
+	// as part of a swap. New nodes must be excluded from the intermediate
+	// CI because their BMC secrets don't exist yet (hardware provisioning
+	// hasn't run).
+	existingHostnames := make(map[string]bool, len(existingNodes))
+	for _, node := range existingNodes {
+		if nodeMap, ok := node.(map[string]any); ok {
+			if hostname, _ := nodeMap["hostName"].(string); hostname != "" {
+				existingHostnames[hostname] = true
+			}
+		}
+	}
+
 	pruneManifests := []any{
 		map[string]any{
 			"apiVersion": "agent-install.openshift.io/v1beta1",
@@ -494,6 +516,10 @@ func buildIntermediateCIWithPruneManifests(
 		map[string]any{
 			"apiVersion": "agent-install.openshift.io/v1beta1",
 			"kind":       "NMStateConfig",
+		},
+		map[string]any{
+			"apiVersion": "metal3.io/v1alpha1",
+			"kind":       "BareMetalHost",
 		},
 	}
 
@@ -516,9 +542,21 @@ func buildIntermediateCIWithPruneManifests(
 	if !ok {
 		return intermediateCI
 	}
+
+	// Filter out new nodes not present in the existing CI (swap case)
 	intermediateNodes, _ := intermediateSpec["nodes"].([]any)
-	intermediateNodes = append(intermediateNodes, removedNodeEntries...)
-	intermediateSpec["nodes"] = intermediateNodes
+	var filteredNodes []any
+	for _, node := range intermediateNodes {
+		if nodeMap, ok := node.(map[string]any); ok {
+			hostname, _ := nodeMap["hostName"].(string)
+			if existingHostnames[hostname] {
+				filteredNodes = append(filteredNodes, node)
+			}
+		}
+	}
+
+	filteredNodes = append(filteredNodes, removedNodeEntries...)
+	intermediateSpec["nodes"] = filteredNodes
 
 	return intermediateCI
 }
@@ -728,11 +766,11 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx contex
 			slog.Int("fulfilledNodeCount", fulfilledCount),
 			slog.Int("renderedNodeCount", renderedNodeCount))
 
-		// Only set InProgress on the first detection (when ClusterProvisioned is
-		// still Completed).
+		message := fmt.Sprintf("Scale-out: waiting for new node to join the cluster (%d → %d nodes)",
+			fulfilledCount, renderedNodeCount)
+
 		if ctlrutils.IsClusterProvisionCompleted(t.object) {
-			message := fmt.Sprintf("Scale-out: waiting for new node to join the cluster (%d → %d nodes)",
-				fulfilledCount, renderedNodeCount)
+			// First detection: set InProgress and record start time
 			t.logger.InfoContext(ctx, message)
 			ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
 				provisioningv1alpha1.PRconditionTypes.ClusterProvisioned,
@@ -746,6 +784,10 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx contex
 			if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
 				return fmt.Errorf("failed to update scale-out status for ProvisioningRequest %s: %w", t.object.Name, updateErr)
 			}
+		} else {
+			// Already InProgress (e.g. from scale-in portion of a swap).
+			// Update the message to reflect scale-out phase.
+			ctlrutils.SetProvisioningStateInProgress(t.object, message)
 		}
 
 		// WORKAROUND: Approve pending CSRs for scale-out worker nodes.
@@ -792,17 +834,32 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx contex
 		}
 	}
 
-	// Detect scale-in: if the rendered CI has fewer nodes than the last fulfilled
-	// count, wait for removed nodes to leave the spoke, then perform cleanup.
-	if fulfilledCount > 0 && renderedNodeCount < fulfilledCount {
+	// Detect scale-in: check if any hostname in the AllocatedNodeHostMap is
+	// absent from the rendered CI. This catches both pure scale-in (count
+	// decreased) and the scale-in portion of a swap (count unchanged but
+	// hostnames differ).
+	removedNodesExist := false
+	numRemoved := 0
+	if fulfilledCount > 0 {
+		renderedNodes := getNodeRolesByHostname(clusterInstance)
+		for _, hostname := range t.object.Status.Extensions.AllocatedNodeHostMap {
+			if _, exists := renderedNodes[hostname]; !exists {
+				removedNodesExist = true
+				numRemoved++
+			}
+		}
+	}
+
+	if removedNodesExist {
 		t.logger.InfoContext(ctx, "Scale-in in progress",
 			slog.Int("fulfilledNodeCount", fulfilledCount),
-			slog.Int("renderedNodeCount", renderedNodeCount))
+			slog.Int("renderedNodeCount", renderedNodeCount),
+			slog.Int("numRemoved", numRemoved))
 
 		// Only set InProgress on the first detection
 		if ctlrutils.IsClusterProvisionCompleted(t.object) {
 			message := fmt.Sprintf("Scale-in: waiting for removed node(s) to leave the cluster (%d → %d nodes)",
-				fulfilledCount, renderedNodeCount)
+				fulfilledCount, fulfilledCount-numRemoved)
 			t.logger.InfoContext(ctx, message)
 			ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
 				provisioningv1alpha1.PRconditionTypes.ClusterProvisioned,
@@ -843,7 +900,21 @@ func (t *provisioningRequestReconcilerTask) handleClusterInstallation(ctx contex
 				return nil
 			}
 
-			t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount = renderedNodeCount
+			newFulfilledCount := fulfilledCount - numRemoved
+			t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount = newFulfilledCount
+
+			if renderedNodeCount > newFulfilledCount {
+				// Swap: scale-in complete but scale-out pending. Keep
+				// InProgress so scale-out fires on the next reconcile.
+				t.logger.InfoContext(ctx, "Scale-in cleanup complete, scale-out pending (swap)",
+					slog.Int("newFulfilledCount", newFulfilledCount),
+					slog.Int("renderedNodeCount", renderedNodeCount))
+				if updateErr := ctlrutils.UpdateK8sCRStatus(ctx, t.client, t.object); updateErr != nil {
+					return fmt.Errorf("failed to update swap transition status: %w", updateErr)
+				}
+				return nil
+			}
+
 			ctlrutils.SetStatusCondition(&t.object.Status.Conditions,
 				provisioningv1alpha1.PRconditionTypes.ClusterProvisioned,
 				provisioningv1alpha1.CRconditionReasons.Completed,

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -982,9 +982,10 @@ var _ = Describe("buildIntermediateCIWithPruneManifests", func() {
 		Expect(worker2["pruneManifests"]).ToNot(BeNil())
 
 		prune := worker2["pruneManifests"].([]any)
-		Expect(prune).To(HaveLen(2))
+		Expect(prune).To(HaveLen(3))
 		Expect(prune[0].(map[string]any)["kind"]).To(Equal("InfraEnv"))
 		Expect(prune[1].(map[string]any)["kind"]).To(Equal("NMStateConfig"))
+		Expect(prune[2].(map[string]any)["kind"]).To(Equal("BareMetalHost"))
 	})
 
 	It("should not modify the original rendered CI", func() {
@@ -1034,7 +1035,41 @@ var _ = Describe("buildIntermediateCIWithPruneManifests", func() {
 		}
 	})
 
-	It("should not include BMH in pruneManifests", func() {
+	It("should exclude new nodes not in existing CI (swap case)", func() {
+		existingCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+			{"hostName": "worker2", "role": "worker"},
+		})
+		// Swap: remove worker2, add worker3
+		renderedCI := makeCI([]map[string]any{
+			{"hostName": "master1", "role": "master"},
+			{"hostName": "worker1", "role": "worker"},
+			{"hostName": "worker3", "role": "worker"},
+		})
+
+		result := buildIntermediateCIWithPruneManifests(renderedCI, existingCI, []string{"worker2"})
+
+		spec := result.Object["spec"].(map[string]any)
+		nodes := spec["nodes"].([]any)
+		// Should have: master1, worker1 (kept), worker2 (pruned) = 3 nodes
+		// worker3 should be excluded (not in existing CI)
+		Expect(nodes).To(HaveLen(3))
+
+		hostnames := make([]string, len(nodes))
+		for i, n := range nodes {
+			hostnames[i] = n.(map[string]any)["hostName"].(string)
+		}
+		Expect(hostnames).To(ContainElements("master1", "worker1", "worker2"))
+		Expect(hostnames).ToNot(ContainElement("worker3"))
+
+		// worker2 should have pruneManifests
+		worker2 := nodes[2].(map[string]any)
+		Expect(worker2["hostName"]).To(Equal("worker2"))
+		Expect(worker2["pruneManifests"]).ToNot(BeNil())
+	})
+
+	It("should include BMH in pruneManifests to clear stale manifestsRendered", func() {
 		existingCI := makeCI([]map[string]any{
 			{"hostName": "master1", "role": "master"},
 			{"hostName": "worker1", "role": "worker"},
@@ -1050,10 +1085,12 @@ var _ = Describe("buildIntermediateCIWithPruneManifests", func() {
 		worker1 := nodes[1].(map[string]any)
 		prune := worker1["pruneManifests"].([]any)
 
-		for _, entry := range prune {
-			kind := entry.(map[string]any)["kind"].(string)
-			Expect(kind).ToNot(Equal("BareMetalHost"))
+		Expect(prune).To(HaveLen(3))
+		kinds := make([]string, len(prune))
+		for i, entry := range prune {
+			kinds[i] = entry.(map[string]any)["kind"].(string)
 		}
+		Expect(kinds).To(ContainElements("InfraEnv", "NMStateConfig", "BareMetalHost"))
 	})
 })
 

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -456,12 +456,18 @@ func (t *provisioningRequestReconcilerTask) checkOverallProvisioningTimeout(ctx 
 
 // handleClusterUpgrades handles cluster upgrade logic
 func (t *provisioningRequestReconcilerTask) handleClusterUpgrades(ctx context.Context, clusterName string) (ctrl.Result, error) {
-	// Block upgrades while a scale operation is in progress. Compare the
-	// rendered CI hostname set against the fulfilled node count to detect
-	// active scaling. Use hostname set comparison (not count) because a
-	// mixed add+remove could leave the count unchanged.
+	// Block upgrades while a scale operation is in progress. Check
+	// ClusterProvisioned status as the primary signal — it is set to
+	// InProgress for scale-in, scale-out, and swap operations (including
+	// same-count swaps that a count comparison would miss).
 	if t.object.Status.Extensions.ClusterDetails != nil &&
 		t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount > 0 {
+		if !ctlrutils.IsClusterProvisionCompleted(t.object) {
+			t.logger.InfoContext(ctx, "Skipping upgrade: scale operation in progress")
+			return requeueWithMediumInterval(), nil
+		}
+
+		// Secondary safety net: count mismatch
 		fulfilledCount := t.object.Status.Extensions.ClusterDetails.FulfilledNodeCount
 		existingCI, err := t.getExistingClusterInstance(ctx)
 		if err != nil {

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -118,8 +118,10 @@ func (t *provisioningRequestReconcilerTask) createOrUpdateNodeAllocationRequest(
 	nodeAllocationRequest.Spec.ClusterProvisioned = existingNAR.Spec.ClusterProvisioned
 	renderedConfigTransactionId := nodeAllocationRequest.Spec.ConfigTransactionId
 	nodeAllocationRequest.Spec.ConfigTransactionId = existingNAR.Spec.ConfigTransactionId
-	if !equality.Semantic.DeepEqual(existingNAR.Spec, nodeAllocationRequest.Spec) {
-		// Real NAR-relevant fields changed, restore the actual new ConfigTransactionId
+
+	specChanged := !equality.Semantic.DeepEqual(existingNAR.Spec, nodeAllocationRequest.Spec)
+
+	if specChanged {
 		nodeAllocationRequest.Spec.ConfigTransactionId = renderedConfigTransactionId
 		patch := client.MergeFrom(existingNAR.DeepCopy())
 		existingNAR.Spec = nodeAllocationRequest.Spec
@@ -129,7 +131,35 @@ func (t *provisioningRequestReconcilerTask) createOrUpdateNodeAllocationRequest(
 
 		t.logger.InfoContext(ctx,
 			fmt.Sprintf("NodeAllocationRequest (%s) spec changes have been detected", t.object.Name))
+		return nil
 	}
+
+	// Check for swap case: spec unchanged but AllocatedNode count is short.
+	// After a swap's scale-in removes an AllocatedNode, the spec still has
+	// the same sizes, so DeepEqual sees no change. Only trigger when the
+	// NAR was previously fully provisioned (Provisioned=Completed) — this
+	// distinguishes a swap from initial provisioning where nodes haven't
+	// been allocated yet.
+	provisionedCond := meta.FindStatusCondition(existingNAR.Status.Conditions, string(hwmgmtv1alpha1.Provisioned))
+	isProvisioned := provisionedCond != nil && provisionedCond.Status == metav1.ConditionTrue
+	totalRequested := 0
+	for _, ng := range existingNAR.Spec.NodeGroup {
+		totalRequested += ng.Size
+	}
+	currentAllocated := len(existingNAR.Status.Properties.NodeNames)
+	if isProvisioned &&
+		existingNAR.Status.ObservedConfigTransactionId == existingNAR.Spec.ConfigTransactionId &&
+		currentAllocated < totalRequested {
+		t.logger.InfoContext(ctx, "NAR spec unchanged but allocation incomplete, forcing reallocation",
+			slog.Int("requested", totalRequested),
+			slog.Int("allocated", currentAllocated))
+		patch := client.MergeFrom(existingNAR.DeepCopy())
+		existingNAR.Spec.ConfigTransactionId++
+		if err := t.client.Patch(ctx, existingNAR, patch); err != nil {
+			return fmt.Errorf("failed to bump ConfigTransactionId on NodeAllocationRequest %s: %w", t.object.Name, err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/controllers/utils/provision_test.go
+++ b/internal/controllers/utils/provision_test.go
@@ -305,6 +305,23 @@ var _ = Describe("FindClusterInstanceImmutableFieldUpdates", func() {
 		Expect(updatedFields).To(BeEmpty())
 		Expect(scalingNodes).To(ContainElement("nodes.0"))
 	})
+
+	It("should detect node swap as scaling when hostName changes in-place", func() {
+		// Change the hostName of an existing node (swap)
+		spec := newClusterInstance.Object["spec"].(map[string]any)
+		nodes := spec["nodes"].([]any)
+		node := nodes[0].(map[string]any)
+		node["hostName"] = "replacement-worker.example.com"
+
+		updatedFields, scalingNodes, err := provisioningv1alpha1.FindClusterInstanceImmutableFieldUpdates(
+			oldClusterInstance.Object["spec"].(map[string]any),
+			newClusterInstance.Object["spec"].(map[string]any),
+			IgnoredClusterInstanceFields,
+			provisioningv1alpha1.AllowedClusterInstanceFields)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updatedFields).To(BeEmpty())
+		Expect(scalingNodes).To(ContainElement("nodes.0"))
+	})
 })
 
 var _ = Describe("ClusterIsReadyForPolicyConfig", func() {

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -451,6 +451,11 @@ func (r *NodeAllocationRequestReconciler) handleScaleInNodesAnnotation(
 // drainIfReady checks if a node is Ready and drains it. If the node is
 // NotReady or absent from the spoke, drain is skipped (returns nil).
 // Returns an error only if drain was attempted and failed (caller should retry).
+// drainIfReady drains the node only if it is Ready on the spoke. NotReady or
+// absent nodes are skipped — a failed/unreachable node cannot be drained (the
+// kubelet is unresponsive), so attempting drain would retry indefinitely until
+// the provisioning timeout. Skipping drain and proceeding to deallocation is
+// the intended recovery path for failed worker nodes.
 func (r *NodeAllocationRequestReconciler) drainIfReady(
 	ctx context.Context, nodeOps NodeOps,
 	an *hwmgmtv1alpha1.AllocatedNode, nodeName string) error {


### PR DESCRIPTION
Enable simultaneous worker node removal and addition in a single ProvisioningRequest update. The controller sequences the operation: scale-in (drain, prune, deallocate) completes first, then scale-out (provision, join) fires automatically.

Key changes:
- Webhook: detect in-place hostName changes as node swaps, not immutable field violations
- Filter new nodes from intermediate CI during swap so BMC secret validation doesn't fail before hardware provisioning runs
- Replace count-based scale-in detection with hostname-based check using AllocatedNodeHostMap, catching same-count swaps
- Set FulfilledNodeCount to oldCount - numRemoved after scale-in cleanup, so scale-out naturally triggers on next reconcile
- Force NAR ConfigTransactionId bump when allocation count is short after a swap's scale-in (spec unchanged but nodes are missing)
- Skip already-cleaned-up nodes in handleScaleInDrain by checking AllocatedNodeHostMap, preventing repeated drain processing
- Keep ClusterProvisioned=InProgress between scale-in and scale-out phases of a swap (no cycled state transitions)
- Update scale-out status message when transitioning from scale-in
- Block upgrades during swap via ClusterProvisioned status check
- Include BMH in pruneManifests to clean up stale manifestsRendered entries (siteconfig skips deletion when owned-by label is absent)