### PR TITLE
CNF-26768: Roll out day-2 worker hardware profile updates concurrently across MCPs

### DIFF
--- a/docs/dev/e2e-test-overview.md
+++ b/docs/dev/e2e-test-overview.md
@@ -106,8 +106,9 @@ File: `test/e2e/mno_hw_configuration_test.go`
 1. Should update the PR with new hwProfiles and trigger configuration update
 1. Should detect HW configuration changes and begin update process (NAR InProgress=True)
 1. Should PR reach InProgress
-1. Should complete rolling update: masters first (maxUnavailable=1), then workers (maxUnavailable=3)
+1. Should complete rolling update: masters first (maxUnavailable=1), then both worker pools concurrently (worker-r740-blue maxUnavailable=2, worker-xr8620t-blue maxUnavailable=3)
    - Polling and advancing BMH state transitions for each node
+   - Verifying the two worker pools were updated concurrently
    - Waiting for NAR to reach ConfigApplied
 1. Should PR reach HardwareConfigured=True
 
@@ -128,15 +129,15 @@ File: `test/e2e/mno_hw_configuration_test.go`
 1. Should update PR with v1 worker profile requiring BIOS and firmware changes
 1. Should have 3 workers in ConfigUpdate and advance one BMH to Servicing
    - Detect worker configuration changes and begin update (NAR InProgress)
-   - Waiting for at least 3 workers in ConfigUpdate with v1 profile
+   - Waiting for 3 nodes in the worker-xr8620t-blue pool to be in ConfigUpdate with v1 profile
    - Picking one worker and advancing its BMH to Servicing with config-in-progress
 1. Should change to v2 worker profile mid-flight, defer abandon for Servicing worker, then converge all
    - Changing worker profile to v2 while v1 updates are in-flight
-   - Waiting for 7 workers to converge to v2 while Servicing worker defers abandon
+   - Waiting for the non-servicing worker-xr8620t-blue nodes to converge to v2 while the Servicing worker defers abandon
    - Verifying the Servicing worker is still in ConfigUpdate with v1 profile (deferred abandon)
    - Transitioning the Servicing BMH to OK to allow deferred abandon
    - Waiting for NAR to reach ConfigApplied after all workers converge
-   - Verifying all 8 worker nodes converged to v2 profile
+   - Verifying all worker-xr8620t-blue nodes converged to v2 profile
 1. Should PR reach HardwareConfigured=True
 
 ## MNO Scale-Out test [mno-scale-out]

--- a/docs/user-guide/firmware-update-workflow.md
+++ b/docs/user-guide/firmware-update-workflow.md
@@ -219,15 +219,15 @@ with example status output, see
 
 The Day-2 flow differs from Day-0 in several important ways:
 
-1. **Group-priority ordering** — Node groups are processed by role: master group is
-   updated first, then worker groups. A group must fully complete before the next group
-   begins.
+1. **Group-priority ordering** — Node groups are processed by role: the master
+   (control-plane) group is updated first and must fully complete before any worker
+   group begins.
 
-2. **Rolling concurrency** — Master nodes are updated one at a time (serially). Worker
-   nodes can be updated in parallel — `spec.maxUnavailable` from the corresponding
-   MachineConfigPool (MCP) on the spoke cluster determines how many nodes in the group
-   can be updated concurrently. If the MCP is not found or `maxUnavailable` is not set,
-   the default is 1 (serial update).
+2. **Rolling concurrency** — Master nodes are updated one at a time (serially). Once the
+   master group completes, all worker groups roll out concurrently, and within each group
+   worker nodes are updated in parallel up to `spec.maxUnavailable` from that group's
+   corresponding MachineConfigPool (MCP) on the spoke cluster. If the MCP is not found or
+   `maxUnavailable` is not set, the default is 1 (serial update).
 
 3. **Cordon and drain** — Before applying firmware to a node on a multi-node cluster,
    the hardware manager cordons the Kubernetes node and drains its workloads to ensure pods are

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -1062,10 +1062,11 @@ func handleNodeAllocationRequestConfiguring(
 }
 
 // selectNodesToProcess selects nodes that need to be processed for day2 hardware updates.
-// It selects nodes from one group at a time in priority order (master first, then workers).
-// The next group is not considered until all nodes in the current group have completed.
-// Within the active group, it retrieves the MCP maxUnavailable as a rolling concurrency ceiling.
-// As long as there capacity remains, pending nodes are selected for processing. If there are
+// The control-plane (master) group is updated first: while it still has work, no worker pool
+// is started. Once the master group completes, all worker pools are released to roll out
+// concurrently, each independently bounded by its own MCP maxUnavailable as a rolling
+// concurrency ceiling. As long as capacity remains in a group, pending nodes are selected
+// for processing. If there are no pending nodes, the next group is processed.
 // abandoned nodes (from a mid-flight profile change), they are prioritized over regular pending
 // nodes. Nodes already in progress are also included so they can continue processing to completion.
 func selectNodesToProcess(
@@ -1161,8 +1162,14 @@ func selectNodesToProcess(
 			}
 		}
 
