### PR TITLE
[release-4.22] Make postgres pod compliant with security profiles (tls-scanner)

### DIFF
--- a/.konflux/overlay/pin_images.in.yaml
+++ b/.konflux/overlay/pin_images.in.yaml
@@ -4,5 +4,5 @@
   source: quay.io/openshift-kni/oran-o2ims-operator:4.22.0
   target: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-4-22@sha256:1b0a17a8142f0b51297047efd34c235fbd4f115e1ded4f96f005d2ec1f777038
 - key: postgres_image
-  source: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
-  target: registry.redhat.io/rhel9/postgresql-16@sha256:4f46bed6bce211be83c110a3452bd3f151a1e8ab150c58f2a02c56e9cc83db98
+  source: registry.redhat.io/rhel9/postgresql-18:9.8-1785715946
+  target: registry.redhat.io/rhel9/postgresql-18@sha256:2ba45f058876181c47fe965b2a7b715cadd091b891e3f042357a6302c5f4251e

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -2290,7 +2290,7 @@ spec:
                 - name: IMAGE
                   value: quay.io/openshift-kni/oran-o2ims-operator:4.22.0
                 - name: POSTGRES_IMAGE
-                  value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
+                  value: registry.redhat.io/rhel9/postgresql-18:9.8-1785715946
                 - name: OCLOUD_MANAGER_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -73,7 +73,7 @@ spec:
         - name: IMAGE
           value: controller:latest
         - name: POSTGRES_IMAGE
-          value: registry.redhat.io/rhel9/postgresql-16:9.5-1731610873
+          value: registry.redhat.io/rhel9/postgresql-18:9.8-1785715946
         - name: OCLOUD_MANAGER_NAMESPACE
           valueFrom:
             fieldRef:

--- a/docs/dev/tls-configuration.md
+++ b/docs/dev/tls-configuration.md
@@ -102,10 +102,23 @@ flowchart TB
         Serve["serve.go (GetServerTLSConfig)"]
     end
 
+    subgraph hw_mgr_pod["Hardware Manager Pod"]
+        HWEnvRead["reads TLS_PROFILE_* env vars"]
+        HWMgr["controller-runtime metrics server (TLSOpts)"]
+    end
+
+    subgraph postgres_pod["PostgreSQL Pod"]
+        PGConf["postgresql.conf (ssl_min_protocol_version,
+        ssl_ciphers, ssl_tls13_ciphers, ssl_groups)"]
+    end
+
+
     APIServerRes -->|"watch"| Watcher
     Watcher -->|"OnProfileChange: cancel()"| MgrTLS
     Watcher -->|"OnProfileChange: patch annotation"| Reconciler
     Reconciler -->|"rolling restart + env var injection"| http_pods
+    Reconciler -->|"rolling restart + env var injection"| hw_mgr_pod
+    Reconciler -->|"regenerate ConfigMap + rolling restart"| PGConf
     EnvRead -->|"builds tls.Config"| Serve
 ```
 
@@ -118,6 +131,23 @@ Key design decisions:
 - **Profile changes trigger rolling restarts** via annotation changes on
   the pod template. The new pods start with the updated environment
   variables and apply the new TLS configuration at startup.
+- **PostgreSQL inherits the TLS profile** through dynamic `postgresql.conf`
+  generation. The operator appends the following settings to the embedded
+  base configuration:
+  - `ssl_min_protocol_version` — mapped from the cluster profile via
+    `TLSVersionToPostgres()`
+  - `ssl_ciphers` — TLS 1.2 ciphers only, filtered via
+    `TLSCiphersToPostgres()` (TLS 1.3 cipher names are excluded because
+    PostgreSQL's `ssl_ciphers` only accepts TLS 1.2 names)
+  - `ssl_tls13_ciphers` — statically set to exclude `TLS_AES_128_CCM_SHA256`
+    (not in the OpenShift Modern profile's allowed list)
+  - `ssl_groups` — statically set to `X25519MLKEM768:X25519:prime256v1`
+    to enable ML-KEM post-quantum key exchange
+
+  The `tls-profile-hash` annotation triggers a rolling restart when the
+  profile changes. These native PostgreSQL 18 settings replace the
+  `opensslcnf.config` crypto-policy override that was required with
+  PostgreSQL 16.
 - **The operator itself restarts** when the profile changes because
   `controller-runtime` does not support modifying `TLSOpts` on a running
   manager. The `SecurityProfileWatcher` calls `cancel()` on the manager
@@ -201,18 +231,25 @@ Expected: `TLS_PROFILE_MIN_VERSION=VersionTLS12` and
 Run a test pod inside the cluster:
 
 ```bash
