### PR TITLE
CNF-26439: accept nodeGroups format inputs for ClusterInstance in ClusterTemplate

### DIFF
--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -218,8 +218,7 @@ func (t *clusterTemplateReconcilerTask) validateClusterTemplateCR(ctx context.Co
 	validationErrs = append(validationErrs, hwMgmtErrs...)
 
 	// Validate the ClusterInstance defaults configmap
-	err = validateConfigmapReference[map[string]any](
-		ctx, t.client,
+	err = t.validateConfigmapReference(ctx,
 		t.object.Spec.TemplateDefaults.ClusterInstanceDefaults,
 		t.object.Namespace,
 		ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
@@ -252,8 +251,7 @@ func (t *clusterTemplateReconcilerTask) validateClusterTemplateCR(ctx context.Co
 	}
 
 	// Validation for the policy template defaults configmap.
-	err = validateConfigmapReference[map[string]any](
-		ctx, t.client,
+	err = t.validateConfigmapReference(ctx,
 		t.object.Spec.TemplateDefaults.PolicyTemplateDefaults,
 		t.object.Namespace,
 		ctlrutils.PolicyTemplateDefaultsConfigmapKey,
@@ -456,28 +454,24 @@ func (t *clusterTemplateReconcilerTask) validateUpgradeDefaultsAgainstSchema(
 	return nil
 }
 
-// validateConfigmapReference validates a given configmap reference within the ClusterTemplate
-func validateConfigmapReference[T any](
-	ctx context.Context, c client.Client, name, namespace, templateDataKey, timeoutConfigKey string) error {
+// validateConfigmapReference validates a given configmap reference within the ClusterTemplate.
+func (t *clusterTemplateReconcilerTask) validateConfigmapReference(
+	ctx context.Context, name, namespace, templateDataKey, timeoutConfigKey string) error {
 
-	existingConfigmap, err := ctlrutils.GetConfigmap(ctx, c, name, namespace)
+	existingConfigmap, err := ctlrutils.GetConfigmap(ctx, t.client, name, namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get ConfigmapReference: %w", err)
 	}
 
 	// Extract and validate the template from the configmap
-	data, err := ctlrutils.ExtractTemplateDataFromConfigMap[T](existingConfigmap, templateDataKey)
+	data, err := ctlrutils.ExtractTemplateDataFromConfigMap[map[string]any](existingConfigmap, templateDataKey)
 	if err != nil {
 		return err
 	}
 
 	if templateDataKey == ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey {
-		if err = ctlrutils.ValidateDefaultInterfaces(data); err != nil {
-			return typederrors.NewInputError("failed to validate the default ConfigMap: %w", err)
-		}
-
-		if err = ctlrutils.ValidateConfigmapSchemaAgainstClusterInstanceCRD(ctx, c, data); err != nil {
-			return typederrors.NewInputError("failed to validate the default ConfigMap: %w", err)
+		if err := t.validateClusterInstanceDefaults(ctx, data); err != nil {
+			return err
 		}
 	}
 
@@ -496,12 +490,109 @@ func validateConfigmapReference[T any](
 		newConfigmap := existingConfigmap.DeepCopy()
 		newConfigmap.Immutable = &immutable
 
-		if err := ctlrutils.CreateK8sCR(ctx, c, newConfigmap, nil, ctlrutils.PATCH); err != nil {
+		if err := ctlrutils.CreateK8sCR(ctx, t.client, newConfigmap, nil, ctlrutils.PATCH); err != nil {
 			return fmt.Errorf("failed to patch ConfigMap as immutable: %w", err)
 		}
 	}
 
 	return nil
+}
+
+// validateClusterInstanceDefaults validates clusterinstance-defaults data against the
+// ClusterInstance CRD and ensures its nodes/nodeGroups format matches the
+// ClusterInstanceParameters schema.
+func (t *clusterTemplateReconcilerTask) validateClusterInstanceDefaults(
+	ctx context.Context, data map[string]any) error {
+
+	defaultsFormat, err := validateClusterInstanceDefaultsFormat(
+		t.object.Spec.TemplateParameterSchema.Raw, data)
+	if err != nil {
+		return typederrors.NewInputError("%s", err.Error())
+	}
+
+	if err := ctlrutils.ValidateDefaultInterfaces(data, defaultsFormat); err != nil {
+		return typederrors.NewInputError("failed to validate the default ConfigMap: %w", err)
+	}
+
+	if defaultsFormat == ctlrutils.ClusterInstanceNodeGroupsKey {
+		// A nil map skips the membership check when hardware groups come from
+		// hwMgmtParameters instead of hwMgmtDefaults.nodeGroupData.
+		var hwMgmtNames map[string]struct{}
+		if len(t.object.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData) > 0 {
+			// Collect the hardware node group names.
+			hwMgmtNames = map[string]struct{}{}
+			for _, ng := range t.object.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData {
+				hwMgmtNames[ng.Name] = struct{}{}
+			}
+		}
+		if err := ctlrutils.ValidateNodeGroupsNames(data, hwMgmtNames); err != nil {
+			return typederrors.NewInputError("failed to validate the default ConfigMap: %w", err)
+		}
+		// Strip O-Cloud-only nodeGroups[].name before ClusterInstance CRD schema validation.
+		if err := ctlrutils.RemoveNodeGroupNames(data); err != nil {
+			return typederrors.NewInputError("failed to validate the default ConfigMap: %w", err)
+		}
+	}
+
+	// Strip O-Cloud-only interface labels before ClusterInstance CRD schema validation.
+	if err := ctlrutils.RemoveLabelFromInterfaces(data, defaultsFormat); err != nil {
+		return typederrors.NewInputError("failed to validate the default ConfigMap: %w", err)
+	}
+
+	if err := ctlrutils.ValidateConfigmapSchemaAgainstClusterInstanceCRD(
+		ctx, t.client, data, defaultsFormat); err != nil {
+		return typederrors.NewInputError("failed to validate the default ConfigMap: %w", err)
+	}
+
+	return nil
+}
+
+// validateClusterInstanceDefaultsFormat ensures clusterinstance-defaults uses
+// exactly one of nodes / nodeGroups and that clusterInstanceParameters in the
+// templateParameterSchema exposes a matching property.
+// Returns the defaults format key ("nodes" or "nodeGroups") or an error if
+// the format is invalid.
+func validateClusterInstanceDefaultsFormat(
+	schemaRaw []byte, data map[string]any) (string, error) {
+	_, hasNodes := data[ctlrutils.ClusterInstanceNodesKey]
+	_, hasNodeGroups := data[ctlrutils.ClusterInstanceNodeGroupsKey]
+
+	var defaultsFormat string
+	switch {
+	case hasNodes && hasNodeGroups:
+		return "", fmt.Errorf("%s must not define both %q and %q",
+			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
+			ctlrutils.ClusterInstanceNodesKey, ctlrutils.ClusterInstanceNodeGroupsKey)
+	case hasNodes:
+		defaultsFormat = ctlrutils.ClusterInstanceNodesKey
+	case hasNodeGroups:
+		defaultsFormat = ctlrutils.ClusterInstanceNodeGroupsKey
+	default:
+		return "", fmt.Errorf("%s must define either %q or %q",
+			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
+			ctlrutils.ClusterInstanceNodesKey, ctlrutils.ClusterInstanceNodeGroupsKey)
+	}
+
+	cipSchema, err := provisioningv1alpha1.ExtractSubSchema(
+		schemaRaw, constants.TemplateParamClusterInstance)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract %q schema for defaults validation: %w",
+			constants.TemplateParamClusterInstance, err)
+	}
+	props, ok := cipSchema["properties"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("%q schema must have a properties section",
+			constants.TemplateParamClusterInstance)
+	}
+
+	hasFormat := schemaPropertyExists(props, defaultsFormat)
+	if !hasFormat {
+		return "", fmt.Errorf(
+			"%s defines %q, but %s schema does not include a matching %q definition",
+			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
+			defaultsFormat, constants.TemplateParamClusterInstance, defaultsFormat)
+	}
+	return defaultsFormat, nil
 }
 
 // validateName return true if the ClusterTemplate name is the
@@ -620,6 +711,7 @@ func validateTemplateParameterSchema(object *provisioningv1alpha1.ClusterTemplat
 	validationFailureReason := fmt.Sprintf("failed to validate ClusterTemplate: %s.", object.Name)
 	if len(missingParameter) != 0 {
 		validationFailureReason += fmt.Sprintf(" The following mandatory fields are missing: %s.", strings.Join(missingParameter, ","))
+		return typederrors.NewInputError("%s", validationFailureReason)
 	}
 	if len(badType) != 0 {
 		validationFailureReason += fmt.Sprintf(" The following entries are present but have a unexpected type: %s.",
@@ -630,6 +722,12 @@ func validateTemplateParameterSchema(object *provisioningv1alpha1.ClusterTemplat
 		validationFailureReason += fmt.Sprintf(" The following entries are missing in the required section of the template: %s",
 			strings.Join(missingRequired, ","))
 		return typederrors.NewInputError("%s", validationFailureReason)
+	}
+
+	clusterInstanceParamsSchema := subSchemas[constants.TemplateParamClusterInstance].(map[string]any)
+	if err := validateClusterInstanceParametersSchema(clusterInstanceParamsSchema); err != nil {
+		return typederrors.NewInputError("Error validating the %s schema: %s",
+			constants.TemplateParamClusterInstance, err.Error())
 	}
 
 	policyTemplateParamsSchema := subSchemas[constants.TemplateParamPolicyConfig].(map[string]any)
@@ -651,6 +749,32 @@ func validateTemplateParameterSchema(object *provisioningv1alpha1.ClusterTemplat
 		return typederrors.NewInputError("Error validating the %s schema: %s", constants.TemplateParamUpgrade, err.Error())
 	}
 
+	return nil
+}
+
+// validateClusterInstanceParametersSchema requires clusterInstanceParameters.properties to
+// expose exactly one of "nodes" or "nodeGroups".
+func validateClusterInstanceParametersSchema(cipSchema map[string]any) error {
+	props, ok := cipSchema["properties"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("%q schema must have a properties section",
+			constants.TemplateParamClusterInstance)
+	}
+
+	hasNodes := schemaPropertyExists(props, ctlrutils.ClusterInstanceNodesKey)
+	hasNodeGroups := schemaPropertyExists(props, ctlrutils.ClusterInstanceNodeGroupsKey)
+	if hasNodes && hasNodeGroups {
+		return fmt.Errorf("%q schema must not define both %q and %q; choose exactly one",
+			constants.TemplateParamClusterInstance,
+			ctlrutils.ClusterInstanceNodesKey,
+			ctlrutils.ClusterInstanceNodeGroupsKey)
+	}
+	if !hasNodes && !hasNodeGroups {
+		return fmt.Errorf("%q schema must define either %q or %q",
+			constants.TemplateParamClusterInstance,
+			ctlrutils.ClusterInstanceNodesKey,
+			ctlrutils.ClusterInstanceNodeGroupsKey)
+	}
 	return nil
 }
 

--- a/internal/controllers/clustertemplate_controller_test.go
+++ b/internal/controllers/clustertemplate_controller_test.go
@@ -160,7 +160,8 @@ var _ = Describe("ClusterTemplateReconciler", func() {
 				Data: map[string]string{
 					ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
 baseDomain: value
-clusterImageSetNameRef: "4.15.0"`,
+clusterImageSetNameRef: "4.15.0"
+nodes: []`,
 				},
 			},
 			{
@@ -550,7 +551,8 @@ var _ = Describe("validateClusterTemplateCR", func() {
 					ctlrutils.ClusterInstallationTimeoutConfigKey: "80m",
 					ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
 baseDomain: value
-clusterImageSetNameRef: "4.15.0"`,
+clusterImageSetNameRef: "4.15.0"
+nodes: []`,
 				},
 			},
 			{
@@ -735,15 +737,21 @@ var _ = Describe("validateConfigmapReference", func() {
 	var (
 		c             client.Client
 		ctx           context.Context
+		ctTask        *clusterTemplateReconcilerTask
 		namespace     = "default"
 		configmapName = "test-configmap"
 	)
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		clusterInstanceCRD, err := ctlrutils.BuildTestClusterInstanceCRD(ctlrutils.TestClusterInstanceSpecOk)
-		Expect(err).ToNot(HaveOccurred())
-		c = fakeclient.GetFakeClientFromObjects([]client.Object{clusterInstanceCRD}...)
+		c = fakeclient.GetFakeClientFromObjects()
+		ctTask = &clusterTemplateReconcilerTask{
+			client: c,
+			logger: slog.Default(),
+			object: &provisioningv1alpha1.ClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "ct", Namespace: namespace},
+			},
+		}
 	})
 
 	It("should validate a valid configmap", func() {
@@ -754,53 +762,29 @@ var _ = Describe("validateConfigmapReference", func() {
 				Namespace: namespace,
 			},
 			Data: map[string]string{
-				ctlrutils.ClusterInstallationTimeoutConfigKey: "40m",
-				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
+				ctlrutils.ClusterConfigurationTimeoutConfigKey: "40m",
+				ctlrutils.PolicyTemplateDefaultsConfigmapKey: `
 baseDomain: example.sno.com`,
 			},
 		}
 		Expect(c.Create(ctx, cm)).To(Succeed())
-		err := validateConfigmapReference[map[string]any](
-			ctx, c, configmapName, namespace,
-			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			ctlrutils.ClusterInstallationTimeoutConfigKey)
+		err := ctTask.validateConfigmapReference(
+			ctx, configmapName, namespace,
+			ctlrutils.PolicyTemplateDefaultsConfigmapKey,
+			ctlrutils.ClusterConfigurationTimeoutConfigKey)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should return validation error message for a missing configmap", func() {
 		// No ConfigMap created
-		err := validateConfigmapReference[map[string]any](
-			ctx, c, configmapName, namespace,
-			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			ctlrutils.ClusterInstallationTimeoutConfigKey)
+		err := ctTask.validateConfigmapReference(
+			ctx, configmapName, namespace,
+			ctlrutils.PolicyTemplateDefaultsConfigmapKey,
+			ctlrutils.ClusterConfigurationTimeoutConfigKey)
 		Expect(err).To(HaveOccurred())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(Equal(fmt.Sprintf(
 			"failed to get ConfigmapReference: the ConfigMap '%s' is not found in the namespace '%s'", configmapName, namespace)))
-	})
-
-	It("should return validation error message for a configmap that does not match the ClusterInstance CRD", func() {
-		// Create a valid ConfigMap but with a wrong schema.
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configmapName,
-				Namespace: namespace,
-			},
-			Data: map[string]string{
-				ctlrutils.ClusterInstallationTimeoutConfigKey: "40m",
-				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
-baDomain: example.sno.com`,
-			},
-		}
-		Expect(c.Create(ctx, cm)).To(Succeed())
-		// Cluster Instance schema error.
-		err := validateConfigmapReference[map[string]any](
-			ctx, c, configmapName, namespace,
-			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			ctlrutils.ClusterInstallationTimeoutConfigKey)
-		Expect(err).To(HaveOccurred())
-		Expect(typederrors.IsInputError(err)).To(BeTrue())
-		Expect(err.Error()).To(ContainSubstring("failed to validate the default ConfigMap: the ConfigMap does not match the ClusterInstance schema"))
 	})
 
 	It("should return validation error message for missing template data key in configmap", func() {
@@ -816,14 +800,14 @@ baDomain: example.sno.com`,
 		}
 		Expect(c.Create(ctx, cm)).To(Succeed())
 
-		err := validateConfigmapReference[map[string]any](
-			ctx, c, configmapName, namespace,
-			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			ctlrutils.ClusterInstallationTimeoutConfigKey)
+		err := ctTask.validateConfigmapReference(
+			ctx, configmapName, namespace,
+			ctlrutils.PolicyTemplateDefaultsConfigmapKey,
+			ctlrutils.ClusterConfigurationTimeoutConfigKey)
 		Expect(err).To(HaveOccurred())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(Equal(fmt.Sprintf(
-			"the ConfigMap '%s' does not contain a field named '%s'", configmapName, ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey)))
+			"the ConfigMap '%s' does not contain a field named '%s'", configmapName, ctlrutils.PolicyTemplateDefaultsConfigmapKey)))
 	})
 
 	It("should return validation error message for invalid YAML in configmap template data", func() {
@@ -834,75 +818,18 @@ baDomain: example.sno.com`,
 				Namespace: namespace,
 			},
 			Data: map[string]string{
-				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `invalid-yaml`,
+				ctlrutils.PolicyTemplateDefaultsConfigmapKey: `invalid-yaml`,
 			},
 		}
 		Expect(c.Create(ctx, cm)).To(Succeed())
 
-		err := validateConfigmapReference[map[string]any](
-			ctx, c, configmapName, namespace,
-			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			ctlrutils.ClusterInstallationTimeoutConfigKey)
+		err := ctTask.validateConfigmapReference(
+			ctx, configmapName, namespace,
+			ctlrutils.PolicyTemplateDefaultsConfigmapKey,
+			ctlrutils.ClusterConfigurationTimeoutConfigKey)
 		Expect(err).To(HaveOccurred())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(ContainSubstring("the value of key"))
-	})
-
-	It("should return validation error message for missing interface label in configmap template data", func() {
-		// Create a ConfigMap with invalid data YAML
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configmapName,
-				Namespace: namespace,
-			},
-			Data: map[string]string{
-				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
-nodes:
-- hostname: "node1"
-  nodeNetwork:
-    interfaces:
-    - name: "eno1"
-`,
-			},
-		}
-		Expect(c.Create(ctx, cm)).To(Succeed())
-
-		err := validateConfigmapReference[map[string]any](
-			ctx, c, configmapName, namespace,
-			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			ctlrutils.ClusterInstallationTimeoutConfigKey)
-		Expect(err).To(HaveOccurred())
-		Expect(typederrors.IsInputError(err)).To(BeTrue())
-		Expect(err.Error()).To(ContainSubstring("'label' is missing for interface"))
-	})
-
-	It("should return validation error message for an empty interface label in configmap template data", func() {
-		// Create a ConfigMap with invalid data YAML
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configmapName,
-				Namespace: namespace,
-			},
-			Data: map[string]string{
-				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
-nodes:
-- hostname: "node1"
-  nodeNetwork:
-    interfaces:
-    - name: "eno1"
-      label: ""
-`,
-			},
-		}
-		Expect(c.Create(ctx, cm)).To(Succeed())
-
-		err := validateConfigmapReference[map[string]any](
-			ctx, c, configmapName, namespace,
-			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			ctlrutils.ClusterInstallationTimeoutConfigKey)
-		Expect(err).To(HaveOccurred())
-		Expect(typederrors.IsInputError(err)).To(BeTrue())
-		Expect(err.Error()).To(ContainSubstring("'label' is empty for interface"))
 	})
 
 	It("should return validation error message for invalid timeout value in configmap", func() {
@@ -913,17 +840,17 @@ nodes:
 				Namespace: namespace,
 			},
 			Data: map[string]string{
-				ctlrutils.ClusterInstallationTimeoutConfigKey: "invalid-timeout",
-				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
+				ctlrutils.ClusterConfigurationTimeoutConfigKey: "invalid-timeout",
+				ctlrutils.PolicyTemplateDefaultsConfigmapKey: `
 baseDomain: value`,
 			},
 		}
 		Expect(c.Create(ctx, cm)).To(Succeed())
 
-		err := validateConfigmapReference[map[string]any](
-			ctx, c, configmapName, namespace,
-			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			ctlrutils.ClusterInstallationTimeoutConfigKey)
+		err := ctTask.validateConfigmapReference(
+			ctx, configmapName, namespace,
+			ctlrutils.PolicyTemplateDefaultsConfigmapKey,
+			ctlrutils.ClusterConfigurationTimeoutConfigKey)
 		Expect(err).To(HaveOccurred())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(ContainSubstring("is not a valid duration string"))
@@ -938,17 +865,17 @@ baseDomain: value`,
 				Namespace: namespace,
 			},
 			Data: map[string]string{
-				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
+				ctlrutils.PolicyTemplateDefaultsConfigmapKey: `
 baseDomain: value`,
 			},
 			Immutable: &mutable,
 		}
 		Expect(c.Create(ctx, cm)).To(Succeed())
 
-		err := validateConfigmapReference[map[string]any](
-			ctx, c, configmapName, namespace,
-			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			ctlrutils.ClusterInstallationTimeoutConfigKey)
+		err := ctTask.validateConfigmapReference(
+			ctx, configmapName, namespace,
+			ctlrutils.PolicyTemplateDefaultsConfigmapKey,
+			ctlrutils.ClusterConfigurationTimeoutConfigKey)
 		Expect(err).To(HaveOccurred())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
 		Expect(err.Error()).To(Equal(fmt.Sprintf(
@@ -963,16 +890,16 @@ baseDomain: value`,
 				Namespace: namespace,
 			},
 			Data: map[string]string{
-				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
+				ctlrutils.PolicyTemplateDefaultsConfigmapKey: `
 baseDomain: value`,
 			},
 		}
 		Expect(c.Create(ctx, cm)).To(Succeed())
 
-		err := validateConfigmapReference[map[string]any](
-			ctx, c, configmapName, namespace,
-			ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey,
-			ctlrutils.ClusterInstallationTimeoutConfigKey)
+		err := ctTask.validateConfigmapReference(
+			ctx, configmapName, namespace,
+			ctlrutils.PolicyTemplateDefaultsConfigmapKey,
+			ctlrutils.ClusterConfigurationTimeoutConfigKey)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify that the configmap is patched to be immutable
@@ -980,6 +907,335 @@ baseDomain: value`,
 		Expect(c.Get(ctx, client.ObjectKey{Name: configmapName, Namespace: namespace}, updatedCM)).To(Succeed())
 		Expect(updatedCM.Immutable).ToNot(BeNil())
 		Expect(*updatedCM.Immutable).To(BeTrue())
+	})
+})
+
+var _ = Describe("validateClusterInstanceDefaults", func() {
+	var (
+		t             *clusterTemplateReconcilerTask
+		c             client.Client
+		ctx           context.Context
+		namespace     = "default"
+		configmapName = "ci-defaults"
+		tName         = "cluster-template-a"
+		tVersion      = "v1.0.0"
+	)
+
+	cipSchemaWithNodes := runtime.RawExtension{Raw: []byte(`{
+		"properties": {
+			"nodeClusterName": {"type": "string"},
+			"oCloudSiteId": {"type": "string"},
+			"clusterInstanceParameters": {
+				"type": "object",
+				"properties": {"nodes": {"type": "array"}}
+			},
+			"policyTemplateParameters": {"type": "object", "properties": {}}
+		},
+		"type": "object",
+		"required": ["nodeClusterName", "oCloudSiteId", "policyTemplateParameters", "clusterInstanceParameters"]
+	}`)}
+
+	cipSchemaWithNodeGroups := runtime.RawExtension{Raw: []byte(`{
+		"properties": {
+			"nodeClusterName": {"type": "string"},
+			"oCloudSiteId": {"type": "string"},
+			"clusterInstanceParameters": {
+				"type": "object",
+				"properties": {"nodeGroups": {"type": "array"}}
+			},
+			"policyTemplateParameters": {"type": "object", "properties": {}}
+		},
+		"type": "object",
+		"required": ["nodeClusterName", "oCloudSiteId", "policyTemplateParameters", "clusterInstanceParameters"]
+	}`)}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clusterInstanceCRD, err := ctlrutils.BuildTestClusterInstanceCRD(ctlrutils.TestClusterInstanceSpecOk)
+		Expect(err).ToNot(HaveOccurred())
+		c = fakeclient.GetFakeClientFromObjects([]client.Object{clusterInstanceCRD}...)
+	})
+
+	newTask := func(schema runtime.RawExtension, hwMgmt []hwmgmtv1alpha1.NodeGroupData) *clusterTemplateReconcilerTask {
+		return &clusterTemplateReconcilerTask{
+			client: c,
+			logger: slog.Default(),
+			object: &provisioningv1alpha1.ClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      GetClusterTemplateRefName(tName, tVersion),
+					Namespace: namespace,
+				},
+				Spec: provisioningv1alpha1.ClusterTemplateSpec{
+					Name:    tName,
+					Version: tVersion,
+					TemplateDefaults: provisioningv1alpha1.TemplateDefaults{
+						ClusterInstanceDefaults: configmapName,
+						HwMgmtDefaults: provisioningv1alpha1.HwMgmtDefaults{
+							NodeGroupData: hwMgmt,
+						},
+					},
+					TemplateParameterSchema: schema,
+				},
+			},
+		}
+	}
+
+	loadDefaults := func(yamlBody string) map[string]any {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: configmapName, Namespace: namespace},
+			Data: map[string]string{
+				ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: yamlBody,
+			},
+		}
+		Expect(c.Create(ctx, cm)).To(Succeed())
+		data, err := ctlrutils.ExtractTemplateDataFromConfigMap[map[string]any](
+			cm, ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey)
+		Expect(err).ToNot(HaveOccurred())
+		return data
+	}
+
+	It("validates nodes defaults matching schema", func() {
+		data := loadDefaults(`
+baseDomain: example.sno.com
+nodes:
+- hostName: node1
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: boot-interface
+`)
+		t = newTask(cipSchemaWithNodes, nil)
+		Expect(t.validateClusterInstanceDefaults(ctx, data)).To(Succeed())
+	})
+
+	It("rejects nodes defaults with unknown fields against ClusterInstance CRD", func() {
+		data := loadDefaults(`
+baDomain: example.sno.com
+nodes: []
+`)
+		t = newTask(cipSchemaWithNodes, nil)
+		err := t.validateClusterInstanceDefaults(ctx, data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("does not match the ClusterInstance schema"))
+		Expect(err.Error()).To(ContainSubstring("Additional property baDomain is not allowed"))
+	})
+
+	It("rejects missing interface label on nodes", func() {
+		data := loadDefaults(`
+nodes:
+- hostName: "node1"
+  nodeNetwork:
+    interfaces:
+    - name: "eno1"
+`)
+		t = newTask(cipSchemaWithNodes, nil)
+		err := t.validateClusterInstanceDefaults(ctx, data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("'label' is missing for interface"))
+	})
+
+	It("rejects defaults that define both nodes and nodeGroups", func() {
+		data := loadDefaults(`
+nodes: []
+nodeGroups:
+- name: master
+  role: master
+`)
+		t = newTask(cipSchemaWithNodes, []hwmgmtv1alpha1.NodeGroupData{
+			{Name: "master", Role: "master", HwProfile: "profile"},
+		})
+		err := t.validateClusterInstanceDefaults(ctx, data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("must not define both"))
+	})
+
+	It("rejects format mismatch between defaults nodeGroups and schema nodes", func() {
+		data := loadDefaults(`
+nodeGroups:
+- name: master
+  role: master
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: boot-interface
+`)
+		t = newTask(cipSchemaWithNodes, []hwmgmtv1alpha1.NodeGroupData{
+			{Name: "master", Role: "master", HwProfile: "profile"},
+		})
+		err := t.validateClusterInstanceDefaults(ctx, data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("does not include a matching"))
+	})
+
+	It("validates nodeGroups defaults matching schema", func() {
+		data := loadDefaults(`
+baseDomain: example.com
+nodeGroups:
+- name: master
+  role: master
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: boot-interface
+`)
+		t = newTask(cipSchemaWithNodeGroups, []hwmgmtv1alpha1.NodeGroupData{
+			{Name: "master", Role: "master", HwProfile: "profile"},
+		})
+		Expect(t.validateClusterInstanceDefaults(ctx, data)).To(Succeed())
+	})
+
+	It("validates nodeGroups defaults when hwMgmtDefaults.nodeGroupData is empty", func() {
+		data := loadDefaults(`
+baseDomain: example.com
+nodeGroups:
+- name: master
+  role: master
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: boot-interface
+`)
+		// Hardware groups may be supplied later via hwMgmtParameters; skip membership check.
+		t = newTask(cipSchemaWithNodeGroups, nil)
+		Expect(t.validateClusterInstanceDefaults(ctx, data)).To(Succeed())
+	})
+
+	It("rejects nodeGroups defaults with wrong field type against ClusterInstance CRD", func() {
+		data := loadDefaults(`
+baseDomain: example.com
+nodeGroups:
+- name: master
+  role: 123
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: boot-interface
+`)
+		t = newTask(cipSchemaWithNodeGroups, []hwmgmtv1alpha1.NodeGroupData{
+			{Name: "master", Role: "master", HwProfile: "profile"},
+		})
+		err := t.validateClusterInstanceDefaults(ctx, data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("does not match the ClusterInstance schema"))
+		Expect(err.Error()).To(ContainSubstring("Invalid type. Expected: string, given: integer"))
+	})
+
+	It("rejects nodeGroups[].nodes in defaults", func() {
+		data := loadDefaults(`
+nodeGroups:
+- name: master
+  role: master
+  nodes: []
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: boot-interface
+`)
+		t = newTask(cipSchemaWithNodeGroups, []hwmgmtv1alpha1.NodeGroupData{
+			{Name: "master", Role: "master", HwProfile: "profile"},
+		})
+		err := t.validateClusterInstanceDefaults(ctx, data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`nodeGroups[0] must omit "nodes"`))
+	})
+
+	It("rejects empty interface label on nodeGroups", func() {
+		data := loadDefaults(`
+nodeGroups:
+- name: master
+  role: master
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: ""
+`)
+		t = newTask(cipSchemaWithNodeGroups, []hwmgmtv1alpha1.NodeGroupData{
+			{Name: "master", Role: "master", HwProfile: "profile"},
+		})
+		err := t.validateClusterInstanceDefaults(ctx, data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("'label' is empty for interface"))
+	})
+
+	It("rejects nodeGroups name not in allowed hardware node groups", func() {
+		data := loadDefaults(`
+nodeGroups:
+- name: unknown
+  role: master
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: boot-interface
+`)
+		t = newTask(cipSchemaWithNodeGroups, []hwmgmtv1alpha1.NodeGroupData{
+			{Name: "master", Role: "master", HwProfile: "profile"},
+		})
+		err := t.validateClusterInstanceDefaults(ctx, data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("does not match any hardware node group"))
+	})
+})
+
+var _ = Describe("validateClusterInstanceDefaultsFormat", func() {
+	cipSchemaNodes := []byte(`{
+		"properties": {
+			"clusterInstanceParameters": {
+				"type": "object",
+				"properties": {"nodes": {"type": "array"}}
+			}
+		}
+	}`)
+	cipSchemaNodeGroups := []byte(`{
+		"properties": {
+			"clusterInstanceParameters": {
+				"type": "object",
+				"properties": {"nodeGroups": {"type": "array"}}
+			}
+		}
+	}`)
+
+	It("accepts nodes defaults matching schema", func() {
+		format, err := validateClusterInstanceDefaultsFormat(cipSchemaNodes, map[string]any{
+			"nodes": []any{},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(format).To(Equal(ctlrutils.ClusterInstanceNodesKey))
+	})
+
+	It("accepts nodeGroups defaults matching schema", func() {
+		format, err := validateClusterInstanceDefaultsFormat(cipSchemaNodeGroups, map[string]any{
+			"nodeGroups": []any{},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(format).To(Equal(ctlrutils.ClusterInstanceNodeGroupsKey))
+	})
+
+	It("rejects both nodes and nodeGroups in defaults", func() {
+		_, err := validateClusterInstanceDefaultsFormat(cipSchemaNodes, map[string]any{
+			"nodes":      []any{},
+			"nodeGroups": []any{},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(
+			`clusterinstance-defaults must not define both "nodes" and "nodeGroups"`))
+	})
+
+	It("rejects neither nodes nor nodeGroups in defaults", func() {
+		_, err := validateClusterInstanceDefaultsFormat(cipSchemaNodes, map[string]any{
+			"baseDomain": "example.com",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(
+			`clusterinstance-defaults must define either "nodes" or "nodeGroups"`))
+	})
+
+	It("rejects defaults format that does not match schema", func() {
+		_, err := validateClusterInstanceDefaultsFormat(cipSchemaNodes, map[string]any{
+			"nodeGroups": []any{},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(
+			`clusterinstance-defaults defines "nodeGroups", but clusterInstanceParameters schema does not include a matching "nodeGroups" definition`))
 	})
 })
 
@@ -1243,7 +1499,12 @@ func Test_validateTemplateParameterSchema(t *testing.T) {
 		"properties": {
 			"nodeClusterName": {"type": "string"},
 			"oCloudSiteId": {"type": "string"},
-			"clusterInstanceParameters": {"type": "object"},
+			"clusterInstanceParameters": {
+				"type": "object",
+				"properties": {
+					"nodeGroups": {"type": "array"}
+				}
+			},
 			"policyTemplateParameters": {"type": "object", "properties": {}}
 		},
 		"type": "object",
@@ -1279,7 +1540,12 @@ func Test_validateTemplateParameterSchema(t *testing.T) {
 		"properties": {
 			"nodeClusterName": {"type": "string"},
 			"oCloudSiteId": {"type": "string"},
-			"clusterInstanceParameters": {"type": "object"},
+			"clusterInstanceParameters": {
+				"type": "object",
+				"properties": {
+					"nodeGroups": {"type": "array"}
+				}
+			},
 			"policyTemplateParameters": {"type": "object", "properties": {"a": {}}}
 		},
 		"type": "object",
@@ -1365,7 +1631,42 @@ func Test_validateTemplateParameterSchema(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errText: "failed to validate ClusterTemplate: cluster-template-a.v1.0.0. The following mandatory fields are missing: nodeClusterName. The following entries are present but have a unexpected type: clusterInstanceParameters (expected = object actual= string).",
+			errText: "failed to validate ClusterTemplate: cluster-template-a.v1.0.0. The following mandatory fields are missing: nodeClusterName.",
+		},
+		{
+			name: "missing parameter still listed in required",
+			args: args{
+				object: &provisioningv1alpha1.ClusterTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: GetClusterTemplateRefName(tName, tVersion),
+					},
+					Spec: provisioningv1alpha1.ClusterTemplateSpec{
+						TemplateDefaults: provisioningv1alpha1.TemplateDefaults{
+							HwMgmtDefaults: provisioningv1alpha1.HwMgmtDefaults{
+								NodeGroupData: []hwmgmtv1alpha1.NodeGroupData{
+									{Name: "controller", Role: "master", HwProfile: "profile-64G"},
+								},
+							},
+						},
+						TemplateParameterSchema: runtime.RawExtension{Raw: []byte(`{
+		"properties": {
+			"nodeClusterName": {"type": "string"},
+			"oCloudSiteId": {"type": "string"},
+			"policyTemplateParameters": {"type": "object", "properties": {"a": {"type": "string"}}}
+		},
+		"type": "object",
+		"required": [
+	"nodeClusterName",
+	"oCloudSiteId",
+	"policyTemplateParameters",
+	"clusterInstanceParameters"
+	]
+	}`)},
+					},
+				},
+			},
+			wantErr: true,
+			errText: "failed to validate ClusterTemplate: cluster-template-a.v1.0.0. The following mandatory fields are missing: clusterInstanceParameters.",
 		},
 		{
 			name: "missing parameter and bad type, and missing required entry",
@@ -1399,7 +1700,7 @@ func Test_validateTemplateParameterSchema(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errText: "failed to validate ClusterTemplate: cluster-template-a.v1.0.0. The following mandatory fields are missing: nodeClusterName. The following entries are present but have a unexpected type: clusterInstanceParameters (expected = object actual= string).",
+			errText: "failed to validate ClusterTemplate: cluster-template-a.v1.0.0. The following mandatory fields are missing: nodeClusterName.",
 		},
 	}
 	for _, tt := range tests {
@@ -1410,6 +1711,80 @@ func Test_validateTemplateParameterSchema(t *testing.T) {
 			}
 			if err != nil && err.Error() != tt.errText {
 				t.Errorf("validateTemplateParameterSchema() errorText = %s, wantErrorText %s", err.Error(), tt.errText)
+			}
+		})
+	}
+}
+
+func Test_validateClusterInstanceParametersSchema(t *testing.T) {
+	tests := []struct {
+		name      string
+		cipSchema string
+		wantErr   bool
+		errText   string
+	}{
+		{
+			name: "nodes only is ok",
+			cipSchema: `{
+				"type": "object",
+				"properties": {
+					"nodes": {"type": "array"}
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "nodeGroups only is ok",
+			cipSchema: `{
+				"type": "object",
+				"properties": {
+					"nodeGroups": {"type": "array"}
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "missing nodes and nodeGroups",
+			cipSchema: `{
+				"type": "object",
+				"properties": {}
+			}`,
+			wantErr: true,
+			errText: `"clusterInstanceParameters" schema must define either "nodes" or "nodeGroups"`,
+		},
+		{
+			name: "defines both nodes and nodeGroups",
+			cipSchema: `{
+				"type": "object",
+				"properties": {
+					"nodes": {"type": "array"},
+					"nodeGroups": {"type": "array"}
+				}
+			}`,
+			wantErr: true,
+			errText: `"clusterInstanceParameters" schema must not define both "nodes" and "nodeGroups"; choose exactly one`,
+		},
+		{
+			name: "missing properties section",
+			cipSchema: `{
+				"type": "object"
+			}`,
+			wantErr: true,
+			errText: `"clusterInstanceParameters" schema must have a properties section`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cipSchema map[string]any
+			if err := json.Unmarshal([]byte(tt.cipSchema), &cipSchema); err != nil {
+				t.Fatalf("failed to unmarshal cipSchema: %v", err)
+			}
+			err := validateClusterInstanceParametersSchema(cipSchema)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateClusterInstanceParametersSchema() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && err.Error() != tt.errText {
+				t.Errorf("validateClusterInstanceParametersSchema() errorText = %s, wantErrorText %s", err.Error(), tt.errText)
 			}
 		})
 	}

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -197,7 +197,11 @@ func (t *provisioningRequestReconcilerTask) buildClusterInstanceUnstructured() (
 
 	// Remove interface labels from the ClusterInstance spec as they are not part of the ClusterInstance CRD schema
 	// but are needed during hardware provisioning for MAC address assignment
-	if err := ctlrutils.RemoveLabelFromInterfaces(renderedClusterInstanceUnstructured.Object["spec"]); err != nil {
+	spec, ok := renderedClusterInstanceUnstructured.Object["spec"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("clusterInstance spec is not a map")
+	}
+	if err := ctlrutils.RemoveLabelFromInterfaces(spec, ctlrutils.ClusterInstanceNodesKey); err != nil {
 		return nil, fmt.Errorf("failed to remove interface labels from ClusterInstance spec: %w", err)
 	}
 

--- a/internal/controllers/utils/constants.go
+++ b/internal/controllers/utils/constants.go
@@ -168,6 +168,11 @@ const (
 	ClusterInstanceTemplateName                 = "ClusterInstance"
 	ClusterInstanceTemplateDefaultsConfigmapKey = "clusterinstance-defaults"
 	ClusterInstanceCrdName                      = "clusterinstances"
+
+	// ClusterInstanceNodesKey is the legacy flat nodes list in ClusterInstanceParameters / ClusterInstance data.
+	ClusterInstanceNodesKey = "nodes"
+	// ClusterInstanceNodeGroupsKey is the grouped node config list in ClusterInstanceParameters / ClusterInstance data.
+	ClusterInstanceNodeGroupsKey = "nodeGroups"
 )
 
 var (

--- a/internal/controllers/utils/provision.go
+++ b/internal/controllers/utils/provision.go
@@ -112,17 +112,15 @@ func ClusterIsReadyForPolicyConfig(
 
 // ValidateDefaultInterfaces verifies that each interface has a specified label field,
 // as labels are not part of the ClusterInstance structure by default.
-func ValidateDefaultInterfaces[T any](data T) error {
-	// clusterinstance-default data
-	dataMap, _ := any(data).(map[string]any)
-	nodes, ok := dataMap["nodes"].([]any)
+func ValidateDefaultInterfaces(data map[string]any, entriesKey string) error {
+	entries, ok := data[entriesKey].([]any)
 	if ok {
-		for _, node := range nodes {
-			nodeMap, ok := node.(map[string]interface{})
+		for _, entry := range entries {
+			entryMap, ok := entry.(map[string]any)
 			if !ok {
-				return fmt.Errorf("unexpected: invalid node data structure")
+				return fmt.Errorf("unexpected: invalid %s data structure", entriesKey)
 			}
-			interfaces := getInterfaces(nodeMap)
+			interfaces := getInterfaces(entryMap)
 			if interfaces == nil {
 				return fmt.Errorf("failed to extract the interfaces from the node map")
 			}
@@ -142,16 +140,15 @@ func ValidateDefaultInterfaces[T any](data T) error {
 
 // RemoveLabelFromInterfaces removes the label property for each interface as the label
 // property is not part of the ClusterInstance schema.
-func RemoveLabelFromInterfaces[T any](data T) error {
-	dataMap, _ := any(data).(map[string]any)
-	nodes, ok := dataMap["nodes"].([]any)
+func RemoveLabelFromInterfaces(data map[string]any, entriesKey string) error {
+	entries, ok := data[entriesKey].([]any)
 	if ok {
-		for _, node := range nodes {
-			nodeMap, ok := node.(map[string]interface{})
+		for _, entry := range entries {
+			entryMap, ok := entry.(map[string]any)
 			if !ok {
-				return fmt.Errorf("unexpected: invalid node data structure")
+				return fmt.Errorf("unexpected: invalid %s data structure", entriesKey)
 			}
-			interfaces := getInterfaces(nodeMap)
+			interfaces := getInterfaces(entryMap)
 			if interfaces == nil {
 				return fmt.Errorf("failed to extract the interfaces from the node map")
 			}
@@ -187,9 +184,69 @@ func removeRequiredFromSchema(schema map[string]any) {
 	}
 }
 
+// ValidateNodeGroupsNames validates nodeGroups entries: unique non-empty names,
+// optional existence in allowedGroupNames, and rejects nested nodes.
+func ValidateNodeGroupsNames(
+	data map[string]any, allowedGroupNames map[string]struct{}) error {
+	groups, ok := data[ClusterInstanceNodeGroupsKey].([]any)
+	if !ok {
+		return fmt.Errorf("%q must be an array", ClusterInstanceNodeGroupsKey)
+	}
+
+	seen := map[string]struct{}{}
+	for i, group := range groups {
+		groupMap, ok := group.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s[%d] is not an object", ClusterInstanceNodeGroupsKey, i)
+		}
+		if _, hasNodes := groupMap[ClusterInstanceNodesKey]; hasNodes {
+			return fmt.Errorf(
+				"%s[%d] must omit %q; per-host identity belongs only in the ProvisioningRequest",
+				ClusterInstanceNodeGroupsKey, i, ClusterInstanceNodesKey)
+		}
+		name, _ := groupMap["name"].(string)
+		if name == "" {
+			return fmt.Errorf("%s[%d].name must be a non-empty string",
+				ClusterInstanceNodeGroupsKey, i)
+		}
+		if _, exists := seen[name]; exists {
+			return fmt.Errorf("duplicate %s name %q", ClusterInstanceNodeGroupsKey, name)
+		}
+		seen[name] = struct{}{}
+		if allowedGroupNames != nil {
+			if _, exists := allowedGroupNames[name]; !exists {
+				return fmt.Errorf(
+					"%s name %q does not match any hardware node group in the nodeGroupData",
+					ClusterInstanceNodeGroupsKey, name)
+			}
+		}
+	}
+	return nil
+}
+
+// RemoveNodeGroupNames strips the O-Cloud-only name field from each nodeGroup entry.
+func RemoveNodeGroupNames(data map[string]any) error {
+	groups, ok := data[ClusterInstanceNodeGroupsKey].([]any)
+	if !ok {
+		return nil
+	}
+	for i, group := range groups {
+		groupMap, ok := group.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s[%d] is not an object", ClusterInstanceNodeGroupsKey, i)
+		}
+		delete(groupMap, "name")
+	}
+	return nil
+}
+
 // ValidateConfigmapSchemaAgainstClusterInstanceCRD checks if the data of the ClusterInstance
-// default ConfigMap matches the ClusterInstance CRD schema.
-func ValidateConfigmapSchemaAgainstClusterInstanceCRD[T any](ctx context.Context, c client.Client, data T) error {
+// default ConfigMap matches the ClusterInstance CRD schema. The entriesKey is "nodes" or "nodeGroups".
+// For nodeGroups, the CRD nodes property is renamed to nodeGroups before validation.
+// Caller must strip O-Cloud-only fields (interface labels, and nodeGroups[].name) from the
+// data before validation.
+func ValidateConfigmapSchemaAgainstClusterInstanceCRD(
+	ctx context.Context, c client.Client, data map[string]any, entriesKey string) error {
 	// Get the ClusterInstance CRD.
 	clusterInstanceCrd := &unstructured.Unstructured{}
 	clusterInstanceCrd.SetGroupVersionKind(schema.GroupVersionKind{
@@ -204,7 +261,7 @@ func ValidateConfigmapSchemaAgainstClusterInstanceCRD[T any](ctx context.Context
 	}
 
 	// Extract the OpenAPIV3Schema.
-	openAPIV3Schema := make(map[string]interface{})
+	openAPIV3Schema := make(map[string]any)
 	versions, found, err := unstructured.NestedSlice(clusterInstanceCrd.Object, "spec", "versions")
 	if err != nil || !found {
 		return fmt.Errorf("failed to obtain the versions of the %s.%s CRD: %w", ClusterInstanceCrdName, siteconfig.Group, err)
@@ -212,7 +269,7 @@ func ValidateConfigmapSchemaAgainstClusterInstanceCRD[T any](ctx context.Context
 
 	// Find the version that is stored and served.
 	for index, version := range versions {
-		versionMap, ok := version.(map[string]interface{})
+		versionMap, ok := version.(map[string]any)
 		if !ok {
 			return fmt.Errorf(
 				"failed to convert version %d of the %s.%s CRD to map: %w",
@@ -236,20 +293,28 @@ func ValidateConfigmapSchemaAgainstClusterInstanceCRD[T any](ctx context.Context
 
 	// If the properties and spec attributes are missing or the conversion fails, then something is wrong
 	// with k8s itself.
-	openAPIV3SchemaSpec := openAPIV3Schema["properties"].(map[string]interface{})["spec"].(map[string]interface{})
+	openAPIV3SchemaSpec := openAPIV3Schema["properties"].(map[string]any)["spec"].(map[string]any)
+
+	if entriesKey == ClusterInstanceNodeGroupsKey {
+		props, ok := openAPIV3SchemaSpec["properties"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s CRD spec schema is missing properties", ClusterInstanceCrdName)
+		}
+		nodesSchema, ok := props[ClusterInstanceNodesKey]
+		if !ok {
+			return fmt.Errorf("%s CRD schema is missing %q property", ClusterInstanceCrdName, ClusterInstanceNodesKey)
+		}
+		props[ClusterInstanceNodeGroupsKey] = nodesSchema
+		delete(props, ClusterInstanceNodesKey)
+	}
 
 	// Prepare the data for schema validation.
 	// Remove the `required` property as the default ConfigMaps contains only a subset of the ClusterInstance spec.
 	removeRequiredFromSchema(openAPIV3SchemaSpec)
-	// Disalllow unknown properties in the ClusterInstance CRD schema.
+	// Disallow unknown properties in the ClusterInstance CRD schema.
 	provisioningv1alpha1.DisallowUnknownFieldsInSchema(openAPIV3SchemaSpec)
-	// Remove the interface label properties as it's not part of the ClusterInstance CRD schema.
-	dataMap, _ := any(data).(map[string]any)
-	if err := RemoveLabelFromInterfaces(dataMap); err != nil {
-		return fmt.Errorf("error removing label from interfaces")
-	}
 
-	err = provisioningv1alpha1.ValidateJsonAgainstJsonSchema(openAPIV3SchemaSpec, dataMap)
+	err = provisioningv1alpha1.ValidateJsonAgainstJsonSchema(openAPIV3SchemaSpec, data)
 	if err != nil {
 		return fmt.Errorf("the ConfigMap does not match the ClusterInstance schema: %w", err)
 	}

--- a/internal/controllers/utils/provision_test.go
+++ b/internal/controllers/utils/provision_test.go
@@ -421,19 +421,19 @@ var _ = Describe("ClusterIsReadyForPolicyConfig", func() {
 
 var _ = Describe("RemoveLabelFromInterfaces", func() {
 
-	It("returns error for invalid node structure", func() {
+	It("returns error for invalid nodes structure", func() {
 		data := map[string]interface{}{
 			"baseDomain": "example.sno",
 			"nodes": []interface{}{
 				42, // should be a map
 			},
 		}
-		err := RemoveLabelFromInterfaces(data)
+		err := RemoveLabelFromInterfaces(data, ClusterInstanceNodesKey)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("unexpected: invalid node data structure"))
+		Expect(err.Error()).To(Equal("unexpected: invalid nodes data structure"))
 	})
 
-	It("returns error for failing to extract node interfaces", func() {
+	It("returns error for failing to extract nodes interfaces", func() {
 		data := map[string]interface{}{
 			"baseDomain": "example.sno",
 			"nodes": []interface{}{
@@ -442,12 +442,12 @@ var _ = Describe("RemoveLabelFromInterfaces", func() {
 				},
 			},
 		}
-		err := RemoveLabelFromInterfaces(data)
+		err := RemoveLabelFromInterfaces(data, ClusterInstanceNodesKey)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("failed to extract the interfaces from the node map"))
 	})
 
-	It("removes the labels from the  node interfaces", func() {
+	It("removes the labels from the nodes interfaces", func() {
 		data := map[string]interface{}{
 			"baseDomain": "example.sno",
 			"nodes": []interface{}{
@@ -464,7 +464,7 @@ var _ = Describe("RemoveLabelFromInterfaces", func() {
 				},
 			},
 		}
-		err := RemoveLabelFromInterfaces(data)
+		err := RemoveLabelFromInterfaces(data, ClusterInstanceNodesKey)
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(
 			data["nodes"].([]interface{})[0].(map[string]interface{})["nodeNetwork"].(map[string]interface{})["interfaces"].([]interface{})[0].(map[string]interface{})).
@@ -475,41 +475,208 @@ var _ = Describe("RemoveLabelFromInterfaces", func() {
 				}),
 			)
 	})
-})
 
-var _ = Describe("removeRequiredFromClusterInstanceSchema", func() {
+	It("returns error for invalid nodeGroups structure", func() {
+		data := map[string]any{
+			"nodeGroups": []any{
+				42, // should be a map
+			},
+		}
+		err := RemoveLabelFromInterfaces(data, ClusterInstanceNodeGroupsKey)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("unexpected: invalid nodeGroups data structure"))
+	})
 
-	It("removes all the requested attributes from maps and arrays", func() {
-		var specIntf map[string]interface{}
-		err := yaml.Unmarshal([]byte(TestClusterInstancePropertiesRequiredRemoval), &specIntf)
+	It("returns error for failing to extract nodeGroups interfaces", func() {
+		data := map[string]any{
+			"nodeGroups": []any{
+				map[string]any{
+					"nodeNetwork": "value", // should be a map
+				},
+			},
+		}
+		err := RemoveLabelFromInterfaces(data, ClusterInstanceNodeGroupsKey)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("failed to extract the interfaces from the node map"))
+	})
+
+	It("removes the labels from the nodeGroups interfaces", func() {
+		data := map[string]any{
+			"nodeGroups": []any{
+				map[string]any{
+					"nodeNetwork": map[string]any{
+						"interfaces": []any{
+							map[string]any{
+								"name":       "ens3f0",
+								"label":      constants.BootInterfaceLabel,
+								"macAddress": "some-mac",
+							},
+						},
+					},
+				},
+			},
+		}
+		err := RemoveLabelFromInterfaces(data, ClusterInstanceNodeGroupsKey)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(specIntf).To(HaveKey("required"))
 		Expect(
-			specIntf["properties"].(map[string]interface{})["machineNetwork"].(map[string]interface{})["items"].(map[string]interface{})).To(HaveKey("required"))
-		removeRequiredFromSchema(specIntf)
-		Expect(specIntf).To(Not(HaveKey("required")))
-		Expect(
-			specIntf["properties"].(map[string]interface{})["machineNetwork"].(map[string]interface{})["items"].(map[string]interface{})).To(Not(HaveKey("required")))
-		nodeItems := specIntf["properties"].(map[string]interface{})["nodes"].(map[string]interface{})["items"].(map[string]interface{})
-		nodeNetworkProperties := nodeItems["properties"].(map[string]interface{})["nodeNetwork"].(map[string]interface{})["properties"].(map[string]interface{})
-		interfacesItems := nodeNetworkProperties["interfaces"].(map[string]interface{})["items"].(map[string]interface{})
-		Expect(interfacesItems).To(Not(HaveKey("required")))
+			data["nodeGroups"].([]any)[0].(map[string]any)["nodeNetwork"].(map[string]any)["interfaces"].([]any)[0].(map[string]any)).
+			To(Equal(
+				map[string]any{
+					"name":       "ens3f0",
+					"macAddress": "some-mac",
+				}),
+			)
 	})
 })
 
-var _ = Describe("ValidateDefaultConfigmapSchema", func() {
+var _ = Describe("ValidateNodeGroupsNames", func() {
+	hwMgmt := map[string]struct{}{"master": {}, "worker": {}}
+
+	It("accepts well-formed groups", func() {
+		err := ValidateNodeGroupsNames(map[string]any{
+			"nodeGroups": []any{
+				map[string]any{"name": "master", "role": "master"},
+				map[string]any{"name": "worker", "role": "worker"},
+			},
+		}, hwMgmt)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("rejects nested nodes including empty list", func() {
+		err := ValidateNodeGroupsNames(map[string]any{
+			"nodeGroups": []any{
+				map[string]any{"name": "master", "nodes": []any{}},
+			},
+		}, hwMgmt)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(
+			`nodeGroups[0] must omit "nodes"; per-host identity belongs only in the ProvisioningRequest`))
+	})
+
+	It("rejects missing name", func() {
+		err := ValidateNodeGroupsNames(map[string]any{
+			"nodeGroups": []any{
+				map[string]any{"role": "master"},
+			},
+		}, hwMgmt)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(`nodeGroups[0].name must be a non-empty string`))
+	})
+
+	It("rejects duplicate names", func() {
+		err := ValidateNodeGroupsNames(map[string]any{
+			"nodeGroups": []any{
+				map[string]any{"name": "master"},
+				map[string]any{"name": "master"},
+			},
+		}, hwMgmt)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(`duplicate nodeGroups name "master"`))
+	})
+
+	It("rejects name not in allowed hardware node groups", func() {
+		err := ValidateNodeGroupsNames(map[string]any{
+			"nodeGroups": []any{
+				map[string]any{"name": "extra"},
+			},
+		}, hwMgmt)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(
+			`nodeGroups name "extra" does not match any hardware node group in the nodeGroupData`))
+	})
+
+	It("skips membership check when allowedGroupNames is nil", func() {
+		err := ValidateNodeGroupsNames(map[string]any{
+			"nodeGroups": []any{
+				map[string]any{"name": "any-group"},
+			},
+		}, nil)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("ValidateDefaultInterfaces", func() {
+	It("returns error if nodes interfaces are missing labels", func() {
+		err := ValidateDefaultInterfaces(map[string]any{
+			"nodes": []any{
+				map[string]any{
+					"hostName": "node1",
+					"nodeNetwork": map[string]any{
+						"interfaces": []any{
+							map[string]any{"name": "eno1"},
+						},
+					},
+				},
+			},
+		}, ClusterInstanceNodesKey)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("'label' is missing for interface: eno1"))
+	})
+
+	It("returns no error if nodes interfaces have labels", func() {
+		err := ValidateDefaultInterfaces(map[string]any{
+			"nodes": []any{
+				map[string]any{
+					"hostName": "node1",
+					"nodeNetwork": map[string]any{
+						"interfaces": []any{
+							map[string]any{"name": "eno1", "label": "boot-interface"},
+						},
+					},
+				},
+			},
+		}, ClusterInstanceNodesKey)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("returns error if nodeGroups interfaces are missing labels", func() {
+		err := ValidateDefaultInterfaces(map[string]any{
+			"nodeGroups": []any{
+				map[string]any{
+					"name": "master",
+					"nodeNetwork": map[string]any{
+						"interfaces": []any{
+							map[string]any{"name": "ens3f0"},
+						},
+					},
+				},
+			},
+		}, ClusterInstanceNodeGroupsKey)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("'label' is missing for interface: ens3f0"))
+	})
+
+	It("returns no error if nodeGroups interfaces have labels", func() {
+		err := ValidateDefaultInterfaces(map[string]any{
+			"nodeGroups": []any{
+				map[string]any{
+					"name": "master",
+					"nodeNetwork": map[string]any{
+						"interfaces": []any{
+							map[string]any{"name": "ens3f0", "label": "boot-interface"},
+						},
+					},
+				},
+			},
+		}, ClusterInstanceNodeGroupsKey)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("ValidateConfigmapSchemaAgainstClusterInstanceCRD", func() {
 	var (
 		ctx        context.Context
 		fakeClient client.Client
 	)
 
 	BeforeEach(func() {
+		ctx = context.Background()
 		fakeClient = fakeclient.GetFakeClientFromObjects()
 	})
 
 	It("returns an error when the ClusterInstance CRD does not exist", func() {
-		var data map[string]interface{}
-		err := ValidateConfigmapSchemaAgainstClusterInstanceCRD(ctx, fakeClient, data)
+		err := ValidateConfigmapSchemaAgainstClusterInstanceCRD(
+			ctx, fakeClient, nil, ClusterInstanceNodesKey)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).
 			To(Equal(
@@ -524,8 +691,8 @@ var _ = Describe("ValidateDefaultConfigmapSchema", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fakeClient.Create(ctx, clusterInstanceCRD)).To(Succeed())
 
-			var data map[string]interface{}
-			err = ValidateConfigmapSchemaAgainstClusterInstanceCRD(ctx, fakeClient, data)
+			err = ValidateConfigmapSchemaAgainstClusterInstanceCRD(
+				ctx, fakeClient, nil, ClusterInstanceNodesKey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to obtain the versions of the %s.%s CRD", ClusterInstanceCrdName, siteconfig.Group)))
 		})
@@ -535,43 +702,92 @@ var _ = Describe("ValidateDefaultConfigmapSchema", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fakeClient.Create(ctx, clusterInstanceCRD)).To(Succeed())
 
-			var data map[string]interface{}
-			err = ValidateConfigmapSchemaAgainstClusterInstanceCRD(ctx, fakeClient, data)
+			err = ValidateConfigmapSchemaAgainstClusterInstanceCRD(
+				ctx, fakeClient, nil, ClusterInstanceNodesKey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no version served & stored in the %s.%s CRD ", ClusterInstanceCrdName, siteconfig.Group)))
 		})
 
-		It("returns error if the ConfigMap schema does not match the ClusterInstance CRD schema", func() {
+		It("returns error if the nodes-format ConfigMap schema does not match the ClusterInstance CRD schema", func() {
 			clusterInstanceCRD, err := BuildTestClusterInstanceCRD(TestClusterInstanceSpecOk)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fakeClient.Create(ctx, clusterInstanceCRD)).To(Succeed())
 
-			data := map[string]interface{}{
+			data := map[string]any{
 				"clusterImageSetNameRef": "4.15",
-				"pullSecretRef": map[string]interface{}{
+				"pullSecretRef": map[string]any{
 					"should-be-name": "pull-secret",
 				},
 			}
-			err = ValidateConfigmapSchemaAgainstClusterInstanceCRD(ctx, fakeClient, data)
+			err = ValidateConfigmapSchemaAgainstClusterInstanceCRD(
+				ctx, fakeClient, data, ClusterInstanceNodesKey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(
 				"ConfigMap does not match the ClusterInstance schema: " +
 					"invalid input: pullSecretRef: Additional property should-be-name is not allowed"))
 		})
 
-		It("returns no error if the ConfigMap schema matches the ClusterInstance CRD schema", func() {
+		It("returns no error if the nodes-format ConfigMap schema matches the ClusterInstance CRD schema", func() {
 			clusterInstanceCRD, err := BuildTestClusterInstanceCRD(TestClusterInstanceSpecOk)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fakeClient.Create(ctx, clusterInstanceCRD)).To(Succeed())
 
-			data := map[string]interface{}{
+			data := map[string]any{
 				"clusterImageSetNameRef": "4.15",
-				"pullSecretRef": map[string]interface{}{
+				"pullSecretRef": map[string]any{
 					"name": "pull-secret",
 				},
 			}
-			err = ValidateConfigmapSchemaAgainstClusterInstanceCRD(ctx, fakeClient, data)
+			err = ValidateConfigmapSchemaAgainstClusterInstanceCRD(
+				ctx, fakeClient, data, ClusterInstanceNodesKey)
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns no error if the nodeGroups-format ConfigMap schema matches the ClusterInstance CRD schema", func() {
+			clusterInstanceCRD, err := BuildTestClusterInstanceCRD(TestClusterInstanceSpecOk)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeClient.Create(ctx, clusterInstanceCRD)).To(Succeed())
+
+			data := map[string]any{
+				"baseDomain": "example.com",
+				"nodeGroups": []any{
+					map[string]any{
+						"role": "master",
+						"nodeNetwork": map[string]any{
+							"interfaces": []any{
+								map[string]any{"name": "ens3f0"},
+							},
+						},
+					},
+				},
+			}
+			Expect(ValidateConfigmapSchemaAgainstClusterInstanceCRD(
+				ctx, fakeClient, data, ClusterInstanceNodeGroupsKey)).To(Succeed())
+		})
+
+		It("returns error if the nodeGroups-format ConfigMap schema does not match the ClusterInstance CRD schema", func() {
+			clusterInstanceCRD, err := BuildTestClusterInstanceCRD(TestClusterInstanceSpecOk)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeClient.Create(ctx, clusterInstanceCRD)).To(Succeed())
+
+			data := map[string]any{
+				"nodeGroups": []any{
+					map[string]any{
+						"notAField": true,
+						"nodeNetwork": map[string]any{
+							"interfaces": []any{
+								map[string]any{"name": "ens3f0"},
+							},
+						},
+					},
+				},
+			}
+			err = ValidateConfigmapSchemaAgainstClusterInstanceCRD(
+				ctx, fakeClient, data, ClusterInstanceNodeGroupsKey)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(
+				"ConfigMap does not match the ClusterInstance schema: " +
+					"invalid input: nodeGroups.0: Additional property notAField is not allowed"))
 		})
 	})
 })


### PR DESCRIPTION
Introduce support for the new "nodeGroups" format alongside the existing "nodes" format so ClusterTemplate ClusterInstance defaults and clusterInstanceParameters can use either shape during the dual-format migration (See [proposal](https://github.com/openshift-kni/oran-o2ims/blob/main/docs/proposals/nodegroups-clusterinstance-input.md)).

Today, ClusterInstance input uses a flat nodes[] list, so MNO templates must duplicate shared per-host settings once per node. nodeGroups organizes that input by group (aligned with hwMgmtDefaults.nodeGroupData by name): shared fields live once per group in defaults, and per-host identity/addressing comes later from the ProvisioningRequest. Example defaults shape:

```
  nodeGroups:
  - name: master          # matches hwMgmtDefaults.nodeGroupData[].name
    role: master
    nodeNetwork:
      interfaces:
      - name: ens3f0
        label: boot-interface
  - name: worker
    role: worker
    ...
```

This story updates ClusterTemplate validation to accept that format. Validations added or adapted:
- clusterInstanceParameters schema must expose exactly one of nodes or nodeGroups (xor)
- clusterinstance-defaults must define exactly one of nodes or nodeGroups and match the ClusterInstanceParameters schema format
- interface labels validated (and stripped before CRD check) for both formats
- nodeGroups-only: unique non-empty group names; names must exist in hwMgmtDefaults.nodeGroupData; nested nodeGroups[].nodes rejected; group name stripped before CRD check
- ClusterInstance CRD schema check adapted for nodeGroups (rename CRD nodes property to nodeGroups for validation)

Existing nodes path behavior is preserved. Unit tests cover success and failure cases for both formats.