### PR TITLE
Update postgres image mapping to postgresql-18

### DIFF
--- a/.konflux/overlay/map_images.in.yaml
+++ b/.konflux/overlay/map_images.in.yaml
@@ -4,6 +4,6 @@
   staging: registry.stage.redhat.io/openshift4/o-cloud-manager-rhel9-operator
   production: registry.redhat.io/openshift4/o-cloud-manager-rhel9-operator
 - key: postgres_image
-  staging: registry.stage.redhat.io/rhel9/postgresql-16
-  production: registry.redhat.io/rhel9/postgresql-16
+  staging: registry.stage.redhat.io/rhel9/postgresql-18
+  production: registry.redhat.io/rhel9/postgresql-18
 


### PR DESCRIPTION
## Summary
- Update `postgres_image` entries in `.konflux/overlay/map_images.in.yaml` from `postgresql-16` to `postgresql-18`
- Aligns the image mapping with `pin_images.in.yaml`, `config/manager/manager.yaml`, and the CSV, which already reference `postgresql-18`

## Test plan
- [ ] Verify `map_images.in.yaml` references `postgresql-18` for both staging and production
- [ ] Confirm Konflux overlay pipeline resolves the correct postgres image

Made with [Cursor](https://cursor.com)