### PR TITLE
CNF-26652: Provision clusters with multiple worker MachineConfigPools

### DIFF
--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/extra-manifest/custom-manifest/custom-machine-config-pools.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/extra-manifest/custom-manifest/custom-machine-config-pools.yaml
@@ -1,0 +1,56 @@
+# Custom worker MachineConfigPools. Copy into the extra-manifests ConfigMap
+# alongside the telco-reference extra manifests. Each metadata.name must match
+# the corresponding nodeGroups[].name / hwMgmtDefaults.nodeGroupData[].name.
+#
+# machineConfigSelector includes "worker" so these pools inherit worker
+# MachineConfigs.
+# The pools.operator.machineconfiguration.openshift.io/<pool> label is needed
+# so the PerformanceProfile can use it to select the pool and bind its generated
+# KubeletConfig to the pool.
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-dell-r740
+  labels:
+    pools.operator.machineconfiguration.openshift.io/worker-dell-r740: ""
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [worker, worker-dell-r740]
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-dell-r740: ""
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-dell-xr8620t
+  labels:
+    pools.operator.machineconfiguration.openshift.io/worker-dell-xr8620t: ""
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [worker, worker-dell-xr8620t]
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-dell-xr8620t: ""
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-hpe-dl380
+  labels:
+    pools.operator.machineconfiguration.openshift.io/worker-hpe-dl380: ""
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [worker, worker-hpe-dl380]
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-hpe-dl380: ""

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/kustomization.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/kustomization.yaml
@@ -4,6 +4,14 @@ configMapGenerator:
   - extra-manifest/....
   name: sno-ran-du-extra-manifest-1
   namespace: sno-ran-du-v4-Y-Z
+- files:
+  - extra-manifest/....
+  name: std-ran-du-extra-manifest-1
+- files:
+  - extra-manifest/....
+  - extra-manifest/custom-manifest/custom-machine-config-pools.yaml
+  name: std-ran-du-multi-mcp-extra-manifest-1
+  namespace: std-ran-du-v4-Y-Z
 generatorOptions:
   disableNameSuffixHash: true
 
@@ -42,3 +50,7 @@ resources:
 - std-ran-du/policytemplates-defaults-v1.yaml
 - std-ran-du/std-ran-du-v4-Y-Z-1.yaml
 - std-ran-du/clusterinstance-defaults-v1.yaml
+# Standard cluster with multiple worker MachineConfigPools:
+- std-ran-du/policytemplates-defaults-multi-mcp-v1.yaml
+- std-ran-du/std-ran-du-multi-mcp-v4-Y-Z-1.yaml
+- std-ran-du/clusterinstance-defaults-multi-mcp-v1.yaml

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/clusterinstance-defaults-multi-mcp-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/clusterinstance-defaults-multi-mcp-v1.yaml
@@ -1,0 +1,160 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clusterinstance-defaults-multi-mcp-v1
+  namespace: std-ran-du-v4-Y-Z
+data:
+  # clusterInstallationTimeout is optional.
+  # The value should be a duration string
+  # (e.g., "180m" for 180 minutes)
+  # clusterInstallationTimeout: "180m"
+  clusterInstallationTimeout: "240m"
+  clusterinstance-defaults: |
+    baseDomain: example.com
+    extraLabels:
+      ManagedCluster:
+        cluster-version: "v4-Y-Z"
+        std-ran-du-multi-mcp-policy: "v1"
+    clusterType: HighlyAvailable
+    clusterImageSetNameRef: "4.Y.Z"
+    pullSecretRef:
+      name: pull-secret
+    networkType: OVNKubernetes
+    sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTca4Qyu5AYBmZbSl74cNTKuNINJ7d+ceBRzKUrhHcQpMbl8UnAYhjh/ffTyVCsgwzm1RjTAm6/tPj9euEa+YX4U78Sx+ioLHmjDvACYsti4DekIR+opFwfIw+JTDXoyVv06lOPaTOa/vtgpe+gDEL364j47f3p9H/tGhsLmpjeG3DVAhbqSh3s0IHpd4OzF/r6g6mbPyHadvedkBZp/qeUX054Gc2QqJeg/s/eddPlQDJbmL8yRVkZu+SsFTOEOAtrdA3czeaEaA8s+aWP9PN3X539Ddw3qahyOSCXpCE2eJXPh8DJCBWVEcFFYgmIFVvCQ+o9cjEmIYg6drGGvRV
+    installConfigOverrides: '{"capabilities": {"baselineCapabilitySet": "None", "additionalEnabledCapabilities": ["NodeTuning", "OperatorLifecycleManager", "Ingress", "baremetal", "MachineAPI"]}}'
+    clusterNetwork:
+      - cidr: 203.0.113.0/24
+        hostPrefix: 25
+    serviceNetwork:
+      - cidr: 198.51.100.0/24
+    additionalNTPSources:
+      - 1.pool.ntp.org
+    templateRefs:
+      - name: ai-cluster-templates-v1
+        namespace: open-cluster-management
+    cpuPartitioningMode: AllNodes
+    holdInstallation: false
+    extraManifestsRefs:
+      - name: std-ran-du-multi-mcp-extra-manifest-1
+    nodeGroups:
+      - name: master
+        role: master
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: ens1f0
+              label: boot-interface
+            - name: ens1f1
+              label: data-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens1f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens1f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      # Configure common configuration for each worker group that maps to the corresponding hardware node group.
+      - name: worker-dell-r740
+        role: worker
+        nodeLabels:
+          node-role.kubernetes.io/worker-dell-r740: ""
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: ens1f0
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens1f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens1f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - name: worker-dell-xr8620t
+        role: worker
+        nodeLabels:
+          node-role.kubernetes.io/worker-dell-xr8620t: ""
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:44:00.0-nvme-1
+        nodeNetwork:
+          interfaces:
+            - name: eno8303np0
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno8303np0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno8303np0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - name: worker-hpe-dl380
+        role: worker
+        nodeLabels:
+          node-role.kubernetes.io/worker-hpe-dl380: ""
+        bootMode: UEFI
+        ironicInspect: "disabled"
+        automatedCleaningMode: disabled
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:62:00.0-scsi-0:2:7:0
+        nodeNetwork:
+          interfaces:
+            - name: ens15f0
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: ens15f0
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: ens15f0
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/policytemplates-defaults-multi-mcp-v1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/policytemplates-defaults-multi-mcp-v1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: policytemplate-defaults-multi-mcp-v1
+  namespace: std-ran-du-v4-Y-Z
+data:
+  # clusterConfigurationTimeout is optional.
+  # The value should be a duration string
+  # (e.g., "60m" for 60 minutes)
+  # clusterConfigurationTimeout: "60m"
+  policytemplate-defaults: |
+    sriov-network-vlan-1: "140"
+    sriov-network-pfNames-1: '["ens2f0"]'
+    sriov-network-vlan-2: "150"
+    sriov-network-pfNames-2: '["ens2f1"]'
+    worker-dell-r740-cpu-isolated: "4-63"
+    worker-dell-r740-cpu-reserved: "0-3"
+    worker-dell-xr8620t-cpu-isolated: "4-107"
+    worker-dell-xr8620t-cpu-reserved: "0-3"
+    worker-hpe-dl380-cpu-isolated: "4-55"
+    worker-hpe-dl380-cpu-reserved: "0-3"
+    hugepages-default: "1G"
+    hugepages-size: "1G"
+    hugepages-count: "32"
+    install-plan-approval: "Automatic"

