### PR TITLE
CNF-26586: Update registry namespace from openshift4 to openshift5

### DIFF
--- a/.konflux/Dockerfile.bundle
+++ b/.konflux/Dockerfile.bundle
@@ -44,7 +44,7 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL com.redhat.openshift.versions="=v5.0"
 LABEL com.redhat.delivery.backport=false
 LABEL com.redhat.component="o-cloud-manager-operator-bundle-container"
-LABEL name="openshift4/o-cloud-manager-operator-bundle-container-rhel9"
+LABEL name="openshift5/o-cloud-manager-operator-bundle-container-rhel9"
 LABEL summary="o-cloud"
 LABEL io.k8s.display-name="o-cloud-manager"
 LABEL io.k8s.description="o-cloud-manager"

--- a/.konflux/catalog/catalog-idms.yaml
+++ b/.konflux/catalog/catalog-idms.yaml
@@ -9,3 +9,6 @@ spec:
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-5-0
     source: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle
+  - mirrors:
+    - quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-5-0
+    source: registry.redhat.io/openshift5/o-cloud-manager-operator-bundle

--- a/.konflux/catalog/fbc-images-resolvable-integration-test-idms.yaml
+++ b/.konflux/catalog/fbc-images-resolvable-integration-test-idms.yaml
@@ -12,3 +12,9 @@ spec:
     - mirrors:
         - registry.stage.redhat.io/openshift4/o-cloud-manager-operator-bundle
       source: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle
+    - mirrors:
+        - registry.stage.redhat.io/openshift5/o-cloud-manager-rhel9-operator
+      source: registry.redhat.io/openshift5/o-cloud-manager-rhel9-operator
+    - mirrors:
+        - registry.stage.redhat.io/openshift5/o-cloud-manager-operator-bundle
+      source: registry.redhat.io/openshift5/o-cloud-manager-operator-bundle

--- a/.konflux/overlay/map_images.in.yaml
+++ b/.konflux/overlay/map_images.in.yaml
@@ -1,8 +1,8 @@
 # Do not modify the manager 'key' value: 'manager'
 ---
 - key: manager
-  staging: registry.stage.redhat.io/openshift4/o-cloud-manager-rhel9-operator
-  production: registry.redhat.io/openshift4/o-cloud-manager-rhel9-operator
+  staging: registry.stage.redhat.io/openshift5/o-cloud-manager-rhel9-operator
+  production: registry.redhat.io/openshift5/o-cloud-manager-rhel9-operator
 - key: postgres_image
   staging: registry.stage.redhat.io/rhel9/postgresql-18
   production: registry.redhat.io/rhel9/postgresql-18

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -12,3 +12,9 @@ spec:
     - mirrors:
         - quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-5-0
       source: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle
+    - mirrors:
+        - quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-5-0
+      source: registry.redhat.io/openshift5/o-cloud-manager-rhel9-operator
+    - mirrors:
+        - quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-5-0
+      source: registry.redhat.io/openshift5/o-cloud-manager-operator-bundle

--- a/.tekton/o-cloud-manager-5-0-pull-request.yaml
+++ b/.tekton/o-cloud-manager-5-0-pull-request.yaml
@@ -61,7 +61,7 @@ spec:
       value: []
     - name: additional-labels
       value:
-        - name=openshift4/o-cloud-manager-rhel9-operator
+        - name=openshift5/o-cloud-manager-rhel9-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/o-cloud-manager-5-0-push.yaml
+++ b/.tekton/o-cloud-manager-5-0-push.yaml
@@ -58,7 +58,7 @@ spec:
       value: ['latest']
     - name: additional-labels
       value:
-        - name=openshift4/o-cloud-manager-rhel9-operator
+        - name=openshift5/o-cloud-manager-rhel9-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/o-cloud-manager-bundle-5-0-pull-request.yaml
+++ b/.tekton/o-cloud-manager-bundle-5-0-pull-request.yaml
@@ -61,7 +61,7 @@ spec:
       value: []
     - name: additional-labels
       value:
-        - name=openshift4/o-cloud-manager-operator-bundle
+        - name=openshift5/o-cloud-manager-operator-bundle
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/o-cloud-manager-bundle-5-0-push.yaml
+++ b/.tekton/o-cloud-manager-bundle-5-0-push.yaml
@@ -58,7 +58,7 @@ spec:
       value: ["latest"]
     - name: additional-labels
       value:
-        - name=openshift4/o-cloud-manager-operator-bundle
+        - name=openshift5/o-cloud-manager-operator-bundle
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
## Summary
- Updates the registry namespace from `openshift4` to `openshift5` across Konflux and Tekton pipeline configuration files, image mirror sets, overlay mappings, and the bundle Dockerfile label.
- Does not touch submodules (`telco5g-konflux/`), vendored dependencies, docs, or OpenShift base images (`ose-cli`, `ose-operator-registry`).

## Test plan
- [ ] Verify Konflux builds resolve images correctly under the new `openshift5` namespace
- [ ] Verify Tekton pipeline labels reference the correct registry path
- [ ] Verify image mirror sets point to the correct source/mirrors


Made with [Cursor](https://cursor.com)