### PR TITLE
Switch runtime base image to ubi9-minimal-pqc for PQC enablement

### DIFF
--- a/.konflux/Dockerfile
+++ b/.konflux/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN GOEXPERIMENT=strictfipsruntime CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -tags strictfipsruntime -a -o /bin/oran-o2ims main.go
 
 # Runtime stage
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:57c8151c51445a07e503dab9dc9211dc3cdeac9d45ed81a10954b7d770659b3b
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest@sha256:e7f7720259142a68a8087fb4df9d21a91189863aa083e9b27c2c2801878ef5c4
 
 WORKDIR /
 


### PR DESCRIPTION
## Summary

- Replace the `ubi9/ubi-minimal` runtime base image with `ubi9/ubi-minimal-pqc` in `.konflux/Dockerfile`
- The `-pqc` image sets the system crypto-policy to `DEFAULT:PQ`, enabling Post-Quantum Cryptography algorithms (ML-KEM, ML-DSA) in OpenSSL
- This aligns with the platform-wide PQC enablement initiative ([OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113)) for consistency across all OpenShift operators

## Changes

The only change is in `.konflux/Dockerfile`: the runtime stage base image is switched from:
```
registry.access.redhat.com/ubi9/ubi-minimal:latest
```
to:
```
registry.redhat.io/ubi9/ubi-minimal-pqc:latest
```

## Testing Requirements

- [ ] Verify no regressions in standard (non-FIPS) mode
- [ ] Verify no regressions in FIPS mode (PQC modules are auto-disabled by the FIPS provider)
- [ ] Run `tls-scanner` to confirm ML-KEM (`X25519MLKEM768`) negotiation on TLS endpoints (ports 6443, 9443)
- [ ] Link testing results to [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113)

## References

- [CNF-26444](https://redhat.atlassian.net/browse/CNF-26444) — O-Cloud Manager PQC base image tracker
- [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113) — PQC images enablement initiative
- [CNF-21765](https://redhat.atlassian.net/browse/CNF-21765) — Parent epic: Central TLS Profile Consistency


Made with [Cursor](https://cursor.com)