--- a/docs/samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/std-ran-du-multi-mcp-v4-Y-Z-1.yaml
+++ b/docs/samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/std-ran-du-multi-mcp-v4-Y-Z-1.yaml
@@ -1,0 +1,328 @@
+apiVersion: clcm.openshift.io/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: std-ran-du-multi-mcp.v4-Y-Z-1
+  namespace: std-ran-du-v4-Y-Z
+spec:
+  name: std-ran-du-multi-mcp
+  version: v4-Y-Z-1
+  release: 4.Y.Z
+  templateDefaults:
+    hwMgmtDefaults:
+      hardwareProvisioningTimeout: "4h"
+      nodeGroupData:
+        - name: master
+          role: master
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "R740"
+            "resourceselector.clcm.openshift.io/server-colour": "green"
+            "hardwaredata/cpu_arch": "x86_64"
+        # Define selectors for each worker group that maps to the corresponding custom machine config pool.
+        - name: worker-dell-r740
+          role: worker
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "R740"
+            "resourceselector.clcm.openshift.io/server-colour": "blue"
+            "hardwaredata/cpu_arch": "x86_64"
+        - name: worker-dell-xr8620t
+          role: worker
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "XR8620t"
+            "resourceselector.clcm.openshift.io/server-colour": "green"
+            "hardwaredata/cpu_arch": "x86_64"
+        - name: worker-hpe-dl380
+          role: worker
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "DL380"
+            "resourceselector.clcm.openshift.io/server-colour": "green"
+            "hardwaredata/cpu_arch": "x86_64"
+    clusterInstanceDefaults: clusterinstance-defaults-multi-mcp-v1
+    policyTemplateDefaults: policytemplate-defaults-multi-mcp-v1
+  templateParameterSchema:
+    properties:
+      nodeClusterName:
+        type: string
+      oCloudSiteId:
+        type: string
+      hwMgmtParameters:
+        description: >
+          hwMgmtParameters allows overriding hardware management defaults.
+        properties:
+          hardwareProvisioningTimeout:
+            type: string
+          nodeGroupData:
+            type: array
+            items:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                role:
+                  type: string
+                  enum:
+                    - master
+                    - worker
+                hwProfile:
+                  type: string
+                resourcePoolId:
+                  type: string
+                resourceSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+        type: object
+      policyTemplateParameters:
+        description: policyTemplateSchema defines the available parameters for cluster configuration
+        properties:
+          sriov-network-vlan-1:
+            type: string
+          sriov-network-pfNames-1:
+            type: string
+          sriov-network-vlan-2:
+            type: string
+          sriov-network-pfNames-2:
+            type: string
+          worker-dell-r740-cpu-isolated:
+            type: string
+          worker-dell-r740-cpu-reserved:
+            type: string
+          worker-dell-xr8620t-cpu-isolated:
+            type: string
+          worker-dell-xr8620t-cpu-reserved:
+            type: string
+          worker-hpe-dl380-cpu-isolated:
+            type: string
+          worker-hpe-dl380-cpu-reserved:
+            type: string
+          hugepages-default:
+            type: string
+          hugepages-size:
+            type: string
+          hugepages-count:
+            type: string
+          install-plan-approval:
+            type: string
+        type: object
+      clusterInstanceParameters:
+        description: clusterInstanceParameters defines the available parameters for cluster installation
+        properties:
+          additionalNTPSources:
+            description: AdditionalNTPSources is a list of NTP sources (hostname
+              or IP) to be added to all cluster hosts. They are added to any NTP
+              sources that were configured through other means.
+            items:
+              type: string
+            type: array
+          apiVIPs:
+            description: APIVIPs are the virtual IPs used to reach the OpenShift
+              cluster's API. Enter one IP address for single-stack clusters, or
+              up to two for dual-stack clusters (at most one IP address per IP
+              stack used). The order of stacks should be the same as order of
+              subnets in Cluster Networks, Service Networks, and Machine Networks.
+            items:
+              type: string
+            maxItems: 2
+            type: array
+          baseDomain:
+            description: BaseDomain is the base domain to use for the deployed
+              cluster.
+            type: string
+          clusterName:
+            description: ClusterName is the name of the cluster.
+            type: string
+          extraAnnotations:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            description: Additional cluster-wide annotations to be applied to
+              the rendered templates
+            type: object
+          extraLabels:
+            additionalProperties:
+              additionalProperties:
+                type: string
+              type: object
+            description: Additional cluster-wide labels to be applied to the rendered
+              templates
+            type: object
+          ingressVIPs:
+            description: IngressVIPs are the virtual IPs used for cluster ingress
+              traffic. Enter one IP address for single-stack clusters, or up to
+              two for dual-stack clusters (at most one IP address per IP stack
+              used). The order of stacks should be the same as order of subnets
+              in Cluster Networks, Service Networks, and Machine Networks.
+            items:
+              type: string
+            maxItems: 2
+            type: array
+          machineNetwork:
+            description: MachineNetwork is the list of IP address pools for machines.
+            items:
+              description: MachineNetworkEntry is a single IP address block for
+                node IP blocks.
+              properties:
+                cidr:
+                  description: CIDR is the IP block address pool for machines
+                    within the cluster.
+                  type: string
+              required:
+              - cidr
+              type: object
+            type: array
+          nodeGroups:
+            description: Node configuration by group.
+            items:
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: >
+                    Node group name. Must match a ClusterTemplate defaults
+                    nodeGroups entry and the corresponding hardware node
+                    group / MachineConfigPool name.
+                extraAnnotations:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Additional node-level annotations applied to every
+                    host in this group
+                  type: object
+                extraLabels:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Additional node-level labels applied to every host
+                    in this group
+                  type: object
+                nodeLabels:
+                  additionalProperties:
+                    type: string
+                  description: NodeLabels allows the specification of custom roles
+                    for your nodes in your managed clusters. These are additional
+                    roles are not used by any OpenShift Container Platform components,
+                    only by the user. When you add a custom role, it can be associated
+                    with a custom machine config pool that references a specific
+                    configuration for that role. Adding custom labels or roles
+                    during installation makes the deployment process more effective
+                    and prevents the need for additional reboots after the installation
+                    is complete.
+                  type: object
+                nodeNetwork:
+                  description: Group-level network overlay applied to every host
+                    in this group.
+                  properties:
+                    config:
+                      description: Opaque nmstate overlay (for example dns-resolver
+                        and routes) shared by every host in this group.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                nodes:
+                  description: Per-host identity and addressing for this group.
+                  items:
+                    properties:
+                      hostName:
+                        description: Hostname is the desired hostname for the host
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional annotations for this host
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Additional labels for this host
+                        type: object
+                      nodeLabels:
+                        additionalProperties:
+                          type: string
+                        description: Custom node labels for this host
+                        type: object
+                      nodeNetwork:
+                        description: Per-host addressing keyed by interface name.
+                        properties:
+                          interfaces:
+                            description: Per-interface addressing. Each name must
+                              match a defaults nodeNetwork.interfaces[].name.
+                            minItems: 1
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                addresses:
+                                  description: At least one of ipv4 or ipv6; CIDR
+                                    strings, e.g. "192.0.2.10/24" or "fd00:1:1::10/64".
+                                  properties:
+                                    ipv4:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                    ipv6:
+                                      items:
+                                        type: string
+                                        minLength: 1
+                                      minItems: 1
+                                      type: array
+                                  minProperties: 1
+                                  type: object
+                              required:
+                              - name
+                              - addresses
+                              type: object
+                            type: array
+                        required:
+                        - interfaces
+                        type: object
+                    required:
+                    - hostName
+                    - nodeNetwork
+                    type: object
+                  type: array
+              required:
+              - name
+              - nodes
+              type: object
+            type: array
+          serviceNetwork:
+            description: ServiceNetwork is the list of IP address pools for services.
+            items:
+              description: ServiceNetworkEntry is a single IP address block for
+                node IP blocks.
+              properties:
+                cidr:
+                  description: CIDR is the IP block address pool for machines
+                    within the cluster.
+                  type: string
+              required:
+              - cidr
+              type: object
+            type: array
+          sshPublicKey:
+            description: SSHPublicKey is the public Secure Shell (SSH) key to
+              provide access to instances. This key will be added to the host
+              to allow ssh access
+            type: string
+        required:
+        - clusterName
+        - nodeGroups
+        type: object
+    required:
+      - nodeClusterName
+      - oCloudSiteId
+      - policyTemplateParameters
+      - clusterInstanceParameters
+    type: object

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/kustomization.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/kustomization.yaml
@@ -9,6 +9,7 @@ generators:
 - 3node-ran-du/3node-ran-du-pg-v4-Y-Z-v1.yaml
 # Standard cluster:
 - std-ran-du/std-ran-du-pg-v4-Y-Z-v1.yaml
+- std-ran-du/std-ran-du-pg-multi-mcp-v4-Y-Z-v1.yaml
 
 resources:
 - sno-ran-du/ns.yaml

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/source-crs/custom-crs/ptpDaemonValidator.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/source-crs/custom-crs/ptpDaemonValidator.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: linuxptp-daemon
+  namespace: openshift-ptp

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/source-crs/custom-crs/sriovNetworkNodeStateValidator.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/source-crs/custom-crs/sriovNetworkNodeStateValidator.yaml
@@ -1,0 +1,6 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodeState
+metadata:
+  namespace: openshift-sriov-network-operator
+status:
+  syncStatus: Succeeded

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/source-crs/custom-crs/workerMcpsValidator.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/source-crs/custom-crs/workerMcpsValidator.yaml
@@ -1,0 +1,68 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-hpe-dl380
+status:
+  conditions:
+    - type: Updated
+      status: "True"
+    - type: Updating
+      status: "False"
+  degradedMachineCount: 0
+  unavailableMachineCount: 0
+  configuration:
+    source:
+      - apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        # This name must match the associated PerformanceProfile name:
+        # name: 50-performance-${PerformanceProfile.metadata.name}
+        name: 50-performance-openshift-node-performance-worker-hpe-dl380-profile
+      - apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        name: 50-nto-worker-hpe-dl380
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-dell-xr8620t
+status:
+  conditions:
+    - type: Updated
+      status: "True"
+    - type: Updating
+      status: "False"
+  degradedMachineCount: 0
+  unavailableMachineCount: 0
+  configuration:
+    source:
+      - apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        # This name must match the associated PerformanceProfile name:
+        # name: 50-performance-${PerformanceProfile.metadata.name}
+        name: 50-performance-openshift-node-performance-worker-dell-xr8620t-profile
+      - apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        name: 50-nto-worker-dell-xr8620t
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-dell-r740
+status:
+  conditions:
+    - type: Updated
+      status: "True"
+    - type: Updating
+      status: "False"
+  degradedMachineCount: 0
+  unavailableMachineCount: 0
+  configuration:
+    source:
+      - apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        # This name must match the associated PerformanceProfile name:
+        # name: 50-performance-${PerformanceProfile.metadata.name}
+        name: 50-performance-openshift-node-performance-worker-dell-r740-profile
+      - apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        name: 50-nto-worker-dell-r740

