### PR TITLE
OCPBUGS-99223: validate boot interface label before firmware updates

### DIFF
--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -1504,6 +1504,13 @@ func allocateBMHToNodeAllocationRequest(
 		return "", fmt.Errorf("failed to create allocated node (%s): %w", nodeName, err)
 	}
 
+	// Set bootMACAddress from interface labels before processing the HW
+	// profile. If the boot-interface label doesn't match any NIC on the BMH,
+	// we want to fail before submitting firmware/BIOS update jobs to the BMC.
+	if err := setBootMACAddressFromLabel(ctx, c, logger, bmh); err != nil {
+		return "", fmt.Errorf("failed to set bootMACAddress from interface label for BMH (%s): %w", bmh.Name, err)
+	}
+
 	// Process HW profile
 	updating, err := processHwProfileWithHandledError(ctx, c, noncachedClient, logger, namespace, bmh, node, group.NodeGroupData.HwProfile, false, false)
 	if err != nil {
@@ -1526,13 +1533,6 @@ func allocateBMHToNodeAllocationRequest(
 	// Allow Host Management
 	if err := allowHostManagement(ctx, c, logger, bmh); err != nil {
 		return "", fmt.Errorf("failed to add host management annotation to BMH (%s): %w", bmh.Name, err)
-	}
-
-	// Set bootMACAddress from interface labels if not already set
-	// This enables the pre-provisioned hardware workflow where boot interface
-	// is identified via labels instead of requiring bootMACAddress in the spec
-	if err := setBootMACAddressFromLabel(ctx, c, logger, bmh); err != nil {
-		return "", fmt.Errorf("failed to set bootMACAddress from interface label for BMH (%s): %w", bmh.Name, err)
 	}
 
 	// Update node status


### PR DESCRIPTION
Move setBootMACAddressFromLabel before processHwProfileWithHandledError in the BMH allocation sequence. Previously, if the boot-interface label didn't match any NIC on the BMH, the error was only detected after firmware/BIOS update jobs had already been submitted to the BMC. This blocked PR deletion until the updates completed.

With this change, a mismatched boot-interface label fails allocation immediately, before any hardware-modifying operations are submitted.