+HOST=resource-server.oran-o2ims.svc.cluster.local:8443
 oc run tls-test --rm -i --restart=Never \
   --image=registry.access.redhat.com/ubi9/ubi:latest -n oran-o2ims \
-  --overrides='{"spec":{"securityContext":{"runAsNonRoot":true,
-    "seccompProfile":{"type":"RuntimeDefault"}},"containers":[{"name":"tls-test",
-    "image":"registry.access.redhat.com/ubi9/ubi:latest","command":["bash","-c",
-    "echo \"=== TLS 1.1 (expect FAIL) ===\"
-     echo | openssl s_client -connect resource-server.oran-o2ims.svc.cluster.local:8443 -tls1_1 2>&1 | grep -E \"error|Protocol|Cipher\"
-     echo \"=== TLS 1.2 (expect PASS) ===\"
-     echo | openssl s_client -connect resource-server.oran-o2ims.svc.cluster.local:8443 -tls1_2 2>&1 | grep -E \"Protocol|Cipher\" | head -3
-     echo \"=== TLS 1.3 (expect PASS) ===\"
-     echo | openssl s_client -connect resource-server.oran-o2ims.svc.cluster.local:8443 -tls1_3 2>&1 | grep -E \"Protocol|Cipher\" | head -3"],
-    "securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}}]}}'
+  --overrides='{
+    "spec":{
+      "securityContext":{
+        "runAsNonRoot":true,
+        "seccompProfile":{"type":"RuntimeDefault"}
+      }
+    }
+  }' \
+  -- bash -c "
+    echo '=== TLS 1.1 (expect FAIL) ==='
+    echo | openssl s_client -connect $HOST -tls1_1 2>&1 | grep -E 'error|Protocol|Cipher'
+    echo '=== TLS 1.2 (expect PASS) ==='
+    echo | openssl s_client -connect $HOST -tls1_2 2>&1 | grep -E 'Protocol|Cipher' | head -3
+    echo '=== TLS 1.3 (expect PASS) ==='
+    echo | openssl s_client -connect $HOST -tls1_3 2>&1 | grep -E 'Protocol|Cipher' | head -3
+  "
 ```
 
 Expected results:
@@ -264,16 +301,23 @@ Expected:
 **2.5 Verify TLS 1.2 is now rejected:**
 
 ```bash
+HOST=resource-server.oran-o2ims.svc.cluster.local:8443
 oc run tls-modern-test --rm -i --restart=Never \
   --image=registry.access.redhat.com/ubi9/ubi:latest -n oran-o2ims \
-  --overrides='{"spec":{"securityContext":{"runAsNonRoot":true,
-    "seccompProfile":{"type":"RuntimeDefault"}},"containers":[{"name":"tls-modern-test",
-    "image":"registry.access.redhat.com/ubi9/ubi:latest","command":["bash","-c",
-    "echo \"=== TLS 1.2 (expect FAIL with Modern) ===\"
-     echo | openssl s_client -connect resource-server.oran-o2ims.svc.cluster.local:8443 -tls1_2 2>&1 | grep -E \"error|alert|Cipher\"
-     echo \"=== TLS 1.3 (expect PASS) ===\"
-     echo | openssl s_client -connect resource-server.oran-o2ims.svc.cluster.local:8443 -tls1_3 2>&1 | grep -E \"Protocol|Cipher\" | head -3"],
-    "securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}}]}}'
+  --overrides='{
+    "spec":{
+      "securityContext":{
+        "runAsNonRoot":true,
+        "seccompProfile":{"type":"RuntimeDefault"}
+      }
+    }
+  }' \
+  -- bash -c "
+    echo '=== TLS 1.2 (expect FAIL with Modern) ==='
+    echo | openssl s_client -connect $HOST -tls1_2 2>&1 | grep -E 'error|alert|Cipher'
+    echo '=== TLS 1.3 (expect PASS) ==='
+    echo | openssl s_client -connect $HOST -tls1_3 2>&1 | grep -E 'Protocol|Cipher' | head -3
+  "
 ```
 
 Expected results:
@@ -299,6 +343,20 @@ After pods restart, verify that only the listed ciphers are accepted:
 | `ECDHE-RSA-AES128-GCM-SHA256` | **Accepted** |
 | `ECDHE-RSA-AES256-GCM-SHA384` | **Accepted** |
 | `ECDHE-RSA-CHACHA20-POLY1305` (not in list) | `handshake failure` — **rejected** |
+
+> **Note:** Custom profiles only accept TLS 1.2 cipher names. The APIServer
+> rejects TLS 1.3 cipher suites — for example, attempting to set
+> `"ciphers":["TLS_CHACHA20_POLY1305_SHA256"]` returns:
+>
+> ```text
+> spec.tlsSecurityProfile.custom.ciphers: Invalid value:
+>   ["TLS_CHACHA20_POLY1305_SHA256"]: TLS 1.3 cipher suites are not configurable
+> ```
+>
+> TLS 1.3 ciphers are managed by the platform (OpenSSL) and cannot be
+> restricted through the APIServer's `tlsSecurityProfile`. This is why
+> the operator's PostgreSQL configuration uses a static `ssl_tls13_ciphers`
+> value rather than deriving it from the profile.
 
 **2.7 Revert to original configuration:**
 
@@ -366,8 +424,15 @@ export KUBECONFIG=/path/to/kubeconfig
 export SCANNER_IMAGE="quay.io/<your-username>/tls-scanner:1.0"
 export NAMESPACE="oran-o2ims"
 export NAMESPACE_FILTER="oran-o2ims"
+export STARTTLS_PORTS="postgres=5432"
 ./deploy.sh --verbose deploy
 ```
+
+The `STARTTLS_PORTS` variable enables the scanner's
+[STARTTLS support](https://github.com/openshift/tls-scanner#command-line-options)
+for PostgreSQL. Without it, the scanner cannot negotiate PostgreSQL's in-band
+TLS handshake (`SSLRequest` wire protocol) and will report `NO_TLS` for port
+5432.
 
 The scanner discovers all pods in the namespace, probes their listening ports
 for TLS, and produces results in `./artifacts/` (CSV and JSON formats).
@@ -383,30 +448,36 @@ After the scan completes, clean up cluster resources:
 With the cluster running the default Intermediate profile
 (`spec.tlsSecurityProfile` unset on APIServer), the scanner reports:
 
-| Pod | Port | TLS Versions | PQC Ready | API MinVersion Compliance | API Cipher Compliance |
-|-----|------|-------------|-----------|---------------------------|----------------------|
-| cluster-server | 8443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
-| oran-o2ims-controller-manager | 6443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
-| oran-o2ims-controller-manager | 9443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
-| artifacts-server | 8443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
-| provisioning-server | 8443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
-| resource-server | 8443 | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
+| Pod | Port | STARTTLS | TLS Versions | PQC Ready | API MinVersion Compliance | API Cipher Compliance |
+|-----|------|----------|-------------|-----------|---------------------------|----------------------|
+| artifacts-server | 8443 | N/A | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
+| cluster-server | 8443 | N/A | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
+| hardwaremanager-server | 8443 | N/A | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
+| oran-o2ims-controller-manager | 6443 | N/A | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
+| oran-o2ims-controller-manager | 9443 | N/A | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
+| provisioning-server | 8443 | N/A | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
+| resource-server | 8443 | N/A | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
+| postgres-server | 5432 | postgres | TLSv1.2, TLSv1.3 | Yes (ML-KEM X25519MLKEM768) | true | true |
 
 Key observations:
 
-- **All endpoints pass API MinVersion Compliance** — the offered minimum TLS
-  version matches (or exceeds) what the cluster profile requires.
-- **All endpoints pass API Cipher Compliance** — only ciphers allowed by the
-  Intermediate profile are offered.
-- **All endpoints are PQC-ready** — ML-KEM (`X25519MLKEM768`) key exchange is
-  supported, provided by Go 1.25's native TLS 1.3 implementation.
-- **Forward Secrecy confirmed** on all TLS-enabled endpoints (only ECDHE
-  and TLS 1.3 AEAD ciphers offered).
+- **All endpoints pass API MinVersion and Cipher Compliance** — the offered
+  minimum TLS version and cipher suites match the cluster profile requirements.
+- **Go-based endpoints** achieve compliance via Go's native TLS implementation.
+  ML-KEM (`X25519MLKEM768`) support comes from Go's `crypto/tls` (available
+  since Go 1.24; this project requires Go 1.26).
+- **postgres-server** achieves compliance through dynamic `postgresql.conf`
+  generation using PostgreSQL 18's native TLS controls:
+  - `ssl_min_protocol_version` — enforces the cluster profile's minimum
+    TLS version (e.g. `TLSv1.3` under Modern)
+  - `ssl_ciphers` — restricts TLS 1.2 cipher suites to those in the
+    cluster profile (filtered via `TLSCiphersToPostgres()`)
+  - `ssl_tls13_ciphers` — excludes `TLS_AES_128_CCM_SHA256` (not in
+    OpenShift profiles) to pass scanner cipher compliance
+  - `ssl_groups` — enables ML-KEM (`X25519MLKEM768`) for PQC readiness
+- **Forward Secrecy confirmed** on all endpoints (only ECDHE and TLS 1.3
+  AEAD ciphers offered).
 - **No weak ciphers** — NULL, export, DES, RC4, and CBC cipher categories are
   all confirmed "not offered".
 - Scanner readiness note: *"Endpoint offers TLS 1.3 and ML-KEM — ready for
   Modern profile"*.
-
-The `postgres-server` pod (port 5432) reports `NO_TLS` which is expected — it
-uses PostgreSQL's native wire protocol without TLS on the pod network (traffic
-is cluster-internal only).

