### PR TITLE
CNF-26441: Migrate SNO samples and e2e to nodeGroups and deprecate flat nodes

### DIFF
--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -101,7 +101,7 @@ metadata:
                 "nodeGroupData": [
                   {
                     "hwProfile": "hardwareprofile-sample",
-                    "name": "controller",
+                    "name": "master",
                     "resourceSelector": {
                       "resourceselector.clcm.openshift.io/server-type": "xr8620t"
                     },
@@ -258,9 +258,9 @@ metadata:
                       },
                       "type": "array"
                     },
-                    "nodes": {
+                    "nodeGroups": {
+                      "description": "Node configuration by group.",
                       "items": {
-                        "description": "NodeSpec",
                         "properties": {
                           "extraAnnotations": {
                             "additionalProperties": {
@@ -269,7 +269,7 @@ metadata:
                               },
                               "type": "object"
                             },
-                            "description": "Additional node-level annotations to be applied to the rendered templates",
+                            "description": "Additional node-level annotations applied to every host in this group",
                             "type": "object"
                           },
                           "extraLabels": {
@@ -279,11 +279,12 @@ metadata:
                               },
                               "type": "object"
                             },
-                            "description": "Additional node-level labels to be applied to the rendered templates",
+                            "description": "Additional node-level labels applied to every host in this group",
                             "type": "object"
                           },
-                          "hostName": {
-                            "description": "Hostname is the desired hostname for the host",
+                          "name": {
+                            "description": "Node group name. Must match a ClusterTemplate defaults nodeGroups entry and the corresponding hardware node group / MachineConfigPool name.\n",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "nodeLabels": {
@@ -294,19 +295,114 @@ metadata:
                             "type": "object"
                           },
                           "nodeNetwork": {
-                            "description": "NodeNetwork is a set of configurations pertaining to the network settings for the node.",
+                            "description": "Group-level network overlay applied to every host in this group.",
                             "properties": {
                               "config": {
-                                "description": "yaml that can be processed by nmstate, using custom marshaling/unmarshaling that will allow to populate nmstate config as plain yaml.",
+                                "description": "Opaque nmstate overlay (for example dns-resolver and routes) shared by every host in this group.",
                                 "type": "object",
                                 "x-kubernetes-preserve-unknown-fields": true
                               }
                             },
                             "type": "object"
+                          },
+                          "nodes": {
+                            "description": "Per-host identity and addressing for this group.",
+                            "items": {
+                              "properties": {
+                                "extraAnnotations": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "description": "Additional annotations for this host",
+                                  "type": "object"
+                                },
+                                "extraLabels": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "description": "Additional labels for this host",
+                                  "type": "object"
+                                },
+                                "hostName": {
+                                  "description": "Hostname is the desired hostname for the host",
+                                  "type": "string"
+                                },
+                                "nodeLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Custom node labels for this host",
+                                  "type": "object"
+                                },
+                                "nodeNetwork": {
+                                  "description": "Per-host addressing keyed by interface name.",
+                                  "properties": {
+                                    "interfaces": {
+                                      "description": "Per-interface addressing. Each name must match a defaults nodeNetwork.interfaces[].name.",
+                                      "items": {
+                                        "properties": {
+                                          "addresses": {
+                                            "description": "At least one of ipv4 or ipv6; CIDR strings, e.g. \"192.0.2.10/24\" or \"fd00:1:1::10/64\".",
+                                            "minProperties": 1,
+                                            "properties": {
+                                              "ipv4": {
+                                                "items": {
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "minItems": 1,
+                                                "type": "array"
+                                              },
+                                              "ipv6": {
+                                                "items": {
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "minItems": 1,
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "addresses"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "minItems": 1,
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "interfaces"
+                                  ],
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "hostName",
+                                "nodeNetwork"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
                           }
                         },
                         "required": [
-                          "hostName"
+                          "name",
+                          "nodes"
                         ],
                         "type": "object"
                       },
@@ -336,7 +432,7 @@ metadata:
                   },
                   "required": [
                     "clusterName",
-                    "nodes"
+                    "nodeGroups"
                   ],
                   "type": "object"
                 },
@@ -690,9 +786,8 @@ metadata:
                     "cidr": "192.0.2.0/24"
                   }
                 ],
-                "nodes": [
+                "nodeGroups": [
                   {
-                    "bootMode": "UEFI",
                     "extraAnnotations": {
                       "BareMetalHost": {
                         "extra-annotation-key": "extra-annotation-value"
@@ -703,7 +798,7 @@ metadata:
                         "extra-label-key": "extra-label-value"
                       }
                     },
-                    "hostName": "node1.baseDomain.com",
+                    "name": "master",
                     "nodeLabels": {
                       "node-role.kubernetes.io/infra": "",
                       "node-role.kubernetes.io/master": ""
@@ -717,48 +812,6 @@ metadata:
                             ]
                           }
                         },
-                        "interfaces": [
-                          {
-                            "ipv4": {
-                              "address": [
-                                {
-                                  "ip": "192.0.2.10",
-                                  "prefix-length": 24
-                                },
-                                {
-                                  "ip": "192.0.2.11",
-                                  "prefix-length": 24
-                                },
-                                {
-                                  "ip": "192.0.2.12",
-                                  "prefix-length": 24
-                                }
-                              ],
-                              "dhcp": false,
-                              "enabled": true
-                            },
-                            "ipv6": {
-                              "address": [
-                                {
-                                  "ip": "2620:52:0:10e7:e42:a1ff:fe8a:601",
-                                  "prefix-length": 64
-                                },
-                                {
-                                  "ip": "2620:52:0:10e7:e42:a1ff:fe8a:602",
-                                  "prefix-length": 64
-                                },
-                                {
-                                  "ip": "2620:52:0:10e7:e42:a1ff:fe8a:603",
-                                  "prefix-length": 64
-                                }
-                              ],
-                              "dhcp": false,
-                              "enabled": true
-                            },
-                            "name": "ens3f0",
-                            "type": "ethernet"
-                          }
-                        ],
                         "routes": {
                           "config": [
                             {
@@ -770,7 +823,31 @@ metadata:
                           ]
                         }
                       }
-                    }
+                    },
+                    "nodes": [
+                      {
+                        "hostName": "node1.baseDomain.com",
+                        "nodeNetwork": {
+                          "interfaces": [
+                            {
+                              "addresses": {
+                                "ipv4": [
+                                  "192.0.2.10/24",
+                                  "192.0.2.11/24",
+                                  "192.0.2.12/24"
+                                ],
+                                "ipv6": [
+                                  "2620:52:0:10e7:e42:a1ff:fe8a:601/64",
+                                  "2620:52:0:10e7:e42:a1ff:fe8a:602/64",
+                                  "2620:52:0:10e7:e42:a1ff:fe8a:603/64"
+                                ]
+                              },
+                              "name": "ens3f0"
+                            }
+                          ]
+                        }
+                      }
+                    ]
                   }
                 ],
                 "serviceNetwork": [
@@ -784,7 +861,7 @@ metadata:
                 "nodeGroupData": [
                   {
                     "hwProfile": "hardwareprofile-sample",
-                    "name": "controller"
+                    "name": "master"
                   }
                 ]
               },

--- a/config/samples/v1alpha1_clustertemplate.yaml
+++ b/config/samples/v1alpha1_clustertemplate.yaml
@@ -16,7 +16,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           hwProfile: hardwareprofile-sample
           resourceSelector:
@@ -266,29 +266,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -303,18 +307,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -338,7 +411,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
     required:
       - nodeClusterName

--- a/config/samples/v1alpha1_provisioningrequest.yaml
+++ b/config/samples/v1alpha1_provisioningrequest.yaml
@@ -21,7 +21,7 @@ spec:
       # Override the hardware provisioning timeout (optional)
       # hardwareProvisioningTimeout: "120m"
       nodeGroupData:
-        - name: controller
+        - name: master
           hwProfile: hardwareprofile-sample
           # Additional resource selector criteria (optional, merged with hwMgmtDefaults selectors)
           # resourceSelector:
@@ -50,15 +50,14 @@ spec:
         - 192.0.2.3
       machineNetwork:
         - cidr: 192.0.2.0/24
-      nodes:
-        - bootMode: UEFI
+      nodeGroups:
+        - name: master
           extraAnnotations:
             BareMetalHost:
               extra-annotation-key: extra-annotation-value
           extraLabels:
             BareMetalHost:
               extra-label-key: extra-label-value
-          hostName: node1.baseDomain.com
           nodeLabels:
             node-role.kubernetes.io/infra: ""
             node-role.kubernetes.io/master: ""
@@ -68,35 +67,26 @@ spec:
                 config:
                   server:
                     - 192.0.2.22
-              interfaces:
-                - ipv4:
-                    address:
-                      - ip: 192.0.2.10
-                        prefix-length: 24
-                      - ip: 192.0.2.11
-                        prefix-length: 24
-                      - ip: 192.0.2.12
-                        prefix-length: 24
-                    dhcp: false
-                    enabled: true
-                  ipv6:
-                    address:
-                      - ip: 2620:52:0:10e7:e42:a1ff:fe8a:601
-                        prefix-length: 64
-                      - ip: 2620:52:0:10e7:e42:a1ff:fe8a:602
-                        prefix-length: 64
-                      - ip: 2620:52:0:10e7:e42:a1ff:fe8a:603
-                        prefix-length: 64
-                    dhcp: false
-                    enabled: true
-                  name: ens3f0
-                  type: ethernet
               routes:
                 config:
                   - destination: 0.0.0.0/0
                     next-hop-address: 192.0.2.254
                     next-hop-interface: ens3f0
                     table-id: 254
+          nodes:
+            - hostName: node1.baseDomain.com
+              nodeNetwork:
+                interfaces:
+                  - name: ens3f0
+                    addresses:
+                      ipv4:
+                        - 192.0.2.10/24
+                        - 192.0.2.11/24
+                        - 192.0.2.12/24
+                      ipv6:
+                        - 2620:52:0:10e7:e42:a1ff:fe8a:601/64
+                        - 2620:52:0:10e7:e42:a1ff:fe8a:602/64
+                        - 2620:52:0:10e7:e42:a1ff:fe8a:603/64
       serviceNetwork:
         - cidr: 233.252.0.0/24
       sshPublicKey: ssh-rsa

--- a/docs/samples/clusterInstanceParameters-legacy-nodes.yaml
+++ b/docs/samples/clusterInstanceParameters-legacy-nodes.yaml
@@ -1,5 +1,6 @@
-# Sample clusterInstanceParameters schema using legacy flat nodes.
-# Prefer clusterInstanceParameters-nodeGroups.yaml for new templates.
+# DEPRECATED: Sample clusterInstanceParameters schema using flat nodes.
+# New templates must use clusterInstanceParameters-nodeGroups.yaml.
+# This format remains valid for existing templates until the legacy path is removed.
 # Copy under ClusterTemplate spec.templateParameterSchema.properties.
 
 clusterInstanceParameters:

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/sno-ran-du/clusterinstance-defaults-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/sno-ran-du/clusterinstance-defaults-v1.yaml
@@ -37,8 +37,9 @@ data:
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
-    nodes:
-      - role: master
+    nodeGroups:
+      - name: master
+        role: master
         bootMode: UEFI
         ironicInspect: "disabled"
         automatedCleaningMode: disabled

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/sno-ran-du/sno-ran-du-v4-Y-Z+1-1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/sno-ran-du/sno-ran-du-v4-Y-Z+1-1.yaml
@@ -11,7 +11,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
@@ -140,29 +140,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -177,18 +181,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -212,7 +285,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
     required:
       - nodeClusterName

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/sno-ran-du/sno-ran-du-v4-Y-Z+1-2.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z+1/sno-ran-du/sno-ran-du-v4-Y-Z+1-2.yaml
@@ -11,7 +11,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
@@ -249,29 +249,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -286,18 +290,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -321,7 +394,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
     required:
       - nodeClusterName

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-ibi.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-ibi.yaml
@@ -40,8 +40,9 @@ data:
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
-    nodes:
-      - role: master
+    nodeGroups:
+      - name: master
+        role: master
         bootMode: UEFI
         ironicInspect: "disabled"
         automatedCleaningMode: disabled

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v1.yaml
@@ -37,8 +37,9 @@ data:
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
-    nodes:
-      - role: master
+    nodeGroups:
+      - name: master
+        role: master
         bootMode: UEFI
         ironicInspect: "disabled"
         automatedCleaningMode: disabled

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v2.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v2.yaml
@@ -40,8 +40,9 @@ data:
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
-    nodes:
-      - role: master
+    nodeGroups:
+      - name: master
+        role: master
         bootMode: UEFI
         ironicInspect: "disabled"
         automatedCleaningMode: disabled

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v3.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v3.yaml
@@ -40,8 +40,9 @@ data:
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
-    nodes:
-      - role: master
+    nodeGroups:
+      - name: master
+        role: master
         bootMode: UEFI
         ironicInspect: "disabled"
         automatedCleaningMode: disabled

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v4.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v4.yaml
@@ -40,8 +40,9 @@ data:
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
-    nodes:
-      - role: master
+    nodeGroups:
+      - name: master
+        role: master
         bootMode: UEFI
         ironicInspect: "disabled"
         automatedCleaningMode: disabled

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-ibi-v4-Y-Z-1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-ibi-v4-Y-Z-1.yaml
@@ -11,7 +11,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
@@ -140,29 +140,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -177,18 +181,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -212,7 +285,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
     required:
       - nodeClusterName

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1.yaml
@@ -11,7 +11,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
@@ -140,29 +140,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -177,18 +181,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -212,7 +285,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
     required:
       - nodeClusterName

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-2.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-2.yaml
@@ -11,7 +11,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
@@ -140,29 +140,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -177,18 +181,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -212,7 +285,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
     required:
       - nodeClusterName

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-3.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-3.yaml
@@ -11,7 +11,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
@@ -140,29 +140,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -177,18 +181,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -212,7 +285,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
     required:
       - nodeClusterName

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-4.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-4.yaml
@@ -11,7 +11,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
@@ -144,29 +144,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -181,18 +185,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -216,7 +289,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
     required:
       - nodeClusterName

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-5.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-5.yaml
@@ -11,7 +11,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
@@ -144,29 +144,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -181,18 +185,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -216,7 +289,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
     required:
       - nodeClusterName

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-6.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-6.yaml
@@ -17,7 +17,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
@@ -146,29 +146,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -183,18 +187,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -218,7 +291,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
     required:
       - nodeClusterName

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-full-du/clusterinstance-defaults-full-du-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-full-du/clusterinstance-defaults-full-du-v1.yaml
@@ -37,8 +37,9 @@ data:
     cpuPartitioningMode: AllNodes
     extraManifestsRefs:
       - name: clustertemplate-sample.v1.0.0-extramanifests
-    nodes:
-      - role: master
+    nodeGroups:
+      - name: master
+        role: master
         bootMode: UEFISecureBoot
         ironicInspect: "disabled"
         automatedCleaningMode: disabled

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-full-du/sno-ran-full-du-v4-Y-Z-1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-full-du/sno-ran-full-du-v4-Y-Z-1.yaml
@@ -11,7 +11,7 @@ spec:
     hwMgmtDefaults:
       hardwareProvisioningTimeout: "90m"
       nodeGroupData:
-        - name: controller
+        - name: master
           role: master
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
@@ -154,47 +154,33 @@ spec:
               - cidr
               type: object
             type: array
-          nodes:
+          nodeGroups:
+            description: Node configuration by group.
             items:
-              description: NodeSpec
               properties:
-                bmcAddress:
-                  description: BmcAddress holds the URL for accessing the controller
-                    on the network.
+                name:
                   type: string
-                bmcCredentialsName:
-                  description: BmcCredentialsName is the name of the secret containing
-                    the BMC credentials (requires keys "username" and "password").
-                  properties:
-                    name:
-                      type: string
-                  required:
-                  - name
-                  type: object
-                bootMACAddress:
-                  description: Which MAC address will PXE boot? This is optional
-                    for some types, but required for libvirt VMs driven by vbmc.
-                  pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
-                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
                 extraAnnotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level annotations to be applied
-                    to the rendered templates
+                  description: Additional node-level annotations applied to every
+                    host in this group
                   type: object
                 extraLabels:
                   additionalProperties:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Additional node-level labels to be applied to the
-                    rendered templates
+                  description: Additional node-level labels applied to every host
+                    in this group
                   type: object
-                hostName:
-                  description: Hostname is the desired hostname for the host
-                  type: string
                 nodeLabels:
                   additionalProperties:
                     type: string
@@ -209,90 +195,87 @@ spec:
                     is complete.
                   type: object
                 nodeNetwork:
-                  description: NodeNetwork is a set of configurations pertaining
-                    to the network settings for the node.
+                  description: Group-level network overlay applied to every host
+                    in this group.
                   properties:
                     config:
-                      description: yaml that can be processed by nmstate, using
-                        custom marshaling/unmarshaling that will allow to populate
-                        nmstate config as plain yaml.
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                    interfaces:
-                      description: Interfaces is an array of interface objects
-                        containing the name and MAC address for interfaces that
-                        are referenced in the raw nmstate config YAML. Interfaces
-                        listed here will be automatically renamed in the nmstate
-                        config YAML to match the real device name that is observed
-                        to have the corresponding MAC address. At least one interface
-                        must be listed so that it can be used to identify the
-                        correct host, which is done by matching any MAC address
-                        in this list to any MAC address observed on the host.
-                      items:
-                        properties:
-                          macAddress:
-                            description: mac address present on the host.
-                            pattern: ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
+                  type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
                             type: string
-                          name:
-                            description: 'nic name used in the yaml, which relates
-                              1:1 to the mac address. Name in REST API: logicalNICName'
-                            type: string
-                        required:
-                        - macAddress
+                          type: object
+                        description: Additional annotations for this host
                         type: object
-                      minItems: 1
-                      type: array
-                  type: object
-                rootDeviceHints:
-                  description: 'RootDeviceHints specifies the device for deployment.
-                    Identifiers that are stable across reboots are recommended,
-                    for example, wwn: <disk_wwn> or deviceName: /dev/disk/by-path/<device_path>'
-                  properties:
-                    deviceName:
-                      description: A Linux device name like "/dev/vda", or a by-path
-                        link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
-                        The hint must match the actual value exactly.
-                      type: string
-                    hctl:
-                      description: A SCSI bus address like 0:0:0:0. The hint must
-                        match the actual value exactly.
-                      type: string
-                    minSizeGigabytes:
-                      description: The minimum size of the device in Gigabytes.
-                      minimum: 0
-                      type: integer
-                    model:
-                      description: A vendor-specific device identifier. The hint
-                        can be a substring of the actual value.
-                      type: string
-                    rotational:
-                      description: True if the device should use spinning media,
-                        false otherwise.
-                      type: boolean
-                    serialNumber:
-                      description: Device serial number. The hint must match the
-                        actual value exactly.
-                      type: string
-                    vendor:
-                      description: The name of the vendor or manufacturer of the
-                        device. The hint can be a substring of the actual value.
-                      type: string
-                    wwn:
-                      description: Unique storage identifier. The hint must match
-                        the actual value exactly.
-                      type: string
-                    wwnVendorExtension:
-                      description: Unique vendor storage identifier. The hint
-                        must match the actual value exactly.
-                      type: string
-                    wwnWithExtension:
-                      description: Unique storage identifier with the vendor extension
-                        appended. The hint must match the actual value exactly.
-                      type: string
-                  type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
               required:
-              - hostName
+              - name
+              - nodes
               type: object
             type: array
           serviceNetwork:
@@ -316,7 +299,7 @@ spec:
             type: string
         required:
         - clusterName
-        - nodes
+        - nodeGroups
         type: object
 
 # Notes:

--- a/docs/user-guide/cluster-configuration.md
+++ b/docs/user-guide/cluster-configuration.md
@@ -112,15 +112,15 @@ spec:
   templateParameters:
     clusterInstanceParameters:
       clusterName: sno-ran-du-1
-      nodes:
-      - bmcCredentialsName:
-          name: sno-ran-du-1-bmc-secret
-        extraAnnotations:
-          BareMetalHost:
-            test: test <<< added as a Day 2 change
-        extraLabels:
-          BareMetalHost:
-            test: test <<< added as a Day 2 change
+      nodeGroups:
+      - name: master
+        nodes:
+        - extraAnnotations:
+            BareMetalHost:
+              test: test <<< added as a Day 2 change
+          extraLabels:
+            BareMetalHost:
+              test: test <<< added as a Day 2 change
 ```
 
 The `status.conditions` records the success/failure of the update.
@@ -552,14 +552,14 @@ The following steps are required:
     * Update the kustomization files to include the new `HardwareProfile`. ArgoCD will automatically sync it to the hub cluster.
     * No changes to `hwMgmtDefaults` or `ClusterTemplate` CRs are needed.
 2. Update the `ProvisioningRequest` to reference the new `HardwareProfile`:
-    * Set the `hwProfile` for the controller node group in `spec.templateParameters.hwMgmtParameters.nodeGroupData` to the new profile name (`dell-xr8620t-bios-2.6.3-bmc-7.20.30.50`).
+    * Set the `hwProfile` for the master node group in `spec.templateParameters.hwMgmtParameters.nodeGroupData` to the new profile name (`dell-xr8620t-bios-2.6.3-bmc-7.20.30.50`).
 
     ```yaml
     spec:
       templateParameters:
         hwMgmtParameters:
           nodeGroupData:
-            - name: controller
+            - name: master
               hwProfile: dell-xr8620t-bios-2.6.3-bmc-7.20.30.50
     ```
 

--- a/docs/user-guide/cluster-provisioning.md
+++ b/docs/user-guide/cluster-provisioning.md
@@ -449,7 +449,7 @@ curl -sk -X POST \
     "oCloudSiteId": "local-west",
     "hwMgmtParameters": {
       "nodeGroupData": {
-        "controller": {
+        "master": {
           "hwProfile": "rh-profile-xr8620t-bios-settings"
         }
       }
@@ -465,9 +465,9 @@ curl -sk -X POST \
         }
       },
       "clusterName": "sno1",
-      "nodes": [
+      "nodeGroups": [
         {
-          "hostName": "sno1.example.com",
+          "name": "master",
           "nodeNetwork": {
             "config": {
               "dns-resolver": {
@@ -481,25 +481,24 @@ curl -sk -X POST \
                     "next-hop-address": "192.0.2.254"
                   }
                 ]
-              },
-              "interfaces": [
-                {
-                  "ipv6": {
-                    "enabled": false
-                  },
-                  "ipv4": {
-                    "enabled": true,
-                    "address": [
-                      {
-                        "ip": "192.0.2.34",
-                        "prefix-length": 24
-                      }
-                    ]
-                  }
-                }
-              ]
+              }
             }
-          }
+          },
+          "nodes": [
+            {
+              "hostName": "sno1.example.com",
+              "nodeNetwork": {
+                "interfaces": [
+                  {
+                    "name": "ens3f0",
+                    "addresses": {
+                      "ipv4": ["192.0.2.34/24"]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     }
@@ -525,7 +524,7 @@ curl -sk -X PUT \
     "oCloudSiteId": "local-west",
     "hwMgmtParameters": {
       "nodeGroupData": {
-        "controller": {
+        "master": {
           "hwProfile": "rh-profile-xr8620t-bios-settings"
         }
       }
@@ -541,9 +540,9 @@ curl -sk -X PUT \
         }
       },
       "clusterName": "sno1",
-      "nodes": [
+      "nodeGroups": [
         {
-          "hostName": "sno1.example.com",
+          "name": "master",
           "nodeNetwork": {
             "config": {
               "dns-resolver": {
@@ -557,25 +556,24 @@ curl -sk -X PUT \
                     "next-hop-address": "192.0.2.254"
                   }
                 ]
-              },
-              "interfaces": [
-                {
-                  "ipv6": {
-                    "enabled": false
-                  },
-                  "ipv4": {
-                    "enabled": true,
-                    "address": [
-                      {
-                        "ip": "192.0.2.34",
-                        "prefix-length": 24
-                      }
-                    ]
-                  }
-                }
-              ]
+              }
             }
-          }
+          },
+          "nodes": [
+            {
+              "hostName": "sno1.example.com",
+              "nodeNetwork": {
+                "interfaces": [
+                  {
+                    "name": "ens3f0",
+                    "addresses": {
+                      "ipv4": ["192.0.2.34/24"]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/docs/user-guide/server-onboarding.md
+++ b/docs/user-guide/server-onboarding.md
@@ -411,8 +411,9 @@ interfaces in the ClusterInstance defaults.
 For example, if the ClusterInstance defaults define:
 
 ```yaml
-nodes:
-  - nodeNetwork:
+nodeGroups:
+  - name: master
+    nodeNetwork:
       interfaces:
         - name: eno1
           label: boot-interface

--- a/docs/user-guide/template-overview.md
+++ b/docs/user-guide/template-overview.md
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
         - [Hardware data selectors](#hardware-data-selectors)
         - [Complete example](#complete-example)
     - [ClusterInstance defaults ConfigMap](#clusterinstance-defaults-configmap)
-      - [Legacy format (`nodes`)](#legacy-format-nodes)
+      - [Deprecated format (`nodes`)](#deprecated-format-nodes)
       - [Recommended format (`nodeGroups`)](#recommended-format-nodegroups)
     - [PolicyTemplate defaults ConfigMap](#policytemplate-defaults-configmap)
   - [Validation](#validation)
@@ -154,16 +154,16 @@ ClusterInstance-shaped in both cases; the difference is how hosts are expressed:
 | Format | Status | Host layout | Sample schema |
 | --- | --- | --- | --- |
 | `nodeGroups` | Recommended | O-Cloud extension: hosts are grouped; node-group-level configuration remains ClusterInstance-shaped | [`clusterInstanceParameters-nodeGroups.yaml`](../samples/clusterInstanceParameters-nodeGroups.yaml) |
-| `nodes` | Legacy | Flat top-level ClusterInstance `nodes` subschema (as used by current SNO samples) | [`clusterInstanceParameters-legacy-nodes.yaml`](../samples/clusterInstanceParameters-legacy-nodes.yaml) |
+| `nodes` | Deprecated | Flat top-level ClusterInstance `nodes` subschema. Still accepted for existing templates; new templates must use `nodeGroups` | [`clusterInstanceParameters-legacy-nodes.yaml`](../samples/clusterInstanceParameters-legacy-nodes.yaml) |
 
 The referenced `clusterInstanceDefaults` ConfigMap must use the **same** format.
 Mixing `nodes` and `nodeGroups` across the schema, defaults, and ProvisioningRequest
 is rejected.
 
 Full ClusterTemplate examples that embed these schemas:
-[Standard](../samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/std-ran-du-v4-Y-Z-1.yaml),
+[SNO](../samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1.yaml),
 [3node](../samples/git-setup/clustertemplates/version_4.Y.Z/3node-ran-du/3node-ran-du-v4-Y-Z-1.yaml),
-[SNO (legacy)](../samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/sno-ran-du-v4-Y-Z-1.yaml).
+[Standard](../samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/std-ran-du-v4-Y-Z-1.yaml).
 
 ##### Providing `nodeGroups` in the ProvisioningRequest
 
@@ -188,10 +188,12 @@ string (for example `"192.0.2.10/24"` or `"fd00:1:1::10/64"`), not a bare IP.
 O-Cloud Manager maps those addresses into the matching nmstate interface config
 when it expands `nodeGroups` to the flat ClusterInstance `nodes[]` list.
 
-**Example.** Defaults define `master` and `worker` groups with interface skeletons
+The following examples are ProvisioningRequest `clusterInstanceParameters`
+excerpts. Group names and interface `name` values must already exist in the
+ClusterInstance defaults
 (see [Recommended format (`nodeGroups`)](#recommended-format-nodegroups)).
-A ProvisioningRequest can then supply hosts, optional group-wide overlays, and
-addresses:
+
+A multi-node cluster uses `master` and `worker` groups:
 
 ```yaml
 # ProvisioningRequest clusterInstanceParameters (excerpt)
@@ -234,8 +236,30 @@ clusterInstanceParameters:
         # ... additional workers
 ```
 
-A single-node cluster uses the same shape with one group and one host under
-`nodes`.
+A single-node cluster uses the same shape with one group and one host:
+
+```yaml
+# SNO ProvisioningRequest clusterInstanceParameters (excerpt)
+clusterInstanceParameters:
+  clusterName: sno1
+  nodeGroups:
+    - name: master
+      nodeNetwork:
+        config:
+          dns-resolver:
+            config:
+              server: ["198.51.100.20"]
+          routes:
+            config:
+              - next-hop-address: 192.0.2.254
+      nodes:
+        - hostName: sno1.example.com
+          nodeNetwork:
+            interfaces:
+              - name: ens3f0
+                addresses:
+                  ipv4: ["192.0.2.34/24"]
+```
 
 > [!NOTE]
 >
@@ -437,17 +461,17 @@ Each node’s boot interface in the `interfaces` list must include a `boot-inter
 This allows the O-Cloud manager to resolve the boot NIC’s MAC address from the NIC-to-MAC
 mappings retrieved from the hardware manager.
 
-#### Legacy format (`nodes`)
+#### Deprecated format (`nodes`)
 
 Flat `nodes` list: one stub per expected host with defaults such as role, boot
 mode, interface skeleton, and nmstate config. The ProvisioningRequest supplies
 host-specific values (hostname, addresses, MAC) by index merge.
 
-Current SNO sample templates still use this format; they will move to
-`nodeGroups` later.
+This format is deprecated. Existing templates that still use it continue to
+work; new templates must use `nodeGroups`.
 
 ```yaml
-# ConfigMap data.clusterinstance-defaults (legacy nodes excerpt)
+# ConfigMap data.clusterinstance-defaults (deprecated nodes excerpt)
 nodes:
   - role: master
     bootMode: UEFI
@@ -457,9 +481,6 @@ nodes:
           label: boot-interface
         - name: ens3f1
 ```
-
-Complete example (current SNO sample):
-[clusterinstance-defaults-v1](../samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v1.yaml).
 
 #### Recommended format (`nodeGroups`)
 
@@ -494,6 +515,7 @@ nodeGroups:
 ```
 
 Complete examples:
+[SNO](../samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/clusterinstance-defaults-v1.yaml),
 [3node](../samples/git-setup/clustertemplates/version_4.Y.Z/3node-ran-du/clusterinstance-defaults-v1.yaml)
 and
 [Standard](../samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/clusterinstance-defaults-v1.yaml).

--- a/internal/controllers/clustertemplate_controller_test.go
+++ b/internal/controllers/clustertemplate_controller_test.go
@@ -161,7 +161,7 @@ var _ = Describe("ClusterTemplateReconciler", func() {
 					ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
 baseDomain: value
 clusterImageSetNameRef: "4.15.0"
-nodes: []`,
+nodeGroups: []`,
 				},
 			},
 			{
@@ -552,7 +552,7 @@ var _ = Describe("validateClusterTemplateCR", func() {
 					ctlrutils.ClusterInstanceTemplateDefaultsConfigmapKey: `
 baseDomain: value
 clusterImageSetNameRef: "4.15.0"
-nodes: []`,
+nodeGroups: []`,
 				},
 			},
 			{

--- a/internal/controllers/provisioningrequest_clusterconfig_test.go
+++ b/internal/controllers/provisioningrequest_clusterconfig_test.go
@@ -176,7 +176,7 @@ var _ = Describe("policyManagement", func() {
 						HwMgmtDefaults: provisioningv1alpha1.HwMgmtDefaults{
 							HardwareProvisioningTimeout: &metav1.Duration{Duration: 1 * time.Minute},
 							NodeGroupData: []hwmgmtv1alpha1.NodeGroupData{
-								{Name: "controller", Role: "master", ResourcePoolId: "xyz", HwProfile: "profile-spr-single-processor-64G"},
+								{Name: "master", Role: "master", ResourcePoolId: "xyz", HwProfile: "profile-spr-single-processor-64G"},
 								{Name: "worker", Role: "worker", ResourcePoolId: "xyz", HwProfile: "profile-spr-dual-processor-128G"},
 							},
 						},
@@ -207,8 +207,8 @@ pullSecretRef:
 templateRefs:
 - name: "ai-cluster-templates-v1"
   namespace: "siteconfig-operator"
-nodes:
-- hostName: "node1"
+nodeGroups:
+- name: master
   role: master
   ironicInspect: ""
   automatedCleaningMode: "disabled"
@@ -348,7 +348,7 @@ defaultHugepagesSize: "1G"`,
 				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
 					{
 						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
-							Name:           "controller",
+							Name:           "master",
 							Role:           "master",
 							HwProfile:      "profile-spr-single-processor-64G",
 							ResourcePoolId: "xyz",
@@ -1845,7 +1845,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 						HwMgmtDefaults: provisioningv1alpha1.HwMgmtDefaults{
 							HardwareProvisioningTimeout: &metav1.Duration{Duration: 1 * time.Minute},
 							NodeGroupData: []hwmgmtv1alpha1.NodeGroupData{
-								{Name: "controller", Role: "master", ResourcePoolId: "xyz", HwProfile: "profile-spr-single-processor-64G"},
+								{Name: "master", Role: "master", ResourcePoolId: "xyz", HwProfile: "profile-spr-single-processor-64G"},
 								{Name: "worker", Role: "worker", ResourcePoolId: "xyz", HwProfile: "profile-spr-dual-processor-128G"},
 							},
 						},
@@ -1888,7 +1888,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
 					{
 						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
-							Name:           "controller",
+							Name:           "master",
 							Role:           "master",
 							HwProfile:      "profile-spr-single-processor-64G",
 							ResourcePoolId: "xyz",
@@ -1936,7 +1936,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 					HwMgmtDefaults: provisioningv1alpha1.HwMgmtDefaults{
 						HardwareProvisioningTimeout: &metav1.Duration{Duration: 1 * time.Minute},
 						NodeGroupData: []hwmgmtv1alpha1.NodeGroupData{
-							{Name: "controller", Role: "master", ResourcePoolId: "xyz", HwProfile: "profile-spr-single-processor-64G"},
+							{Name: "master", Role: "master", ResourcePoolId: "xyz", HwProfile: "profile-spr-single-processor-64G"},
 							{Name: "worker", Role: "worker", ResourcePoolId: "xyz", HwProfile: "profile-spr-dual-processor-128G"},
 						},
 					},
@@ -2162,7 +2162,7 @@ var _ = Describe("addPostProvisioningLabels", func() {
 					},
 					Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
 						NodeAllocationRequest: "cluster-1",
-						GroupName:             "controller",
+						GroupName:             "master",
 					},
 				}
 				Expect(c.Create(ctx, allocatedNode)).To(Succeed())

--- a/internal/controllers/provisioningrequest_clusterinstall_test.go
+++ b/internal/controllers/provisioningrequest_clusterinstall_test.go
@@ -87,8 +87,8 @@ holdInstallation: false
 templateRefs:
   - name: "ai-cluster-templates-v1"
     namespace: "siteconfig-operator"
-nodes:
-- hostname: "node1"
+nodeGroups:
+- name: master
   role: master
   ironicInspect: ""
   nodeNetwork:
@@ -99,6 +99,15 @@ nodes:
       label: base-interface
     - name: eth1
       label: data-interface
+    config:
+      interfaces:
+      - name: eno1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+        ipv6:
+          enabled: false
   templateRefs:
     - name: "ai-node-templates-v1"
       namespace: "siteconfig-operator"`,

--- a/test/e2e/sno_provisioning_test.go
+++ b/test/e2e/sno_provisioning_test.go
@@ -128,8 +128,9 @@ pullSecretRef:
 templateRefs:
 - name: "ai-cluster-templates-v1"
   namespace: "siteconfig-operator"
-nodes:
-- role: master
+nodeGroups:
+- name: master
+  role: master
   automatedCleaningMode: disabled
   ironicInspect: ""
   bootMode: UEFI
@@ -141,6 +142,15 @@ nodes:
       label: base-interface
     - name: eth1
       label: data-interface
+    config:
+      interfaces:
+      - name: eno1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+        ipv6:
+          enabled: false
 `,
 			},
 		},
@@ -162,12 +172,12 @@ pullSecretRef:
 templateRefs:
 - name: "ai-cluster-templates-v1"
   namespace: "siteconfig-operator"
-nodes:
-- role: master
+nodeGroups:
+- name: master
+  role: master
   automatedCleaningMode: disabled
   ironicInspect: ""
   bootMode: UEFI
-  hostName: node1
   nodeNetwork:
     interfaces:
     - name: eno1
@@ -176,6 +186,15 @@ nodes:
       label: base-interface
     - name: eth1
       label: data-interface
+    config:
+      interfaces:
+      - name: eno1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+        ipv6:
+          enabled: false
   templateRefs:
   - name: test
     namespace: test
@@ -235,7 +254,7 @@ defaultHugepagesSize: "1G"`,
 					HardwareProvisioningTimeout: &metav1.Duration{Duration: 10 * time.Minute},
 					NodeGroupData: []hwmgmtv1alpha1.NodeGroupData{
 						{
-							Name:           "single-node",
+							Name:           "master",
 							Role:           "master",
 							ResourcePoolId: testutils.TestPoolID,
 							HwProfile:      testutils.TestHwProfileName,
@@ -266,7 +285,7 @@ defaultHugepagesSize: "1G"`,
 					HardwareProvisioningTimeout: &metav1.Duration{Duration: 10 * time.Minute},
 					NodeGroupData: []hwmgmtv1alpha1.NodeGroupData{
 						{
-							Name:           "single-node",
+							Name:           "master",
 							Role:           "master",
 							ResourcePoolId: testutils.TestPoolID,
 							HwProfile:      testutils.TestHwProfileName,
@@ -613,12 +632,12 @@ defaultHugepagesSize: "1G"`,
 			return true
 		}, timeout, interval).Should(BeTrue())
 
-		// Verify NodeAllocationRequest contains expected node groups (only 1 single-node group).
+		// Verify NodeAllocationRequest contains expected node groups (only 1 master group).
 		Expect(len(nar.Spec.NodeGroup)).To(Equal(1))
 
 		// Verify the single node group.
 		singleNodeGroup := nar.Spec.NodeGroup[0]
-		Expect(singleNodeGroup.NodeGroupData.Name).To(Equal("single-node"))
+		Expect(singleNodeGroup.NodeGroupData.Name).To(Equal("master"))
 		Expect(singleNodeGroup.Size).To(Equal(1))
 		Expect(singleNodeGroup.NodeGroupData.HwProfile).To(Equal(testutils.TestHwProfileName))
 

--- a/test/utils/functions.go
+++ b/test/utils/functions.go
@@ -217,7 +217,7 @@ func DownloadFile(rawUrl, filename, dirpath string) error {
 }
 
 func CreateNodeResources(ctx context.Context, c client.Client, npName string) {
-	node := CreateNode(MasterNodeName, "idrac-virtualmedia+https://10.16.2.1/redfish/v1/Systems/System.Embedded.1", "bmc-secret", "controller", constants.DefaultNamespace, npName, nil)
+	node := CreateNode(MasterNodeName, "idrac-virtualmedia+https://10.16.2.1/redfish/v1/Systems/System.Embedded.1", "bmc-secret", "master", constants.DefaultNamespace, npName, nil)
 	// Create both the standard secret and the mock server expected secrets
 	secretNames := []string{BmcSecretName, "test-node-1-bmc-secret", "master-node-2-bmc-secret"}
 	secrets := CreateSecrets(secretNames, constants.DefaultNamespace)

--- a/test/utils/vars.go
+++ b/test/utils/vars.go
@@ -16,8 +16,10 @@ import (
 )
 
 const (
-	GithubCommitsAPI          = "https://api.github.com/repos/%s/%s/commits/%s"
-	GithubUserContentLink     = "https://raw.githubusercontent.com/%s/%s/%s/%s/%s"
+	GithubCommitsAPI      = "https://api.github.com/repos/%s/%s/commits/%s"
+	GithubUserContentLink = "https://raw.githubusercontent.com/%s/%s/%s/%s/%s"
+	// TestClusterInstanceSchema is the recommended nodeGroups clusterInstanceParameters
+	// subschema. Tests that exercise the deprecated flat-nodes path use inline schemas.
 	TestClusterInstanceSchema = `{
 		"description": "ClusterInstanceSpec defines the params that are allowed in the ProvisioningRequest spec.clusterInstanceInput",
 		"properties": {
@@ -89,10 +91,14 @@ const (
 			},
 			"type": "array"
 		  },
-		  "nodes": {
+		  "nodeGroups": {
+			"description": "Node configuration by group.",
 			"items": {
-			  "description": "NodeSpec",
 			  "properties": {
+				"name": {
+				  "type": "string",
+				  "minLength": 1
+				},
 				"extraAnnotations": {
 				  "additionalProperties": {
 					"additionalProperties": {
@@ -100,7 +106,6 @@ const (
 					},
 					"type": "object"
 				  },
-				  "description": "Additional node-level annotations to be applied to the rendered templates",
 				  "type": "object"
 				},
 				"extraLabels": {
@@ -110,34 +115,113 @@ const (
 					},
 					"type": "object"
 				  },
-				  "description": "Additional node-level labels to be applied to the rendered templates",
 				  "type": "object"
-				},
-				"hostName": {
-				  "description": "Hostname is the desired hostname for the host",
-				  "type": "string"
 				},
 				"nodeLabels": {
 				  "additionalProperties": {
 					"type": "string"
 				  },
-				  "description": "NodeLabels allows the specification of custom roles for your nodes in your managed clusters. These are additional roles are not used by any OpenShift Container Platform components, only by the user. When you add a custom role, it can be associated with a custom machine config pool that references a specific configuration for that role. Adding custom labels or roles during installation makes the deployment process more effective and prevents the need for additional reboots after the installation is complete.",
 				  "type": "object"
 				},
 				"nodeNetwork": {
-				  "description": "NodeNetwork is a set of configurations pertaining to the network settings for the node.",
 				  "properties": {
 					"config": {
-					  "description": "yaml that can be processed by nmstate, using custom marshaling/unmarshaling that will allow to populate nmstate config as plain yaml.",
 					  "type": "object",
 					  "x-kubernetes-preserve-unknown-fields": true
 					}
 				  },
 				  "type": "object"
+				},
+				"nodes": {
+				  "items": {
+					"properties": {
+					  "hostName": {
+						"type": "string"
+					  },
+					  "extraAnnotations": {
+						"additionalProperties": {
+						  "additionalProperties": {
+							"type": "string"
+						  },
+						  "type": "object"
+						},
+						"type": "object"
+					  },
+					  "extraLabels": {
+						"additionalProperties": {
+						  "additionalProperties": {
+							"type": "string"
+						  },
+						  "type": "object"
+						},
+						"type": "object"
+					  },
+					  "nodeLabels": {
+						"additionalProperties": {
+						  "type": "string"
+						},
+						"type": "object"
+					  },
+					  "nodeNetwork": {
+						"properties": {
+						  "interfaces": {
+							"minItems": 1,
+							"items": {
+							  "properties": {
+								"name": {
+								  "type": "string",
+								  "minLength": 1
+								},
+								"addresses": {
+								  "properties": {
+									"ipv4": {
+									  "items": {
+										"type": "string",
+										"minLength": 1
+									  },
+									  "minItems": 1,
+									  "type": "array"
+									},
+									"ipv6": {
+									  "items": {
+										"type": "string",
+										"minLength": 1
+									  },
+									  "minItems": 1,
+									  "type": "array"
+									}
+								  },
+								  "minProperties": 1,
+								  "type": "object"
+								}
+							  },
+							  "required": [
+								"name",
+								"addresses"
+							  ],
+							  "type": "object"
+							},
+							"type": "array"
+						  }
+						},
+						"required": [
+						  "interfaces"
+						],
+						"type": "object"
+					  }
+					},
+					"required": [
+					  "hostName",
+					  "nodeNetwork"
+					],
+					"type": "object"
+				  },
+				  "type": "array"
 				}
 			  },
 			  "required": [
-				"hostName"
+				"name",
+				"nodes"
 			  ],
 			  "type": "object"
 			},
@@ -167,7 +251,7 @@ const (
 		},
 		"required": [
 		  "clusterName",
-		  "nodes"
+		  "nodeGroups"
 		],
 		"type": "object"
 	  }`
@@ -202,9 +286,9 @@ const (
 		"ingressVIPs": [
 		  "192.0.2.4"
 		],
-		"nodes": [
+		"nodeGroups": [
 		  {
-			"hostName": "node1",
+			"name": "master",
 			"nodeLabels": {
 			  "node-role.kubernetes.io/infra": "",
 			  "node-role.kubernetes.io/master": ""
@@ -218,72 +302,6 @@ const (
 					]
 				  }
 				},
-				"interfaces": [
-				  {
-					"ipv4": {
-					  "address": [
-						{
-						  "ip": "192.0.2.10",
-						  "prefix-length": 24
-						},
-						{
-						  "ip": "192.0.2.11",
-						  "prefix-length": 24
-						},
-						{
-						  "ip": "192.0.2.12",
-						  "prefix-length": 24
-						}
-					  ],
-					  "dhcp": false,
-					  "enabled": true
-					},
-					"ipv6": {
-					  "address": [
-						{
-						  "ip": "2001:db8:0:1::42",
-						  "prefix-length": 32
-						},
-						{
-						  "ip": "2001:db8:0:1::43",
-						  "prefix-length": 32
-						},
-						{
-						  "ip": "2001:db8:0:1::44",
-						  "prefix-length": 32
-						}
-					  ],
-					  "dhcp": false,
-					  "enabled": true
-					},
-					"name": "eno1",
-					"type": "ethernet"
-				  },
-				  {
-					"ipv6": {
-					  "address": [
-						{
-						  "ip": "2001:db8:abcd:1234::1"
-						}
-					  ],
-					  "enabled": true,
-					  "link-aggregation": {
-						"mode": "balance-rr",
-						"options": {
-						  "miimon": "140"
-						},
-						"slaves": [
-						  "eth0",
-						  "eth1"
-						]
-					  },
-					  "prefix-length": 64
-					},
-					"name": "bond99",
-					"state": "up",
-					"type": "bond"
-				  }
-				],
 				"routes": {
 				  "config": [
 					{
@@ -293,9 +311,38 @@ const (
 					  "table-id": 254
 					}
 				  ]
+				},
+				"interfaces": [
+				  {
+					"name": "eno1",
+					"type": "ethernet",
+					"state": "up",
+					"ipv4": {
+					  "enabled": true
+					},
+					"ipv6": {
+					  "enabled": true
+					}
+				  }
+				]
+			  }
+			},
+			"nodes": [
+			  {
+				"hostName": "node1",
+				"nodeNetwork": {
+				  "interfaces": [
+					{
+					  "name": "eno1",
+					  "addresses": {
+						"ipv4": ["192.0.2.10/24"],
+						"ipv6": ["2001:db8:0:1::42/32"]
+					  }
+					}
+				  ]
 				}
 			  }
-			}
+			]
 		  }
 		],
 		"serviceNetwork": [
@@ -360,6 +407,7 @@ var (
 		constants.TemplateParamPolicyConfig,
 		TestPolicyTemplateInput,
 	)
+
 	ExternalCrdData = []map[string]string{
 		{
 			"repoName":    "governance-policy-propagator",


### PR DESCRIPTION
### Summary

Update SNO ClusterTemplates, defaults, operator samples, and e2e to the same `nodeGroups` input already used for MNO after [#3924](https://github.com/openshift-kni/oran-o2ims/pull/3924). SNO uses a single group named `master` (MCP / hardware group name). Document `nodeGroups` as the recommended format and mark flat `nodes` deprecated. The legacy merge path stays in place for existing templates.

### Changes

- Convert SNO ClusterTemplates and `clusterinstance-defaults` ConfigMaps to `nodeGroups` (omit per-host `nodes` from defaults)
- Switch operator samples (`config/samples` ClusterTemplate schema and ProvisioningRequest) and regenerate the CSV via `make bundle`
- Switch SNO e2e and shared test fixtures (`test/utils/vars.go`) to the `nodeGroups` schema
- Document `nodeGroups` as the recommended format in the user guide and mark `nodes` deprecated
- Name the SNO hardware / MCP group `master`

## Acceptance Criteria

- [x] SNO samples and e2e use `nodeGroups`
- [x] Docs deprecate `nodes` and recommend `nodeGroups`
- [x] Legacy `nodes` merge path still works (removal is [CNF-26442](https://issues.redhat.com/browse/CNF-26442))

## Test Plan

- [x] Unit tests updated for ClusterTemplate, cluster install, and cluster config paths that consume the shared fixtures
- [x] Dedicated legacy `nodes` tests keep inline schemas (not converted)
- [x] SNO e2e (`test/e2e/sno_provisioning_test.go`) uses `nodeGroups` defaults and PR input
- [x] SNO provision on a lab cluster with the updated samples