### PR TITLE
[release-4.22] Fix hardware-manager TLS  and metrics

### DIFF
--- a/docs/dev/tls-configuration.md
+++ b/docs/dev/tls-configuration.md
@@ -120,6 +120,7 @@ flowchart TB
     Reconciler -->|"rolling restart + env var injection"| hw_mgr_pod
     Reconciler -->|"regenerate ConfigMap + rolling restart"| PGConf
     EnvRead -->|"builds tls.Config"| Serve
+    HWEnvRead -->|"builds tls.Config"| HWMgr
 ```
 
 Key design decisions:
@@ -194,7 +195,8 @@ oc get pods -n oran-o2ims
 ```
 
 All HTTP server pods (`resource-server`, `cluster-server`,
-`provisioning-server`, `artifacts-server`) should be in `Running` state.
+`provisioning-server`, `artifacts-server`) and the `hardwaremanager-server`
+should be in `Running` state.
 
 ### Test 1: Default Profile Verification
 

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -121,7 +121,7 @@ var (
 		constants.HardwareManagerCmd,
 		constants.StartSubcommand,
 		constants.HealthProbeFlag + "=" + constants.HealthProbePort,
-		constants.MetricsFlag + "=" + constants.MetricsPort,
+		fmt.Sprintf("%s=:%d", constants.MetricsFlag, constants.DefaultContainerPort),
 		fmt.Sprintf("--metrics-tls-cert-dir=%s", constants.TLSServerMountPath),
 		constants.LeaderElectFlag,
 	}

--- a/internal/controllers/utils/tls_profile.go
+++ b/internal/controllers/utils/tls_profile.go
@@ -130,8 +130,8 @@ func TLSProfileHash(profile configv1.TLSProfileSpec) string {
 	return hex.EncodeToString(sum[:])[:16]
 }
 
-// newTLSProfileFromEnv reconstructs a TLSProfileSpec from operator-injected environment variables.
-func newTLSProfileFromEnv() configv1.TLSProfileSpec {
+// NewTLSProfileFromEnv reconstructs a TLSProfileSpec from operator-injected environment variables.
+func NewTLSProfileFromEnv() configv1.TLSProfileSpec {
 	minVersion := os.Getenv(TLSProfileMinVersionEnvName)
 	ciphersStr := os.Getenv(TLSProfileCiphersEnvName)
 

--- a/internal/controllers/utils/tls_profile_test.go
+++ b/internal/controllers/utils/tls_profile_test.go
@@ -160,14 +160,14 @@ var _ = Describe("TLS Profile", func() {
 		})
 	})
 