--- a/internal/controllers/inventory_controller_postgres.go
+++ b/internal/controllers/inventory_controller_postgres.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -169,6 +170,7 @@ func (t *reconcilerTask) deployPostgresServer(ctx context.Context, serverName st
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					"kubectl.kubernetes.io/default-container": constants.ServerContainerName,
+					"ocloud.openshift.io/tls-profile-hash":    t.tlsProfileHash,
 				},
 				Labels: map[string]string{
 					"app": serverName,
@@ -320,11 +322,31 @@ func (t *reconcilerTask) createDatabase(ctx context.Context) (err error) {
 		return
 	}
 
-	// Create the config volume
+	// Create the config volume with TLS profile settings appended dynamically
 	t.logger.DebugContext(ctx, "[createDatabase] creating database config volume")
 	configVolumeName := fmt.Sprintf("%s-config", ctlrutils.InventoryDatabaseServerName)
-	err = ctlrutils.CreateConfigMapFromEmbeddedFile(ctx, t.client, t.object,
-		postgres.Artifacts, postgres.ConfigFilePath, t.object.Namespace, configVolumeName, postgres.ConfigFileName)
+	pgConfData, readErr := postgres.Artifacts.ReadFile(postgres.ConfigFilePath)
+	if readErr != nil {
+		err = fmt.Errorf("failed to read embedded %s: %w", postgres.ConfigFilePath, readErr)
+		t.logger.ErrorContext(ctx, "Failed to read embedded postgresql.conf", slog.Any("error", err))
+		return
+	}
+	pgConf := string(pgConfData)
+	if t.tlsMinVersion != "" {
+		pgConf += fmt.Sprintf("\nssl_min_protocol_version = '%s'", ctlrutils.TLSVersionToPostgres(t.tlsMinVersion))
+	}
+	if t.tlsCiphers != "" {
+		pgCiphers := ctlrutils.TLSCiphersToPostgres(strings.Split(t.tlsCiphers, ","))
+		if pgCiphers != "" {
+			pgConf += fmt.Sprintf("\nssl_ciphers = '%s'", pgCiphers)
+			t.logger.InfoContext(ctx, "PostgreSQL ssl_ciphers configured from cluster TLS profile",
+				slog.String("sslCiphers", pgCiphers))
+		}
+	}
+	pgConf += fmt.Sprintf("\nssl_tls13_ciphers = '%s'", ctlrutils.PostgresTLS13Ciphers)
+	pgConf += fmt.Sprintf("\nssl_groups = '%s'", ctlrutils.PostgresSSLGroups)
+	err = ctlrutils.CreateConfigMapFromString(ctx, t.client, t.object,
+		t.object.Namespace, configVolumeName, postgres.ConfigFileName, pgConf)
 	if err != nil {
 		t.logger.ErrorContext(
 			ctx,

--- a/internal/controllers/inventory_controller_test.go
+++ b/internal/controllers/inventory_controller_test.go
@@ -26,6 +26,25 @@ Test Cases in this file:
      * Artifacts server
      * Provisioning server
    - Validates complete inventory service deployment
+
+3. "NetworkPolicy scopes: API servers allow ingress-controller, database does not"
+   - Verifies API server and hardware manager NetworkPolicies allow ingress-controller,
+     monitoring, and same-namespace traffic
+   - Verifies alarms-server additionally allows alertmanager ingress
+   - Verifies database NetworkPolicy blocks ingress-controller and monitoring but
+     allows same-namespace traffic
+
+4. "Postgres ConfigMap contains TLS profile settings and deployment has tls-profile-hash"
+   - Verifies base ConfigMap (no TLS profile set) has only static PG18 TLS controls
+   - Re-reconciles with a mixed cipher list (Intermediate-style) and verifies:
+     * ssl_min_protocol_version is mapped from the cluster profile
+     * ssl_ciphers contains only TLS 1.2 ciphers (TLS 1.3 filtered out)
+     * ssl_tls13_ciphers excludes CCM and ssl_groups enables ML-KEM
+   - Re-reconciles with Modern profile (TLS 1.3 only, no TLS 1.2 ciphers) and verifies:
+     * ssl_min_protocol_version = TLSv1.3
+     * ssl_ciphers is omitted (no TLS 1.2 ciphers in Modern)
+     * ssl_tls13_ciphers and ssl_groups remain present
+   - Verifies the postgres-server Deployment has the tls-profile-hash annotation
 */
 
 package controllers
@@ -398,6 +417,102 @@ var _ = Describe("Inventory Controller", func() {
 					"database NetworkPolicy should not allow ingress-controller traffic")
 				Expect(hasSameNamespaceRule(dbNP)).To(BeTrue(),
 					"database NetworkPolicy should allow same-namespace traffic")
+			},
+		),
+		Entry(
+			"Postgres ConfigMap contains TLS profile settings and deployment has tls-profile-hash",
+			[]client.Object{
+				&inventoryv1alpha1.Inventory{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "oran-o2ims-sample-1",
+						Namespace:         constants.DefaultNamespace,
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: inventoryv1alpha1.InventorySpec{},
+				},
+			},
+			reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: ctlrutils.InventoryNamespace,
+					Name:      "oran-o2ims-sample-1",
+				},
+			},
+			func(result ctrl.Result, reconciler *Reconciler) {
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Minute}))
+
+				pgConfKey := types.NamespacedName{
+					Name:      ctlrutils.InventoryDatabaseServerName + "-config",
+					Namespace: ctlrutils.InventoryNamespace,
+				}
+				pgDeployKey := types.NamespacedName{
+					Name:      ctlrutils.InventoryDatabaseServerName,
+					Namespace: ctlrutils.InventoryNamespace,
+				}
+				req := reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: ctlrutils.InventoryNamespace,
+						Name:      "oran-o2ims-sample-1",
+					},
+				}
+
+				// --- Phase 1: Base reconcile (no TLS profile set) ---
+				// Static PG18 TLS controls are always appended; dynamic settings are not.
+				cm := &corev1.ConfigMap{}
+				err := reconciler.Client.Get(context.TODO(), pgConfKey, cm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cm.Data).To(HaveKey("postgresql.conf"))
+				pgConf := cm.Data["postgresql.conf"]
+				Expect(pgConf).ToNot(ContainSubstring("ssl_min_protocol_version"))
+				Expect(pgConf).ToNot(ContainSubstring("ssl_ciphers"))
+				Expect(pgConf).To(ContainSubstring("ssl_tls13_ciphers"))
+				Expect(pgConf).To(ContainSubstring("ssl_groups"))
+
+				// --- Phase 2: Mixed cipher list (Intermediate-style with TLS 1.2 + 1.3 ciphers) ---
+				reconciler.TLSMinVersion = "VersionTLS12"
+				reconciler.TLSProfileHash = "intermediate-hash"
+				reconciler.TLSCiphers = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-RSA-AES256-GCM-SHA384"
+				_, err = reconciler.Reconcile(context.TODO(), req)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = reconciler.Client.Get(context.TODO(), pgConfKey, cm)
+				Expect(err).ToNot(HaveOccurred())
+				pgConf = cm.Data["postgresql.conf"]
+				Expect(pgConf).To(ContainSubstring("ssl_min_protocol_version = 'TLSv1.2'"))
+				Expect(pgConf).To(ContainSubstring(
+					"ssl_ciphers = 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384'"))
+				Expect(pgConf).To(ContainSubstring(
+					"ssl_tls13_ciphers = 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256'"))
+				Expect(pgConf).ToNot(ContainSubstring("TLS_AES_128_CCM_SHA256"))
+				Expect(pgConf).To(ContainSubstring(
+					"ssl_groups = 'X25519MLKEM768:X25519:prime256v1'"))
+
+				deployment := &appsv1.Deployment{}
+				err = reconciler.Client.Get(context.TODO(), pgDeployKey, deployment)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deployment.Spec.Template.Annotations).To(
+					HaveKeyWithValue("ocloud.openshift.io/tls-profile-hash", "intermediate-hash"))
+
+				// --- Phase 3: Modern profile (TLS 1.3 only — no TLS 1.2 ciphers) ---
+				reconciler.TLSMinVersion = "VersionTLS13"
+				reconciler.TLSProfileHash = "modern-hash"
+				reconciler.TLSCiphers = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256"
+				_, err = reconciler.Reconcile(context.TODO(), req)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = reconciler.Client.Get(context.TODO(), pgConfKey, cm)
+				Expect(err).ToNot(HaveOccurred())
+				pgConf = cm.Data["postgresql.conf"]
+				Expect(pgConf).To(ContainSubstring("ssl_min_protocol_version = 'TLSv1.3'"))
+				Expect(pgConf).ToNot(ContainSubstring("ssl_ciphers ="),
+					"Modern profile has no TLS 1.2 ciphers; ssl_ciphers should not be set")
+				Expect(pgConf).To(ContainSubstring("ssl_tls13_ciphers"))
+				Expect(pgConf).To(ContainSubstring("ssl_groups"))
+
+				err = reconciler.Client.Get(context.TODO(), pgDeployKey, deployment)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deployment.Spec.Template.Annotations).To(
+					HaveKeyWithValue("ocloud.openshift.io/tls-profile-hash", "modern-hash"),
+					"annotation should update on profile change to trigger rolling restart")
 			},
 		),
 	)

