### PR TITLE
CNF-26586: Fix catalog-idms to use only openshift5 for bundle post-rendering

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,3 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-5-0@sha256:5321f80a1e2f78370de2e3596ce8c6e787dcefd9adfe03b7e1ff8a0858851cdc
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-5-0@sha256:2bdb82ad845cc4130b19cd8596705228b04f01feeb1190e9ca1e62edb026b5df
 

--- a/.konflux/catalog/catalog-idms.yaml
+++ b/.konflux/catalog/catalog-idms.yaml
@@ -8,7 +8,4 @@ spec:
   imageDigestMirrors:
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-5-0
-    source: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle
-  - mirrors:
-    - quay.io/redhat-user-workloads/telco-5g-tenant/o-cloud-manager-bundle-5-0
     source: registry.redhat.io/openshift5/o-cloud-manager-operator-bundle


### PR DESCRIPTION
## Summary
- Removes the duplicate `openshift4` entry from `catalog-idms.yaml`, keeping only `openshift5`.
- This IDMS controls the post-rendering of the FBC catalog: the pipeline replaces quay.io build URLs with `registry.redhat.io` sources. Having `openshift4` listed first caused the rendered catalog to reference `openshift4/o-cloud-manager-operator-bundle`, which no longer exists and fails the `fbc-images-resolvable` integration test.

## Test plan
- [ ] Verify `fbc-images-resolvable` integration test passes (bundle resolves under `openshift5`)


Made with [Cursor](https://cursor.com)