-		// Stop processing the next group as the current group is not fully updated.
-		break
+		// Masters must complete before workers begin: if this is the control-plane
+		// group and it still has work, stop here so no worker pool starts this
+		// reconcile. Worker pools roll out concurrently - keep looping to accumulate
+		// candidates from every worker group, each bounded by its own MCP maxUnavailable
+		// (computed per-group above).
+		if strings.EqualFold(nodegroup.NodeGroupData.Role, hwmgmtv1alpha1.NodeRoleMaster) {
+			break
+		}
 	}
 
 	return nodesToProcess, nil

--- a/internal/hardwaremanager/controller/helpers_test.go
+++ b/internal/hardwaremanager/controller/helpers_test.go
@@ -552,6 +552,45 @@ var _ = Describe("Helpers", func() {
 			Expect(reason).To(Equal(string(hwmgmtv1alpha1.ConfigApplied)))
 			Expect(message).To(Equal(string(hwmgmtv1alpha1.ConfigSuccess)))
 		})
+
+		It("should stay in-progress until every worker pool completes", func() {
+			// Add a second worker pool to the NAR. Even with the master and
+			// the first worker pool fully applied, the NAR must remain in-progress
+			// (so ObservedGeneration is not advanced) until the second worker pool
+			// also finishes.
+			mnoNAR.Spec.NodeGroup = append(mnoNAR.Spec.NodeGroup,
+				hwmgmtv1alpha1.NodeGroup{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker-b", HwProfile: "profile-v2", Role: "worker"}, Size: 3})
+
+			var nodes []hwmgmtv1alpha1.AllocatedNode
+			for _, name := range []string{"m1", "m2", "m3"} {
+				n := createNodeWithCondition(name, testNamespace, configured, string(hwmgmtv1alpha1.ConfigApplied), metav1.ConditionTrue)
+				n.Spec.GroupName = testGroupMaster
+				nodes = append(nodes, *n)
+			}
+			for _, name := range []string{"w1", "w2"} {
+				n := createNodeWithCondition(name, testNamespace, configured, string(hwmgmtv1alpha1.ConfigApplied), metav1.ConditionTrue)
+				n.Spec.GroupName = testGroupWorker
+				nodes = append(nodes, *n)
+			}
+			for _, name := range []string{"wb1", "wb2"} {
+				n := createNodeWithCondition(name, testNamespace, configured, string(hwmgmtv1alpha1.ConfigApplied), metav1.ConditionTrue)
+				n.Spec.GroupName = "worker-b"
+				nodes = append(nodes, *n)
+			}
+			wb3 := createNodeWithCondition("wb3", testNamespace, configured, string(hwmgmtv1alpha1.ConfigUpdatePending), metav1.ConditionFalse)
+			wb3.Spec.GroupName = "worker-b"
+			nodes = append(nodes, *wb3)
+
+			for i := range nodes {
+				Expect(fakeClient.Create(ctx, &nodes[i])).To(Succeed())
+			}
+
+			nodeList := &hwmgmtv1alpha1.AllocatedNodeList{Items: nodes}
+			status, reason, message := deriveNARStatusFromMultipleNodes(ctx, fakeNoncached, logger, nodeList, mnoNAR)
+			Expect(status).To(Equal(metav1.ConditionFalse))
+			Expect(reason).To(Equal(string(hwmgmtv1alpha1.InProgress)))
+			Expect(message).To(Equal(fmt.Sprintf("%s (group master: 3/3 completed, group worker: 2/2 completed, group worker-b: 2/3 completed)", string(hwmgmtv1alpha1.ConfigInProgress))))
+		})
 	})
 
 	Describe("processNewNodeAllocationRequest", func() {
@@ -2511,6 +2550,48 @@ var _ = Describe("Helpers", func() {
 			Expect(nodesToProcess).To(HaveLen(2))
 			Expect(nodesToProcess[0].actionType).To(Equal(actionInitiate))
 			Expect(nodesToProcess[1].actionType).To(Equal(actionInitiate))
+		})
+
+		It("should move to all worker pools concurrently once masters are done, each bounded by its own maxUnavailable", func() {
+			var items []hwmgmtv1alpha1.AllocatedNode
+			m1 := createNodeWithCondition("m1", testNamespace, configured, string(hwmgmtv1alpha1.ConfigApplied), metav1.ConditionTrue)
+			m1.Spec.GroupName = testGroupMaster
+			m1.Spec.HwProfile = newProfile
+			items = append(items, *m1)
+			for _, name := range []string{"wa1", "wa2", "wa3"} {
+				n := createNodeWithCondition(name, testNamespace, configured, string(hwmgmtv1alpha1.ConfigUpdatePending), metav1.ConditionFalse)
+				n.Spec.GroupName = "worker-a"
+				n.Spec.HwProfile = newProfile
+				items = append(items, *n)
+			}
+			for _, name := range []string{"wb1", "wb2", "wb3"} {
+				n := createNodeWithCondition(name, testNamespace, configured, string(hwmgmtv1alpha1.ConfigUpdatePending), metav1.ConditionFalse)
+				n.Spec.GroupName = "worker-b"
+				n.Spec.HwProfile = newProfile
+				items = append(items, *n)
+			}
+
+			nodelist := &hwmgmtv1alpha1.AllocatedNodeList{Items: items}
+			// Workers listed before master in spec to exercise sorting.
+			nar := createNAR([]hwmgmtv1alpha1.NodeGroup{
+				{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker-a", Role: hwmgmtv1alpha1.NodeRoleWorker, HwProfile: newProfile}},
+				{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker-b", Role: hwmgmtv1alpha1.NodeRoleWorker, HwProfile: newProfile}},
+				{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "master", Role: hwmgmtv1alpha1.NodeRoleMaster, HwProfile: newProfile}},
+			})
+			// Master group is done (skipped); both worker pools are released in the same
+			// pass, each capped by its own maxUnavailable (worker-a=1, worker-b=2).
+			mockOps.EXPECT().GetMaxUnavailable(gomock.Any(), "worker-a", 3).Return(1, nil)
+			mockOps.EXPECT().GetMaxUnavailable(gomock.Any(), "worker-b", 3).Return(2, nil)
+
+			nodesToProcess, err := selectNodesToProcess(ctx, logger, mockOps, nodelist, nar)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodesToProcess).To(HaveLen(3))
+			perGroup := map[string]int{}
+			for _, r := range nodesToProcess {
+				perGroup[r.node.Spec.GroupName]++
+			}
+			Expect(perGroup["worker-a"]).To(Equal(1))
+			Expect(perGroup["worker-b"]).To(Equal(2))
 		})
 
 		It("should return error when GetMaxUnavailable fails", func() {

--- a/test/e2e/mno_hw_configuration_test.go
+++ b/test/e2e/mno_hw_configuration_test.go
@@ -47,14 +47,18 @@ const (
 
 var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day2-hw-updates"), func() {
 	const (
-		timeout     = mnoTimeout
-		interval    = mnoInterval
-		master      = "master"
-		worker      = "worker"
-		masterCount = 3
-		workerCount = 8
+		timeout       = mnoTimeout
+		interval      = mnoInterval
+		master        = "master"
+		workerR740    = "worker-r740-blue"
+		workerXR8620t = "worker-xr8620t-blue"
+		masterCount   = 3
+		// Two worker pools exercise concurrent per-MCP day2 updates.
+		r740WorkerCount    = 4
+		xr8620tWorkerCount = 4
+		workerCount        = r740WorkerCount + xr8620tWorkerCount
 
-		// Resource pool label values on MNO BMHs (see testutils.MnoBMHs).
+		// Resource pool label values on MNO BMHs (see testutils.MnoBMHsTwoWorkerPools).
 		mnoBMHResourcePoolDellR740   = "dell-r740-pool"
 		mnoBMHResourcePoolDellXR8620 = "dell-xr8620t-pool"
 	)
@@ -195,7 +199,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		}
 
 		By("Creating 11 BMHs with BMC secrets, HardwareData, HFS, and HFC")
-		bmhList := testutils.MnoBMHs(masterCount, workerCount)
+		bmhList := mnoBMHsTwoWorkerPools(masterCount, r740WorkerCount, xr8620tWorkerCount)
 		for _, bmhData := range bmhList {
 			bmh := testutils.CreateBareMetalHost(bmhData)
 			bmcSecret := testutils.CreateBMCSecret(bmhData.Name)
@@ -334,7 +338,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
 		nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 		hostMap := make(map[string]string)
-		masterIdx, workerIdx := 1, 1
+		masterIdx, r740Idx, xr8620tIdx := 1, 1, 1
 		hostnames := []string{}
 		for _, node := range nodeList.Items {
 			hostname := ""
@@ -343,10 +347,14 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 				Expect(masterIdx).To(BeNumerically("<=", masterCount))
 				hostname = fmt.Sprintf("master-%d.%s.example.com", masterIdx, clusterName)
 				masterIdx++
-			case worker:
-				Expect(workerIdx).To(BeNumerically("<=", workerCount))
-				hostname = fmt.Sprintf("worker-%d.%s.example.com", workerIdx, clusterName)
-				workerIdx++
+			case workerR740:
+				Expect(r740Idx).To(BeNumerically("<=", r740WorkerCount))
+				hostname = fmt.Sprintf("worker-r740-%d.%s.example.com", r740Idx, clusterName)
+				r740Idx++
+			case workerXR8620t:
+				Expect(xr8620tIdx).To(BeNumerically("<=", xr8620tWorkerCount))
+				hostname = fmt.Sprintf("worker-xr8620t-%d.%s.example.com", xr8620tIdx, clusterName)
+				xr8620tIdx++
 			}
 			hostMap[node.Name] = hostname
 			hostnames = append(hostnames, hostname)
@@ -369,7 +377,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 
 		By("Deleting created resources")
 		// Delete BMH-related resources first (BMH, HardwareData, HFS, HFC, FirmwareSchema, BMC secrets)
-		bmhList := testutils.MnoBMHs(masterCount, workerCount)
+		bmhList := mnoBMHsTwoWorkerPools(masterCount, r740WorkerCount, xr8620tWorkerCount)
 		for _, bmhData := range bmhList {
 			for _, obj := range []client.Object{
 				&metal3v1alpha1.BareMetalHost{ObjectMeta: metav1.ObjectMeta{Name: bmhData.Name, Namespace: bmhData.Namespace}},
@@ -477,8 +485,11 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			}, timeout, interval).Should(BeTrue(), "PR should reach InProgress")
 		})
 
-		It("Should complete rolling update: masters first (maxUnavailable=1), then workers (maxUnavailable=3)", func() {
+		It("Should complete rolling update: masters first (maxUnavailable=1), then both worker pools concurrently (worker-r740-blue maxUnavailable=2, worker-xr8620t-blue maxUnavailable=3)", func() {
 			By("Polling and advancing BMH state transitions for each node")
+			// Tracks whether both worker pools were ever observed updating at the
+			// same time (proves cross-pool concurrency).
+			bothWorkerPoolsConcurrent := false
 			Eventually(func() bool {
 				allComplete := true
 				nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
@@ -486,7 +497,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 				// Track rolling-update invariants
 				mastersAllDone := true
 				mastersInProgress := 0
-				workersInProgress := 0
+				inProgressByWorkerPool := map[string]int{} // keyed by worker pool GroupName
 
 				for i := range nodeList.Items {
 					node := &nodeList.Items[i]
@@ -503,10 +514,9 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 						if isInProgress {
 							mastersInProgress++
 						}
-					} else if node.Spec.GroupName == worker {
-						if isInProgress {
-							workersInProgress++
-						}
+					} else if isInProgress {
+						// Any non-master group is a worker pool; count per pool.
+						inProgressByWorkerPool[node.Spec.GroupName]++
 					}
 
 					// Skip nodes that are already completed
@@ -579,21 +589,34 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 					}
 				}
 
-				// Verify rolling-update invariants:
-				// 1. No workers should be in-progress before all masters are done
+				// Verify rolling-update invariants, split by rollout phase.
 				if !mastersAllDone {
-					Expect(workersInProgress).To(Equal(0),
+					// Masters roll first, serially: no worker pool may start yet,
+					// and masters honor the control-plane maxUnavailable=1.
+					inProgressWorkers := inProgressByWorkerPool[workerR740] + inProgressByWorkerPool[workerXR8620t]
+					Expect(inProgressWorkers).To(Equal(0),
 						"workers should not start updates before all masters complete")
+					Expect(mastersInProgress).To(BeNumerically("<=", 1),
+						"masters in-progress should not exceed maxUnavailable=1")
+				} else {
+					// Masters done: worker pools roll concurrently, each bounded by
+					// its own MCP maxUnavailable.
+					Expect(inProgressByWorkerPool[workerR740]).To(BeNumerically("<=", 2),
+						"worker-r740-blue in-progress should not exceed its maxUnavailable=2")
+					Expect(inProgressByWorkerPool[workerXR8620t]).To(BeNumerically("<=", 3),
+						"worker-xr8620t-blue in-progress should not exceed its maxUnavailable=3")
+					// Record cross-pool concurrency: both worker pools updating at once.
+					if inProgressByWorkerPool[workerR740] > 0 && inProgressByWorkerPool[workerXR8620t] > 0 {
+						bothWorkerPoolsConcurrent = true
+					}
 				}
-				// 2. Masters in-progress should not exceed maxUnavailable (1)
-				Expect(mastersInProgress).To(BeNumerically("<=", 1),
-					"masters in-progress should not exceed maxUnavailable=1")
-				// 3. Workers in-progress should not exceed maxUnavailable (3)
-				Expect(workersInProgress).To(BeNumerically("<=", 3),
-					"workers in-progress should not exceed maxUnavailable=3")
 
 				return allComplete
 			}, timeout*5, interval).Should(BeTrue(), "All nodes should reach ConfigApplied after rolling update")
+
+			By("Verifying the two worker pools were updated concurrently")
+			Expect(bothWorkerPoolsConcurrent).To(BeTrue(),
+				"worker-r740-blue and worker-xr8620t-blue should be in-progress simultaneously after masters complete")
 
 			By("Waiting for NAR to reach ConfigApplied")
 			Eventually(func() bool {
@@ -701,14 +724,14 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		})
 	})
 
-	// Test mid-flight profile change with mixed BMH states:
-	// 1. Trigger a real v1 update (BIOS + firmware changes) so workers enter ConfigUpdate
+	// Test mid-flight profile change with mixed BMH states (scoped to the worker-xr8620t-blue pool):
+	// 1. Trigger a real v1 update (BIOS + firmware changes) so its workers enter ConfigUpdate
 	// 2. Advance ONE worker's BMH to Servicing with config-in-progress annotation
 	// 3. Change profile to v2 mid-flight
-	// 4. The 2 workers with BMH=OK are abandoned immediately
+	// 4. Workers with BMH=OK are abandoned immediately
 	// 5. The 1 worker with BMH=Servicing defers abandon (controller requeues)
 	// 6. Transition the Servicing BMH to OK -> deferred abandon proceeds
-	// 7. All workers reconverge to v2
+	// 7. All worker-xr8620t-blue nodes reconverge to v2
 	Describe("Handles mid-flight profile change by abandoning stale updates", func() {
 		var (
 			servicingNodeKey types.NamespacedName
@@ -719,9 +742,11 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		v2WorkerProfile := "dell-xr8620t-bios-2.3.5-bmc-7.10.70.10"
 
 		It("Should update PR with v1 worker profile requiring BIOS and firmware changes", func() {
-			// Start from pr-std-succeed (master=v2, worker=v2), then override worker
-			// hwProfile to v1. This forces real BIOS changes (AcPwrRcvryUserDelay 130→120)
-			// and firmware downgrades (bios 2.3.5→2.1.0, bmc 7.10.70.10→7.0.0).
+			// Start from pr-std-succeed, then override only the worker-xr8620t-blue
+			// hwProfile to v1 (dell-xr8620t-bios-basic). Master and worker-r740-blue
+			// stay on their succeed profiles, so only the xr8620t pool rolls. This
+			// forces real BIOS changes (AcPwrRcvryUserDelay 130→120) and firmware
+			// downgrades (bios 2.3.5→2.1.0, bmc 7.10.70.10→7.0.0).
 			Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
 			v2PR, err := testutils.LoadYAML[provisioningv1alpha1.ProvisioningRequest](
 				"../resources/mno_hw_configuration/pr-std-succeed.yaml")
@@ -734,7 +759,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			nodeGroupData := hwParams["nodeGroupData"].([]interface{})
 			for _, ng := range nodeGroupData {
 				ngMap := ng.(map[string]interface{})
-				if ngMap["name"] == "worker" {
+				if ngMap["name"] == workerXR8620t {
 					ngMap["hwProfile"] = v1Profile
 				}
 			}
@@ -752,13 +777,13 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 				return cond != nil && cond.Reason == string(hwmgmtv1alpha1.InProgress)
 			}, timeout, interval).Should(BeTrue(), "NAR should be in InProgress")
 
-			By("Waiting for at least 3 workers in ConfigUpdate with v1 profile")
+			By("Waiting for 3 nodes in the worker-xr8620t-blue pool to be in ConfigUpdate with v1 profile")
 			Eventually(func() int {
 				count := 0
 				nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 				for i := range nodeList.Items {
 					node := &nodeList.Items[i]
-					if node.Spec.GroupName != worker || node.Spec.HwProfile != v1Profile {
+					if node.Spec.GroupName != workerXR8620t || node.Spec.HwProfile != v1Profile {
 						continue
 					}
 					cond := meta.FindStatusCondition(node.Status.Conditions, string(hwmgmtv1alpha1.Configured))
@@ -768,13 +793,13 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 				}
 				return count
 			}, timeout, interval).Should(BeNumerically(">=", 3),
-				"At least 3 workers should be in ConfigUpdate with v1 profile")
+				"3 nodes in the worker-xr8620t-blue pool should be in ConfigUpdate with the v1 profile")
 
 			By("Picking one worker and advancing its BMH to Servicing with config-in-progress")
 			nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 			for i := range nodeList.Items {
 				node := &nodeList.Items[i]
-				if node.Spec.GroupName != worker || node.Spec.HwProfile != v1Profile {
+				if node.Spec.GroupName != workerXR8620t || node.Spec.HwProfile != v1Profile {
 					continue
 				}
 				cond := meta.FindStatusCondition(node.Status.Conditions, string(hwmgmtv1alpha1.Configured))
@@ -816,18 +841,16 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			pr.Spec.TemplateParameters = v2PR.Spec.TemplateParameters
 			Expect(K8SClient.Update(testCtx, pr)).To(Succeed())
 
-			By("Waiting for 7 workers to converge to v2 while Servicing worker defers abandon")
-			// The 2 workers with BMH=OK are abandoned immediately -> re-initiated with v2 ->
-			// ConfigApplied quickly (HFS/HFC status already matches v2 from the success test,
-			// so no actual HW changes are needed).
-			// The 5 pending workers are reset to v2 -> initiated -> ConfigApplied quickly
-			// (same reason: HFS/HFC status already at v2 values).
+			By("Waiting for the non-servicing worker-xr8620t-blue nodes to converge to v2 while the Servicing worker defers abandon")
+			// Within the worker-xr8620t-blue pool: workers with BMH=OK are abandoned
+			// immediately -> re-initiated with v2 -> ConfigApplied quickly (HFS/HFC status
+			// already matches v2 from the success test, so no actual HW changes are needed).
 			// The 1 Servicing worker can't be abandoned (BMH Servicing) -> stays in ConfigUpdate.
 			Eventually(func() int {
 				count := 0
 				nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 				for _, node := range nodeList.Items {
-					if node.Spec.GroupName != worker {
+					if node.Spec.GroupName != workerXR8620t {
 						continue
 					}
 					cond := meta.FindStatusCondition(node.Status.Conditions, string(hwmgmtv1alpha1.Configured))
@@ -838,8 +861,8 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 					}
 				}
 				return count
-			}, mnoLongTimeout, interval).Should(Equal(7),
-				"7 workers should converge to v2 ConfigApplied while Servicing worker defers")
+			}, mnoLongTimeout, interval).Should(Equal(xr8620tWorkerCount-1),
+				"all worker-xr8620t-blue nodes except the deferred Servicing one should converge to v2")
 
 			By("Verifying the Servicing worker is still in ConfigUpdate with v1 profile (deferred abandon)")
 			n := &hwmgmtv1alpha1.AllocatedNode{}
@@ -865,10 +888,10 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 					cond.Reason == string(hwmgmtv1alpha1.ConfigApplied)
 			}, timeout, interval).Should(BeTrue(), "NAR should reach ConfigApplied")
 
-			By("Verifying all 8 worker nodes converged to v2 profile")
+			By("Verifying all worker-xr8620t-blue nodes converged to v2 profile")
 			nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 			for _, node := range nodeList.Items {
-				if node.Spec.GroupName != worker {
+				if node.Spec.GroupName != workerXR8620t {
 					continue
 				}
 				Expect(node.Spec.HwProfile).To(Equal(v2WorkerProfile),
@@ -920,15 +943,22 @@ func setupSpokeClientMock(ctx context.Context, hostnames []string) func() {
 			MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
 		},
 	}
-	// Set worker MCP maxUnavailable to 3.
-	workerMCP := &machineconfigv1.MachineConfigPool{
-		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+	// Two worker MCPs with different maxUnavailable, keyed by group/MCP name, so
+	// GetMaxUnavailable resolves each worker pool's own rolling ceiling.
+	workerR740MCP := &machineconfigv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-r740-blue"},
+		Spec: machineconfigv1.MachineConfigPoolSpec{
+			MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+		},
+	}
+	workerXR8620tMCP := &machineconfigv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-xr8620t-blue"},
 		Spec: machineconfigv1.MachineConfigPoolSpec{
 			MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 3},
 		},
 	}
 	var spokeObjects []client.Object
-	spokeObjects = append(spokeObjects, masterMCP, workerMCP)
+	spokeObjects = append(spokeObjects, masterMCP, workerR740MCP, workerXR8620tMCP)
 	var k8sNodes []runtime.Object
 	for _, hostname := range hostnames {
 		node := &corev1.Node{
@@ -1129,4 +1159,45 @@ func patchBMHStatus(ctx context.Context, bmhKey types.NamespacedName, mutateFn f
 	patch := client.MergeFrom(bmh.DeepCopy())
 	mutateFn(bmh)
 	Expect(K8SClient.Status().Patch(ctx, bmh, patch)).To(Succeed())
+}
+
+// Masters and the R740 worker pool share the same server-type (R740) and are
+// distinguished by colour (green vs blue); the two worker pools share the same
+// colour (blue) and are distinguished by server-type (R740 vs XR8620t).
+func mnoBMHsTwoWorkerPools(masterCount, r740WorkerCount, xr8620tWorkerCount int) []testutils.BMHData {
+	var bmhs []testutils.BMHData
+	for i := 1; i <= masterCount; i++ {
+		bmhs = append(bmhs, testutils.BMHData{
+			Name:           fmt.Sprintf("test-master%d", i),
+			Namespace:      "dell-r740-pool",
+			MacAddress:     fmt.Sprintf("aa:bb:cc:11:00:%02x", i),
+			BmcAddress:     fmt.Sprintf("redfish://192.168.1.%d/redfish/v1/Systems/1", 100+i),
+			ServerType:     "R740",
+			Colour:         "green",
+			ResourcePoolId: "dell-r740-pool",
+		})
+	}
+	for i := 1; i <= r740WorkerCount; i++ {
+		bmhs = append(bmhs, testutils.BMHData{
+			Name:           fmt.Sprintf("test-worker-r740-%d", i),
+			Namespace:      "dell-r740-pool",
+			MacAddress:     fmt.Sprintf("aa:bb:cc:33:00:%02x", i),
+			BmcAddress:     fmt.Sprintf("redfish://192.168.3.%d/redfish/v1/Systems/1", 100+i),
+			ServerType:     "R740",
+			Colour:         "blue",
+			ResourcePoolId: "dell-r740-pool",
+		})
+	}
+	for i := 1; i <= xr8620tWorkerCount; i++ {
+		bmhs = append(bmhs, testutils.BMHData{
+			Name:           fmt.Sprintf("test-worker-xr8620t-%d", i),
+			Namespace:      "dell-xr8620t-pool",
+			MacAddress:     fmt.Sprintf("aa:bb:cc:22:00:%02x", i),
+			BmcAddress:     fmt.Sprintf("redfish://192.168.2.%d/redfish/v1/Systems/1", 100+i),
+			ServerType:     "XR8620t",
+			Colour:         "blue",
+			ResourcePoolId: "dell-xr8620t-pool",
+		})
+	}
+	return bmhs
 }

--- a/test/resources/mno_hw_configuration/clusterinstance-defaults-v1.yaml
+++ b/test/resources/mno_hw_configuration/clusterinstance-defaults-v1.yaml
@@ -58,7 +58,33 @@ data:
         templateRefs:
           - name: ai-node-templates-v1
             namespace: open-cluster-management
-      - name: worker
+      - name: worker-r740-blue
+        role: worker
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - name: worker-xr8620t-blue
         role: worker
         bootMode: UEFI
         rootDeviceHints:

--- a/test/resources/mno_hw_configuration/ct-std-dell-r740-green-xr8620t-blue.yaml
+++ b/test/resources/mno_hw_configuration/ct-std-dell-r740-green-xr8620t-blue.yaml
@@ -16,7 +16,12 @@ spec:
           resourceSelector:
             "resourceselector.clcm.openshift.io/server-type": "R740"
             "resourceselector.clcm.openshift.io/server-colour": "green"
-        - name: worker
+        - name: worker-r740-blue
+          role: worker
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "R740"
+            "resourceselector.clcm.openshift.io/server-colour": "blue"
+        - name: worker-xr8620t-blue
           role: worker
           resourceSelector:
             "resourceselector.clcm.openshift.io/server-type": "XR8620t"

--- a/test/resources/mno_hw_configuration/pr-std-fail.yaml
+++ b/test/resources/mno_hw_configuration/pr-std-fail.yaml
@@ -13,7 +13,9 @@ spec:
       nodeGroupData:
         - name: master
           hwProfile: dell-r740-bios-2.22.2-bmc-7.00.00.173-nic-16.35.30.06
-        - name: worker
+        - name: worker-r740-blue
+          hwProfile: dell-r740-bios-2.22.2-bmc-7.00.00.173-nic-16.35.30.06
+        - name: worker-xr8620t-blue
           hwProfile: dell-xr8620t-bios-2.4.0-bmc-7.10.80.00
     policyTemplateParameters: {}
     clusterInstanceParameters:
@@ -54,7 +56,7 @@ spec:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.18/24"]
-        - name: worker
+        - name: worker-r740-blue
           nodeNetwork:
             config:
               dns-resolver:
@@ -67,49 +69,62 @@ spec:
                 config:
                   - next-hop-address: 192.0.2.254
           nodes:
-            - hostName: worker-1.std-test.example.com
+            - hostName: worker-r740-1.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.123/24"]
-            - hostName: worker-2.std-test.example.com
+            - hostName: worker-r740-2.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.51/24"]
-            - hostName: worker-3.std-test.example.com
+            - hostName: worker-r740-3.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.54/24"]
-            - hostName: worker-4.std-test.example.com
+            - hostName: worker-r740-4.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.55/24"]
-            - hostName: worker-5.std-test.example.com
+        - name: worker-xr8620t-blue
+          nodeNetwork:
+            config:
+              dns-resolver:
+                config:
+                  search:
+                    - example.com
+                  server:
+                    - 8.8.8.8
+              routes:
+                config:
+                  - next-hop-address: 192.0.2.254
+          nodes:
+            - hostName: worker-xr8620t-1.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.56/24"]
-            - hostName: worker-6.std-test.example.com
+            - hostName: worker-xr8620t-2.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.57/24"]
-            - hostName: worker-7.std-test.example.com
+            - hostName: worker-xr8620t-3.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.58/24"]
-            - hostName: worker-8.std-test.example.com
+            - hostName: worker-xr8620t-4.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1

--- a/test/resources/mno_hw_configuration/pr-std-succeed.yaml
+++ b/test/resources/mno_hw_configuration/pr-std-succeed.yaml
@@ -13,7 +13,9 @@ spec:
       nodeGroupData:
         - name: master
           hwProfile: dell-r740-bios-2.22.2-bmc-7.00.00.173-nic-16.35.30.06
-        - name: worker
+        - name: worker-r740-blue
+          hwProfile: dell-r740-bios-2.22.2-bmc-7.00.00.173-nic-16.35.30.06
+        - name: worker-xr8620t-blue
           hwProfile: dell-xr8620t-bios-2.3.5-bmc-7.10.70.10
     policyTemplateParameters: {}
     clusterInstanceParameters:
@@ -54,7 +56,7 @@ spec:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.18/24"] 
-        - name: worker
+        - name: worker-r740-blue
           nodeNetwork:
             config:
               dns-resolver:
@@ -67,49 +69,62 @@ spec:
                 config:
                   - next-hop-address: 192.0.2.254
           nodes:
-            - hostName: worker-1.std-test.example.com
+            - hostName: worker-r740-1.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.123/24"]
-            - hostName: worker-2.std-test.example.com
+            - hostName: worker-r740-2.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.51/24"]
-            - hostName: worker-3.std-test.example.com
+            - hostName: worker-r740-3.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.54/24"]
-            - hostName: worker-4.std-test.example.com
+            - hostName: worker-r740-4.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.55/24"]
-            - hostName: worker-5.std-test.example.com
+        - name: worker-xr8620t-blue
+          nodeNetwork:
+            config:
+              dns-resolver:
+                config:
+                  search:
+                    - example.com
+                  server:
+                    - 8.8.8.8
+              routes:
+                config:
+                  - next-hop-address: 192.0.2.254
+          nodes:
+            - hostName: worker-xr8620t-1.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.56/24"]
-            - hostName: worker-6.std-test.example.com
+            - hostName: worker-xr8620t-2.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.57/24"]
-            - hostName: worker-7.std-test.example.com
+            - hostName: worker-xr8620t-3.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.58/24"]
-            - hostName: worker-8.std-test.example.com
+            - hostName: worker-xr8620t-4.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1

--- a/test/resources/mno_hw_configuration/pr-std.yaml
+++ b/test/resources/mno_hw_configuration/pr-std.yaml
@@ -13,7 +13,9 @@ spec:
       nodeGroupData:
         - name: master
           hwProfile: dell-r740-bios-basic
-        - name: worker
+        - name: worker-r740-blue
+          hwProfile: dell-r740-bios-basic
+        - name: worker-xr8620t-blue
           hwProfile: dell-xr8620t-bios-basic
     policyTemplateParameters: {}
     clusterInstanceParameters:
@@ -54,7 +56,7 @@ spec:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.18/24"] 
-        - name: worker
+        - name: worker-r740-blue
           nodeNetwork:
             config:
               dns-resolver:
@@ -67,49 +69,62 @@ spec:
                 config:
                   - next-hop-address: 192.0.2.254
           nodes:
-            - hostName: worker-1.std-test.example.com
+            - hostName: worker-r740-1.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.123/24"]
-            - hostName: worker-2.std-test.example.com
+            - hostName: worker-r740-2.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.51/24"]
-            - hostName: worker-3.std-test.example.com
+            - hostName: worker-r740-3.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.54/24"]
-            - hostName: worker-4.std-test.example.com
+            - hostName: worker-r740-4.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.55/24"]
-            - hostName: worker-5.std-test.example.com
+        - name: worker-xr8620t-blue
+          nodeNetwork:
+            config:
+              dns-resolver:
+                config:
+                  search:
+                    - example.com
+                  server:
+                    - 8.8.8.8
+              routes:
+                config:
+                  - next-hop-address: 192.0.2.254
+          nodes:
+            - hostName: worker-xr8620t-1.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.56/24"]
-            - hostName: worker-6.std-test.example.com
+            - hostName: worker-xr8620t-2.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.57/24"]
-            - hostName: worker-7.std-test.example.com
+            - hostName: worker-xr8620t-3.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.58/24"]
-            - hostName: worker-8.std-test.example.com
+            - hostName: worker-xr8620t-4.std-test.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1


### PR DESCRIPTION
### Summary
Day-2 hardware profile (firmware/BIOS) rollout previously updated worker MachineConfigPools one at a time. This PR makes all worker pools roll out concurrently once the master (control-plane) group completes, each pool still bounded independently by its own MCP maxUnavailable. Masters remain serialized ahead of workers.

Jira: [CNF-26768](https://redhat.atlassian.net/browse/CNF-26768) — Day-2: concurrent hardware profile updates across worker MCPs

### Changes

- Controller (internal/hardwaremanager/controller/helpers.go): In selectNodesToProcess, replace the unconditional break after the first group with remaining work with a break scoped to the control-plane (master) group only. Worker groups now keep accumulating candidates so every worker pool is released in the same reconcile, each capped by its own MCP maxUnavailable. Updated the function doc comment.
- Docs (docs/user-guide/firmware-update-workflow.md): Updated the day-2 "Group-priority ordering" / "Rolling concurrency" description to reflect concurrent worker-pool rollout.

### Test Plan

- UnitTests: Added multi-worker-pool selection cases (all pools released concurrently once masters are done, each honoring its own maxUnavailable) and an deriveNARStatusFromMultipleNodes aggregation case that stays InProgress until every worker pool completes.
- E2E test: The MNO day-2 test now provisions two worker pools — worker-r740-blue (maxUnavailable=2) and worker-xr8620t-blue (maxUnavailable=3) — plus masters. Assertions verify per-pool maxUnavailable, masters-before-workers ordering, and a cross-pool concurrency invariant (both pools in-progress simultaneously). `make test-e2e` passes.
- Cluster: Verified day-2 firmware updates rollout with concurrent worker pools on STD (2 worker pools)