### PR TITLE
OCPBUGS-113988: Fix IBI PR deletion stall by cleaning up network-data secret during deallocation

### DIFF
--- a/internal/hardwaremanager/controller/allocatednode_controller.go
+++ b/internal/hardwaremanager/controller/allocatednode_controller.go
@@ -146,6 +146,17 @@ func (r *AllocatedNodeReconciler) handleAllocatedNodeDeletion(ctx context.Contex
 
 	skipCleanup := allocatednode.Spec.SkipCleanup
 
+	// Delete the IBI network-data secret if it exists. On the happy path this
+	// is handled during post-provisioning (enableBMOManagementForIBINodes), but
+	// if provisioning timed out or failed, the cleanup never ran. The secret
+	// has a BMO finalizer that blocks siteconfig's ClusterInstance deletion, so
+	// it must be removed before the cluster namespace can be deleted.
+	if !skipCleanup && bmh.Spec.ExternallyProvisioned {
+		if err := deleteIBINetworkDataSecret(ctx, r.Client, r.Logger, bmh); err != nil {
+			return false, fmt.Errorf("failed to delete IBI network-data secret for BMH %s: %w", bmh.Name, err)
+		}
+	}
+
 	if !isBMHDeallocated(bmh) {
 		if err = deallocateBMH(ctx, r.Client, r.Logger, bmh, skipCleanup); err != nil {
 			return false, fmt.Errorf("failed to deallocate BMH: %w", err)

--- a/internal/hardwaremanager/controller/allocatednode_controller_test.go
+++ b/internal/hardwaremanager/controller/allocatednode_controller_test.go
@@ -710,6 +710,87 @@ var _ = Describe("AllocatedNodeReconciler", func() {
 				Expect(completed).To(BeFalse())
 			})
 		})
+
+		Context("when IBI BMH has network-data secret with BMO finalizer", func() {
+			It("should delete the IBI network-data secret during deletion", func() {
+				// Set up BMH as IBI (ExternallyProvisioned)
+				bmh.Spec.ExternallyProvisioned = true
+				bmh.Spec.PreprovisioningNetworkDataName = "ibi-secret"
+				bmh.Annotations = map[string]string{
+					OrigNetworkDataAnnotation: "original-netdata",
+				}
+				Expect(fakeClient.Update(ctx, bmh)).To(Succeed())
+
+				// Create the IBI network-data secret with BMO finalizer and owner references
+				ibiSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "ibi-secret",
+						Namespace:  bmh.Namespace,
+						Finalizers: []string{BmhSecretFinalizer},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "metal3.io/v1alpha1",
+								Kind:       "BareMetalHost",
+								Name:       bmh.Name,
+								UID:        bmh.UID,
+							},
+							{
+								APIVersion: "metal3.io/v1alpha1",
+								Kind:       "PreprovisioningImage",
+								Name:       bmh.Name,
+							},
+						},
+					},
+					Data: map[string][]byte{"nmstate": []byte("test")},
+				}
+				Expect(fakeClient.Create(ctx, ibiSecret)).To(Succeed())
+
+				// Create PreprovisioningImage
+				ppi := &metal3v1alpha1.PreprovisioningImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      bmh.Name,
+						Namespace: bmh.Namespace,
+					},
+					Spec: metal3v1alpha1.PreprovisioningImageSpec{
+						NetworkDataName: "ibi-secret",
+					},
+				}
+				Expect(fakeClient.Create(ctx, ppi)).To(Succeed())
+
+				completed, err := reconciler.handleAllocatedNodeDeletion(ctx, allocatedNode)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(completed).To(BeFalse()) // Deallocation in progress
+
+				// Verify the IBI secret was deleted (or at least finalizer removed)
+				updatedSecret := &corev1.Secret{}
+				err = fakeClient.Get(ctx, types.NamespacedName{
+					Name: "ibi-secret", Namespace: bmh.Namespace,
+				}, updatedSecret)
+				if err == nil {
+					Expect(controllerutil.ContainsFinalizer(updatedSecret, BmhSecretFinalizer)).To(BeFalse())
+				}
+				// else: secret already deleted, which is also correct
+			})
+
+			It("should skip IBI cleanup for non-IBI BMHs", func() {
+				// BMH is not ExternallyProvisioned (non-IBI)
+				bmh.Spec.ExternallyProvisioned = false
+				Expect(fakeClient.Update(ctx, bmh)).To(Succeed())
+
+				// Create PreprovisioningImage
+				ppi := &metal3v1alpha1.PreprovisioningImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      bmh.Name,
+						Namespace: bmh.Namespace,
+					},
+				}
+				Expect(fakeClient.Create(ctx, ppi)).To(Succeed())
+
+				completed, err := reconciler.handleAllocatedNodeDeletion(ctx, allocatedNode)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(completed).To(BeFalse()) // Deallocation in progress, no IBI cleanup needed
+			})
+		})
 	})
 
 	Describe("Helper function tests", func() {


### PR DESCRIPTION
OCPBUGS-99224 fixed IBI deletion stalls by deleting the IBI network-data secret during post-provisioning (enableBMOManagementForIBINodes). However, that cleanup only runs on the success path when provisioning completes successfully. When provisioning times out or fails, the secret is never cleaned up. During subsequent PR deletion, siteconfig tries to delete it as part of ClusterInstance cleanup, but BMO holds a baremetalhost.metal3.io/secret finalizer on it. Siteconfig times out, sets a paused annotation on the ClusterInstance, and the entire deletion chain stalls.

Fix by calling deleteIBINetworkDataSecret during AllocatedNode deletion (handleAllocatedNodeDeletion) for IBI BMHs (ExternallyProvisioned=true), before deallocateBMH runs. This ensures the secret is cleaned up regardless of whether provisioning completed. The call is idempotent — if the secret was already deleted during post-provisioning, it's a no-op.