--- a/internal/controllers/utils/configmap.go
+++ b/internal/controllers/utils/configmap.go
@@ -47,6 +47,30 @@ func CreateConfigMapFromEmbeddedFile(ctx context.Context, c client.Client, owner
 	return nil
 }
 
+// CreateConfigMapFromString creates a ConfigMap from a string value.
+func CreateConfigMapFromString(ctx context.Context, c client.Client, ownerObject client.Object, namespace, name, key, data string) error {
+	configmap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: map[string]string{
+			key: data,
+		},
+	}
+
+	err := CreateK8sCR(ctx, c, configmap, ownerObject, UPDATE)
+	if err != nil {
+		return fmt.Errorf("failed to create configmap '%s/%s': %w", namespace, name, err)
+	}
+
+	return nil
+}
+
 // GetConfigmap attempts to retrieve a ConfigMap object for the given name
 func GetConfigmap(ctx context.Context, c client.Client, name, namespace string) (*corev1.ConfigMap, error) {
 	existingConfigmap := &corev1.ConfigMap{}

--- a/internal/controllers/utils/tls_profile.go
+++ b/internal/controllers/utils/tls_profile.go
@@ -171,6 +171,56 @@ func newTLSProfileFromEnv() configv1.TLSProfileSpec {
 	}
 }
 