-	Describe("newTLSProfileFromEnv", func() {
+	Describe("NewTLSProfileFromEnv", func() {
 		AfterEach(func() {
 			os.Unsetenv(TLSProfileMinVersionEnvName)
 			os.Unsetenv(TLSProfileCiphersEnvName)
 		})
 
 		It("should fall back to Intermediate when env vars are not set", func() {
-			profile := newTLSProfileFromEnv()
+			profile := NewTLSProfileFromEnv()
 			Expect(profile.MinTLSVersion).To(Equal(configv1.VersionTLS12))
 			Expect(profile.Ciphers).ToNot(BeEmpty())
 		})
@@ -176,7 +176,7 @@ var _ = Describe("TLS Profile", func() {
 			os.Setenv(TLSProfileMinVersionEnvName, string(configv1.VersionTLS13))
 			os.Setenv(TLSProfileCiphersEnvName, "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384")
 
-			profile := newTLSProfileFromEnv()
+			profile := NewTLSProfileFromEnv()
 			Expect(profile.MinTLSVersion).To(Equal(configv1.VersionTLS13))
 			Expect(profile.Ciphers).To(Equal([]string{
 				"TLS_AES_128_GCM_SHA256",
@@ -188,7 +188,7 @@ var _ = Describe("TLS Profile", func() {
 			os.Setenv(TLSProfileMinVersionEnvName, string(configv1.VersionTLS13))
 			os.Setenv(TLSProfileCiphersEnvName, "")
 
-			profile := newTLSProfileFromEnv()
+			profile := NewTLSProfileFromEnv()
 			Expect(profile.MinTLSVersion).To(Equal(configv1.VersionTLS13))
 			Expect(profile.Ciphers).To(BeEmpty())
 		})
@@ -197,7 +197,7 @@ var _ = Describe("TLS Profile", func() {
 			os.Setenv(TLSProfileMinVersionEnvName, "TLS1.2") // invalid format
 			os.Setenv(TLSProfileCiphersEnvName, "ECDHE-RSA-AES128-GCM-SHA256")
 
-			profile := newTLSProfileFromEnv()
+			profile := NewTLSProfileFromEnv()
 			Expect(profile.MinTLSVersion).To(Equal(configv1.VersionTLS12))
 			Expect(profile.Ciphers).ToNot(BeEmpty())
 		})

--- a/internal/controllers/utils/utils.go
+++ b/internal/controllers/utils/utils.go
@@ -865,7 +865,7 @@ func loadDefaultCABundles(config *tls.Config) error {
 // When loadCAs is true, default in-cluster CA bundles are loaded.
 // Pass loadCAs=false when the caller provides its own trust anchors (e.g., a pinned service CA).
 func GetDefaultTLSConfig(config *tls.Config, loadCAs bool) (*tls.Config, error) {
-	profile := newTLSProfileFromEnv()
+	profile := NewTLSProfileFromEnv()
 	tlsConfig, err := NewOutboundTLSConfig(profile, config)
 	if err != nil {
 		return nil, err
@@ -899,7 +899,7 @@ func AddCABundle(config *tls.Config, caBundle string) error {
 // TLS version and cipher suites are inherited from the cluster TLS security profile
 // (via operator-injected environment variables).
 func GetClientTLSConfig(ctx context.Context, certFile, keyFile, caFile string) (*tls.Config, error) {
-	profile := newTLSProfileFromEnv()
+	profile := NewTLSProfileFromEnv()
 	return NewOutboundMTLSConfig(ctx, profile, certFile, keyFile, caFile)
 }
 
@@ -907,7 +907,7 @@ func GetClientTLSConfig(ctx context.Context, certFile, keyFile, caFile string) (
 // TLS version and cipher suites are inherited from the cluster TLS security profile
 // (via operator-injected environment variables).
 func GetServerTLSConfig(ctx context.Context, certFile, keyFile string) (*tls.Config, error) {
-	profile := newTLSProfileFromEnv()
+	profile := NewTLSProfileFromEnv()
 	return NewInboundTLSConfig(ctx, profile, certFile, keyFile)
 }
 

--- a/internal/hardwaremanager/cmd/start_hardwaremanager.go
+++ b/internal/hardwaremanager/cmd/start_hardwaremanager.go
@@ -139,6 +139,8 @@ func (c *ControllerManagerCommand) run(cmd *cobra.Command, argv []string) error 
 			c.NextProtos = []string{"http/1.1"}
 		})
 	}
+	tlsProfile := ctlrutils.NewTLSProfileFromEnv()
+	tlsOpts = append(tlsOpts, ctlrutils.NewTLSConfiguratorFromProfile(tlsProfile))
 
 	if err := hwmgrutils.InitNodeAllocationRequestUtils(scheme); err != nil {
 		logger.ErrorContext(ctx, "failed InitNodeAllocationRequestUtils", slog.Any("error", err))


### PR DESCRIPTION
## Summary

- Backport of #3620 from main to release-4.22, including only:

1. TLS support.
2. Fix for the metrics port on hardware-manager.

A direct cherry-pick was not possible because #3620 also includes Prometheus metrics exposure changes (ServiceMonitor, services-monitor.yaml, prometheus-metrics.md, ... ) that depend on the metrics feature, which is not present in release-4.22.

## Test plan

- [x] `make ci-job` passes
- [x] `make test-e2e` passes
- [x] Verify hardware-manager pod starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)