### PR TITLE
Update Go version to 1.26.5

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/.konflux/Dockerfile
+++ b/.konflux/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25@sha256:977bd041377a1367c8b102a460ae8e63f89905f7cf9d8235484ae658c9b47646 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26@sha256:c1488dc4364e229cb6963b4e0b088e3e93ef377bf92463d68b7b7e2ab1166f8f AS builder
 
 WORKDIR /app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.hub.docker.com/library/golang:1.25 AS dlvbuilder
+FROM registry.hub.docker.com/library/golang:1.26 AS dlvbuilder
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 FROM dlvbuilder AS builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-kni/oran-o2ims
 
-go 1.25.9
+go 1.26.5
 
 // Needed for importing the siteconfig operator, taken from the siteconfig operator repo.
 replace (


### PR DESCRIPTION
Update build tooling and go.mod to Go 1.26.5:
- go.mod: 1.25.9 → 1.26.5
- Dockerfile: golang:1.25 → golang:1.26
- .konflux/Dockerfile: rhel_9_golang_1.25 → rhel_9_golang_1.26
- .ci-operator.yaml: golang-1.25-openshift-4.22 → golang-1.26-openshift-5.0