--- a/docs/samples/git-setup/policytemplates/version_4.Y.Z/std-ran-du/std-ran-du-pg-multi-mcp-v4-Y-Z-v1.yaml
+++ b/docs/samples/git-setup/policytemplates/version_4.Y.Z/std-ran-du/std-ran-du-pg-multi-mcp-v4-Y-Z-v1.yaml
@@ -1,0 +1,271 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: std-ran-du-pg-multi-mcp-v4-Y-Z-v1
+policyDefaults:
+  namespace: ztp-std-ran-du-v4-Y-Z
+  # Use an existing placement rule so that placement bindings can be consolidated
+  placement:
+    # These labels must match the labels set for the ManagedCluster either through the ProvisioningRequest
+    # or the ClusterInstance ConfigMap.
+    labelSelector:
+      cluster-version: "v4-Y-Z"
+      std-ran-du-multi-mcp-policy: "v1"
+  policyAnnotations:
+    # This annotation contains a comma-separated list of ClusterTemplates (metadata.name) this PG is associated with.
+    # This is used for linking the generated root policies to the ClusterTemplate used by the ProvisioningRequest.
+    clustertemplates.clcm.openshift.io/templates: "std-ran-du-multi-mcp.v4-Y-Z-1"
+  remediationAction: enforce
+  severity: low
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+    compliant: 5m
+    noncompliant: 10s
+  orderPolicies: true
+policies:
+# CATALOG SOURCE - DISCONNECTED REGISTRY
+- name: v1-multi-mcp-catalog-source-policy
+  manifests:
+    - path: source-crs/disconnected-registry/DefaultCatsrc.yaml
+      patches:
+      - metadata:
+          name: redhat-operators-disconnected
+        spec:
+          displayName: disconnected-redhat-operators
+          image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.21
+# SUBSCRIPTIONS
+- name: v1-multi-mcp-subscriptions-policy
+  manifests:
+    # Cluster Logging operator
+    - path: source-crs/cluster-logging/ClusterLogNS.yaml
+    - path: source-crs/cluster-logging/ClusterLogOperGroup.yaml
+    - path: source-crs/cluster-logging/ClusterLogSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/cluster-logging/ClusterLogOperatorStatus.yaml
+    - path: source-crs/cluster-logging/ClusterLogServiceAccount.yaml
+    - path: source-crs/cluster-logging/ClusterLogServiceAccountAuditBinding.yaml
+    - path: source-crs/cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml
+    # Ptp operator
+    - path: source-crs/ptp-operator/PtpSubscriptionNS.yaml
+    - path: source-crs/ptp-operator/PtpSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/ptp-operator/PtpSubscriptionOperGroup.yaml
+    - path: source-crs/ptp-operator/PtpOperatorStatus.yaml
+    # SRIOV operator
+    - path: source-crs/sriov-operator/SriovSubscriptionNS.yaml
+    - path: source-crs/sriov-operator/SriovSubscriptionOperGroup.yaml
+    - path: source-crs/sriov-operator/SriovSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/sriov-operator/SriovOperatorStatus.yaml
+    # Storage operator
+    - path: source-crs/storage-lso/StorageNS.yaml
+    - path: source-crs/storage-lso/StorageOperGroup.yaml
+    - path: source-crs/storage-lso/StorageSubscription.yaml
+      patches:
+      - spec:
+          source: redhat-operators-disconnected
+          installPlanApproval:
+            '{{hub $configMap:=(lookup "v1" "ConfigMap" "" (printf "%s-pg" .ManagedClusterName)) hub}}{{hub dig "data" "install-plan-approval" "Manual" $configMap hub}}'
+    - path: source-crs/storage-lso/StorageOperatorStatus.yaml
+- name: v1-multi-mcp-config-policy
+  manifests:
+    - path: source-crs/sriov-operator/SriovOperatorConfig-SetSelector.yaml
+      patches:
+      - spec:
+          configDaemonNodeSelector:
+            node-role.kubernetes.io/worker: ""
+    # One PerformanceProfile per worker MCP. Each profile selects its own pool via the
+    # per-pool labels below: machineConfigPoolSelector matches the MCP's
+    # pools.operator.machineconfiguration.openshift.io/<pool> label, and nodeSelector
+    # matches the node-role.kubernetes.io/<pool> label.
+    - path: source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
+      patches:
+      - metadata:
+          name: openshift-node-performance-worker-dell-r740-profile
+        spec:
+          cpu:
+            isolated: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "worker-dell-r740-cpu-isolated" hub}}'
+            reserved: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "worker-dell-r740-cpu-reserved" hub}}'
+          hugepages:
+            defaultHugepagesSize: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-default" hub}}'
+            pages:
+              - size: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-size" hub}}'
+                count: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-count" | toInt hub}}'
+          machineConfigPoolSelector:
+            pools.operator.machineconfiguration.openshift.io/worker-dell-r740: ""
+          nodeSelector:
+            node-role.kubernetes.io/worker-dell-r740: ''
+    - path: source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
+      patches:
+      - metadata:
+          name: openshift-node-performance-worker-dell-xr8620t-profile
+        spec:
+          cpu:
+            isolated: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "worker-dell-xr8620t-cpu-isolated" hub}}'
+            reserved: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "worker-dell-xr8620t-cpu-reserved" hub}}'
+          hugepages:
+            defaultHugepagesSize: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-default" hub}}'
+            pages:
+              - size: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-size" hub}}'
+                count: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-count" | toInt hub}}'
+          machineConfigPoolSelector:
+            pools.operator.machineconfiguration.openshift.io/worker-dell-xr8620t: ""
+          nodeSelector:
+            node-role.kubernetes.io/worker-dell-xr8620t: ''
+    - path: source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
+      patches:
+      - metadata:
+          name: openshift-node-performance-worker-hpe-dl380-profile
+        spec:
+          cpu:
+            isolated: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "worker-hpe-dl380-cpu-isolated" hub}}'
+            reserved: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "worker-hpe-dl380-cpu-reserved" hub}}'
+          hugepages:
+            defaultHugepagesSize: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-default" hub}}'
+            pages:
+              - size: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-size" hub}}'
+                count: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "hugepages-count" | toInt hub}}'
+          machineConfigPoolSelector:
+            pools.operator.machineconfiguration.openshift.io/worker-hpe-dl380: ""
+          nodeSelector:
+            node-role.kubernetes.io/worker-hpe-dl380: ''
+    - path: source-crs/node-tuning-operator/TunedPerformancePatch.yaml
+      patches:
+      # One Tuned CR carries a patch profile per worker pool. Each recommend
+      # entry maps the pool's MachineConfig role to its profile.
+      - spec:
+          profile:
+          - name: performance-patch-worker-dell-r740
+            # The include line must match the worker-dell-r740 PerformanceProfile metadata.name:
+            # include=openshift-node-performance-${PerformanceProfile.metadata.name}
+            data: |
+              [main]
+              summary=Top-level ran-du performance tuning overrides
+              include=openshift-node-performance-openshift-node-performance-worker-dell-r740-profile,ran-du-performance-architecture-common
+          - name: performance-patch-worker-dell-xr8620t
+            # The include line must match the worker-dell-xr8620t PerformanceProfile metadata.name:
+            # include=openshift-node-performance-${PerformanceProfile.metadata.name}
+            data: |
+              [main]
+              summary=Top-level ran-du performance tuning overrides
+              include=openshift-node-performance-openshift-node-performance-worker-dell-xr8620t-profile,ran-du-performance-architecture-common
+          - name: performance-patch-worker-hpe-dl380
+            # The include line must match the worker-hpe-dl380 PerformanceProfile metadata.name:
+            # include=openshift-node-performance-${PerformanceProfile.metadata.name}
+            data: |
+              [main]
+              summary=Top-level ran-du performance tuning overrides
+              include=openshift-node-performance-openshift-node-performance-worker-hpe-dl380-profile,ran-du-performance-architecture-common
+          - name: ran-du-performance-architecture-common
+            data: |
+              [main]
+              summary=Common cross-architecture performance tuning which also includes architecture-specific profiles
+              include=ran-du-common-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}
+              [service]
+              service.chronyd=stop,disable
+              service.stalld=start,enable
+              [bootloader]
+              cmdline_ran_rcu=rcupdate.rcu_normal_after_boot=0
+              cmdline_ran_efi=efi=runtime
+          - name: ran-du-common-aarch64
+            data: |
+              [main]
+              summary=Configuration specific to aarch64 performance
+              # No aarch64-specific tuning needed at this time
+          - name: ran-du-common-x86
+            data: |
+              [main]
+              summary=Configuration specific to x86_64 performance
+              # Note: If processor family-specific tuning is needed, uncomment this line and add appropriate profiles for 'ran-du-intel' and 'ran-du-amd'
+              #include=ran-du-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd}
+              [scheduler]
+              group.ice-ptp=0:f:10:*:ice-ptp.*
+              group.ice-gnss=0:f:10:*:ice-gnss.*
+              group.ice-dplls=0:f:10:*:ice-dplls.*
+              [bootloader]
+              cmdline_x86_blacklist=module_blacklist=irdma,mgag200
+              cmdline_x86_iavf=rd.driver.pre=iavf
+              [sysctl]
+              kernel.panic_on_unrecovered_nmi=1
+          recommend:
+          - machineConfigLabels:
+              machineconfiguration.openshift.io/role: "worker-dell-r740"
+            priority: 18
+            profile: performance-patch-worker-dell-r740
+          - machineConfigLabels:
+              machineconfiguration.openshift.io/role: "worker-dell-xr8620t"
+            priority: 18
+            profile: performance-patch-worker-dell-xr8620t
+          - machineConfigLabels:
+              machineconfiguration.openshift.io/role: "worker-hpe-dl380"
+            priority: 18
+            profile: performance-patch-worker-hpe-dl380
+    - path: source-crs/sriov-operator/SriovNetwork.yaml
+      patches:
+      - metadata:
+          name: sriov-nw-du-fh
+        spec:
+          resourceName: du_fh
+          vlan: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-vlan-1" | toInt hub}}'
+    - path: source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml
+      patches:
+      - metadata:
+          name: sriov-nnp-du-fh
+        spec:
+          deviceType: netdevice
+          isRdma: false
+          nicSelector:
+            pfNames: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-pfNames-1" | toLiteral hub}}'
+          nodeSelector:
+            node-role.kubernetes.io/worker: ""
+          numVfs: 8
+          priority: 10
+          resourceName: du_fh
+    - path: source-crs/sriov-operator/SriovNetwork.yaml
+      patches:
+      - metadata:
+          name: sriov-nw-du-mh
+        spec:
+          resourceName: du_mh
+          vlan: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-vlan-2" | toInt hub}}'
+    - path: source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml
+      patches:
+      - metadata:
+          name: sriov-nnp-du-mh
+        spec:
+          deviceType: vfio-pci
+          isRdma: false
+          nicSelector:
+            pfNames: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "sriov-network-pfNames-2" | toLiteral hub}}'
+          nodeSelector:
+            node-role.kubernetes.io/worker: ""
+          numVfs: 8
+          priority: 10
+          resourceName: du_mh
+- name: v1-multi-mcp-du-validator-policy
+  remediationAction: inform
+  # This policy is not re-evaluated after it becomes
+  # compliant to reduce resource usage.
+  evaluationInterval:
+    compliant: never
+    noncompliant: 10s
+  manifests:
+    - path: source-crs/custom-crs/workerMcpsValidator.yaml
+    - path: source-crs/custom-crs/ptpDaemonValidator.yaml
+    - path: source-crs/custom-crs/sriovNetworkNodeStateValidator.yaml

