### PR TITLE
CNF-26398: Upstream release-config version bump — O-Cloud 4.22.1

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -5,6 +5,6 @@ variables:
   description: |
       O-cloud manager operator
   display_name: "o-cloud manager"
-  manager_version: "o-cloud-manager.v4.22.1"
+  manager_version: "o-cloud-manager.v4.22.2"
   min_kube_version: "1.32.0"
-  version: "4.22.1"
+  version: "4.22.2"


### PR DESCRIPTION
Automated post-release update for O-Cloud 4.22.1 → 4.22.2.

Generated by release-automator-konflux.