+// TLSVersionToPostgres converts an OpenShift TLS version string (e.g. "VersionTLS13")
+// to the PostgreSQL ssl_min_protocol_version format (e.g. "TLSv1.3").
+// Returns "TLSv1.2" as a safe default for unrecognized values.
+func TLSVersionToPostgres(version string) string {
+	pgVersions := map[string]string{
+		string(configv1.VersionTLS10): "TLSv1",
+		string(configv1.VersionTLS11): "TLSv1.1",
+		string(configv1.VersionTLS12): "TLSv1.2",
+		string(configv1.VersionTLS13): "TLSv1.3",
+	}
+	if v, ok := pgVersions[version]; ok {
+		return v
+	}
+	slog.Warn("Unrecognized TLS version for PostgreSQL, falling back to TLSv1.2",
+		slog.String("version", version))
+	return "TLSv1.2"
+}
+
+// TLSCiphersToPostgres converts a cipher list from the cluster TLS profile into
+// the colon-separated format expected by PostgreSQL's ssl_ciphers setting.
+//
+// TLS 1.3 cipher suites (prefixed with "TLS_") are excluded because PostgreSQL's
+// ssl_ciphers only accepts TLS 1.2 cipher names — passing TLS 1.3 names causes
+// "could not set the cipher list (no valid ciphers available)".
+// PostgreSQL manages TLS 1.3 ciphers internally via OpenSSL.
+//
+// Returns an empty string if no TLS 1.2 ciphers are present (e.g., Modern profile),
+// signaling to the caller that ssl_ciphers should not be set.
+func TLSCiphersToPostgres(ciphers []string) string {
+	var pgCiphers []string
+	for _, c := range ciphers {
+		if !strings.HasPrefix(c, "TLS_") {
+			pgCiphers = append(pgCiphers, c)
+		}
+	}
+	return strings.Join(pgCiphers, ":")
+}
+
+// PostgreSQL TLS 1.3 and key-exchange defaults for PG18+ native controls.
+// These are the OpenShift-approved values that satisfy tls-scanner compliance.
+const (
+	// PostgresTLS13Ciphers is the ssl_tls13_ciphers value: all standard TLS 1.3
+	// ciphers except TLS_AES_128_CCM_SHA256 (not in the OpenShift Modern profile).
+	PostgresTLS13Ciphers = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+
+	// PostgresSSLGroups is the ssl_groups value: ML-KEM for PQC key exchange
+	// alongside classical fallbacks.
+	PostgresSSLGroups = "X25519MLKEM768:X25519:prime256v1"
+)
+
 var validTLSVersions = map[string]bool{
 	string(configv1.VersionTLS10): true,
 	string(configv1.VersionTLS11): true,

--- a/internal/controllers/utils/tls_profile_test.go
+++ b/internal/controllers/utils/tls_profile_test.go
@@ -231,6 +231,67 @@ var _ = Describe("TLS Profile", func() {
 		})
 	})
 