--- a/docs/user-guide/template-overview.md
+++ b/docs/user-guide/template-overview.md
@@ -22,6 +22,7 @@ SPDX-License-Identifier: Apache-2.0
       - [Deprecated format (`nodes`)](#deprecated-format-nodes)
       - [Recommended format (`nodeGroups`)](#recommended-format-nodegroups)
     - [PolicyTemplate defaults ConfigMap](#policytemplate-defaults-configmap)
+    - [Preparing templates for multiple worker MachineConfigPools](#preparing-templates-for-multiple-worker-machineconfigpools)
   - [Validation](#validation)
   - [Viewing ClusterTemplates](#viewing-clustertemplates)
     - [Using the CLI](#using-the-cli)
@@ -529,6 +530,198 @@ Complete examples of PolicyTemplate defaults:
 [SNO](../samples/git-setup/clustertemplates/version_4.Y.Z/sno-ran-du/policytemplates-defaults-v1.yaml),
 [3node](../samples/git-setup/clustertemplates/version_4.Y.Z/3node-ran-du/policytemplates-defaults-v1.yaml) and
 [Standard](../samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/policytemplates-defaults-v1.yaml).
+
+### Preparing templates for multiple worker MachineConfigPools
+
+This section describes how to author a ClusterTemplate for provisioning a
+multi-node cluster with more than one worker MachineConfigPool.
+
+> [!NOTE]
+> This is supported only for clusters provisioned through the assisted installer.
+
+Complete sample:
+
+- [ClusterTemplate](../samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/std-ran-du-multi-mcp-v4-Y-Z-1.yaml)
+- [ClusterInstance defaults](../samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/clusterinstance-defaults-multi-mcp-v1.yaml)
+- [PolicyTemplate defaults](../samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/policytemplates-defaults-multi-mcp-v1.yaml)
+- [Custom MCP extra manifests](../samples/git-setup/clustertemplates/version_4.Y.Z/extra-manifest/custom-machine-config-pools.yaml)
+- [PolicyGenerator](../samples/git-setup/policytemplates/version_4.Y.Z/std-ran-du/std-ran-du-pg-multi-mcp-v4-Y-Z-v1.yaml)
+- [Custom inform validators](../samples/git-setup/policytemplates/version_4.Y.Z/source-crs/custom-crs/)
+
+#### Extra-manifest MachineConfigPool CRs
+
+The extra-manifest MachineConfigPool CR defines the spoke pool name
+(`metadata.name`). The hardware node group
+(`hwMgmtDefaults.nodeGroupData[].name`) and ClusterInstance node group
+(`nodeGroups[].name`) use that same name. Pools can be grouped by hardware
+type, for example `worker-dell-xr8620t`, `worker-hpe-dl380` etc.
+
+Add one MachineConfigPool CR per custom worker pool as a day-0 extra
+manifest, alongside the telco-reference manifests. Those files are rendered
+into the extra-manifest ConfigMap, which ClusterInstance references through
+`extraManifestsRefs` so the pools are applied at installation.
+
+Each pool CR needs three things:
+
+- `machineConfigSelector` includes `"worker"` so the pool inherits the base
+  worker MachineConfigs.
+- `nodeSelector` uses `node-role.kubernetes.io/<pool>: ""` so nodes with that
+  label join the pool.
+- Label the MCP with `pools.operator.machineconfiguration.openshift.io/<pool>: ""`.
+  The PerformanceProfile `machineConfigPoolSelector` uses that label to apply
+  the profile's MachineConfigs to this pool.
+
+```yaml
+# One MachineConfigPool per worker pool (worker-dell-xr8620t shown)
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-dell-xr8620t
+  labels:
+    pools.operator.machineconfiguration.openshift.io/worker-dell-xr8620t: ""
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [worker, worker-dell-xr8620t]
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-dell-xr8620t: ""
+```
+
+#### Hardware node groups
+
+Add one `hwMgmtDefaults.nodeGroupData` entry per worker pool. Use the MCP
+`metadata.name` as `name`, keep `role: worker`, and set `resourceSelector`
+to the hardware that belongs in that pool:
+
+```yaml
+# ClusterTemplate spec.templateDefaults.hwMgmtDefaults (excerpt)
+nodeGroupData:
+  - name: master
+    role: master
+    resourceSelector:
+      "resourceselector.clcm.openshift.io/server-type": "R740"
+      "resourceselector.clcm.openshift.io/server-colour": "green"
+  - name: worker-dell-r740  # same hardware as master, split by colour
+    role: worker
+    resourceSelector:
+      "resourceselector.clcm.openshift.io/server-type": "R740"
+      "resourceselector.clcm.openshift.io/server-colour": "blue"
+  - name: worker-dell-xr8620t
+    role: worker
+    resourceSelector:
+      "resourceselector.clcm.openshift.io/server-type": "XR8620t"
+      "resourceselector.clcm.openshift.io/server-colour": "green"
+  - name: worker-hpe-dl380
+    role: worker
+    resourceSelector:
+      "resourceselector.clcm.openshift.io/server-type": "DL380"
+      "resourceselector.clcm.openshift.io/server-colour": "green"
+```
+
+#### ClusterInstance defaults
+
+Add a `nodeGroups` entry per worker pool. Use the MCP `metadata.name`
+as `name`, and keep `role: worker`. Set `nodeLabels` to `node-role.kubernetes.io/<pool>: ""`
+so they match the MCP `nodeSelector` and hosts in the group join that pool.
+Set `extraManifestsRefs` to the extra-manifest ConfigMap that contains
+those MCP CRs (along with the usual telco extra manifests).
+
+```yaml
+# ConfigMap data.clusterinstance-defaults (excerpt)
+extraManifestsRefs:
+  - name: std-ran-du-multi-mcp-extra-manifest-1
+nodeGroups:
+  - name: master
+    role: master
+    # ...
+  - name: worker-dell-r740
+    role: worker
+    nodeLabels:
+      node-role.kubernetes.io/worker-dell-r740: ""
+    # per-hardware boot mode, rootDeviceHints, interfaces, nmstate, ...
+  - name: worker-dell-xr8620t
+    role: worker
+    nodeLabels:
+      node-role.kubernetes.io/worker-dell-xr8620t: ""
+    # per-hardware boot mode, rootDeviceHints, interfaces, nmstate, ...
+  - name: worker-hpe-dl380
+    role: worker
+    nodeLabels:
+      node-role.kubernetes.io/worker-hpe-dl380: ""
+    # per-hardware boot mode, rootDeviceHints, interfaces, nmstate, ...
+```
+
+Site host data is still supplied in the ProvisioningRequest as described in
+[Providing `nodeGroups` in the ProvisioningRequest](#providing-nodegroups-in-the-provisioningrequest).
+Use the extra pool names from these ClusterInstance defaults; unknown
+`nodeGroups[].name` values are rejected.
+
+#### Policy generator
+
+Each heterogeneous worker group needs its own PerformanceProfile. Select that
+pool with `machineConfigPoolSelector` and `nodeSelector` on the pool labels,
+not `node-role.kubernetes.io/worker`.
+
+CPU isolation and reservation are per pool. Declare
+`<pool>-cpu-isolated` and `<pool>-cpu-reserved` in the ClusterTemplate
+`policyTemplateParameters` schema, set default values in the PolicyTemplate
+defaults ConfigMap, and substitute them into each PerformanceProfile with
+`fromConfigMap`. See the
+[ClusterTemplate](../samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/std-ran-du-multi-mcp-v4-Y-Z-1.yaml)
+schema and
+[PolicyTemplate defaults](../samples/git-setup/clustertemplates/version_4.Y.Z/std-ran-du/policytemplates-defaults-multi-mcp-v1.yaml).
+
+```yaml
+# PolicyGenerator PerformanceProfile patch (excerpt)
+spec:
+  # other configuration ...
+  cpu:
+    isolated: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "worker-dell-xr8620t-cpu-isolated" hub}}'
+    reserved: '{{hub fromConfigMap "" (printf "%s-pg" .ManagedClusterName) "worker-dell-xr8620t-cpu-reserved" hub}}'
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/worker-dell-xr8620t: ""
+  nodeSelector:
+    node-role.kubernetes.io/worker-dell-xr8620t: ""
+```
+
+A single Tuned CR can cover every worker pool (one `profile` and `recommend`
+entry per pool), or each pool can have its own Tuned CR. Either approach
+works. Each pool profile `include`s that pool's PerformanceProfile
+(`include=openshift-node-performance-${PerformanceProfile.metadata.name}`)
+and any shared common profiles, and can also carry pool-specific settings.
+Tuned `machineConfigLabels` use the MCP MachineConfig role (the pool name).
+
+```yaml
+# PolicyGenerator Tuned patch (excerpt)
+spec:
+  profile:
+    - name: performance-patch-worker-dell-xr8620t
+      data: |
+        [main]
+        summary=Top-level ran-du performance tuning overrides
+        include=openshift-node-performance-openshift-node-performance-worker-dell-xr8620t-profile,ran-du-performance-architecture-common
+        # Optional pool-specific settings go here.
+    # ran-du-performance-architecture-common and related profiles omitted
+  recommend:
+    - machineConfigLabels:
+        machineconfiguration.openshift.io/role: "worker-dell-xr8620t"
+      priority: 18
+      profile: performance-patch-worker-dell-xr8620t
+```
+
+To confirm each custom worker MCP has applied its PerformanceProfile, the
+PolicyGenerator should include an inform validator that checks pool status and that
+the generated MachineConfigs
+(`50-performance-${PerformanceProfile.metadata.name}` and `50-nto-<pool>`)
+appear in `status.configuration.source`. See
+[workerMcpsValidator.yaml](../samples/git-setup/policytemplates/version_4.Y.Z/source-crs/custom-crs/workerMcpsValidator.yaml).
+Include custom inform CRs [ptpDaemonValidator.yaml](../samples/git-setup/policytemplates/version_4.Y.Z/source-crs/custom-crs/ptpDaemonValidator.yaml) and
+[sriovNetworkNodeStateValidator.yaml](../samples/git-setup/policytemplates/version_4.Y.Z/source-crs/custom-crs/sriovNetworkNodeStateValidator.yaml)
+(the same PTP and SR-IOV checks, split out of the stock validator `validatorCRs/informDuValidatorWorker.yaml` so they can be included with the custom MCP validator) together
+in the same inform policy.
 
 ## Validation
 

--- a/internal/controllers/clustertemplate_controller.go
+++ b/internal/controllers/clustertemplate_controller.go
@@ -305,7 +305,7 @@ func (t *clusterTemplateReconcilerTask) validateHwMgmtDefaults(ctx context.Conte
 
 	if len(t.object.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData) > 0 {
 		seenNodeGroups := map[string]struct{}{}
-		seenRoles := map[string]string{}
+		var masterGroup string
 		hwProfileNS := ctlrutils.GetEnvOrDefault(constants.DefaultNamespaceEnvName, constants.DefaultNamespace)
 		for _, ng := range t.object.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData {
 			if _, exists := seenNodeGroups[ng.Name]; exists {
@@ -313,11 +313,13 @@ func (t *clusterTemplateReconcilerTask) validateHwMgmtDefaults(ctx context.Conte
 					fmt.Sprintf("duplicate nodeGroupData name %q in hwMgmtDefaults", ng.Name))
 			}
 			seenNodeGroups[ng.Name] = struct{}{}
-			if prev, exists := seenRoles[ng.Role]; exists {
-				validationErrs = append(validationErrs,
-					fmt.Sprintf("duplicate role %q in hwMgmtDefaults for groups %q and %q", ng.Role, prev, ng.Name))
+			if ng.Role == hwmgmtv1alpha1.NodeRoleMaster {
+				if masterGroup != "" {
+					validationErrs = append(validationErrs,
+						fmt.Sprintf("duplicate role %q in hwMgmtDefaults for groups %q and %q", ng.Role, masterGroup, ng.Name))
+				}
+				masterGroup = ng.Name
 			}
-			seenRoles[ng.Role] = ng.Name
 			if ng.HwProfile != "" {
 				hwProfileObj := &hwmgmtv1alpha1.HardwareProfile{}
 				if err := t.client.Get(ctx, client.ObjectKey{Name: ng.HwProfile, Namespace: hwProfileNS}, hwProfileObj); err != nil {

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -48,20 +48,6 @@ func collectNodeDetails(nodeList *hwmgmtv1alpha1.AllocatedNodeList) (map[string]
 	return hwNodes, nil
 }
 
-// newNodeGroup populates NodeGroup
-func newNodeGroup(group hwmgmtv1alpha1.NodeGroupData, roleCounts map[string]int) hwmgmtv1alpha1.NodeGroup {
-	nodeGroup := hwmgmtv1alpha1.NodeGroup{
-		NodeGroupData: group,
-	}
-
-	// Assign size if available in roleCounts
-	if count, ok := roleCounts[group.Role]; ok {
-		nodeGroup.Size = count
-	}
-
-	return nodeGroup
-}
-
 // listAllocatedNodesForNAR lists AllocatedNodes that belong to the given NodeAllocationRequest
 // using a field index on spec.nodeAllocationRequest. The client must have the field indexer
 // registered (via RegisterAllocatedNodeFieldIndexer or SetupWithManager).

--- a/internal/controllers/provisioningrequest_controller.go
+++ b/internal/controllers/provisioningrequest_controller.go
@@ -54,6 +54,10 @@ type clusterInput struct {
 	clusterInstanceData map[string]any
 	policyTemplateData  map[string]any
 	hwMgmtData          map[string]any
+	// hostToGroupName maps ClusterInstance hostName to nodeGroups[].name
+	// Populated only for the ClusterInstance nodeGroups input format,
+	// before expansion strips group identity from spec.nodes[].
+	hostToGroupName map[string]string
 }
 
 // clusterTemplateDetails holds the details for the referenced ClusterTemplate

--- a/internal/controllers/provisioningrequest_controller_test.go
+++ b/internal/controllers/provisioningrequest_controller_test.go
@@ -5699,4 +5699,25 @@ var _ = Describe("validateAndMergeHwMgmtInput", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("nodeGroupData must not be empty"))
 	})
+
+	It("should return error for duplicate master role in merged nodeGroupData", func() {
+		ct.Spec.TemplateDefaults.HwMgmtDefaults = provisioningv1alpha1.HwMgmtDefaults{
+			NodeGroupData: []hwmgmtv1alpha1.NodeGroupData{
+				{Name: "controller", Role: "master", HwProfile: "profile-64G"},
+			},
+		}
+		c = fakeclient.GetFakeClientFromObjects(createHwProfiles()...)
+		task = buildTask(c, `{
+			"nodeClusterName": "test",
+			"hwMgmtParameters": {
+				"nodeGroupData": [
+					{"name": "controller-b", "role": "master", "hwProfile": "profile-128G"}
+				]
+			}
+		}`)
+
+		err := task.validateAndMergeHwMgmtInput(ctx, ct)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`duplicate role "master"`))
+	})
 })

--- a/internal/controllers/provisioningrequest_hwprovision.go
+++ b/internal/controllers/provisioningrequest_hwprovision.go
@@ -462,7 +462,13 @@ func (t *provisioningRequestReconcilerTask) applyNodeConfiguration(
 	// Create a map to track unmatched nodes
 	unmatchedNodes := make(map[int]string)
 
+	// ClusterInstance nodes format (legacy): one hardware group per installer role.
 	roleToNodeGroupName := getRoleToGroupNameMap(&nar.Spec)
+	// ClusterInstance nodeGroups format: hardware group by hostname.
+	hostToGroupName := map[string]string{}
+	if t.clusterInput != nil {
+		hostToGroupName = t.clusterInput.hostToGroupName
+	}
 
 	// Extract the nodes slice
 	nodes, found, err := unstructured.NestedSlice(clusterInstance.Object, "spec", "nodes")
@@ -497,7 +503,12 @@ func (t *provisioningRequestReconcilerTask) applyNodeConfiguration(
 
 		role, _, _ := unstructured.NestedString(nodeMap, "role")
 		hostName, _, _ := unstructured.NestedString(nodeMap, "hostName")
-		groupName := roleToNodeGroupName[role]
+		var groupName string
+		if len(hostToGroupName) > 0 {
+			groupName = hostToGroupName[hostName]
+		} else {
+			groupName = roleToNodeGroupName[role]
+		}
 
 		var nodeInfo ctlrutils.NodeInfo
 		matched := false
@@ -771,6 +782,8 @@ func (t *provisioningRequestReconcilerTask) buildNodeAllocationRequestSpec(
 
 	hwMgmtData := t.clusterInput.hwMgmtData
 
+	// ClusterInstance nodes format (legacy): size each hardware group by installer role
+	// (one hardware group per role).
 	roleCounts := make(map[string]int)
 	nodes, found, err := unstructured.NestedSlice(clusterInstance.Object, "spec", "nodes")
 	if err != nil {
@@ -788,6 +801,12 @@ func (t *provisioningRequestReconcilerTask) buildNodeAllocationRequestSpec(
 
 		role, _, _ := unstructured.NestedString(nodeMap, "role")
 		roleCounts[role]++
+	}
+
+	// ClusterInstance nodeGroups format: size each hardware group by hostname membership.
+	groupSizes := make(map[string]int)
+	for _, groupName := range t.clusterInput.hostToGroupName {
+		groupSizes[groupName]++
 	}
 
 	// Extract nodeGroupData from the pre-merged hwMgmt data
@@ -830,8 +849,19 @@ func (t *provisioningRequestReconcilerTask) buildNodeAllocationRequestSpec(
 			ResourceSelector: resourceSelector,
 			Role:             role,
 		}
-		nodeGroup := newNodeGroup(ngd, roleCounts)
-		nodeGroups = append(nodeGroups, nodeGroup)
+
+		var size int
+		if len(t.clusterInput.hostToGroupName) > 0 {
+			// ClusterInstance nodeGroups format path
+			size = groupSizes[name]
+		} else {
+			// ClusterInstance nodes format path (legacy)
+			size = roleCounts[role]
+		}
+		nodeGroups = append(nodeGroups, hwmgmtv1alpha1.NodeGroup{
+			NodeGroupData: ngd,
+			Size:          size,
+		})
 	}
 
 	siteIDRaw, err := provisioningv1alpha1.ExtractMatchingInput(

--- a/internal/controllers/provisioningrequest_hwprovision_test.go
+++ b/internal/controllers/provisioningrequest_hwprovision_test.go
@@ -89,10 +89,10 @@ import (
 )
 
 const (
-	groupNameController = "controller"
-	groupNameWorker     = "worker"
-	testNodeID          = "node-1"
-	testHostName        = "host-1"
+	groupNameMaster = "master"
+	groupNameWorker = "worker"
+	testNodeID      = "node-1"
+	testHostName    = "host-1"
 )
 
 var _ = Describe("buildNodeAllocationRequest", func() {
@@ -189,7 +189,7 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		task.clusterInput = &clusterInput{
 			hwMgmtData: map[string]any{
 				"nodeGroupData": []any{
-					map[string]any{"name": "controller", "role": "master", "hwProfile": "profile-spr-single-processor-64G", "resourcePoolId": "xyz"},
+					map[string]any{"name": "master", "role": "master", "hwProfile": "profile-spr-single-processor-64G", "resourcePoolId": "xyz"},
 					map[string]any{"name": "worker", "role": "worker", "hwProfile": "profile-spr-dual-processor-128G", "resourcePoolId": "xyz"},
 				},
 			},
@@ -211,8 +211,8 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		expectedNodeGroups := map[string]struct {
 			size int
 		}{
-			groupNameController: {size: roleCounts["master"]},
-			groupNameWorker:     {size: roleCounts["worker"]},
+			groupNameMaster: {size: roleCounts["master"]},
+			groupNameWorker: {size: roleCounts["worker"]},
 		}
 
 		for _, group := range nodeAllocationRequest.Spec.NodeGroup {
@@ -910,7 +910,7 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		task.clusterInput = &clusterInput{
 			hwMgmtData: map[string]any{
 				"nodeGroupData": []any{
-					map[string]any{"name": "controller", "role": "master", "hwProfile": "profile-1", "resourcePoolId": "pool-1"},
+					map[string]any{"name": "master", "role": "master", "hwProfile": "profile-1", "resourcePoolId": "pool-1"},
 					map[string]any{"name": "worker", "role": "worker", "hwProfile": "profile-2", "resourcePoolId": "pool-2"},
 				},
 			},
@@ -926,9 +926,10 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		// Check master nodes
 		var masterGroup, workerGroup *hwmgmtv1alpha1.NodeGroup
 		for i := range nar.Spec.NodeGroup {
-			if nar.Spec.NodeGroup[i].NodeGroupData.Name == "controller" {
+			switch nar.Spec.NodeGroup[i].NodeGroupData.Name {
+			case groupNameMaster:
 				masterGroup = &nar.Spec.NodeGroup[i]
-			} else if nar.Spec.NodeGroup[i].NodeGroupData.Name == groupNameWorker {
+			case groupNameWorker:
 				workerGroup = &nar.Spec.NodeGroup[i]
 			}
 		}
@@ -940,6 +941,97 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		Expect(workerGroup).ToNot(BeNil())
 		Expect(workerGroup.Size).To(Equal(1)) // 1 worker node
 		Expect(workerGroup.NodeGroupData.Role).To(Equal("worker"))
+	})
+
+	It("builds NodeAllocationRequest with multiple worker pools for nodeGroups format", func() {
+		clusterInstance := &unstructured.Unstructured{}
+		clusterInstance.Object = map[string]interface{}{
+			"spec": map[string]interface{}{
+				"nodes": []interface{}{
+					map[string]interface{}{
+						"role":     "master",
+						"hostName": "master-1",
+					},
+					map[string]interface{}{
+						"role":     "master",
+						"hostName": "master-2",
+					},
+					map[string]interface{}{
+						"role":     "worker",
+						"hostName": "worker-1",
+					},
+					map[string]interface{}{
+						"role":     "worker",
+						"hostName": "worker-2",
+					},
+					map[string]interface{}{
+						"role":     "worker",
+						"hostName": "worker-3",
+					},
+					map[string]interface{}{
+						"role":     "worker",
+						"hostName": "worker-4",
+					},
+				},
+			},
+		}
+
+		task.clusterInput = &clusterInput{
+			hwMgmtData: map[string]any{
+				"nodeGroupData": []any{
+					map[string]any{"name": "master", "role": "master", "hwProfile": "profile-1"},
+					map[string]any{"name": "worker-group-1", "role": "worker", "hwProfile": "profile-2"},
+					map[string]any{"name": "worker-group-2", "role": "worker", "hwProfile": "profile-3"},
+					map[string]any{"name": "worker-group-3", "role": "worker", "hwProfile": "profile-4"},
+				},
+			},
+			hostToGroupName: map[string]string{
+				"master-1": "master",
+				"master-2": "master",
+				"worker-1": "worker-group-1",
+				"worker-2": "worker-group-1",
+				"worker-3": "worker-group-2",
+				"worker-4": "worker-group-3",
+			},
+		}
+
+		nar, err := task.buildNodeAllocationRequestSpec(clusterInstance)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nar).ToNot(BeNil())
+		Expect(nar.Spec.LocationSpec.Site).To(Equal("local-123"))
+		Expect(nar.Spec.ClusterId).To(Equal("exampleCluster"))
+		Expect(nar.Spec.NodeGroup).To(HaveLen(4))
+
+		// Check node groups
+		var masterGroup, workerGroup1, workerGroup2, workerGroup3 *hwmgmtv1alpha1.NodeGroup
+		for i := range nar.Spec.NodeGroup {
+			switch nar.Spec.NodeGroup[i].NodeGroupData.Name {
+			case groupNameMaster:
+				masterGroup = &nar.Spec.NodeGroup[i]
+			case "worker-group-1":
+				workerGroup1 = &nar.Spec.NodeGroup[i]
+			case "worker-group-2":
+				workerGroup2 = &nar.Spec.NodeGroup[i]
+			case "worker-group-3":
+				workerGroup3 = &nar.Spec.NodeGroup[i]
+			}
+		}
+
+		Expect(masterGroup).ToNot(BeNil())
+		Expect(masterGroup.Size).To(Equal(2)) // 2 master nodes
+		Expect(masterGroup.NodeGroupData.Role).To(Equal("master"))
+
+		Expect(workerGroup1).ToNot(BeNil())
+		Expect(workerGroup1.Size).To(Equal(2))
+		Expect(workerGroup1.NodeGroupData.Role).To(Equal("worker"))
+
+		Expect(workerGroup2).ToNot(BeNil())
+		Expect(workerGroup2.Size).To(Equal(1))
+		Expect(workerGroup2.NodeGroupData.Role).To(Equal("worker"))
+
+		Expect(workerGroup3).ToNot(BeNil())
+		Expect(workerGroup3.Size).To(Equal(1))
+		Expect(workerGroup3.NodeGroupData.Role).To(Equal("worker"))
 	})
 
 	It("should set ConfigTransactionId to ProvisioningRequest generation", func() {
@@ -1118,7 +1210,7 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		task.clusterInput = &clusterInput{
 			hwMgmtData: map[string]any{
 				"nodeGroupData": []any{
-					map[string]any{"name": "controller", "role": "master", "hwProfile": "override-profile-1", "resourcePoolId": "pool-1"},
+					map[string]any{"name": "master", "role": "master", "hwProfile": "override-profile-1", "resourcePoolId": "pool-1"},
 					map[string]any{"name": "worker", "role": "worker", "hwProfile": "template-profile-2", "resourcePoolId": "pool-2"},
 				},
 			},
@@ -1132,9 +1224,10 @@ var _ = Describe("buildNodeAllocationRequest", func() {
 		// Check that controller group uses the overridden profile
 		var controllerGroup, workerGroup *hwmgmtv1alpha1.NodeGroup
 		for i := range nar.Spec.NodeGroup {
-			if nar.Spec.NodeGroup[i].NodeGroupData.Name == "controller" {
+			switch nar.Spec.NodeGroup[i].NodeGroupData.Name {
+			case groupNameMaster:
 				controllerGroup = &nar.Spec.NodeGroup[i]
-			} else if nar.Spec.NodeGroup[i].NodeGroupData.Name == groupNameWorker {
+			case groupNameWorker:
 				workerGroup = &nar.Spec.NodeGroup[i]
 			}
 		}
@@ -1537,7 +1630,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 					HwMgmtDefaults: provisioningv1alpha1.HwMgmtDefaults{
 						HardwareProvisioningTimeout: &metav1.Duration{Duration: 90 * time.Minute},
 						NodeGroupData: []hwmgmtv1alpha1.NodeGroupData{
-							{Name: "controller", Role: "master", HwProfile: "profile-64G"},
+							{Name: "master", Role: "master", HwProfile: "profile-64G"},
 						},
 					},
 				},
@@ -1555,7 +1648,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 
 		// Set up hardware nodes map
 		hwNodes = map[string][]utils.NodeInfo{
-			"controller": {
+			"master": {
 				{
 					BmcAddress:     "192.168.1.100",
 					BmcCredentials: "master-01-bmc-secret",
@@ -1614,7 +1707,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
 					{
 						NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
-							Name: "controller",
+							Name: "master",
 							Role: "master",
 						},
 					},
@@ -1642,7 +1735,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 					HwMgmtDefaults: provisioningv1alpha1.HwMgmtDefaults{
 						HardwareProvisioningTimeout: &metav1.Duration{Duration: 90 * time.Minute},
 						NodeGroupData: []hwmgmtv1alpha1.NodeGroupData{
-							{Name: "controller", Role: "master", HwProfile: "profile-64G"},
+							{Name: "master", Role: "master", HwProfile: "profile-64G"},
 						},
 					},
 				},
@@ -1740,6 +1833,48 @@ var _ = Describe("applyNodeConfiguration", func() {
 		Expect(workerNode2["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:22"))
 	})
 
+	It("successfully applies node configuration for nodeGroups format with multiple worker MCPs", func() {
+		// Workers use custom MCPs.
+		hwNodes["worker-group-1"] = []utils.NodeInfo{hwNodes["worker"][0]}
+		hwNodes["worker-group-2"] = []utils.NodeInfo{hwNodes["worker"][1]}
+		delete(hwNodes, "worker")
+		nar.Spec.NodeGroup = []hwmgmtv1alpha1.NodeGroup{
+			{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "master", Role: "master"}},
+			{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker-group-1", Role: "worker"}},
+			{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker-group-2", Role: "worker"}},
+		}
+		task.clusterInput.hostToGroupName = map[string]string{
+			"master-01": "master",
+			"worker-01": "worker-group-1",
+			"worker-02": "worker-group-2",
+		}
+
+		err := task.applyNodeConfiguration(ctx, hwNodes, nar, ci)
+		Expect(err).ToNot(HaveOccurred())
+
+		nodes, found, err := unstructured.NestedSlice(ci.Object, "spec", "nodes")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(nodes).To(HaveLen(3))
+
+		masterNode := nodes[0].(map[string]interface{})
+		Expect(masterNode["bmcAddress"]).To(Equal("192.168.1.100"))
+		bmcCreds, found, err := unstructured.NestedString(masterNode, "bmcCredentialsName", "name")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(bmcCreds).To(Equal("master-01-bmc-secret"))
+		Expect(masterNode["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:01"))
+
+		// worker-01 from hardware group "worker-group-1", worker-02 from "worker-group-2"
+		workerNode1 := nodes[1].(map[string]interface{})
+		Expect(workerNode1["bmcAddress"]).To(Equal("192.168.1.101"))
+		Expect(workerNode1["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:11"))
+
+		workerNode2 := nodes[2].(map[string]interface{})
+		Expect(workerNode2["bmcAddress"]).To(Equal("192.168.1.102"))
+		Expect(workerNode2["bootMACAddress"]).To(Equal("aa:bb:cc:dd:ee:22"))
+	})
+
 	It("returns error when spec.nodes not found in cluster instance", func() {
 		// Remove nodes from cluster instance spec
 		ci.Object = map[string]interface{}{
@@ -1781,7 +1916,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 		// Remove HwMgrNodeId and HwMgrNodeNs from hardware nodes
 		// Also provide both interfaces to match the cluster instance structure
 		hwNodesWithoutHostRef := map[string][]utils.NodeInfo{
-			"controller": {
+			"master": {
 				{
 					BmcAddress:     "192.168.1.100",
 					BmcCredentials: "master-01-bmc-secret",
@@ -1886,8 +2021,8 @@ var _ = Describe("applyNodeConfiguration", func() {
 			},
 		}
 
-		// Add second controller node
-		hwNodes["controller"] = append(hwNodes["controller"], utils.NodeInfo{
+		// Add second master node
+		hwNodes["master"] = append(hwNodes["master"], utils.NodeInfo{
 			BmcAddress:     "192.168.1.102",
 			BmcCredentials: "master-02-bmc-secret",
 			NodeID:         "node-master-02",
@@ -1902,7 +2037,7 @@ var _ = Describe("applyNodeConfiguration", func() {
 			},
 		})
 
-		Expect(hwNodes["controller"]).To(HaveLen(2))
+		Expect(hwNodes["master"]).To(HaveLen(2))
 
 		err := task.applyNodeConfiguration(ctx, hwNodes, nar, ci)
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/controllers/provisioningrequest_validation.go
+++ b/internal/controllers/provisioningrequest_validation.go
@@ -328,7 +328,7 @@ func validateMergedNodeGroups(mergedData map[string]any) error {
 				"or hwMgmtParameters", ctlrutils.HwMgmtNodeGroupDataKey)
 	}
 
-	seenRoles := map[string]string{}
+	var masterGroup string
 	for _, ng := range ngSlice {
 		ngMap, ok := ng.(map[string]any)
 		if !ok {
@@ -345,10 +345,12 @@ func validateMergedNodeGroups(mergedData map[string]any) error {
 		if role != "master" && role != "worker" {
 			return typederrors.NewInputError("invalid role %q for nodeGroup %q: must be 'master' or 'worker'", role, name)
 		}
-		if prev, exists := seenRoles[role]; exists {
-			return typederrors.NewInputError("duplicate role %q in %s for groups %q and %q", role, ctlrutils.HwMgmtNodeGroupDataKey, prev, name)
+		if role == "master" {
+			if masterGroup != "" {
+				return typederrors.NewInputError("duplicate role %q in %s for groups %q and %q", role, ctlrutils.HwMgmtNodeGroupDataKey, masterGroup, name)
+			}
+			masterGroup = name
 		}
-		seenRoles[role] = name
 
 		// hwProfile, resourcePoolId, and resourceSelector are all optional.
 		// The hardware manager handles node selection based on whatever criteria are provided.
@@ -492,10 +494,15 @@ func (t *provisioningRequestReconcilerTask) getMergedClusterInstanceData(
 	}
 
 	if format == constants.ClusterInstanceNodeGroupsKey {
-		if err := ctlrutils.ExpandNodeGroupsToNodes(mergedClusterDataMap); err != nil {
+		// Expand nodeGroups to flat nodes and capture hostName -> group name
+		// before expansion strips nodeGroups[].name.
+		hostToGroupName, err := ctlrutils.ExpandNodeGroupsToNodes(mergedClusterDataMap)
+		if err != nil {
 			return nil, typederrors.NewInputError(
-				"failed to merge data for %s: %s", constants.TemplateParamClusterInstance, err.Error())
+				"failed to expand %s nodeGroups: %s",
+				constants.TemplateParamClusterInstance, err.Error())
 		}
+		t.clusterInput.hostToGroupName = hostToGroupName
 	}
 
 	t.logger.InfoContext(ctx,

--- a/internal/controllers/provisioningrequest_validation_test.go
+++ b/internal/controllers/provisioningrequest_validation_test.go
@@ -785,6 +785,10 @@ nodes:
 		task = newTask(defaults, params)
 		merged, err := task.getMergedClusterInstanceData(ctx, ciDefaultsCm, extractClusterInstanceInput(task))
 		Expect(err).ToNot(HaveOccurred())
+		Expect(task.clusterInput.hostToGroupName).To(Equal(map[string]string{
+			"master-1.example.com": "master",
+			"master-2.example.com": "master",
+		}))
 		mergedYAML, err := yaml.Marshal(merged)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(mergedYAML).To(MatchYAML(expectedYAML))
@@ -833,6 +837,7 @@ nodes:
 		task = newTask(defaults, params)
 		merged, err := task.getMergedClusterInstanceData(ctx, ciDefaultsCm, extractClusterInstanceInput(task))
 		Expect(err).ToNot(HaveOccurred())
+		Expect(task.clusterInput.hostToGroupName).To(BeNil())
 		mergedYAML, err := yaml.Marshal(merged)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(mergedYAML).To(MatchYAML(expectedYAML))
@@ -957,6 +962,9 @@ nodeGroups:
 		task = newTask(defaults, params)
 		merged, err := task.getMergedClusterInstanceData(ctx, ciDefaultsCm, extractClusterInstanceInput(task))
 		Expect(err).ToNot(HaveOccurred())
+		Expect(task.clusterInput.hostToGroupName).To(Equal(map[string]string{
+			"m1": "master",
+		}))
 		Expect(merged).To(HaveKey("nodes"))
 		nodes := merged["nodes"].([]any)
 		Expect(nodes).To(HaveLen(1))
@@ -985,6 +993,9 @@ nodeGroups:
 		task = newTask(defaults, params)
 		merged, err := task.getMergedClusterInstanceData(ctx, ciDefaultsCm, extractClusterInstanceInput(task))
 		Expect(err).ToNot(HaveOccurred())
+		Expect(task.clusterInput.hostToGroupName).To(Equal(map[string]string{
+			"m1": "master",
+		}))
 		nodes := merged["nodes"].([]any)
 		Expect(nodes).To(HaveLen(1))
 		Expect(nodes[0].(map[string]any)["hostName"]).To(Equal("m1"))

--- a/internal/controllers/utils/provision.go
+++ b/internal/controllers/utils/provision.go
@@ -391,15 +391,16 @@ func PrepareClusterInstanceForServerSideApply(ci *siteconfig.ClusterInstance) {
 // slice. For each group, shared fields are deep-copied onto every host, then the
 // host overlay is merged on top (interfaces by name). Flattened interface
 // addresses (CIDR strings) are mapped into nmstate config. O-cloud-only sugar fields
-// (group name, interfaces[].addresses) are stripped.
-func ExpandNodeGroupsToNodes(merged map[string]any) error {
+// (group name, interfaces[].addresses) are stripped. It also returns a map of
+// hostName -> nodeGroups[].name (spoke MCP name).
+func ExpandNodeGroupsToNodes(merged map[string]any) (map[string]string, error) {
 	raw, ok := merged[constants.ClusterInstanceNodeGroupsKey]
 	if !ok {
-		return fmt.Errorf("%q is required for the nodeGroups format", constants.ClusterInstanceNodeGroupsKey)
+		return nil, fmt.Errorf("%q is required for the nodeGroups format", constants.ClusterInstanceNodeGroupsKey)
 	}
 	groups, ok := raw.([]any)
 	if !ok {
-		return fmt.Errorf("%q must be an array", constants.ClusterInstanceNodeGroupsKey)
+		return nil, fmt.Errorf("%q must be an array", constants.ClusterInstanceNodeGroupsKey)
 	}
 
 	nodeMergeRules := SliceMergeRules{
@@ -412,13 +413,17 @@ func ExpandNodeGroupsToNodes(merged map[string]any) error {
 		},
 	}
 
+	hostToGroupName := map[string]string{}
 	flatNodes := []any{}
 	for i, group := range groups {
 		groupMap, ok := group.(map[string]any)
 		if !ok {
-			return fmt.Errorf("%s[%d] is not an object", constants.ClusterInstanceNodeGroupsKey, i)
+			return nil, fmt.Errorf("%s[%d] is not an object", constants.ClusterInstanceNodeGroupsKey, i)
 		}
 		groupName, _ := groupMap["name"].(string)
+		if groupName == "" {
+			return nil, fmt.Errorf("%s[%d] is missing required field %q", constants.ClusterInstanceNodeGroupsKey, i, "name")
+		}
 
 		// Groups with missing or empty nodes are kept in defaults for shared
 		// template fields (e.g. a worker group with no hosts yet) and contribute
@@ -429,7 +434,7 @@ func ExpandNodeGroupsToNodes(merged map[string]any) error {
 		}
 		groupNodes, ok := nodesRaw.([]any)
 		if !ok {
-			return fmt.Errorf("node group %q nodes must be an array", groupName)
+			return nil, fmt.Errorf("node group %q nodes must be an array", groupName)
 		}
 		if len(groupNodes) == 0 {
 			continue
@@ -444,18 +449,28 @@ func ExpandNodeGroupsToNodes(merged map[string]any) error {
 		for j, node := range groupNodes {
 			nodeMap, ok := node.(map[string]any)
 			if !ok {
-				return fmt.Errorf("node group %q node[%d] is not an object", groupName, j)
+				return nil, fmt.Errorf("node group %q node[%d] is not an object", groupName, j)
 			}
+			// Capture the hostName -> groupName mapping.
+			hostName, _ := nodeMap["hostName"].(string)
+			if hostName == "" {
+				return nil, fmt.Errorf("node group %q node[%d] is missing required field %q", groupName, j, "hostName")
+			}
+			if existing, ok := hostToGroupName[hostName]; ok {
+				return nil, fmt.Errorf("node group %q node[%d] has duplicate hostName %q (already in node group %q)",
+					groupName, j, hostName, existing)
+			}
+			hostToGroupName[hostName] = groupName
 
 			// Fresh copy of the shared/common fields per node so expanded nodes are independent.
 			flatNode := runtime.DeepCopyJSON(groupMap)
 			if err := DeepMergeMaps(flatNode, nodeMap, false, nodeMergeRules); err != nil {
-				return fmt.Errorf("failed to merge node[%d] onto node group %q: %w", j, groupName, err)
+				return nil, fmt.Errorf("failed to merge node[%d] onto node group %q: %w", j, groupName, err)
 			}
 
 			// Map flattened nodeNetwork.interfaces[].addresses CIDR strings into the matching nmstate entry.
 			if err := applyInterfaceAddresses(flatNode); err != nil {
-				return fmt.Errorf("node group %q node[%d]: %w", groupName, j, err)
+				return nil, fmt.Errorf("node group %q node[%d]: %w", groupName, j, err)
 			}
 
 			flatNodes = append(flatNodes, flatNode)
@@ -463,14 +478,14 @@ func ExpandNodeGroupsToNodes(merged map[string]any) error {
 	}
 
 	if len(groups) > 0 && len(flatNodes) == 0 {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"at least one node is required across %s in clusterInstanceParameters",
 			constants.ClusterInstanceNodeGroupsKey)
 	}
 
 	delete(merged, constants.ClusterInstanceNodeGroupsKey)
 	merged[constants.ClusterInstanceNodesKey] = flatNodes
-	return nil
+	return hostToGroupName, nil
 }
 
 // applyInterfaceAddresses maps flattened nodeNetwork.interfaces[].addresses CIDR

--- a/internal/controllers/utils/provision_test.go
+++ b/internal/controllers/utils/provision_test.go
@@ -1185,6 +1185,30 @@ nodeGroups:
         addresses:
           ipv4:
           - "192.0.2.20/24"
+- name: worker-cnf
+  role: worker
+  bootMode: UEFI
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: boot-interface
+    config:
+      interfaces:
+      - name: eno1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+        ipv6:
+          enabled: false
+  nodes:
+  - hostName: worker-2.example.com
+    nodeNetwork:
+      interfaces:
+      - name: eno1
+        addresses:
+          ipv4:
+          - "192.0.2.21/24"
 `)
 		expected := `
 clusterName: from-defaults
@@ -1260,9 +1284,35 @@ nodes:
             prefix-length: 24
         ipv6:
           enabled: false
+- hostName: worker-2.example.com
+  role: worker
+  bootMode: UEFI
+  nodeNetwork:
+    interfaces:
+    - name: eno1
+      label: boot-interface
+    config:
+      interfaces:
+      - name: eno1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+          address:
+          - ip: "192.0.2.21"
+            prefix-length: 24
+        ipv6:
+          enabled: false
 `
 
-		Expect(ExpandNodeGroupsToNodes(merged)).To(Succeed())
+		hostToGroupName, err := ExpandNodeGroupsToNodes(merged)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hostToGroupName).To(Equal(map[string]string{
+			"master-1.example.com": "master",
+			"master-2.example.com": "master",
+			"worker-1.example.com": "worker",
+			"worker-2.example.com": "worker-cnf",
+		}))
 		got, err := yaml.Marshal(merged)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(got).To(MatchYAML(expected))
@@ -1317,7 +1367,8 @@ nodes:
             prefix-length: 24
 `
 
-		Expect(ExpandNodeGroupsToNodes(merged)).To(Succeed())
+		_, err := ExpandNodeGroupsToNodes(merged)
+		Expect(err).ToNot(HaveOccurred())
 		got, err := yaml.Marshal(merged)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(got).To(MatchYAML(expected))
@@ -1345,7 +1396,7 @@ nodeGroups:
           ipv4:
           - "192.0.2.10/24"
 `)
-		err := ExpandNodeGroupsToNodes(merged)
+		_, err := ExpandNodeGroupsToNodes(merged)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(`name "eth99" at path "nodeNetwork.interfaces" in source does not match any destination entry`))
 	})
@@ -1370,7 +1421,7 @@ nodeGroups:
           ipv4:
           - "192.0.2.10/24"
 `)
-		err := ExpandNodeGroupsToNodes(merged)
+		_, err := ExpandNodeGroupsToNodes(merged)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(`interface "eno1" has addresses but no matching entry in nodeNetwork.config.interfaces`))
 	})
@@ -1399,7 +1450,7 @@ nodeGroups:
           ipv4:
           - "192.0.2.10"
 `)
-		err := ExpandNodeGroupsToNodes(merged)
+		_, err := ExpandNodeGroupsToNodes(merged)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not a valid CIDR"))
 	})
@@ -1419,7 +1470,11 @@ nodes:
 - hostName: master-1.example.com
   role: master
 `
-		Expect(ExpandNodeGroupsToNodes(merged)).To(Succeed())
+		hostToGroupName, err := ExpandNodeGroupsToNodes(merged)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hostToGroupName).To(Equal(map[string]string{
+			"master-1.example.com": "master",
+		}))
 		got, err := yaml.Marshal(merged)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(got).To(MatchYAML(expected))
@@ -1441,7 +1496,11 @@ nodes:
 - hostName: master-1.example.com
   role: master
 `
-		Expect(ExpandNodeGroupsToNodes(merged)).To(Succeed())
+		hostToGroupName, err := ExpandNodeGroupsToNodes(merged)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hostToGroupName).To(Equal(map[string]string{
+			"master-1.example.com": "master",
+		}))
 		got, err := yaml.Marshal(merged)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(got).To(MatchYAML(expected))
@@ -1456,7 +1515,7 @@ nodeGroups:
   role: worker
   nodes: []
 `)
-		err := ExpandNodeGroupsToNodes(merged)
+		_, err := ExpandNodeGroupsToNodes(merged)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("at least one node is required across nodeGroups"))
 	})
@@ -1470,9 +1529,80 @@ nodeGroups: []
 clusterName: x
 nodes: []
 `
-		Expect(ExpandNodeGroupsToNodes(merged)).To(Succeed())
+		hostToGroupName, err := ExpandNodeGroupsToNodes(merged)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hostToGroupName).To(BeEmpty())
 		got, err := yaml.Marshal(merged)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(got).To(MatchYAML(expected))
+	})
+
+	It("rejects malformed nodeGroups", func() {
+		_, err := ExpandNodeGroupsToNodes(map[string]any{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`"nodeGroups" is required for the nodeGroups format`))
+
+		_, err = ExpandNodeGroupsToNodes(map[string]any{
+			"nodeGroups": "not-an-array",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`"nodeGroups" must be an array`))
+
+		_, err = ExpandNodeGroupsToNodes(map[string]any{
+			"nodeGroups": []any{"not-an-object"},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("nodeGroups[0] is not an object"))
+
+		_, err = ExpandNodeGroupsToNodes(map[string]any{
+			"nodeGroups": []any{map[string]any{"nodes": []any{}}},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`nodeGroups[0] is missing required field "name"`))
+
+		_, err = ExpandNodeGroupsToNodes(map[string]any{
+			"nodeGroups": []any{map[string]any{"name": "master", "nodes": "not-an-array"}},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`node group "master" nodes must be an array`))
+
+		_, err = ExpandNodeGroupsToNodes(map[string]any{
+			"nodeGroups": []any{map[string]any{"name": "master", "nodes": []any{"not-an-object"}}},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`node group "master" node[0] is not an object`))
+
+		_, err = ExpandNodeGroupsToNodes(map[string]any{
+			"nodeGroups": []any{map[string]any{"name": "master", "nodes": []any{map[string]any{}}}},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`node group "master" node[0] is missing required field "hostName"`))
+	})
+
+	It("rejects duplicate hostName within or across groups", func() {
+		_, err := ExpandNodeGroupsToNodes(mustYAMLMap(`
+nodeGroups:
+- name: master
+  role: master
+  nodes:
+  - hostName: master-1.example.com
+  - hostName: master-1.example.com
+`))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(`node group "master" node[1] has duplicate hostName "master-1.example.com" (already in node group "master")`))
+
+		_, err = ExpandNodeGroupsToNodes(mustYAMLMap(`
+nodeGroups:
+- name: master
+  role: master
+  nodes:
+  - hostName: shared.example.com
+- name: worker
+  role: worker
+  nodes:
+  - hostName: shared.example.com
+`))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(`node group "worker" node[0] has duplicate hostName "shared.example.com" (already in node group "master")`))
 	})
 })

--- a/internal/hardwaremanager/controller/baremetalhost_manager.go
+++ b/internal/hardwaremanager/controller/baremetalhost_manager.go
@@ -48,6 +48,7 @@ const (
 	BmhDeallocationDoneAnnotation            = "clcm.openshift.io/deallocation-complete"
 	BmhErrorTimestampAnnotation              = "clcm.openshift.io/bmh-error-timestamp"
 	BmhHostMgmtAnnotation                    = "bmac.agent-install.openshift.io/allow-provisioned-host-management"
+	BmhNodeLabelAnnotationPrefix             = "bmac.agent-install.openshift.io.node-label."
 	BmhInfraEnvLabel                         = "infraenvs.agent-install.openshift.io"
 	BmhSecretFinalizer                       = "baremetalhost.metal3.io/secret"
 	PreprovisioningImageDeprovisionFinalizer = "preprovisioningimage.agent-install.openshift.io/ai-deprovision"
@@ -1099,6 +1100,15 @@ func finalizeBMHDeallocation(ctx context.Context, c client.Client, logger *slog.
 		// Remove configuration-related annotations
 		for _, key := range []string{BiosUpdateNeededAnnotation, FirmwareUpdateNeededAnnotation} {
 			delete(patched.Annotations, key)
+		}
+
+		// Remove node-label annotations that SiteConfig stamped on the BMH from the ClusterInstance nodeLabels.
+		// These are propagated to the node by Baremetal Agent Controller (BAMC), so leaving them behind leaks
+		// stale node labels into the next allocation cycle when the BMH is reused.
+		for key := range patched.Annotations {
+			if strings.HasPrefix(key, BmhNodeLabelAnnotationPrefix) {
+				delete(patched.Annotations, key)
+			}
 		}
 
 		// Initialize annotations map if it's nil

--- a/internal/hardwaremanager/controller/baremetalhost_manager_test.go
+++ b/internal/hardwaremanager/controller/baremetalhost_manager_test.go
@@ -730,6 +730,11 @@ var _ = Describe("BareMetalHost Manager", func() {
 			}, map[string]string{
 				BiosUpdateNeededAnnotation:     ValueTrue,
 				FirmwareUpdateNeededAnnotation: ValueTrue,
+				// node-label.* annotations are stamped from ClusterInstance nodeLabels
+				// and propagated to the node by BMAC; they must be cleared on
+				// deallocation regardless of the underlying label prefix.
+				BmhNodeLabelAnnotationPrefix + "node-role.kubernetes.io/worker-cnf": "",
+				BmhNodeLabelAnnotationPrefix + "custom.example.com/pool":            "blue",
 			}, metal3v1alpha1.StateProvisioned)
 
 			// Set up CustomDeploy and Image
@@ -766,6 +771,12 @@ var _ = Describe("BareMetalHost Manager", func() {
 			Expect(hasBiosAnnotation).To(BeFalse())
 			_, hasFirmwareAnnotation := updatedBMH.Annotations[FirmwareUpdateNeededAnnotation]
 			Expect(hasFirmwareAnnotation).To(BeFalse())
+
+			// Check that node-label annotations were removed
+			_, hasRoleLabel := updatedBMH.Annotations[BmhNodeLabelAnnotationPrefix+"node-role.kubernetes.io/worker-cnf"]
+			Expect(hasRoleLabel).To(BeFalse())
+			_, hasCustomLabel := updatedBMH.Annotations[BmhNodeLabelAnnotationPrefix+"custom.example.com/pool"]
+			Expect(hasCustomLabel).To(BeFalse())
 
 			// Check that spec fields were updated
 			Expect(updatedBMH.Spec.Online).To(BeFalse())


### PR DESCRIPTION
### Summary
Enable provisioning a managed cluster with more than one worker MachineConfigPool at install time. Previously the hardware allocation sized groups by installer role, which allowed only a single worker group.
Jira: [CNF-26652](https://redhat.atlassian.net/browse/CNF-26652) — Provision clusters with multiple worker MachineConfigPools

### Changes
- ExpandNodeGroupsToNodes now returns a hostName → nodeGroups[].name map (captured before expansion strips group identity) and validates that the group name and per-host hostName are present.
- clusterInput carries hostToGroupName; buildNodeAllocationRequestSpec sizes each hardware group by hostname membership, and applyNodeConfiguration matches allocated nodes to their group by hostname.
- Duplicate-role validation now rejects only a duplicate master role; multiple worker groups are permitted, in both the ClusterTemplate hwMgmtDefaults and the merged nodeGroups.
- Strip stale bmac.agent-install.openshift.io.node-label.* annotations from a BareMetalHost on deallocation, so a reused host doesn't leak custom node labels (propagated by BMAC) into the next allocation cycle.
- New std-ran-du multi-MCP sample set: ClusterTemplate, ClusterInstance defaults, PolicyTemplate defaults, custom MachineConfigPool extra manifests, PolicyGenerator, and worker-MCP inform validator source-CRs.
New user-guide section covering the name contract, extra-manifest MCP CRs, and the per-pool PerformanceProfile/Tuned wiring, with a note that this is supported only for the assisted-installer flow.

### Test Plan
- Unit/envtest
- Cluster - Provisioned a standard (MNO) cluster with three custom worker pools through hardware updates to the policy configuration. Verified hareware configuration applied, each node joined its custom MCP, the matching PerformanceProfile/Tuned rendered per pool, and a redeploy onto reused BMHs did not inherit stale node labels.

### Notes
This is only supported with assisted-installer. The image-based installer (IBI) does not support nodeLabels and is single-node today, so multiple worker MachineConfigPools do not apply there.