+	Describe("TLSVersionToPostgres", func() {
+		It("should map VersionTLS12 to TLSv1.2", func() {
+			Expect(TLSVersionToPostgres(string(configv1.VersionTLS12))).To(Equal("TLSv1.2"))
+		})
+
+		It("should map VersionTLS13 to TLSv1.3", func() {
+			Expect(TLSVersionToPostgres(string(configv1.VersionTLS13))).To(Equal("TLSv1.3"))
+		})
+
+		It("should map VersionTLS10 to TLSv1", func() {
+			Expect(TLSVersionToPostgres(string(configv1.VersionTLS10))).To(Equal("TLSv1"))
+		})
+
+		It("should map VersionTLS11 to TLSv1.1", func() {
+			Expect(TLSVersionToPostgres(string(configv1.VersionTLS11))).To(Equal("TLSv1.1"))
+		})
+
+		It("should return TLSv1.2 as default for unrecognized values", func() {
+			Expect(TLSVersionToPostgres("UnknownVersion")).To(Equal("TLSv1.2"))
+		})
+
+		It("should return TLSv1.2 as default for empty string", func() {
+			Expect(TLSVersionToPostgres("")).To(Equal("TLSv1.2"))
+		})
+	})
+
+	Describe("TLSCiphersToPostgres", func() {
+		It("should exclude TLS 1.3 ciphers and join TLS 1.2 ciphers with colons", func() {
+			ciphers := []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"ECDHE-RSA-AES256-GCM-SHA384",
+			}
+			Expect(TLSCiphersToPostgres(ciphers)).To(Equal(
+				"ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384"))
+		})
+
+		It("should return empty string when only TLS 1.3 ciphers are present (Modern profile)", func() {
+			ciphers := []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_CHACHA20_POLY1305_SHA256",
+			}
+			Expect(TLSCiphersToPostgres(ciphers)).To(BeEmpty())
+		})
+
+		It("should return empty string for empty input", func() {
+			Expect(TLSCiphersToPostgres(nil)).To(BeEmpty())
+			Expect(TLSCiphersToPostgres([]string{})).To(BeEmpty())
+		})
+
+		It("should produce the full Intermediate cipher string without TLS 1.3 ciphers", func() {
+			profile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+			result := TLSCiphersToPostgres(profile.Ciphers)
+			Expect(result).To(ContainSubstring("ECDHE-RSA-AES128-GCM-SHA256"))
+			Expect(result).To(ContainSubstring("ECDHE-RSA-CHACHA20-POLY1305"))
+			Expect(result).ToNot(ContainSubstring("TLS_AES"))
+		})
+	})
+
 	Describe("NewOutboundMTLSConfig", func() {
 		var (
 			ctx    context.Context

--- a/internal/service/postgres/files/postgresql.conf
+++ b/internal/service/postgres/files/postgresql.conf
@@ -1,6 +1,6 @@
 # Based on https://github.com/le0pard/pgtune
 
-# DB Version: 16
+# DB Version: 18
 # OS Type: linux
 # DB Type: web
 # Total Memory (RAM): 2 GB


### PR DESCRIPTION
## Summary

Backport of https://github.com/openshift-kni/oran-o2ims/pull/3727 to `release-4.22`.

- Upgrade PostgreSQL 16 → 18 for native `ssl_tls13_ciphers` and `ssl_groups` controls
- Dynamically generate `postgresql.conf` TLS settings from the cluster's TLS security profile
- Add `tls-profile-hash` annotation to trigger rolling restarts on profile changes
- Unit and integration tests for TLS version/cipher conversion and ConfigMap generation
- Document PostgreSQL TLS integration and scanner compliance results

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Envtest tests pass (`make test-envtest`)
- [x] `tls-scanner` reports full compliance under Intermediate (default) profile
- [x] `tls-scanner` reports full compliance under Modern + StrictAllComponents
- [x] Profile change triggers rolling restart of `postgres-server` pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)