### PR TITLE
Ibi

### DIFF
--- a/docs/proposals/automated-seed-image-generation.md
+++ b/docs/proposals/automated-seed-image-generation.md
@@ -778,7 +778,7 @@ The controller creates a Kubernetes Job on the hub cluster that builds the live 
    The pull secret is constructed by merging the hub cluster pull secret (`openshift-config/pull-secret`) with the `seedAuthSecretRef` credentials. If `liveISO.pullSecretRef` is provided, its contents are used directly instead of the auto-merged secret. In disconnected environments,
    the pull secret must include credentials for both the local seed image mirror and the OCP release image mirror.
 
-4. **Build the ISO**: Run `openshift-install image-based create image --dir <workdir>`. This pulls the seed image, generates ignition configuration, and produces the `rhcos-ibi.iso` file. This step requires significant ephemeral storage (~15GB for seed image pull + ISO generation).
+4. **Build the ISO**: Run `openshift-install image-based create image --dir <workdir>`. This pulls the seed image, generates ignition configuration, and produces the `rhcos-ibi.iso` file. This step requires significant workspace storage (~15-20GB for seed image pull + ISO generation).
 
 5. **Upload the ISO**: SCP the ISO to the HTTPS server using the SSH credentials from `uploadSecretRef`, pinning the server host key from `knownHosts` with strict checking:
 
@@ -1067,7 +1067,11 @@ type SeedGenerationStatus struct {
     // ISOServerCACertRef is a typed reference to a ConfigMap the controller
     // materializes on completion (in the O-Cloud Manager namespace, named
     // deterministically from the ProvisioningRequest) holding the PEM CA bundle
-    // for the HTTPS ISO server under a well-known key. Populated only when
+    // for the HTTPS ISO server under the well-known key "ca-bundle.crt".
+    // Consumers that resolve the bundle in a different namespace (e.g. the IBI
+    // pre-provisioning flow, which reads ImageClusterInstall's name-only
+    // ISOServerCACertRef under "ca-bundle.crt" in the ICI namespace) copy this
+    // ConfigMap into the target namespace under the same key. Populated only when
     // uploadSecretRef.caCert is present. The controller creates the ConfigMap
     // rather than storing raw PEM here, so downstream consumers (e.g. BMC
     // virtual media configuration) get a stable object reference, not inline

--- a/docs/proposals/automated-seed-image-generation.md
+++ b/docs/proposals/automated-seed-image-generation.md
@@ -92,9 +92,10 @@ The manual seed generation workflow has several pain points:
   the seed, retain spoke access during generation via the spoke's admin
   kubeconfig retrieved from the hub (which survives ACM teardown and writes
   nothing to the spoke, so nothing is baked into the seed), and do **not**
-  restore ACM afterward. The controller
-  never deletes the `ManagedCluster` itself; the operator deletes the
-  ProvisioningRequest to reclaim the hardware once the seed is captured.
+  restore ACM afterward. The controller never deletes the `ManagedCluster`
+  itself, and it **never auto-deletes the ProvisioningRequest** — results
+  stay readable as conditions on the PR until the operator deletes it to
+  reclaim the hardware once the seed is captured.
 - Reuse the existing `upgradeDefaults` / `upgradeParameters`
   merge-and-validate infrastructure rather than introducing a new CRD or
   controller.
@@ -130,10 +131,15 @@ The manual seed generation workflow has several pain points:
 The seed SNO cluster must be provisioned with the following already in place:
 
 - **LifeCycle Agent (LCA) Operator**: Must be installed as part of the initial cluster configuration via the ClusterTemplate's `policyTemplateDefaults`. The controller validates LCA is present before proceeding with seed generation.
-- **`var-lib-containers` partition**: The ClusterTemplate's `clusterInstanceDefaults` must include the MachineConfig that creates a separate `/var/lib/containers` partition shared between stateroots.
+- **`var-lib-containers` partition**: The ClusterTemplate's `clusterInstanceDefaults` must include the MachineConfig that creates a separate `/var/lib/containers` partition. This is a **seed-generation** prerequisite on the seed cluster:
+  LCA validates a shared `/var/lib/containers` before it will generate the seed, independent of whether the resulting seed is later consumed by IBI or IBU. (The matching *target*-side shared partition is what is IBU-specific — for the dual-stateroot
+  pivot during upgrade — and is out of scope for this proposal, which only produces the seed and, optionally, the IBI live ISO.)
 - **OADP Operator**: Required by LCA for backup/restore operations during seed generation.
 
 These are the responsibility of the cluster template author. The controller validates their presence but does not install them.
+
+Live ISO generation (Phase 4) is **IBI-only and optional**: it is driven by the `liveISO` block and produces the bootable installation ISO that IBI needs to install bare-metal targets. A seed intended only for IBU (in-place upgrade of an existing
+cluster) needs no ISO — omit `liveISO` and the controller stops after the seed image is pushed.
 
 ## Proposed API Changes
 
@@ -1374,6 +1380,9 @@ reference when mounting the ISO via virtual media. The controller does not confi
 responsibility of the hardware manager or the BMC pre-configuration
 workflow. The controller's role is to validate the cert, use it during pre-flight checks, and surface it via the ConfigMap reference for downstream consumption.
 
+BMC-side certificate management proper — for example uploading CA certificates to BMCs via the Redfish `ImportCertificate` action as a day-0/day-2 operation — is intentionally **out of scope** for this proposal and is better handled as a separate
+certificate-management feature (consistent with the Non-Goals). This proposal deliberately stops at validating the ISO server certificate and surfacing it for downstream consumers, rather than taking on BMC trust provisioning.
+
 ### 10. Registry pre-flight check limitations
 
 **Challenge**: The registry validation in Phase 1 runs from the hub cluster, which may have different network access than the spoke (where the actual image push occurs).
@@ -1388,6 +1397,11 @@ may still fail. In disconnected environments, the `seedImage` pull-spec should r
 Detach the spoke entirely by deleting the ClusterInstance/ManagedCluster, as the manual workflow does today. Rejected because deleting the ClusterInstance risks triggering deprovisioning of the running spoke and discards the hub-side record of the cluster. The chosen approach instead
 keeps the `ManagedCluster` intact and removes only the spoke-side ACM agent state (klusterlet + addons), achieving the same seed cleanliness without touching the provisioning lifecycle; the operator reclaims the hardware by deleting the ProvisioningRequest when the seed is captured.
 (Spoke access is obtained the same way either way — the hub-held admin kubeconfig survives klusterlet teardown regardless — so the access credential is not what distinguishes this alternative.)
+
+Taking on spoke cleanup ourselves does add responsibility that deleting the `ManagedCluster` would otherwise leave to ACM, and that responsibility must be bounded so it does not become a maintenance burden as ACM adds features. The design
+deliberately leans on ACM's **own teardown primitives** rather than a hardcoded inventory of agent objects: it deletes the `Klusterlet` CR (so the klusterlet operator tears down *all* of its current and future registration/work agents and
+namespaces) and enumerates and deletes **all** `ManagedClusterAddOn` CRs (so new addons are covered without code changes). The residual risk is limited to spoke state that is neither klusterlet-managed nor modeled as a `ManagedClusterAddOn` — the
+observability secrets in [Challenge 1](#1-incomplete-acm-cleanup-contaminates-the-seed-image) are the known example, and the pattern there (prevent creation at the source via a label rather than chase deletions) is the template for any future such case.
 
 ### B. Separate SeedGenerationRequest CRD
 

--- a/docs/proposals/automated-seed-image-generation.md
+++ b/docs/proposals/automated-seed-image-generation.md
@@ -1084,11 +1084,14 @@ type SeedGenerationStatus struct {
     ISOServerCACertRef *ConfigMapKeyRef `json:"isoServerCACertRef,omitempty"`
 }
 
-// ConfigMapKeyRef references a single key in a ConfigMap.
+// ConfigMapKeyRef references a single key in a ConfigMap. Key is always
+// "ca-bundle.crt" for ISOServerCACertRef: the IBI pre-provisioning consumer
+// reads a name-only reference under that fixed key, so the producer must not
+// emit any other key or the consumer silently fails to resolve the bundle.
 type ConfigMapKeyRef struct {
     Name      string `json:"name"`
     Namespace string `json:"namespace"`
-    Key       string `json:"key"`
+    Key       string `json:"key"` // always "ca-bundle.crt"
 }
 ```
 
@@ -1141,6 +1144,9 @@ spec:
           urlBase: https://iso-server.example.com/ibi/
       clusterUpgradeTimeout: "3h"
   templateParameterSchema:
+    # Abbreviated: field types only. The `additionalProperties: false` guard
+    # (required at every object level) and some fields are elided — the canonical
+    # "Schema in templateParameterSchema" is authoritative; copy from there.
     properties:
       # ... standard provisioning parameters ...
       upgradeParameters:

--- a/docs/proposals/automated-seed-image-generation.md
+++ b/docs/proposals/automated-seed-image-generation.md
@@ -1,0 +1,1521 @@
+<!--
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Proposal: Automated Seed Image and Live ISO Generation via ProvisioningRequest API
+
+## Table of Contents
+
+- [Background](#background)
+- [Problem Statement](#problem-statement)
+- [Goals](#goals)
+- [Non-Goals](#non-goals)
+- [Prerequisites](#prerequisites)
+- [Proposed API Changes](#proposed-api-changes)
+  - [New key: `seedGeneration`](#new-key-seedgeneration)
+  - [ProvisioningRequest overrides](#provisioningrequest-overrides)
+  - [Schema in templateParameterSchema](#schema-in-templateparameterschema)
+- [Controller Workflow](#controller-workflow)
+  - [Functional Overview](#functional-overview)
+  - [Trigger and Dispatch](#trigger-and-dispatch)
+  - [Phase 1: Validation](#phase-1-validation)
+  - [Phase 2: ACM Agent Cleanup](#phase-2-acm-agent-cleanup)
+  - [Phase 3: Trigger Seed Generation](#phase-3-trigger-seed-generation)
+  - [Phase 4: Live ISO Generation](#phase-4-live-iso-generation)
+  - [Phase 5: Completion and Cleanup](#phase-5-completion-and-cleanup)
+- [New Status Fields](#new-status-fields)
+- [New Condition Type](#new-condition-type)
+- [Timeout](#timeout)
+- [Sample: End-to-End ClusterTemplate](#sample-end-to-end-clustertemplate)
+- [Challenges and Mitigations](#challenges-and-mitigations)
+  - [1. Incomplete ACM cleanup contaminates the seed image](#1-incomplete-acm-cleanup-contaminates-the-seed-image)
+  - [2. Spoke client availability during seed generation](#2-spoke-client-availability-during-seed-generation)
+  - [3. ACM self-healing during cleanup phase](#3-acm-self-healing-during-cleanup-phase)
+  - [4. Seed cluster afterlife and PR terminal state](#4-seed-cluster-afterlife-and-pr-terminal-state)
+  - [5. Seed SNO prerequisites](#5-seed-sno-prerequisites)
+  - [6. Standalone access token lifetime and cleanup](#6-standalone-access-token-lifetime-and-cleanup)
+  - [7. ISO generation Job storage requirements](#7-iso-generation-job-storage-requirements)
+  - [8. Disconnected environment registry configuration](#8-disconnected-environment-registry-configuration)
+  - [9. HTTPS ISO server certificate management](#9-https-iso-server-certificate-management)
+  - [10. Registry pre-flight check limitations](#10-registry-pre-flight-check-limitations)
+- [Alternatives Considered](#alternatives-considered)
+  - [A. Full ACM detachment (delete ManagedCluster)](#a-full-acm-detachment-delete-managedcluster)
+  - [B. Separate SeedGenerationRequest CRD](#b-separate-seedgenerationrequest-crd)
+  - [C. External job/pipeline](#c-external-jobpipeline)
+  - [D. Controller-managed LCA installation](#d-controller-managed-lca-installation)
+  - [E. ISO generation via external pipeline (Tekton, CI/CD)](#e-iso-generation-via-external-pipeline-tekton-cicd)
+  - [F. Default to public release image registry](#f-default-to-public-release-image-registry)
+- [Implementation Constants](#implementation-constants)
+- [Effort Estimate](#effort-estimate)
+- [Open Questions](#open-questions)
+
+## Background
+
+Today, generating a seed image and live ISO for IBI-based cluster provisioning is a multi-step manual process (documented in `docs/user-guide/ibi-based-cluster-provisioning.md`). An operator must:
+
+1. Provision a reference SNO cluster via ProvisioningRequest (with a specific `var-lib-containers` MachineConfig)
+2. Annotate the PR with `clcm.openshift.io/skip-cleanup` and delete it to detach the spoke from ACM
+3. SSH into the spoke, install the LifeCycle Agent (LCA) operator, create a `seedgen` Secret and a `SeedGenerator` CR
+4. Monitor the SeedGenerator until the seed image is pushed to the container registry
+5. Obtain the `openshift-install` binary matching the OCP version, create an `ImageBasedInstallationConfig`, and run `openshift-install image-based create image` to produce a live ISO
+6. Upload the ISO to an HTTPS server accessible from the BMC management network
+7. Pre-provision servers using the ISO via BMC virtual media
+
+This proposal automates steps 1 through 6 as a first-class operation within the ProvisioningRequest API.
+
+## Problem Statement
+
+The manual seed generation workflow has several pain points:
+
+- **Error-prone**: Requires precise ordering of annotate → delete → install LCA → create resources → monitor, plus matching the correct `openshift-install` binary version to build the ISO
+- **Untracked**: No status reporting through the O-Cloud Manager API; operators must SSH and tail logs
+- **Inconsistent**: Each team may follow a slightly different procedure
+- **Not scalable**: Generating seed images and ISOs for multiple hardware/OCP configurations requires repeating the full manual procedure
+- **Disconnected complexity**: In disconnected environments (the predominant use case), operators must also manage release image mirrors and ensure the `openshift-install` binary, seed image, and OCP release images are all accessible from the correct registries
+
+## Goals
+
+- Automate seed image generation (annotate → detach → install/create LCA
+  resources → monitor → push) as a first-class operation driven by the
+  existing ProvisioningRequest API, eliminating the manual SSH-based
+  procedure.
+- Automate live installation ISO generation and upload to the HTTPS server
+  as part of the same workflow, matching the correct `openshift-install`
+  version automatically.
+- Report progress and results through the O-Cloud Manager API via a typed
+  `SeedGenerationCompleted` condition and `SeedGenerationStatus` fields, so
+  operators no longer need to SSH and tail logs.
+- Treat the seed cluster as a disposable factory: remove all ACM agent
+  state (klusterlet and addons) from the spoke so it does not contaminate
+  the seed, retain spoke access during generation via a standalone
+  long-lived token, and do **not** restore ACM afterward. The controller
+  never deletes the `ManagedCluster` itself; the operator deletes the
+  ProvisioningRequest to reclaim the hardware once the seed is captured.
+- Reuse the existing `upgradeDefaults` / `upgradeParameters`
+  merge-and-validate infrastructure rather than introducing a new CRD or
+  controller.
+- Validate prerequisites and fail fast with a clear
+  `PreconditionChecksFailed` condition (registry push access, release image
+  reachability, TLS/CA trust, upload credentials) before the lengthy
+  generation begins.
+- Support disconnected environments as the primary use case, auto-deriving
+  mirror mappings and registry trust from the hub (local mirrors, private CA)
+  so the template author supplies only the required `releaseImage`.
+
+## Non-Goals
+
+- Installing or managing the prerequisite operators (LCA, OADP) or the
+  `var-lib-containers` MachineConfig — these remain the cluster template
+  author's responsibility; the controller only validates their presence.
+- Validating hardware-specific seed prerequisites the hub cannot inspect
+  (CPU topology alignment, FIPS, proxy, IP-version match with target SNOs);
+  see [Challenge 5](#5-seed-sno-prerequisites).
+- Configuring BMC virtual media or BMC CA trust to consume the generated
+  ISO — that belongs to the hardware manager / pre-provisioning workflow
+  (see the IBI Server Pre-Provisioning proposal). This proposal only
+  surfaces the ISO server CA cert in status for downstream consumption.
+- Introducing a dedicated seed-generation CRD or a separate controller
+  (rejected in [Alternative B](#b-separate-seedgenerationrequest-crd)).
+- Detaching the spoke from ACM by deleting the ManagedCluster (rejected in
+  [Alternative A](#a-full-acm-detachment-delete-managedcluster)).
+- Supporting ISO upload mechanisms beyond SCP/SFTP in the initial
+  implementation (see [Open Questions](#open-questions)).
+
+## Prerequisites
+
+The seed SNO cluster must be provisioned with the following already in place:
+
+- **LifeCycle Agent (LCA) Operator**: Must be installed as part of the initial cluster configuration via the ClusterTemplate's `policyTemplateDefaults`. The controller validates LCA is present before proceeding with seed generation.
+- **`var-lib-containers` partition**: The ClusterTemplate's `clusterInstanceDefaults` must include the MachineConfig that creates a separate `/var/lib/containers` partition shared between stateroots.
+- **OADP Operator**: Required by LCA for backup/restore operations during seed generation.
+
+These are the responsibility of the cluster template author. The controller validates their presence but does not install them.
+
+## Proposed API Changes
+
+All new attributes go under `upgradeDefaults` / `upgradeParameters` (the existing extensible JSON schema), following the same merge-and-validate pattern used by `clusterVersion` and `imageBasedGroupUpgrade`.
+
+Today two mutually-exclusive upgrade-type keys are recognized — `clusterVersion` and `imageBasedGroupUpgrade` — plus the optional `clusterUpgradeTimeout` and `intermediateVersion` (EUS) keys. `seedGeneration` becomes a third upgrade-type key. Adding it requires updating **both**
+enforcement points that currently require *exactly one of* the two existing types:
+
+- **Schema validation** — `validateUpgradeParametersSchema` / `validateUpgradeTypeProperty` in `clustertemplate_controller.go`, which today require exactly one of `clusterVersion` / `imageBasedGroupUpgrade` in the `templateParameterSchema`.
+- **Runtime parsing** — `parseUpgradeConfig` in `provisioningrequest_upgrade.go`, which today errors if both types are present or if neither is present.
+
+Both must be taught that `seedGeneration` is a valid third type (still mutually exclusive with the other two).
+
+### New key: `seedGeneration`
+
+A new top-level key in `upgradeDefaults`, mutually exclusive with `clusterVersion` and `imageBasedGroupUpgrade`:
+
+```yaml
+# In ClusterTemplate spec.templateDefaults.upgradeDefaults
+upgradeDefaults:
+  seedGeneration:
+    # Required: full pull-spec for the seed image to be published
+    seedImage: quay.io/my-org/seed-image:4.Y.Z
+    # Required: reference to a Secret (in the ClusterTemplate namespace)
+    # containing registry credentials for pushing the seed image.
+    # The Secret must have a 'seedAuth' key with base64-encoded
+    # docker/podman auth JSON (same format as LCA's seedgen Secret).
+    seedAuthSecretRef:
+      name: seed-registry-credentials
+    # Optional: custom recert image override (LCA default used if omitted)
+    recertImage: ""
+    # Optional: live ISO generation configuration. When present, the
+    # controller builds a live installation ISO after seed generation
+    # and uploads it to an external HTTPS server.
+    liveISO:
+      # Required: the OCP release image to extract openshift-install from.
+      # In disconnected environments this may be the canonical release
+      # pull-spec (redirected to the mirror by the hub-derived mappings)
+      # or a direct mirror pull-spec.
+      releaseImage: my-mirror.example.com/ocp-release:4.Y.Z-x86_64
+      # Required: disk device path on the target servers
+      installationDisk: /dev/disk/by-path/pci-0000:43:00.0-nvme-1
+      # Optional: SSH public key baked into the ISO for debugging access
+      sshKey: "ssh-rsa AAAA..."
+      # Required: reference to a Secret containing SSH credentials for
+      # uploading the ISO to the HTTPS server. The Secret must contain:
+      #   host        - hostname or IP of the server
+      #   username    - SSH username
+      #   privateKey  - SSH private key (PEM-encoded)
+      #   remotePath  - destination file path on the server
+      #   knownHosts  - the server's SSH host public key(s) in
+      #                 known_hosts format (host-key pinning). Required:
+      #                 the upload runs with StrictHostKeyChecking=yes
+      #                 against this file and fails closed if the server's
+      #                 key is absent or does not match, preventing a
+      #                 man-in-the-middle from intercepting the ISO and
+      #                 the mounted credentials. Trust-on-first-use is
+      #                 not permitted.
+      #   caCert      - (optional) PEM-encoded CA certificate bundle for
+      #                 the HTTPS server. If provided, the controller
+      #                 validates the server's TLS certificate during
+      #                 pre-flight checks. This CA cert is also used
+      #                 by BMCs that need to trust the server when
+      #                 fetching the ISO via virtual media — the
+      #                 controller stores it in status so it can be
+      #                 referenced when configuring BMC virtual media.
+      uploadSecretRef:
+        name: iso-server-credentials
+      # Required: the HTTPS origin plus base path from which the ISO is
+      # served, backed by the same directory tree the upload writes into.
+      # The controller computes the effective per-run ISO URL as
+      # urlBase + a per-run suffix and records it in status; the full URL
+      # is never supplied directly.
+      urlBase: https://iso-server.example.com/ibi/
+      # Optional: reference to a Secret containing the pull secret for
+      # the ISO build. Must include credentials for both the seed image
+      # registry and the OCP release image registry. If omitted, the
+      # controller merges the hub cluster pull secret with the
+      # seedAuthSecretRef credentials.
+      pullSecretRef:
+        name: iso-pull-secret
+      # Optional: StorageClass for the ISO build workspace PVC (~20GB).
+      # If omitted, the cluster's default StorageClass is used.
+      storageClass: fast-storage
+      # Optional: mirror mappings for the ISO build. If omitted, the
+      # controller auto-derives them from the hub's ImageDigestMirrorSet
+      # (and legacy ImageContentSourcePolicy) resources. Set this only to
+      # target a mirror that differs from the hub's.
+      imageDigestSources:
+        - source: registry.redhat.io/openshift4/ose-cli
+          mirrors:
+            - my-mirror.example.com/openshift4/ose-cli
+      # Optional: reference to a ConfigMap (in the ClusterTemplate
+      # namespace) holding the registry CA trust bundle for the mirror.
+      # If omitted, the controller auto-derives it from the hub's
+      # image.config.openshift.io/cluster additionalTrustedCA.
+      additionalTrustBundleConfigMapRef:
+        name: mirror-registry-ca
+  # Optional: timeout for the entire operation (seed generation + ISO build)
+  clusterUpgradeTimeout: "3h"
+```
+
+### ProvisioningRequest overrides
+
+Per-PR overrides are supplied via `templateParameters.upgradeParameters.seedGeneration`, following the existing merge precedence (PR overrides CT defaults):
+
+```yaml
+# In ProvisioningRequest spec.templateParameters
+upgradeParameters:
+  seedGeneration:
+    # Override the seed image tag for this specific generation
+    seedImage: quay.io/my-org/seed-image:4.Y.Z-custom
+```
+
+**Validation applies to the merged object, not the raw override.** A PR
+override is intentionally partial — the example above supplies only
+`seedImage`, relying on the ClusterTemplate defaults for
+`seedAuthSecretRef`, `liveISO`, and the rest. Required-field validation
+(`required: [seedImage, seedAuthSecretRef]`, and the `liveISO` required
+set) must therefore run **after** the CT defaults are merged over the PR
+overrides, not against the raw `spec.templateParameters` in isolation.
+
+There is a specific ordering hazard here that the implementation must
+resolve. The admission webhook today calls
+`ValidateTemplateInputMatchesSchema` on the **raw** `spec.templateParameters`
+*before* `ValidateUpgradeInput` runs, and that first call does **not** merge
+`TemplateDefaults.UpgradeDefaults`. If the `seedGeneration` sub-schema
+carries `required: [seedImage, seedAuthSecretRef]` (and the `liveISO`
+required set), a partial override supplying only `seedImage` is rejected at
+that first gate before any merge happens. Two acceptable fixes: (a) merge
+`UpgradeDefaults` into the effective object *before* the schema check so the
+same validated document the controller acts on is what admission sees; or
+(b) keep the raw-params schema check structural only (types/patterns) and
+move the `required` enforcement for `seedGeneration` into the
+post-merge `ValidateUpgradeInput` path. This proposal specifies option (a) —
+validate the merged object — so a partial override is never rejected for
+missing fields the defaults provide, and admission and the controller agree
+on one document. This ordering must be covered by a test that submits a
+`seedImage`-only override against defaults that provide the rest.
+
+**Restricting PR-controlled outbound targets and credential selection.**
+Two distinct classes of `seedGeneration` field are dangerous in the hands
+of a less-trusted PR author:
+
+- **Outbound targets** that drive hub-side network egress while credentials
+  are mounted: `liveISO.urlBase`, `liveISO.releaseImage`, `seedImage`,
+  `liveISO.imageDigestSources` / `additionalTrustBundleConfigMapRef`.
+  Overriding these can redirect hub egress to attacker-controlled or
+  internal endpoints (SSRF) or push/pull against an unintended registry.
+- **Executable image references** that select code that runs during seed
+  generation: `recertImage`. Phase 3 passes `recertImage` to the
+  `SeedGenerator` CR, and the LCA runs it (the recert tool) on the spoke, so
+  a PR-supplied value would let an untrusted author run an arbitrary image on
+  the seed cluster. This is template-owned; when set from a PR it is rejected,
+  and the resolved value must be an allowlisted, immutable
+  (`repo@sha256:<digest>`) reference.
+- **Credential references** that select which hub Secret/ConfigMap the
+  workflow reads and mounts into the ISO-build Job: `seedAuthSecretRef`,
+  `liveISO.uploadSecretRef`, `liveISO.pullSecretRef`. Overriding these lets
+  a caller point the workflow at *any* Secret the controller's service
+  account can read, exfiltrating those credentials into an ISO/Job the
+  caller influences.
+
+The default posture is that **all** of these fields are template-owned:
+they are set by trusted authors in `upgradeDefaults` and are **not**
+exposed in `templateParameterSchema.upgradeParameters` (so admission
+rejects any attempt to override them, making them effectively immutable
+from the PR side). The only field expected to be overridable is a benign
+one such as the `seedImage` tag *when* the deployment trusts its PR
+authors. Where a deployment must accept these overrides from less-trusted
+principals, it must enforce admission checks rather than trust the value:
+validate that Secret/ConfigMap references resolve to an allowlisted set,
+that URL schemes are `https`, and that resolved destinations pass an egress
+allowlist rejecting private and link-local addresses after DNS resolution.
+Requiring `https` alone is **not** sufficient SSRF protection.
+
+### Schema in templateParameterSchema
+
+The ClusterTemplate's `templateParameterSchema` would include the `seedGeneration` sub-schema under `upgradeParameters`, following the same pattern as `imageBasedGroupUpgrade`.
+
+Two points about this schema, both tied to the security posture above:
+
+- **Declaring a field here does not make it PR-overridable.** Because the
+  design validates the **merged** object (defaults over PR input — option (a)
+  above), the schema must describe the full `seedGeneration` shape, including
+  the credential and outbound-target fields, or the merged document (which
+  carries those fields from `upgradeDefaults`) would fail validation. JSON
+  Schema alone therefore cannot express "present in defaults but forbidden
+  from PR input." Template-ownership of `seedAuthSecretRef`, `recertImage`,
+  `liveISO.releaseImage`, `uploadSecretRef`, `urlBase`, `pullSecretRef`,
+  `imageDigestSources`, and `additionalTrustBundleConfigMapRef` is instead
+  enforced by an **admission check on the raw `spec.templateParameters`**
+  that rejects any of these keys appearing in PR input unless the deployment
+  has explicitly opted them in (see the security posture above). The schema's
+  job is structural validation of the merged object; the admission check is
+  what makes these fields effectively immutable from the PR side.
+- **`additionalProperties: false` at every object level.** Unknown or
+  mistyped keys are rejected rather than silently ignored, so a typo like
+  `seedimage` or an attempt to smuggle an unrecognized field fails admission
+  instead of being dropped.
+
+```yaml
+upgradeParameters:
+  properties:
+    seedGeneration:
+      type: object
+      additionalProperties: false
+      properties:
+        seedImage:
+          type: string
+          description: Full pull-spec for the seed container image to publish
+          minLength: 1
+          pattern: "^([a-z0-9]+://)?[\\S]+$"
+        seedAuthSecretRef:
+          type: object
+          additionalProperties: false
+          properties:
+            name:
+              type: string
+          required: [name]
+        recertImage:
+          type: string
+          description: >
+            Override for the recert tool image used during seed generation.
+            Template-owned (see the security posture and the admission check
+            above): rejected as PR input, and when set it must be an
+            allowlisted, immutable digest reference (repo@sha256:<digest>),
+            because Phase 3 passes it to the SeedGenerator CR where it runs
+            as executable code during seed generation.
+        liveISO:
+          type: object
+          additionalProperties: false
+          properties:
+            releaseImage:
+              type: string
+              description: >
+                OCP release image to extract openshift-install from.
+                In disconnected environments, either the canonical release
+                pull-spec (redirected by the hub-derived mirror mappings)
+                or a direct mirror pull-spec.
+              minLength: 1
+            installationDisk:
+              type: string
+              description: Disk device path on the target servers
+              minLength: 1
+            sshKey:
+              type: string
+              description: SSH public key for debugging access to pre-provisioned servers
+            uploadSecretRef:
+              type: object
+              additionalProperties: false
+              properties:
+                name:
+                  type: string
+              required: [name]
+            urlBase:
+              type: string
+              description: >
+                HTTPS origin plus base path from which the uploaded ISO is
+                served, backed by the same directory tree the upload
+                writes into. The effective per-run ISO URL is computed by
+                the controller as urlBase + the per-run suffix and recorded
+                in status; it is never supplied directly.
+              minLength: 1
+            pullSecretRef:
+              type: object
+              additionalProperties: false
+              properties:
+                name:
+                  type: string
+              required: [name]
+            storageClass:
+              type: string
+              description: >
+                StorageClass for the ISO build workspace PVC (~20GB).
+                Uses the cluster default StorageClass if omitted.
+            imageDigestSources:
+              type: array
+              description: >
+                Mirror mappings for the ISO build. Auto-derived from the
+                hub's ImageDigestMirrorSet/ImageContentSourcePolicy if
+                omitted; set only to target a different mirror.
+              items:
+                type: object
+                additionalProperties: false
+                properties:
+                  source:
+                    type: string
+                  mirrors:
+                    type: array
+                    items:
+                      type: string
+                required: [source, mirrors]
+            additionalTrustBundleConfigMapRef:
+              type: object
+              additionalProperties: false
+              description: >
+                ConfigMap holding the registry CA trust bundle for the
+                mirror. Auto-derived from the hub's image config
+                additionalTrustedCA if omitted.
+              properties:
+                name:
+                  type: string
+              required: [name]
+          required: [releaseImage, installationDisk, uploadSecretRef, urlBase]
+      required: [seedImage, seedAuthSecretRef]
+```
+
+## Controller Workflow
+
+### Functional Overview
+
+At a functional level, the operator declares — in the cluster definition — that a
+given cluster type should produce a seed image (and, optionally, a ready-to-use
+installation ISO), and the platform performs the rest as a single, self-service
+operation reported through the normal API:
+
+1. **Declare intent** — the cluster definition names where to publish the seed
+   image and, optionally, how to build and deliver the installation ISO.
+2. **Build a reference cluster** — the platform provisions a normal cluster to
+   serve as the template for the image.
+3. **Sanitize it** — everything that ties the cluster to *this* management
+   environment is removed, so the captured image is clean and portable and a
+   clone will not accidentally re-register with the original hub.
+4. **Capture the golden image** — the seed image is generated and published to
+   the operator-named registry.
+5. **Produce the installation media** — the bootable ISO is built from that image
+   and uploaded to the server the field servers boot from, handling the
+   disconnected-registry and certificate details automatically.
+6. **Report and reclaim** — results (image location, ISO URL) are surfaced in the
+   API; the reference cluster is treated as **disposable** and the operator tears
+   it down to reclaim the hardware once the image is captured.
+
+The value: a repeatable API operation replaces a manual, expert-only runbook;
+progress and results are visible instead of requiring SSH-and-tail-logs;
+prerequisite and credential problems fail fast before the long image build; and
+air-gapped environments — the primary use case — are handled without extra
+operator effort.
+
+The rest of this section describes how the controller realizes that flow.
+
+### Trigger and Dispatch
+
+Seed generation reuses the upgrade config plumbing (`upgradeDefaults` / `upgradeParameters`, `parseUpgradeConfig`) but **not** the upgrade *trigger*. The existing `IsUpgradeRequested` returns true only when `ClusterTemplate.spec.release` is strictly greater than the spoke's
+`openshiftVersion` label. Seed generation is different: a seed image is generated from a cluster that is already *at* the target release, so `spec.release == openshiftVersion` and `IsUpgradeRequested` would return false. Seed generation therefore needs its own trigger.
+
+The trigger is the presence of the `seedGeneration` key in the merged upgrade config (PR `upgradeParameters` over CT `upgradeDefaults`) on a spoke that has reached ZTP Done with no pending upgrade.
+**The trigger deliberately does not gate on `spec.release == openshiftVersion`.** Version equality is a Phase 1 *precondition* that is checked and (on any mismatch) fails terminally — it is not part of the predicate.
+Gating the predicate on equality would leave an ahead-of-release spoke (`openshiftVersion > spec.release`) in a state where neither the seed predicate nor `IsUpgradeRequested` is true, stalling the request non-terminally with no progress. Concretely:
+
+- `parseUpgradeConfig` is extended to recognize `seedGeneration` as a third config type (see Proposed API Changes) and return it as the detected type.
+  Because a `seedGeneration` config is **not** an upgrade config, it is never a valid input to `handleUpgrade` — the reconciler must route it to the seed-generation state machine, not the upgrade switch (which has no seed-generation case and would otherwise return without action).
+- The main reconciler checks `IsSeedGenerationRequested` **before** `IsUpgradeRequested` so a `seedGeneration` request is never misrouted into the upgrade path.
+  A new predicate — `IsSeedGenerationRequested` (parallel to `IsUpgradeRequested`) — returns true when the merged upgrade config contains `seedGeneration` and the spoke has reached ZTP Done, **regardless of the version relationship**.
+- **Any version mismatch is a terminal precondition failure, not a stall — fail closed in both directions.** Seed generation requires the cluster to already be *at* `spec.release`; it does not itself perform an upgrade or a downgrade.
+  Phase 1 requires `openshiftVersion == spec.release` and fails terminally with `PreconditionChecksFailed` on either mismatch:
+  - `openshiftVersion < spec.release` (behind): "seed generation requires the cluster at spec.release; upgrade the cluster first, or configure an upgrade".
+  - `openshiftVersion > spec.release` (ahead): "seed generation requires the cluster at spec.release; the cluster is ahead of the template release — align spec.release with the running version".
+  Because the predicate fires on presence alone, a version-mismatched spoke
+  (behind or ahead of `spec.release`) reaches Phase 1 and fails terminally with
+  a clear, direction-specific message. Routing a `seedGeneration`-only config
+  through `IsSeedGenerationRequested` — rather than the upgrade switch, which has
+  no seed case — guarantees the request always reaches a state that makes
+  progress or fails closed, never one that returns without action. Both mismatch
+  directions are covered by tests.
+- The main reconciler dispatches to the seed-generation state machine when `IsSeedGenerationRequested` is true, mutually exclusively with the upgrade path.
+
+#### One-shot semantics
+
+Seed generation runs **at most once** per ProvisioningRequest. The trigger predicate above stays true after a successful run — `spec.release` still equals `openshiftVersion` and the `seedGeneration` key is still present — so dispatch is additionally gated on the `SeedGenerationCompleted` condition:
+
+- **Absent** — the state machine starts.
+- **`False` with a non-terminal reason** (`Validating`, `CleaningACMResources`, `InProgress`, `BuildingISO`) — the state machine resumes from its current phase.
+- **Terminal** — `True / Completed`, or `False` with `Failed`, `TimedOut`, or `PreconditionChecksFailed` — the controller does **not** re-enter the state machine (see [Challenge 4](#4-seed-cluster-afterlife-and-pr-terminal-state)).
+
+`PreconditionChecksFailed` is terminal: it is set by Phase 1 **before** any
+ACM detachment, so the cluster is still ACM-attached and healthy. The
+operator fixes the reported configuration and submits a new
+ProvisioningRequest rather than retrying in place (consistent with the
+one-shot model below). Because no detachment occurred, the terminal-state
+ACM suppression described in [Challenge 4](#4-seed-cluster-afterlife-and-pr-terminal-state)
+does not apply to this reason — normal reconciliation of the still-attached
+cluster continues.
+
+Transient errors inside an active phase (registry blips, spoke API timeouts,
+an evicted Job pod) are handled by the normal reconcile requeue and retried
+until the overall timeout; they do not set a terminal condition. A terminal
+`Failed` / `TimedOut` / `PreconditionChecksFailed` is never retried
+automatically.
+
+#### Idempotent resource handling
+
+Because a reconcile can be interrupted after a resource is created but before
+its status is flushed, every create in the state machine is **create-or-adopt**,
+not blind create. Deterministic names alone are not enough: a restart that
+re-issues a `create` would hit `AlreadyExists`, and a name collision with an
+unrelated object left by a prior run (or an external actor) could silently
+reuse the wrong resource. For each generated resource — the standalone
+`ServiceAccount` and its token `Secret`, the RBAC objects, the `seedgen`
+Secret, the ISO-build `Job`, its workspace `PVC`, and the per-run mirror/CA
+`ConfigMap` — the controller:
+
+- Stamps a **per-run ownership label** carrying the ProvisioningRequest name
+  and UID at creation time.
+- On create, treats `AlreadyExists` as follows: **get** the existing object and
+  compare its ownership label/UID. If it matches this run, **adopt** it (the
+  create is idempotent and reconcile continues). If it does not match — no
+  label, or a different UID — the controller fails closed rather than reusing or
+  mutating an object it does not own (a stale object from a prior run under the
+  same deterministic name is deleted and recreated only when it is provably this
+  PR's own residue).
+- Hub-side resources additionally carry an `ownerReference` to the
+  ProvisioningRequest so Kubernetes garbage-collects them if the PR is deleted
+  mid-run.
+
+Each create operation has restart-after-create test coverage: kill the
+reconcile immediately after the create and assert the next reconcile adopts
+(not duplicates, not `AlreadyExists`-fails) its own resource, and rejects a
+same-named foreign object.
+
+#### Regenerating a seed
+
+There is no in-place re-trigger. To produce a new seed — after a failure, or
+with changed configuration — the operator submits a **new**
+ProvisioningRequest, which provisions a fresh disposable cluster. This keeps
+the workflow strictly one-shot and consistent with the disposable-factory
+model: one ProvisioningRequest maps to one cluster and one seed generation
+attempt.
+
+Rather than silently ignoring a late edit, the validating webhook
+(`provisioningrequest_webhook.go`) is **extended to reject** changes to
+`upgradeParameters.seedGeneration` once `SeedGenerationCompleted` is
+terminal. The existing webhook already allows updates after provisioning
+completes but only compares a disallowed-ClusterInstance-fields set; it does
+not compare `seedGeneration`, so without this addition a changed `seedImage`
+or `urlBase` would be admitted and then dropped by the one-shot dispatch
+gate — an accepted-but-ignored change that misleads the operator. The webhook
+instead returns a validation error directing the operator to submit a new
+ProvisioningRequest. (If in-place regeneration is ever desired, it would
+require an explicit generation-aware retry operation — for example bumping a
+`seedGeneration.generation` counter that the dispatch gate treats as a new
+attempt — which is out of scope here.)
+
+The spoke's `ManagedCluster` on the hub is left intact throughout the process — the controller never deletes it, so there is no re-provisioning or ClusterInstance recreation. What must be removed is the spoke-side ACM *agent state* (the klusterlet and all addon agents), because it
+would otherwise be captured in the seed image and cause a clone to register with the original hub on first boot.
+
+Because a proper klusterlet teardown deletes the ACM agent namespaces (`open-cluster-management-agent*`) — where the existing `ManagedServiceAccount` token and its RBAC live — the controller cannot rely on that token during generation. Instead, before any ACM removal, it mints a
+**standalone long-lived token** (a dedicated ServiceAccount, token Secret, and RBAC RoleBinding, named deterministically from the ProvisioningRequest) in a non-ACM namespace on the spoke and rebuilds the spoke client from it. This token survives the full ACM teardown and provides
+spoke API access for the entire workflow. The seed cluster is a disposable factory, so ACM is **not** restored after generation: the controller removes the standalone token and workflow artifacts during cleanup, sets a terminal `SeedGenerationCompleted` condition, and the operator
+deletes the ProvisioningRequest to reclaim the hardware.
+
+Note that lca-cli's own cleanup does **not** strip klusterlet/registration identity, so the controller must remove it explicitly — it cannot defer this to LCA's seed preparation.
+
+The workflow is a multi-phase state machine tracked via a new `SeedGenerationCompleted` condition and `SeedGenerationStatus` in the PR status.
+
+### Phase 1: Validation
+
+- Verify `seedGeneration` configuration is present and valid
+- Verify the `seedAuthSecretRef` Secret exists in the ClusterTemplate namespace and contains the `seedAuth` key
+- **Validate registry access**: Decode the `seedAuth` credentials and perform a token exchange against the target registry (extracted from the `seedImage` pull-spec) to confirm the credentials are valid and have push access. This catches misconfigured credentials or unreachable
+  registries before the lengthy seed generation process begins. Report a `PreconditionChecksFailed` condition with a specific message on failure (e.g., "registry authentication failed for quay.io/my-org/seed-image", "registry quay.io is not reachable").
+- Verify the spoke cluster is fully provisioned (ZTP Done)
+- Verify the spoke has the `var-lib-containers` partition (check for the MachineConfig via spoke client)
+- Verify the LCA operator is installed and Available on the spoke (check the `openshift-lifecycle-agent` namespace for the LCA operator Deployment via spoke client)
+- Verify the OADP operator is installed on the spoke
+- If `liveISO` is configured:
+  - Verify the `uploadSecretRef` Secret exists and contains the required keys (`host`, `username`, `privateKey`, `remotePath`, `knownHosts`). A missing or empty `knownHosts` is a `PreconditionChecksFailed` — the upload fails closed rather than falling back to trust-on-first-use
+  - If `caCert` is present in the upload Secret, validate that it is a well-formed PEM certificate bundle
+  - Verify HTTPS connectivity to the ISO server: perform a TLS handshake against the `urlBase` host using the `caCert` from the upload Secret (or the system trust store if `caCert` is not provided). Report `PreconditionChecksFailed` if the certificate cannot be verified — this catches
+    CA misconfigurations before the ISO build
+  - Resolve the mirror configuration (hub-derived `ImageDigestMirrorSet`/`ImageContentSourcePolicy` mappings and `additionalTrustedCA` trust bundle, or the `liveISO` overrides) and verify the `releaseImage` is reachable and credentials are valid using it (attempt
+    `oc adm release info <releaseImage>` equivalent)
+  - Verify the `releaseImage` version reported by `oc adm release info` matches `ClusterTemplate.spec.release`. The ISO's `seedVersion` and the extracted `openshift-install` must be the same OCP version as the seed; report `PreconditionChecksFailed` on mismatch (e.g., "releaseImage is
+    4.Y.Z but spec.release is 4.Y.W")
+  - **Resolve and pin the `releaseImage` digest.** `releaseImage` is often a
+    mutable tag (e.g. `...:4.Y.Z-x86_64`). Resolve it to an immutable
+    `repo@sha256:<digest>` during this check (from the same
+    `oc adm release info` call) and persist it in
+    `SeedGenerationStatus.ReleaseImageDigest`, so Phase 4 extracts
+    `openshift-install` from exactly the release validated here rather than
+    re-resolving a tag that could have moved between validation and build.
+    Persisting to status (not an in-memory value) is required so the pin
+    survives a controller restart between Phase 1 and Phase 4. Report
+    `PreconditionChecksFailed` if the digest cannot be resolved.
+    In disconnected environments this resolution has a subtlety: `IDMS`/`ICSP`
+    only redirect **by-digest** pull specs, not tags, so a mutable-tag
+    `releaseImage` will not be redirected to the mirror by the hub's
+    `ImageDigestMirrorSet`/`ImageContentSourcePolicy`. Phase 1 therefore
+    requires one of: a by-digest `releaseImage`, a direct mirror pull-spec, or
+    a hub `ImageTagMirrorSet` covering the tag; if a mutable tag has no
+    tag-mirror or direct-mirror path, resolution fails closed with
+    `PreconditionChecksFailed` rather than silently reaching the (unreachable)
+    upstream registry
+  - **An `ImageTagMirrorSet`-only resolution must be translated into a
+    by-digest mapping for Phase 4.** When the tag was reachable *only* through
+    an `ImageTagMirrorSet` (no by-digest `releaseImage`, no direct mirror
+    pull-spec, no covering `IDMS`/`ICSP`), the digest that Phase 1 persists to
+    `ReleaseImageDigest` is a `repo@sha256:<digest>` on the *source* registry
+    — and Phase 4 passes exactly that digest to
+    `oc adm release extract --idms-file`, which honors only `IDMS`/`ICSP`.
+    Because tag mirrors do **not** redirect digest references, Phase 4 would
+    then fail (or reach the unreachable source) despite Phase 1 passing.
+    Phase 1 therefore does not accept ITMS coverage on its own: it must
+    resolve the digest **through the mirror** and record an equivalent
+    by-digest mirror mapping (source repo → mirror repo, keyed on the resolved
+    digest) that is emitted into the generated `idms.yaml` Phase 4 consumes. If
+    no such digest mapping can be derived from the ITMS mirror (i.e. the mirror
+    repo does not actually hold the resolved digest), resolution fails closed
+    with `PreconditionChecksFailed` rather than deferring the failure to
+    Phase 4
+  - **Validate the effective ISO-build pull secret against both images.** The
+    pull secret used by the ISO-build Job is not the same credential as
+    `seedAuthSecretRef` (which only needs push access to the seed registry).
+    Resolve the effective pull secret exactly as Phase 4 will — the contents
+    of `liveISO.pullSecretRef` if provided, otherwise the hub cluster pull
+    secret (`openshift-config/pull-secret`) merged with the
+    `seedAuthSecretRef` credentials — and confirm it can authenticate to
+    **both** the `seedImage` registry and the `releaseImage` registry (after
+    mirror redirection). Checking only that the Secret exists is
+    insufficient: a `pullSecretRef` that can reach the release mirror but
+    lacks credentials for the seed mirror (or vice versa) passes a
+    mere-existence check and then fails deep in the ISO build. Report
+    `PreconditionChecksFailed` naming the registry that rejected the
+    credentials.
+- **Condition**: `SeedGenerationCompleted = False / Reason: Validating`
+
+### Phase 2: ACM Agent Cleanup
+
+Remove all ACM agent state from the spoke so it doesn't contaminate the seed image. The `ManagedCluster` on the hub is left intact.
+
+1. **Mint a standalone access token**: Using the current (MSA-based) spoke client, create a dedicated ServiceAccount in a non-ACM namespace on the spoke (e.g. the `openshift-lifecycle-agent` namespace), named deterministically from
+   the ProvisioningRequest, plus a **long-lived token**. Because the token
+   must outlive the whole operation (2h/3h) and survive ACM teardown, it is
+   issued as a **`kubernetes.io/service-account-token`-typed Secret annotated
+   with `kubernetes.io/service-account.name`**, not by relying on
+   auto-mounted tokens (absent since Kubernetes 1.24) or a `TokenRequest`
+   token (bounded by a maximum TTL and thus liable to expire mid-operation).
+   The legacy-style token Secret yields a non-expiring credential the
+   controller can read once and rebuild the spoke client from; if the Secret
+   is not populated with a token within a short poll, Phase 2 fails
+   `PreconditionChecksFailed` before any teardown. Phase 5 deletes the
+   ServiceAccount and Secret (which invalidates the token) on every terminal
+   path.
+
+   Bind the required RBAC least-privilege:
+   - A namespaced `RoleBinding` for the namespaced `seedgen` Secret in the LCA
+     namespace.
+   - A `ClusterRole`/`ClusterRoleBinding` scoped to **only** the genuinely
+     cluster-scoped needs: `create`/`get`/`list`/`watch`/`delete` on the
+     cluster-scoped `SeedGenerator` resource (the LCA `SeedGenerator` is the
+     cluster-scoped singleton `seedimage`, so a namespaced `RoleBinding` cannot
+     authorize creating, monitoring, or deleting it); `delete` **and
+     `get`/`list`/`watch`** on the cluster-scoped `Klusterlet` resource (a
+     namespaced `RoleBinding` cannot authorize either operation on a
+     cluster-scoped object, and the teardown poll in step 5 needs read access to
+     observe the `Klusterlet` disappear), plus `get`/`list`/`watch` on
+     `namespaces` (inherently cluster-scoped, so it cannot be limited by a
+     `RoleBinding`).
+   - **Pod read permissions are bound per-namespace, not cluster-wide:**
+     `get`/`list`/`watch` on `pods` is granted through `RoleBinding` objects
+     in the specific agent namespaces the poll watches
+     (`open-cluster-management-agent*`), so the standalone token cannot read
+     pod specs in unrelated namespaces.
+   - **Self-cleanup permissions (so Phase 5 can revoke this very
+     credential).** After ACM/MSA teardown, the standalone token is the *only*
+     path back to the spoke, so it must be able to delete its own artifacts.
+     The grants therefore also include `delete` on the namespaced `seedgen`
+     Secret (via the LCA-namespace `RoleBinding`) and on the cluster-scoped
+     `SeedGenerator` CR (via the `ClusterRole`/`ClusterRoleBinding` above),
+     `delete` on the credential's own `ServiceAccount` and token `Secret`
+     (namespaced), and `delete` on its namespaced `RoleBinding`s. `delete` is
+     not escalation, so this needs no additional `escalate`/`bind`.
+   - **The token does not delete its own `ClusterRole`/`ClusterRoleBinding` —
+     that self-deletion is unsound.** A `ClusterRoleBinding` confers the very
+     permissions the token would use to delete it: removing the binding first
+     immediately revokes the `delete` verb, so the paired `ClusterRole` can no
+     longer be removed; removing the `ClusterRole` first strips the same verb
+     and orphans the binding. Either order leaves one cluster-scoped object
+     behind, so a credential cannot reliably remove the RBAC that grants it.
+     Instead, Phase 5 deletes the `ServiceAccount` and token `Secret` **last**;
+     once the subject `ServiceAccount` is gone the residual
+     `ClusterRole`/`ClusterRoleBinding` grant nothing to anyone (the binding's
+     subject no longer resolves). These two **inert** cluster-scoped objects are
+     reclaimed when the disposable seed cluster is torn down (PR deletion). If
+     the cluster is instead retained for diagnostics, the still-attached hub
+     removes them out of band using an independently granted identity — never
+     the standalone token itself. Because the token never needs cluster-scoped
+     `delete`, that grant is dropped entirely, further shrinking its blast
+     radius.
+
+   Rebuild the spoke client from this token. All subsequent phases use this
+   client, which survives the ACM teardown below. Phase 5 removes the
+   namespaced `RoleBinding`s and, last, the credential itself; the inert
+   cluster-scoped `ClusterRole`/`ClusterRoleBinding` are reclaimed with the
+   disposable cluster (or by the hub out of band) as described above.
+
+   **MSA bootstrap authority (precondition).** The MSA-based client performs
+   the entire bootstrap of the standalone credential, so it needs more than the
+   RBAC-creation verbs. Specifically it requires, on the spoke:
+   - `create` on `serviceaccounts` and `secrets` in the LCA namespace (to make
+     the standalone `ServiceAccount` and its token `Secret`) and `get` on that
+     `Secret` (to read the token the token-controller populates).
+   - `create` on `rolebindings` in each namespace where a namespaced
+     `RoleBinding` is bound (the LCA namespace and the
+     `open-cluster-management-agent*` agent namespaces for pod reads).
+   - `create` on the cluster-scoped `ClusterRole`/`ClusterRoleBinding` **plus
+     `escalate`/`bind`** (or an aggregated role already granting them) —
+     Kubernetes escalation prevention allows creating an RBAC object only if the
+     creator already holds the verbs it confers.
+
+   All of this is a **precondition**: if the MSA client lacks any of these
+   verbs — or the agent namespaces do not yet exist — Phase 2 fails with
+   `PreconditionChecksFailed` **before** any destructive ACM removal, so the
+   spoke is never left partially detached without a working access path.
+2. **Record detachment intent**: Persist
+   `SeedGenerationStatus.DetachmentStarted = true` (and flush the status
+   update) **before** step 3 performs the first destructive ACM removal. This
+   marker must be durable before, not after, any irreversible teardown so that
+   a controller restart mid-detachment still treats the spoke as (partially)
+   detached — see [Challenge 4](#4-seed-cluster-afterlife-and-pr-terminal-state).
+3. **Delete hub-side addon CRs**: Delete all `ManagedClusterAddOn` resources from the spoke's namespace on the hub (including `managed-serviceaccount`). This tells the ACM addon framework to stop reconciling them.
+4. **Delete the klusterlet**: Delete the `Klusterlet` CR on the spoke (via the standalone-token client). The klusterlet operator tears down the registration and work agents and their namespaces (`open-cluster-management-agent*`) — including the identity secrets
+   (`bootstrap-hub-kubeconfig`, `hub-kubeconfig-secret`) that would otherwise be captured in the seed. Deleting only the klusterlet Deployment is **not** sufficient: those secrets persist in etcd and on disk.
+5. **Wait for teardown**: Poll the spoke until the klusterlet and addon agent namespaces/pods are gone.
+
+- **Condition**: `SeedGenerationCompleted = False / Reason: CleaningACMResources`
+
+### Phase 3: Trigger Seed Generation
+
+Using the standalone-token spoke client established in Phase 2:
+
+1. **Create the seedgen Secret**: Deliver the `seedgen` Secret to the `openshift-lifecycle-agent` namespace on the spoke, reading credentials from the hub Secret referenced by `seedAuthSecretRef`.
+2. **Create the SeedGenerator CR**: Apply the singleton `seedimage` SeedGenerator CR with the configured `seedImage` (and optionally `recertImage`).
+3. **Monitor progress**: Poll the SeedGenerator CR status conditions. The LCA orchestrates the full seed image lifecycle:
+   - System validation
+   - Cluster operator shutdown
+   - Seed image generation via lca-cli (`lca_image_builder` container)
+   - Image push to registry
+   - Cluster operator recovery
+4. **Capture the pushed digest**: On completion, read the digest of the
+   pushed seed image from the SeedGenerator status and record it in
+   `SeedGenerationStatus.SeedImage` as an immutable
+   `<repository>@sha256:<digest>` reference. The configured
+   `seedGeneration.seedImage` is a **mutable tag**; between the push in this
+   phase and the ISO build in Phase 4 that tag could be overwritten to point
+   at a different image, so all downstream consumption must pin the digest
+   rather than re-resolving the tag. The digest is taken **only** from the
+   authoritative output of the push itself — the digest the SeedGenerator/LCA
+   reports for the image it just pushed, which is produced atomically with the
+   push and therefore provably identifies this run's image. The controller
+   does **not** fall back to a post-hoc registry tag lookup (a manifest
+   `HEAD`/`GET`): resolving the mutable tag after the fact cannot prove the
+   returned image is the one this run produced — another writer can move the
+   tag before or during the lookup — so a tag lookup would defeat the very
+   integrity guarantee this pin exists to provide. If the SeedGenerator/LCA
+   does not surface an immutable digest for the pushed image, the workflow
+   **fails closed** with a terminal `Failed` rather than building an ISO from
+   an unverifiable tag.
+
+- **Condition**: `SeedGenerationCompleted = False / Reason: InProgress`
+- **Status message**: Reflects the SeedGenerator's condition messages (e.g., `SeedGenInProgress=True` → "Generating seed image", `SeedGenCompleted=True` → generation finished)
+
+### Phase 4: Live ISO Generation
+
+Live ISO generation is a first-class, fully automated part of the workflow. This phase is *conditional on configuration*: it runs whenever the `liveISO` block is present under `seedGeneration`. A template that only needs to publish a seed image (building ISOs elsewhere) may omit
+`liveISO`, in which case the workflow skips directly to Phase 5.
+
+The controller creates a Kubernetes Job on the hub cluster that builds the live installation ISO and uploads it to the configured HTTPS server. The Job runs in the O-Cloud Manager namespace.
+
+**Job workflow:**
+
+1. **Resolve disconnected mirror configuration**: In a disconnected/mirrored environment the Job needs the same mirror mappings and registry trust the hub already uses. Rather than duplicating this in the ClusterTemplate, the controller **auto-derives it from the hub** by default:
+   - **Mirror mappings**: Read the hub's `ImageDigestMirrorSet` resources (field `spec.imageDigestMirrors`)
+     and, if present, legacy `ImageContentSourcePolicy` resources (field `spec.repositoryDigestMirrors` —
+     **not** `imageDigestMirrors`, which ICSP does not define). Translate their source → mirrors entries into
+     both IBI `imageDigestSources` entries and an equivalent `idms.yaml` passed to
+     `oc adm release extract --idms-file`. Reading the wrong field for ICSP yields empty mappings and silently breaks disconnected release extraction, so the ICSP-only path must be covered by a dedicated test.
+     **Preserve `mirrorSourcePolicy`.** When an `ImageDigestMirrorSet` entry sets `mirrorSourcePolicy: NeverContactSource`, copy that policy into the generated `idms.yaml` alongside its `source` and `mirrors`.
+     If it is dropped, `oc adm release extract --idms-file` may fall back to the source registry after a mirror miss, causing upstream egress on a connected hub or an extraction failure on a disconnected one. A dedicated test covers the `NeverContactSource` case.
+   - **Registry trust**: Read the ConfigMap named by `image.config.openshift.io/cluster` `spec.additionalTrustedCA` (in `openshift-config`) and concatenate its CA values into a single PEM bundle, used as the IBI `additionalTrustBundle` and mounted into the Job pod's trust store so
+     `oc` can reach the mirror.
+
+   Optional overrides let a template author point the ISO build at a mirror that differs from the hub's: `liveISO.imageDigestSources` and `liveISO.additionalTrustBundleConfigMapRef`, when set, **replace** the corresponding hub-derived values. On a connected hub with no mirror set and
+   no overrides, nothing is injected and images resolve from their canonical registries.
+
+2. **Extract `openshift-install`**: Run `oc adm release extract --command=openshift-install --idms-file=<derived idms.yaml> <pinned releaseImage digest>` to obtain the binary matching the OCP version from `ClusterTemplate.spec.release`, using the derived registry trust. This uses the **immutable
+   `repo@sha256:<digest>` reference read from `SeedGenerationStatus.ReleaseImageDigest`** (resolved and persisted in Phase 1), not the configured tag, so the installer is extracted from exactly the release that was validated.
+   If that field is empty when `liveISO` is configured (e.g. status was lost), the Job fails terminally rather than re-resolving the tag. The `releaseImage` field is
+   required; in disconnected environments it may be given either as the canonical release pull-spec (redirected to the mirror by the derived mappings) or as a direct mirror pull-spec. There is no default public release image fallback.
+
+3. **Generate `ImageBasedInstallationConfig`**: Build the configuration from the `liveISO` parameters and the resolved mirror config:
+
+   ```yaml
+   apiVersion: v1beta1
+   kind: ImageBasedInstallationConfig
+   metadata:
+     name: ibi-config
+   seedImage: <SeedGenerationStatus.SeedImage>   # immutable repo@sha256:... digest, not the mutable tag
+   seedVersion: <ClusterTemplate.spec.release>
+   installationDisk: <liveISO.installationDisk>
+   sshKey: <liveISO.sshKey>       # if provided
+   pullSecret: <merged pull secret>
+   imageDigestSources:           # hub-derived (or liveISO override); omitted when empty
+     - source: registry.redhat.io/...
+       mirrors:
+         - my-mirror.example.com/...
+   additionalTrustBundle: |      # hub-derived (or liveISO override); omitted when empty
+     -----BEGIN CERTIFICATE-----
+     ...
+   ```
+
+   The pull secret is constructed by merging the hub cluster pull secret (`openshift-config/pull-secret`) with the `seedAuthSecretRef` credentials. If `liveISO.pullSecretRef` is provided, its contents are used directly instead of the auto-merged secret. In disconnected environments,
+   the pull secret must include credentials for both the local seed image mirror and the OCP release image mirror.
+
+4. **Build the ISO**: Run `openshift-install image-based create image --dir <workdir>`. This pulls the seed image, generates ignition configuration, and produces the `rhcos-ibi.iso` file. This step requires significant ephemeral storage (~15GB for seed image pull + ISO generation).
+
+5. **Upload the ISO**: SCP the ISO to the HTTPS server using the SSH credentials from `uploadSecretRef`, pinning the server host key from `knownHosts` with strict checking:
+
+   ```bash
+   scp -i <privateKey> \
+       -o StrictHostKeyChecking=yes \
+       -o UserKnownHostsFile=<knownHosts from uploadSecretRef> \
+       rhcos-ibi.iso <username>@<host>:<remotePath>
+   ```
+
+   Strict host-key checking is mandatory and there is no
+   trust-on-first-use fallback: if the server's key is not present in
+   `knownHosts` or does not match, the upload fails closed. This prevents
+   a man-in-the-middle from impersonating the ISO server and capturing the
+   mounted SSH private key while a bogus (or malicious) ISO is served to
+   the BMCs.
+
+   The upload itself uses SSH (encrypted in transit). The Job computes the
+   ISO's SHA-256 digest locally before upload and records the byte size. After
+   upload, the controller verifies the served artifact is exactly the one it
+   built, not merely that *some* file is reachable:
+   - A HEAD/`Content-Length` check against the effective ISO URL alone is insufficient — it
+     confirms reachability and TLS trust but cannot detect a stale ISO from a
+     previous run, a truncated upload with a matching size, or a same-size
+     substitution.
+   - Uploads therefore target a **unique, per-run remote path** (the
+     `remotePath` from `uploadSecretRef` disambiguated by the
+     ProvisioningRequest name and the seed image digest) so a new build never
+     silently overwrites or is confused with an older ISO at a shared URL.
+   - The controller then confirms **content identity** — this step is
+     **mandatory**, not best-effort. It fetches the digest over the SSH
+     channel it already trusts (`sha256sum` on the remote `remotePath`) and
+     compares it to the locally computed digest; a mismatch or an inability
+     to obtain the remote digest is a terminal `Failed`. Because SSH already
+     gives an authenticated, integrity-checked channel to the exact file just
+     written, this comparison is always available and does not depend on the
+     server exposing anything extra.
+   - The `remotePath` → effective-ISO-URL relationship is **deterministic and
+     explicitly defined**, not merely asserted, so the artifact verified over
+     SSH is provably the same object addressed by the recorded URL. The upload
+     endpoint (`uploadSecretRef.host` + `remotePath`) and the HTTPS origin
+     (`liveISO.urlBase`) must be two views of the **same backing store**; the
+     design derives both sides from a single input and the controller
+     validates the binding before recording `ISOURL`:
+     - `liveISO.urlBase` is the only URL input: the HTTPS origin + base path
+       served from the same directory tree the SSH `remotePath` writes into.
+       Both the SSH target and the effective ISO URL are computed from it plus
+       the per-run suffix (the ProvisioningRequest name + seed image digest +
+       filename) — one rule applied identically to both sides, so there is no
+       independently supplied full URL that could drift from `remotePath`.
+     - Before recording `ISOURL`, the controller validates the binding: the
+       path component of the computed effective ISO URL must equal the
+       served-root-relative form of `remotePath`. A mismatch (e.g. a `urlBase`
+       whose served root does not correspond to where the file was actually
+       written) is a terminal `Failed`, because SSH would otherwise verify one
+       file while status advertises another.
+     - **Path binding is not sufficient on its own, because `uploadSecretRef.host`
+       and the `urlBase` host are independent inputs.** Matching path components
+       do not prove the HTTPS origin and the SSH upload target are the same
+       backing store — an SSH upload to host A and an HTTPS `urlBase` on host B
+       that happen to share a path would pass a path-only check while serving
+       different bytes. The controller therefore binds the hosts as well, in
+       one of two ways, and records `ISOURL` only when one holds:
+       - **Same-host fast path:** the `urlBase` host resolves to the same
+         backing store as `uploadSecretRef.host` (identical host, or an
+         explicitly configured alias mapping the two to one store). Here the
+         mandatory SSH digest verification already covers the served bytes.
+       - **Cross-host path (or any time the same-store relationship cannot be
+         proven): mandatory HTTPS content-digest verification.** The controller
+         fetches the artifact over HTTPS from the computed effective ISO URL
+         (using the `urlBase` `caCert`), hashes it, and requires it to equal the
+         locally computed digest before recording `ISOURL`. In this case the
+         HTTPS check is **not** optional and a HEAD/sidecar is not accepted as a
+         substitute — the actual served bytes at `urlBase` must be hashed. A
+         mismatch or unreachable URL is a terminal `Failed`.
+     - `ISOURL` is recorded **only after** the path binding, the host binding
+       (same-store or mandatory HTTPS content-digest verification), and the
+       mandatory SSH digest verification all pass.
+   - Optionally, if the server publishes a companion `.sha256` sidecar, an
+     HTTPS `GET` of that small file (using the `caCert`) additionally
+     confirms the *publicly served* copy without re-downloading the multi-GB
+     ISO. When present it is compared and must match; when absent the
+     mandatory SSH-side verification above still stands. A plain HEAD is only
+     a "served over HTTPS" liveness probe, never the integrity check.
+
+   The verified SHA-256 digest and the resolved per-run effective ISO URL are recorded
+   in status (`ISODigest`, `ISOURL`) so downstream consumers can pin the
+   exact artifact.
+
+**Job pod spec considerations:**
+
+- The Job image uses `oc` (available from the OCP CLI tools image) and `openshift-install` (extracted at runtime)
+- **PVC for build workspace**: The controller creates a dedicated PersistentVolumeClaim (~20GB) for the ISO build workspace. The PVC is mounted into the Job pod as the working directory. This is required because the `openshift-install` command pulls the full seed image and generates
+  an ISO, which exceeds typical ephemeral storage limits. The PVC is created before the Job and deleted during Phase 5 cleanup after the ISO has been successfully uploaded. The PVC name is derived from the ProvisioningRequest name (e.g., `<pr-name>-iso-build`). The StorageClass is
+  configurable via an optional `storageClass` field in the `liveISO` config; if omitted, the cluster's default StorageClass is used.
+- **Per-run credential copies in the Job namespace.** A pod can only mount
+  Secrets from its own namespace, but the source credentials live elsewhere:
+  `seedAuthSecretRef` resolves in the **ClusterTemplate** namespace and the
+  hub pull secret is `openshift-config/pull-secret`, while the Job runs in the
+  **O-Cloud Manager** namespace. The Job therefore cannot mount either source
+  Secret directly. Before creating the Job, the controller copies the
+  credentials it needs into **short-lived, per-run Secrets in the Job
+  namespace** (named deterministically from the ProvisioningRequest), and the
+  Job references those copies. `uploadSecretRef` and the optional
+  `pullSecretRef` are name-only references that **always resolve in the
+  ClusterTemplate namespace** (the same namespace as `seedAuthSecretRef`),
+  never in the PR or Job namespace — a name-only ref cannot select a Secret
+  the caller controls elsewhere. Because that is not the Job namespace, they
+  are copied into per-run Secrets the same way. These per-run
+  copies are among the credential-bearing artifacts deleted on **every**
+  terminal path (success and failure — see Phase 5), so credentials are not
+  left lingering in the Job namespace.
+- The Job mounts: the build workspace PVC, the per-run copies of
+  `seedAuthSecretRef` (registry auth) and the merged/`pullSecretRef` pull
+  secret, `uploadSecretRef` (SSH credentials), and the resolved mirror config
+  (derived `idms.yaml` and CA trust bundle) as a ConfigMap the controller
+  generates per-run
+- `networkConfig` is intentionally excluded from the ISO configuration — network and hardware-specific configs are applied later through the IBI templates provided by the SiteConfig Operator
+- The Job's active-deadline is bounded by the remaining portion of the overall operation timeout (the `clusterUpgradeTimeout` override, or the with-ISO default of 3h — see [Timeout](#timeout)), not a separate per-Job budget
+- On Job failure, the controller surfaces a **bounded, redacted** summary of
+  the pod logs in the condition message. Raw pod logs must not be written
+  verbatim into `metav1.Condition.message`: that field is capped at 32768
+  bytes (the API server rejects longer values, which would fail the status
+  update and stall the state machine), and the ISO-build environment has
+  registry pull secrets, SSH credentials, and CA material mounted, so
+  unfiltered logs risk leaking secrets into the PR status. The controller
+  extracts a short tail (e.g. the last few lines / a fixed byte budget well
+  under the limit) and redacts known credential patterns for the condition
+  message. For deeper debugging it retains a **redacted** copy of the pod
+  logs — never the raw logs. Because the ISO-build pod has registry pull
+  secrets, SSH credentials, and CA material mounted, raw logs left with the
+  failed Job/pod would expose those credentials, so the controller redacts
+  before persisting, **deletes the original log-bearing artifacts** (the
+  failed pod and its raw logs are not kept), and retains only the bounded,
+  redacted copy under a diagnostic-retention **TTL** (see Phase 5). The
+  condition message points the operator at that redacted copy.
+
+**Hub RBAC contract for the controller.** The operator's hub service account
+needs an explicit set of permissions in the O-Cloud Manager namespace beyond
+the ACM/read permissions already listed; if any are missing the workflow
+fails with `Forbidden` or leaks artifacts. The controller therefore requires,
+in its own namespace:
+
+- `batch/jobs`: `create`, `get`, `list`, `watch`, `delete` (create and
+  monitor the ISO-build Job; delete it in Phase 5).
+- `core/persistentvolumeclaims`: `create`, `get`, `delete` (the ~20GB build
+  workspace PVC).
+- `core/secrets`: `create`, `get`, `delete` (per-run credential copies) and
+  `get` on the source Secrets in the ClusterTemplate namespace and
+  `openshift-config/pull-secret`.
+- `core/configmaps`: `create`, `get`, `delete` (the per-run mirror/CA
+  ConfigMap), `get` on the hub image-config `additionalTrustedCA`, and `get` on
+  the ConfigMap named by `liveISO.additionalTrustBundleConfigMapRef` in the
+  ClusterTemplate namespace. That override **replaces** the hub-derived trust
+  bundle (see Phase 4 step 1); without a namespaced `get` for it the override
+  fails with `Forbidden` and stops ISO generation.
+- `core/pods` and `core/pods/log`: `get`, `list` (read the build pod and its
+  logs for the redacted failure summary).
+- `config.openshift.io` `images` / `ImageDigestMirrorSet` /
+  `ImageTagMirrorSet`: `get`, `list` (derive mirror config).
+- `operator.openshift.io` `ImageContentSourcePolicy`: `get`, `list`. **ICSP
+  lives in a different API group** (`operator.openshift.io`) than IDMS/ITMS
+  (`config.openshift.io`); a single `config.openshift.io` grant cannot
+  authorize reading ICSP, so the ICSP-only mirror-resolution path would fail
+  with `Forbidden` without this separate entry. An authorization test covers
+  the ICSP-only path.
+- `addon.open-cluster-management.io` `ManagedClusterAddOn`: `get`, `list`,
+  `delete`, scoped to the managed-cluster namespace. Phase 2 deletes all
+  `ManagedClusterAddOn` CRs there (including `managed-serviceaccount`) as a
+  hub-side operation; a `get`/`list`/`watch`-only grant would fail the delete
+  with `Forbidden` **after** `DetachmentStarted` was already persisted,
+  leaving the spoke half-detached. `list` and `delete` (with the required
+  namespace scope) must be granted before that marker is written.
+
+These are enumerated so the manually-maintained controller ClusterRole (see
+the repository RBAC conventions) can be updated in one place; every artifact
+created here is deleted on both the success and failure terminal paths
+(Phase 5).
+
+**Monitoring:**
+
+The controller watches the Job status. On completion:
+
+- **Success**: Record the resolved per-run effective ISO URL in `SeedGenerationStatus.ISOURL` and the verified ISO SHA-256 digest in `SeedGenerationStatus.ISODigest`
+- **Failure**: Set `SeedGenerationCompleted = False / Reason: Failed` with the Job failure message. The cluster is left detached (no ACM restore); cleanup of workflow artifacts still proceeds (see Phase 5 for credential-artifact scrubbing).
+
+- **Condition**: `SeedGenerationCompleted = False / Reason: BuildingISO`
+
+### Phase 5: Completion and Cleanup
+
+The seed cluster is a disposable factory, so there is no ACM restoration. Once the seed (and ISO, if configured) is confirmed, the workflow verifies success, cleans up its own artifacts, and reaches a terminal state.
+
+On success (seed generation complete, and ISO generation complete if configured):
+
+1. **Record results**: Store the seed image digest reference in `SeedGenerationStatus.SeedImage` and, if ISO was built, the resolved per-run URL in `SeedGenerationStatus.ISOURL` and the verified digest in `SeedGenerationStatus.ISODigest`.
+2. **Clean up workflow artifacts**: On the spoke, delete the SeedGenerator CR and seedgen Secret first, then the standalone credential's namespaced `RoleBinding`s, and **last** the credential-bearing `ServiceAccount` and token `Secret` —
+   deleting the credential last so the token stays valid for every preceding spoke delete (see the self-cleanup permissions in Phase 2).
+   The token does **not** delete its own `ClusterRole`/`ClusterRoleBinding`
+   (that self-deletion is unsound — Phase 2); once the `ServiceAccount` is gone
+   they are inert and are reclaimed when the disposable cluster is torn down, or
+   removed by the hub out of band if the cluster is retained.
+   Delete the ISO generation Job, its build workspace PVC, the per-run credential Secret copies created in the Job namespace, and associated resources from the hub.
+3. **Update conditions**: `SeedGenerationCompleted = True / Reason: Completed`. This is a **terminal** condition — the controller does not re-run seed generation, and it suppresses the PR's ACM-dependent reconciliation (see [Challenge 4](#4-seed-cluster-afterlife-and-pr-terminal-state)).
+
+The seed cluster is left detached (ACM agents removed) and running. The operator deletes the ProvisioningRequest when ready, which tears the cluster down via the existing deletion path and reclaims the hardware.
+
+On failure (at any phase):
+
+1. **Report the error**: Capture the failure from whichever phase failed (SeedGenerator conditions, Job status, etc.).
+2. **Condition**: The reason depends on **where** the failure occurred, and
+   this distinction is load-bearing (it is what tells the terminal-state
+   handler whether the cluster is still ACM-attached). A **Phase 1**
+   validation/precondition failure — which happens before any ACM detachment,
+   with the cluster still attached and healthy — sets
+   `SeedGenerationCompleted = False / Reason: PreconditionChecksFailed`. A
+   failure **at or after Phase 2** (once generation has begun and the spoke is
+   being detached) sets `SeedGenerationCompleted = False / Reason: Failed`.
+   This mirrors the attached-vs-detached distinction gated on
+   `DetachmentStarted` (see [Challenge 4](#4-seed-cluster-afterlife-and-pr-terminal-state)):
+   `PreconditionChecksFailed` leaves the still-attached cluster reconciling
+   normally, while `Failed` marks a detached cluster whose ACM-dependent
+   checks are suppressed.
+3. **Scrub credential-bearing artifacts immediately, before any diagnostic
+   retention.** The failure path must not leave secrets sitting on hub
+   storage or the spoke. On both hub and spoke the controller, on failure:
+   - **Hub**: deletes **every** per-run credential copy created in the Job
+     namespace — the `seedAuthSecretRef` copy, the pull-secret copy, and the
+     per-run `uploadSecretRef` copy (which holds the SSH **private key** and
+     `knownHosts`) — plus the `idms.yaml`/CA-trust ConfigMap and any Secret
+     projections mounted into the Job pod, and deletes the Job pod's mounted
+     volumes. The upload-credential copy is the most sensitive of the three
+     and is scrubbed on the same immediate failure path as the others, not
+     left behind after the Job and pod are deleted. Every per-run Secret the
+     controller generates is covered by this scrub and by a test.
+     Only *scrubbed* diagnostics are retained: the
+     bounded, redacted log tail (already written to the condition) and, if
+     kept, a copy of pod logs with credential patterns redacted. The build
+     workspace PVC (which may hold the seed image / partial ISO but not the
+     input Secrets) may be retained under a **bounded diagnostic-retention
+     policy** (a TTL after which it is reclaimed), not "until the PR is
+     deleted" indefinitely.
+   - **Spoke**: deletes the `seedgen` Secret, the SeedGenerator CR, and the
+     standalone credential (ServiceAccount, token Secret, and namespaced
+     RoleBindings), the ServiceAccount and token Secret last. The inert
+     cluster-scoped `ClusterRole`/`ClusterRoleBinding` are reclaimed with the
+     disposable cluster (or removed by the hub out of band), not self-deleted by
+     the token — see Phase 2. The standalone token
+     is a **non-expiring** `kubernetes.io/service-account-token` Secret (chosen
+     precisely so it cannot lapse mid-operation), so there is **no token TTL**
+     and revocation is explicit: deleting the ServiceAccount and its token
+     Secret immediately invalidates the credential. Because the token never
+     expires on its own, the design must **not** rely on expiry to bound a
+     leaked credential — an abandoned workflow that never reached Phase 5 would
+     otherwise leave a permanently valid spoke credential. Revocation is
+     therefore driven by two mechanisms, both independent of any TTL: (1) spoke
+     scrubbing runs as part of reaching every terminal state, not lazily on PR
+     deletion; and (2) a hub-side finalizer plus a bounded overall operation
+     **deadline** — after the deadline the controller force-runs Phase 5
+     revocation even for a stuck/abandoned run, deleting the SA and token
+     Secret while the spoke is still reachable. The deadline bounds *when
+     revocation happens*; it is not a lifetime on the token itself. If the
+     spoke is genuinely unreachable at cleanup time (e.g. the controller was
+     down and the spoke was independently torn down), the residual credential
+     is documented as requiring manual removal, and the `seedgen` Secret is the
+     sensitive item to purge.
+4. The spoke cluster remains running (detached) for manual intervention. ACM
+   is **not** restored automatically; the operator can re-import the cluster
+   manually for debugging or delete the ProvisioningRequest to tear it down.
+   If detachment has begun at or after Phase 2
+   (`SeedGenerationStatus.DetachmentStarted == true`; see [Challenge 4](#4-seed-cluster-afterlife-and-pr-terminal-state)),
+   the controller suppresses ACM-dependent reconciliation for this terminal
+   failure exactly as it does on success; a pre-detachment failure leaves the
+   still-attached cluster reconciling normally. Remaining scrubbed
+   diagnostics are removed on PR deletion (finalizer) or when the bounded
+   retention TTL elapses, whichever comes first.
+
+## New Status Fields
+
+```go
+// In provisioningrequest_types.go, inside ClusterDetails:
+type ClusterDetails struct {
+    // ... existing fields ...
+
+    // SeedGenerationStatus holds the state of a seed image generation in progress.
+    SeedGenerationStatus *SeedGenerationStatus `json:"seedGenerationStatus,omitempty"`
+}
+
+type SeedGenerationStatus struct {
+    // StartedAt indicates when seed generation started.
+    StartedAt *metav1.Time `json:"startedAt,omitempty"`
+
+    // DetachmentStarted is set to true and flushed to status immediately
+    // BEFORE Phase 2 performs the first destructive ACM removal (deleting the
+    // ManagedClusterAddOn CRs, which precedes Klusterlet deletion), i.e. it is
+    // persisted before the point of no return, not after teardown finishes.
+    // This is deliberate: if addon/Klusterlet deletion succeeds but the teardown
+    // poll times out before the status could be updated, a "Detached only
+    // after Phase 2 completes" marker would still read false and ACM-
+    // dependent reconciliation would resume against a spoke that is in fact
+    // (partially) detached. Gating suppression on DetachmentStarted instead
+    // means any terminal outcome reached once destruction has begun
+    // suppresses ACM-dependent checks. A pre-Phase-2 terminal failure (e.g.
+    // PreconditionChecksFailed) leaves this false, so the still-attached
+    // cluster reconciles normally. See Challenge 4.
+    DetachmentStarted bool `json:"detachmentStarted,omitempty"`
+
+    // ReleaseImageDigest is the immutable <repository>@sha256:<digest>
+    // resolved from the (often mutable) liveISO.releaseImage tag during
+    // Phase 1 validation. It is persisted here so that Phase 4 — which may
+    // run in a later reconcile, after a controller restart — extracts
+    // openshift-install from exactly the release validated in Phase 1
+    // rather than re-resolving a tag that could have moved in between.
+    // Phase 4 fails terminally if this is empty when liveISO is configured.
+    ReleaseImageDigest string `json:"releaseImageDigest,omitempty"`
+
+    // SeedImage is the published seed image as an immutable
+    // <repository>@sha256:<digest> reference, captured from the
+    // SeedGenerator status in Phase 3 and populated on success. The digest
+    // (not the mutable configured tag) is what Phase 4 builds the ISO from
+    // and what downstream consumers pin to.
+    SeedImage string `json:"seedImage,omitempty"`
+
+    // ISOURL is the HTTPS URL where the live installation ISO is accessible
+    // from the BMC management network, populated on successful ISO build.
+    // This is the resolved per-run URL (unique per run), computed from
+    // liveISO.urlBase plus the per-run suffix.
+    ISOURL string `json:"isoURL,omitempty"`
+
+    // ISODigest is the SHA-256 digest of the built ISO
+    // ("sha256:<hex>"), computed locally before upload and verified against
+    // the uploaded copy over SSH (mandatory). Populated on successful ISO
+    // build so downstream consumers can pin the exact artifact addressed by
+    // ISOURL rather than trusting a mutable URL.
+    ISODigest string `json:"isoDigest,omitempty"`
+
+    // ISOServerCACertRef is a typed reference to a ConfigMap the
+    // controller materializes on completion (in the O-Cloud Manager
+    // namespace, named deterministically from the ProvisioningRequest)
+    // holding the PEM CA bundle for the HTTPS ISO server under a
+    // well-known key. It is populated only when uploadSecretRef.caCert
+    // is present. The controller creates the ConfigMap rather than
+    // storing raw PEM here, so downstream consumers (e.g. BMC virtual
+    // media configuration) get a stable object reference instead of
+    // inline certificate data. Because ProvisioningRequest is cluster-
+    // scoped and this ConfigMap is namespaced, Kubernetes garbage
+    // collection cannot delete it via an ownerReference (a namespaced
+    // dependent may not have a cluster-scoped owner). Cleanup is therefore
+    // explicit: handleFinalizer deletes this ConfigMap (by the
+    // deterministic name recorded here) as part of ProvisioningRequest
+    // teardown. It is not credential-bearing, so it is removed on normal
+    // teardown rather than in the immediate Phase 5 credential-scrub path.
+    ISOServerCACertRef *ConfigMapKeyRef `json:"isoServerCACertRef,omitempty"`
+}
+
+// ConfigMapKeyRef references a single key in a ConfigMap.
+type ConfigMapKeyRef struct {
+    Name      string `json:"name"`
+    Namespace string `json:"namespace"`
+    Key       string `json:"key"`
+}
+```
+
+## New Condition Type
+
+```go
+// In conditions.go
+PRconditionTypes.SeedGenerationCompleted = ConditionType("SeedGenerationCompleted")
+```
+
+With reasons: `Validating`, `PreconditionChecksFailed`, `CleaningACMResources`, `InProgress`, `BuildingISO`, `Completed`, `Failed`, `TimedOut`. The reasons not already present in `CRconditionReasons` (`Validating`, `CleaningACMResources`, `BuildingISO`) must be added to that set in
+`conditions.go`; `Completed`, `Failed`, `InProgress`, `PreconditionChecksFailed`, and `TimedOut` already exist.
+
+## Timeout
+
+The existing `clusterUpgradeTimeout` config key (`ClusterUpgradeTimeoutConfigKey`) is reused, but seed generation gets its **own default constants** rather than the upgrade defaults. For reference, the existing upgrade defaults are `DefaultClusterUpgradeTimeout = 4h` and
+`DefaultClusterEUSUpgradeTimeout = 8h` (`constants.go`); these do not apply to seed generation. The new seed-generation defaults are **2 hours** without `liveISO` and **3 hours** with `liveISO` (ISO generation adds ~30-60 minutes for seed image pull, ISO build, and upload). When the
+`clusterUpgradeTimeout` key is set in `upgradeDefaults` or `upgradeParameters`, it overrides these defaults.
+
+## Sample: End-to-End ClusterTemplate
+
+```yaml
+apiVersion: clcm.openshift.io/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: sno-ran-du-seedgen.v4-Y-Z-1
+  namespace: sno-ran-du-v4-Y-Z
+spec:
+  name: sno-ran-du-seedgen
+  version: v4-Y-Z-1
+  release: 4.Y.Z
+  templateDefaults:
+    hwMgmtDefaults:
+      nodeGroupData:
+        - name: controller
+          role: master
+    clusterInstanceDefaults: clusterinstance-defaults-v1  # includes var-lib-containers MC
+    policyTemplateDefaults: policytemplate-defaults-v1    # includes LCA + OADP operators
+    upgradeDefaults:
+      seedGeneration:
+        seedImage: my-mirror.example.com/seed-repo/seed-image:4.Y.Z
+        seedAuthSecretRef:
+          name: seed-registry-credentials
+        liveISO:
+          releaseImage: my-mirror.example.com/ocp-release:4.Y.Z-x86_64
+          installationDisk: /dev/disk/by-path/pci-0000:43:00.0-nvme-1
+          sshKey: "ssh-rsa AAAA..."
+          uploadSecretRef:
+            name: iso-server-ssh-credentials
+          urlBase: https://iso-server.example.com/ibi/
+      clusterUpgradeTimeout: "3h"
+  templateParameterSchema:
+    properties:
+      # ... standard provisioning parameters ...
+      upgradeParameters:
+        properties:
+          seedGeneration:
+            type: object
+            properties:
+              seedImage:
+                type: string
+                minLength: 1
+              seedAuthSecretRef:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required: [name]
+              recertImage:
+                type: string
+              liveISO:
+                type: object
+                properties:
+                  releaseImage:
+                    type: string
+                    minLength: 1
+                  installationDisk:
+                    type: string
+                    minLength: 1
+                  sshKey:
+                    type: string
+                  uploadSecretRef:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                    required: [name]
+                  urlBase:
+                    type: string
+                    minLength: 1
+                  pullSecretRef:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                    required: [name]
+                  storageClass:
+                    type: string
+                required: [releaseImage, installationDisk, uploadSecretRef, urlBase]
+            required: [seedImage, seedAuthSecretRef]
+        type: object
+    type: object
+```
+
+## Challenges and Mitigations
+
+### 1. Incomplete ACM cleanup contaminates the seed image
+
+**Challenge**: If ACM agent resources are not fully removed, hub-specific artifacts (agent certificates, observability configs, managed-cluster identity) end up in the seed image and cause conflicts when the image is deployed to a different cluster.
+
+**Mitigation**: The controller removes hub-side addon CRs (stopping reconciliation) and deletes the spoke `Klusterlet` CR, letting the klusterlet operator tear down the agent namespaces and their identity secrets (`bootstrap-hub-kubeconfig`, `hub-kubeconfig-secret`). lca-cli's own
+cleanup does **not** strip klusterlet/registration identity, so this explicit removal is required; lca-cli still handles the remaining cluster-specific artifacts (certificates, node identity) as part of recert.
+
+Observability is handled **preventively rather than by post-hoc cleanup**. RHACM's `multicluster-observability-operator` watches for managed clusters and
+automatically deploys the observability-addon (metrics-collector plus the observability-endpoint-operator) to each one; that addon is what creates hub-specific
+secrets such as `hub-alertmanager-router-ca-*` and `observability-alertmanager-accessor-*` in the `openshift-monitoring` and
+`openshift-user-workload-monitoring` namespaces on the spoke — exactly the kind of hub-coupled artifact that must not be baked into a portable seed image. Because
+the seed cluster is a disposable, purpose-built cluster the operator provisions, the seed `ClusterTemplate` sets the `observability: disabled` label on the
+`ManagedCluster` (via `clusterInstanceDefaults`) so the label is present from the moment the cluster is imported. The observability-operator then never deploys
+the addon to it, so the metrics-collector and the secrets above are never created and cannot contaminate the seed. This is strictly preferable to enumerating and
+deleting those secrets during teardown: the exact secret set drifts across RHACM/MCE versions, and spoke-side deletion would require broadening the standalone
+credential's RBAC into `openshift-monitoring`/`openshift-user-workload-monitoring` — enlarging its blast radius for no benefit. A residual secret sweep is needed
+only if a cluster that *already* had observability deployed is later repurposed as a seed cluster (not the standard flow); it is called out as a fallback in
+[Open Question 4](#open-questions), not the default path.
+
+### 2. Spoke client availability during seed generation
+
+**Challenge**: During Phase 3, the lca-cli shuts down cluster operators on the spoke, which may temporarily affect API server availability and disrupt the spoke client.
+
+**Mitigation**: The controller uses polling with backoff when monitoring the SeedGenerator CR. The spoke API server itself stays running (lca-cli stops operators, not the API server). The standalone token minted in Phase 2 remains valid — it is long-lived and independent of ACM — so
+the spoke client keeps working even though the ACM agents are gone. Transient API errors during operator shutdown are retried.
+
+### 3. ACM self-healing during cleanup phase
+
+**Challenge**: ACM's klusterlet operator may attempt to re-deploy agents while the controller is removing them in Phase 2, creating a race condition.
+
+**Mitigation**: The controller deletes the `Klusterlet` CR itself — not just the agent Deployments — so the klusterlet operator tears the agents down and does not recreate them; the race dissolves because there is no CR left to reconcile. Hub-side `ManagedClusterAddOn` CRs are deleted
+first so the addon framework also stops reconciling. The order is: hub addon CRs → spoke `Klusterlet` CR → wait for namespace/pod teardown. The seed cluster is disposable, so nothing reinstalls the klusterlet afterward.
+
+### 4. Seed cluster afterlife and PR terminal state
+
+**Challenge**: The seed cluster is a disposable factory that is intentionally left detached from ACM after generation (klusterlet and addons removed, not restored). But the ProvisioningRequest controller normally reconciles ACM-dependent state — `ConfigurationApplied` (policy
+compliance via the governance addon) and `NonCompliantAt`. Left unhandled, the PR would report those as broken forever once ACM is gone.
+
+**Mitigation**: The controller suppresses the PR's ACM-dependent reconciliation (config/policy compliance)
+whenever the spoke has (begun to) detach and `SeedGenerationCompleted` is terminal. Detachment happens in
+Phase 2, so **any** terminal outcome reached at or after Phase 2 — `True / Completed`, `False / Failed`, or
+`False / TimedOut` — leaves the cluster detached and must suppress those checks; otherwise
+`ConfigurationApplied` and `NonCompliantAt` would report the detached cluster as broken forever. To
+distinguish this from a pre-detachment failure (e.g. `PreconditionChecksFailed` in Phase 1, where the
+cluster is still ACM-attached and should reconcile normally), the controller records a `DetachmentStarted`
+marker in `SeedGenerationStatus` **immediately before** it performs the first destructive ACM removal in
+Phase 2 (deleting the `ManagedClusterAddOn` CRs, which precedes Klusterlet deletion) and gates the
+suppression on it. Persisting the marker before the point of no
+return — rather than after Phase 2 finishes — is deliberate: if that teardown succeeds but the
+teardown poll then times out before status could be written, an "after Phase 2 completes" marker would still
+read false and the controller would resume ACM checks against a spoke that is in fact already (partially)
+detached. On any terminal outcome it
+also stops re-running seed generation. The cluster is left running for the operator to inspect; deleting the
+ProvisioningRequest tears it down via the existing deletion path and reclaims the hardware. This mirrors the
+manual workflow, which also never re-attaches the seed cluster.
+
+### 5. Seed SNO prerequisites
+
+**Challenge**: The seed SNO has hardware-specific prerequisites (CPU topology alignment, FIPS, proxy, IP version match with target SNOs) that cannot be fully validated by the hub controller.
+
+**Mitigation**: The controller validates what it can (OCP version, `var-lib-containers` partition, LCA operator presence, OADP operator presence, registry credentials). Hardware prerequisites are the cluster template author's responsibility — they must ensure the ClusterTemplate's
+`clusterInstanceDefaults` and `policyTemplateDefaults` produce a seed SNO that meets the documented prerequisites.
+
+### 6. Standalone access token lifetime and cleanup
+
+**Challenge**: With ACM fully removed, spoke access depends entirely on the standalone credential minted in Phase 2. It must not expire mid-operation; and if the workflow is abandoned, a valid credential could be left behind on the spoke.
+
+**Mitigation**: The credential is a **non-expiring** `kubernetes.io/service-account-token` Secret (not a TTL-bounded `TokenRequest` token), so it cannot lapse mid-operation.
+Because it never expires on its own, a bounded credential lifetime is enforced by *revocation*, not by a token TTL: its ServiceAccount, token Secret, RoleBinding, and cluster-scoped `ClusterRole`/`ClusterRoleBinding` are named deterministically from the ProvisioningRequest.
+Phase 5 can therefore always find and delete them on both the success and failure paths (deletion immediately invalidates the token).
+The PR finalizer plus a bounded overall operation **deadline** force-runs this revocation if the operation is abandoned, so a leaked credential is bounded by *when cleanup runs*, not by an expiry on the token.
+The RBAC is scoped to only the permissions the workflow needs on the spoke and must be **repeated identically wherever this contract is summarized** (see Phase 2 for the authoritative statement):
+
+- A namespaced `RoleBinding` for the namespaced `seedgen` Secret in the LCA namespace.
+- A `ClusterRole`/`ClusterRoleBinding` for the genuinely cluster-scoped needs:
+  `create`/`get`/`list`/`watch`/`delete` on the cluster-scoped `SeedGenerator`
+  (the singleton `seedimage` CR is cluster-scoped); `delete` **and
+  `get`/`list`/`watch`** on the cluster-scoped `Klusterlet` (read verbs are
+  needed so the teardown poll can observe it disappear), plus
+  `get`/`list`/`watch` on `namespaces`.
+- Per-namespace `RoleBinding`s granting `get`/`list`/`watch` on `pods` in the `open-cluster-management-agent*` namespaces (not a cluster-wide pod-read grant).
+
+The Phase 2 deletion of `ManagedClusterAddOn` CRs is a **hub-side** operation performed with the O-Cloud Manager's own hub client, so it is covered by the hub RBAC contract (see the hub RBAC contract earlier in this document), not by this spoke credential.
+
+### 7. ISO generation Job storage requirements
+
+**Challenge**: The `openshift-install image-based create image` command pulls the full seed image and generates an ISO, requiring ~15-20GB of workspace storage. Ephemeral storage on hub nodes is typically insufficient and risks pod eviction.
+
+**Mitigation**: The controller creates a dedicated PVC (~20GB) for the ISO build workspace, mounted into the Job pod. The PVC uses the StorageClass specified in `liveISO.storageClass`, or the cluster's default StorageClass if omitted. The PVC is cleaned up in Phase 5 after successful
+upload. On failure, the PVC is retained for debugging under the **same bounded diagnostic-retention TTL** described in the failure workflow (reclaimed when the TTL elapses or on PR deletion, whichever comes first) —
+it is **not** kept indefinitely until the ProvisioningRequest is deleted, since a ~20GB workspace per failed request would otherwise accumulate and exhaust hub storage. Operators must ensure the hub cluster has a StorageClass with sufficient capacity available.
+
+### 8. Disconnected environment registry configuration
+
+**Challenge**: In disconnected environments, the ISO build must pull the seed image and OCP release images from local mirrors. The `openshift-install` binary must also be extracted from a mirrored release image. Misconfigured mirrors cause silent failures deep in the ISO build.
+
+**Mitigation**: The controller **auto-derives the mirror configuration from the hub** (Phase 4, step 1) — mirror mappings from the hub's `ImageDigestMirrorSet`/`ImageContentSourcePolicy` and registry trust from the hub's image-config `additionalTrustedCA` — and injects it into both
+`oc adm release extract` (`--idms-file` + CA trust) and the `ImageBasedInstallationConfig` (`imageDigestSources` + `additionalTrustBundle`). Because the hub already operates in the same disconnected environment as the seed and target clusters, this avoids duplicating mirror config in
+the ClusterTemplate and keeps it from drifting. Optional `liveISO.imageDigestSources` / `liveISO.additionalTrustBundleConfigMapRef` overrides cover the case where the ISO build must target a different mirror. The `releaseImage` field is required (no default fallback to a public
+registry), and the pull secret must include credentials for all mirrors involved. Phase 1 validation checks that the `releaseImage` is reachable using the resolved mirror config and that `oc adm release extract` can authenticate to it. The `seedImage` pull-spec in the
+`ImageBasedInstallationConfig` is the immutable `repo@sha256:<digest>` reference captured from the SeedGenerator status in Phase 3, not the mutable `seedGeneration.seedImage` tag, so the ISO is built from exactly the image that was generated.
+
+### 9. HTTPS ISO server certificate management
+
+**Challenge**: In disconnected environments, the HTTPS ISO server uses a private CA. BMCs fetching the ISO via virtual media must trust this CA. Different BMC vendors handle custom CA trust differently — some support injecting a CA cert via the virtual media API, others rely on
+pre-configured trust stores.
+
+**Mitigation**: The `uploadSecretRef` Secret carries an optional `caCert` field containing the PEM-encoded CA
+bundle for the ISO server. Phase 1 validates the certificate chain by performing a TLS handshake against the
+`urlBase` host. On completion, the controller **materializes the PEM bundle into a dedicated ConfigMap** (in the
+O-Cloud Manager namespace, named deterministically from the ProvisioningRequest) and records a typed reference to
+it in `SeedGenerationStatus.ISOServerCACertRef` — a stable object reference, not inline certificate data or a name
+for an object that is never created. Downstream consumers (BMC configuration, hardware manager) resolve that
+reference when mounting the ISO via virtual media. The controller does not configure BMC trust — that is the
+responsibility of the hardware manager or the BMC pre-configuration
+workflow. The controller's role is to validate the cert, use it during pre-flight checks, and surface it via the ConfigMap reference for downstream consumption.
+
+### 10. Registry pre-flight check limitations
+
+**Challenge**: The registry validation in Phase 1 runs from the hub cluster, which may have different network access than the spoke (where the actual image push occurs).
+
+**Mitigation**: The pre-flight check validates credential correctness and basic reachability from the hub. If the hub and spoke have different network paths to the registry (e.g., disconnected environments with different mirrors), the check may pass on the hub but the spoke-side push
+may still fail. In disconnected environments, the `seedImage` pull-spec should reference a mirror accessible to the spoke; the pre-flight check validates what it can and the SeedGenerator reports push failures in its own conditions.
+
+## Alternatives Considered
+
+### A. Full ACM detachment (delete ManagedCluster)
+
+Detach the spoke entirely by deleting the ClusterInstance/ManagedCluster, as the manual workflow does today. Rejected because deleting the ClusterInstance risks triggering deprovisioning of the running spoke and discards the hub-side record of the cluster. The chosen approach instead
+keeps the `ManagedCluster` intact and removes only the spoke-side ACM agent state (klusterlet + addons), achieving the same seed cleanliness without touching the provisioning lifecycle; the operator reclaims the hardware by deleting the ProvisioningRequest when the seed is captured.
+(A standalone spoke token is minted either way — klusterlet teardown removes the MSA token regardless — so token pre-provisioning is not what distinguishes this alternative.)
+
+### B. Separate SeedGenerationRequest CRD
+
+A dedicated CRD that references a ProvisioningRequest and drives seed generation independently. Rejected because it adds API surface, doesn't reuse the existing template-defaults/merge infrastructure, and creates a coordination problem between two controllers.
+
+### C. External job/pipeline
+
+Offload seed generation to an external CI/CD pipeline triggered by the ProvisioningRequest. Rejected because it breaks the single-API contract of the ProvisioningRequest and requires external infrastructure the operator may not have.
+
+### D. Controller-managed LCA installation
+
+Have the controller install the LCA operator on the spoke via ManifestWork during seed generation. Rejected in favor of requiring LCA as a prerequisite in the cluster's initial configuration (via `policyTemplateDefaults`). This keeps the controller simpler and ensures LCA is available
+and stable before seed generation begins, rather than installing it just-in-time.
+
+### E. ISO generation via external pipeline (Tekton, CI/CD)
+
+Offload ISO generation to an external Tekton pipeline or CI/CD system triggered after seed generation. Rejected because it breaks the single-API model, requires additional infrastructure, and adds complexity for disconnected environments where the pipeline itself needs mirror access.
+A hub-side Job keeps the entire workflow within the ProvisioningRequest lifecycle.
+
+### F. Default to public release image registry
+
+Use `quay.io/openshift-release-dev/ocp-release:<version>-<arch>` as the default `releaseImage` when not specified. Rejected because the exact release pull-spec (version and architecture) cannot be inferred reliably, and a silent default risks pulling the wrong image. `releaseImage`
+stays required and explicit; the *mirror redirection* for it (and its trust) is handled automatically via the hub-derived `imageDigestSources`/`additionalTrustBundle`, so the template author supplies the release reference but not the mirror plumbing.
+
+## Implementation Constants
+
+```go
+// New constants in internal/controllers/utils/constants.go
+const UpgradeDefaultsSeedGenerationKey = "seedGeneration"
+
+const DefaultSeedGenerationTimeout = 2 * time.Hour
+const DefaultSeedGenerationWithISOTimeout = 3 * time.Hour
+```
+
+## Effort Estimate
+
+~2900 lines of new/modified code across API types, controller logic, Job template, tests, and docs.
+
+| Area | Files | Est. lines | Complexity |
+|---|---|---|---|
+| API types — `SeedGenerationStatus` (with `ReleaseImageDigest`, `ISOURL`, `ISODigest`, `ISOServerCACertRef`, `DetachmentStarted`), condition type, constants | 3 files | ~50 | Low |
+| `parseUpgradeConfig` + `validateUpgradeParametersSchema` extension — third upgrade type (both runtime and schema mutual-exclusivity checks) | 2 files | ~40 | Low |
+| `IsSeedGenerationRequested` predicate + reconciler dispatch (separate trigger from `IsUpgradeRequested`) | 1 file | ~40 | Medium |
+| CT validation — seedGen defaults, registry pre-flight, release image check, TLS handshake, upload Secret validation | 1 file | ~150 | Medium |
+| Seed generation controller — Phases 1-3 + Phase 5 state machine (ACM cleanup, SeedGenerator lifecycle, spoke client, terminal state) | 1 new file | ~600 | High |
+| ACM removal helpers — standalone token mint, `Klusterlet` CR delete + wait, hub addon-CR delete (no restore) | 1 new file | ~180 | Medium |
+| ISO generation Phase 4 — PVC creation, Job template (extract `openshift-install`, build config, build ISO, SCP upload, HTTPS verification), Job lifecycle monitoring, pull secret merging, hub mirror-config derivation from IDMS/ICSP and `additionalTrustedCA` | 1 new file | ~420 | High |
+| RBAC — spoke (`RoleBinding` for seedgen Secret + per-ns pod read; `ClusterRole` for the cluster-scoped `SeedGenerator`, `Klusterlet` and `namespaces` verbs; self-cleanup deletes — full contract in Phase 2) and hub (see **hub RBAC contract** above) | 2 files | ~40 | Low |
+| Tests — seed gen controller, ACM helpers, ISO Job lifecycle, validation, TLS checks | 2-3 new files | ~1200 | High |
+| Samples — ClusterTemplate YAML, upload Secret | 2 files | ~80 | Low |
+| Docs — update ibi-based-cluster-provisioning.md | 1 file | ~120 | Low |
+| Vendor — add SeedGenerator API types | go mod | — | Low |
+
+Roughly 4 working sessions to implement:
+
+- **Session 1**: API types, constants, conditions, `parseUpgradeConfig` extension, CT validation (registry pre-flight, release image check, TLS handshake, upload Secret validation), sample YAMLs
+- **Session 2**: Core seed generation state machine (Phases 1-3, 5), ACM removal helpers (standalone token mint, `Klusterlet` CR delete, addon-CR delete), terminal-state / config-reconcile suppression, spoke and hub RBAC, wiring into the main reconciler
+- **Session 3**: ISO generation — hub mirror-config derivation, PVC creation, Job template (release image extract, config generation, ISO build, SCP upload, HTTPS post-upload verification), pull secret merging, Job lifecycle monitoring, cleanup
+- **Session 4**: Tests, edge cases, docs update, `make ci-job` pass
+
+## Open Questions
+
+1. **Is deleting the `Klusterlet` CR + all `ManagedClusterAddOn` CRs sufficient to fully remove ACM agent state?** Option B relies on the klusterlet operator's own teardown (triggered by deleting the `Klusterlet` CR) rather than a hardcoded list of Deployments/DaemonSets. This should
+   be validated against the specific ACM/MCE version — in particular that the agent namespaces and identity secrets are fully removed so the captured seed carries no stale hub-registration state. (Confirmed: lca-cli does **not** strip klusterlet identity, so the controller cannot
+   defer this.)
+
+2. **What container image should the ISO generation Job use?** The Job needs `oc` (for `oc adm release extract`) and basic tools (`scp`, shell). Options include the OCP CLI tools image (`registry.redhat.io/openshift4/ose-cli`), which is available on disconnected mirrors and already
+   contains `oc`. The `openshift-install` binary is extracted at runtime from the release image rather than baked into the Job image.
+
+3. **Should ISO upload support mechanisms beyond SCP?** The initial implementation uses SCP/SFTP for simplicity (matching the existing manual workflow). Future iterations could add S3-compatible upload, HTTP PUT, or NFS mount as alternative upload mechanisms if there is demand.
+
+4. **Is a residual observability-secret sweep ever required?** The standard flow prevents observability contamination up front by setting the
+   `observability: disabled` label on the `ManagedCluster` at import time (see [Challenge 1](#1-incomplete-acm-cleanup-contaminates-the-seed-image)), so the
+   observability-addon and its `hub-alertmanager-router-ca-*` / `observability-alertmanager-accessor-*` secrets are never deployed. The only scenario that would
+   still leave those secrets behind is repurposing a cluster that *already* had observability deployed as a seed cluster. If that scenario needs to be supported,
+   a bounded spoke-side sweep of those namespaces would be added — accepting the corresponding RBAC widening — rather than relaxing the preventive default.

--- a/docs/proposals/automated-seed-image-generation.md
+++ b/docs/proposals/automated-seed-image-generation.md
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0
 - [Proposed API Changes](#proposed-api-changes)
   - [New key: `seedGeneration`](#new-key-seedgeneration)
   - [ProvisioningRequest overrides](#provisioningrequest-overrides)
-  - [Schema in templateParameterSchema](#schema-in-templateparameterschema)
+  - [Schema: PR-facing and effective-object](#schema-pr-facing-and-effective-object)
 - [Controller Workflow](#controller-workflow)
   - [Functional Overview](#functional-overview)
   - [Trigger and Dispatch](#trigger-and-dispatch)
@@ -254,36 +254,41 @@ upgradeParameters:
     seedImage: quay.io/my-org/seed-image:4.Y.Z-custom
 ```
 
-**Validation applies to the merged object, not the raw override.** A PR
-override is intentionally partial — the example above supplies only
+**PR input and the merged object are validated by two separate schemas.**
+A PR override is intentionally partial — the example above supplies only
 `seedImage`, relying on the ClusterTemplate defaults for
-`seedAuthSecretRef`, `liveISO`, and the rest. Required-field validation
-(`required: [seedImage, seedAuthSecretRef]`, and the `liveISO` required
-set) must therefore run **after** the CT defaults are merged over the PR
-overrides, not against the raw `spec.templateParameters` in isolation.
+`seedAuthSecretRef`, `liveISO`, and the rest:
 
-There is a specific ordering hazard the implementation must resolve. The
-admission webhook today calls `ValidateTemplateInputMatchesSchema` on the
-**raw** `spec.templateParameters` *before* `ValidateUpgradeInput` runs, and that
-first call does **not** merge `TemplateDefaults.UpgradeDefaults`. If the
-`seedGeneration` sub-schema carries `required: [seedImage, seedAuthSecretRef]`
-(and the `liveISO` required set), a partial override supplying only `seedImage`
-is rejected at that first gate before any merge. Two acceptable fixes: (a) merge
-`UpgradeDefaults` into the effective object *before* the schema check, so
-admission sees the same document the controller acts on; or (b) keep the
-raw-params check structural only (types/patterns) and move `required`
-enforcement into the post-merge `ValidateUpgradeInput` path. This proposal
-specifies option (a) — validate the merged object — so a partial override is
-never rejected for fields the defaults provide, and admission and the controller
-agree on one document. A test must cover this ordering by submitting a
-`seedImage`-only override against defaults that provide the rest.
+- The **PR-facing schema** (`templateParameterSchema.upgradeParameters.seedGeneration`,
+  defined below) lists only the fields a PR may override and sets
+  `additionalProperties: false`. Admission validates the **raw**
+  `spec.templateParameters` against it, so a PR that supplies any
+  template-owned field is rejected structurally by the schema — there is no
+  separate deny-list to keep in sync. Because this schema requires no
+  template-owned field, a partial (`seedImage`-only) override is never
+  rejected for fields the defaults provide.
+- The **effective-object schema** — internal to the controller, not part of
+  `templateParameterSchema` — validates the merged object (defaults ⊕ PR
+  input) in the post-merge `ValidateUpgradeInput` path. It carries the full
+  `seedGeneration` shape and the required-field rules
+  (`required: [seedImage, seedAuthSecretRef]`, the `liveISO` required set),
+  so "does the effective document have everything it needs" is answered
+  after the merge, never against raw PR input.
 
-**Restricting PR-controlled outbound targets and credential selection.**
-Two distinct classes of `seedGeneration` field are dangerous in the hands
-of a less-trusted PR author:
+Splitting the schemas also removes an admission ordering hazard. The webhook
+calls `ValidateTemplateInputMatchesSchema` on the raw `spec.templateParameters`
+*before* `ValidateUpgradeInput` runs, without merging
+`TemplateDefaults.UpgradeDefaults`. Because the PR-facing schema requires
+nothing template-owned, a `seedImage`-only override passes that first gate,
+and the controller's post-merge check owns full-shape validation. A test must
+submit a `seedImage`-only override against defaults that provide the rest.
+
+**Why the template-owned fields stay out of the PR-facing schema.** Three
+classes of `seedGeneration` field are dangerous in the hands of a
+less-trusted PR author, so none of them appears there:
 
 - **Outbound targets** that drive hub-side network egress while credentials
-  are mounted: `liveISO.urlBase`, `liveISO.releaseImage`, `seedImage`,
+  are mounted: `liveISO.urlBase`, `liveISO.releaseImage`,
   `liveISO.imageDigestSources` / `additionalTrustBundleConfigMapRef`.
   Overriding these can redirect hub egress to attacker-controlled or
   internal endpoints (SSRF) or push/pull against an unintended registry.
@@ -291,9 +296,8 @@ of a less-trusted PR author:
   generation: `recertImage`. Phase 3 passes `recertImage` to the
   `SeedGenerator` CR, and the LCA runs it (the recert tool) on the spoke, so
   a PR-supplied value would let an untrusted author run an arbitrary image on
-  the seed cluster. This is template-owned; when set from a PR it is rejected,
-  and the resolved value must be an allowlisted, immutable
-  (`repo@sha256:<digest>`) reference.
+  the seed cluster. When resolved from `upgradeDefaults` it must be an
+  allowlisted, immutable (`repo@sha256:<digest>`) reference.
 - **Credential references** that select which hub Secret/ConfigMap the
   workflow reads and mounts into the ISO-build Job: `seedAuthSecretRef`,
   `liveISO.uploadSecretRef`, `liveISO.pullSecretRef`. Overriding these lets
@@ -301,147 +305,127 @@ of a less-trusted PR author:
   account can read, exfiltrating those credentials into an ISO/Job the
   caller influences.
 
-The default posture is that **all** of these fields are template-owned: set by
-trusted authors in `upgradeDefaults` and **not** exposed in
-`templateParameterSchema.upgradeParameters`, so admission rejects any override
-attempt, making them effectively immutable from the PR side. The only field
-expected to be overridable is a benign one such as the `seedImage` tag *when*
-the deployment trusts its PR authors. Where a deployment must accept these
-overrides from less-trusted principals, it must enforce admission checks rather
-than trust the value: validate that Secret/ConfigMap references resolve to an
-allowlisted set, that URL schemes are `https`, and that resolved destinations
-pass an egress allowlist rejecting private and link-local addresses after DNS
-resolution. Requiring `https` alone is **not** sufficient SSRF protection.
+The default posture is that **every** `seedGeneration` field is
+template-owned: set by trusted authors in `upgradeDefaults` and absent from
+the PR-facing schema, so `additionalProperties: false` rejects any override
+attempt. The one field a deployment may choose to expose — when it trusts its
+PR authors — is the benign `seedImage` tag, by adding it to the PR-facing
+schema as shown below. A deployment that opts in any richer override must not
+trust the value: it must validate that Secret/ConfigMap references resolve to
+an allowlisted set, that URL schemes are `https`, and that resolved
+destinations pass an egress allowlist rejecting private and link-local
+addresses after DNS resolution. Requiring `https` alone is **not** sufficient
+SSRF protection.
 
-### Schema in templateParameterSchema
+### Schema: PR-facing and effective-object
 
-The ClusterTemplate's `templateParameterSchema` would include the `seedGeneration` sub-schema under `upgradeParameters`, following the same pattern as `imageBasedGroupUpgrade`.
+Two schemas validate `seedGeneration`; only the PR-facing one is exposed to
+PR authors, and it follows the same `templateParameterSchema` pattern as
+`imageBasedGroupUpgrade`.
 
-Two points about this schema, both tied to the security posture above:
-
-- **Declaring a field here does not make it PR-overridable.** Because the
-  design validates the **merged** object (defaults over PR input — option (a)
-  above), the schema must describe the full `seedGeneration` shape, including
-  the credential and outbound-target fields, or the merged document would fail
-  validation. JSON Schema alone therefore cannot express "present in defaults
-  but forbidden from PR input." Template-ownership of `seedAuthSecretRef`,
-  `recertImage`, `liveISO.releaseImage`, `uploadSecretRef`, `urlBase`,
-  `pullSecretRef`, `imageDigestSources`, and `additionalTrustBundleConfigMapRef`
-  is instead enforced by an **admission check on the raw
-  `spec.templateParameters`** that rejects those keys in PR input unless the
-  deployment has explicitly opted them in. The schema does structural
-  validation of the merged object; the admission check is what makes these
-  fields effectively immutable from the PR side.
-- **`additionalProperties: false` at every object level.** Unknown or
-  mistyped keys are rejected rather than silently ignored, so a typo like
-  `seedimage` or an attempt to smuggle an unrecognized field fails admission
-  instead of being dropped.
+**PR-facing schema.** Lists only the fields a PR may override, with
+`additionalProperties: false` at every object level so unknown or mistyped
+keys — and every template-owned field — are rejected rather than silently
+ignored. The strictest posture exposes nothing; the example below opts in the
+benign `seedImage` tag:
 
 ```yaml
-upgradeParameters:
+# templateParameterSchema.upgradeParameters
+properties:
+  seedGeneration:
+    type: object
+    additionalProperties: false
+    properties:
+      seedImage:
+        type: string
+        description: Full pull-spec for the seed container image to publish
+        minLength: 1
+        pattern: "^([a-z0-9]+://)?[\\S]+$"
+    # No template-owned field (seedAuthSecretRef, recertImage, liveISO.*,
+    # uploadSecretRef, pullSecretRef, urlBase, imageDigestSources,
+    # additionalTrustBundleConfigMapRef) appears here, so additionalProperties:
+    # false rejects any attempt to set one from a PR.
+```
+
+**Effective-object schema.** The controller validates the merged object
+(defaults ⊕ PR input) against this internal schema in `ValidateUpgradeInput`,
+after the merge — it never sees raw PR input. It carries the full shape and
+the required-field rules, and sets `additionalProperties: false` at every
+level so a typo in `upgradeDefaults` (e.g. `seedimage`) fails validation:
+
+```yaml
+# Controller-internal; not part of templateParameterSchema.
+seedGeneration:
+  type: object
+  additionalProperties: false
   properties:
-    seedGeneration:
+    seedImage: { type: string, minLength: 1, pattern: "^([a-z0-9]+://)?[\\S]+$" }
+    seedAuthSecretRef:
+      type: object
+      additionalProperties: false
+      properties: { name: { type: string } }
+      required: [name]
+    recertImage:
+      type: string
+      description: >
+        Template-owned; when set it must be an allowlisted, immutable digest
+        reference (repo@sha256:<digest>), because Phase 3 passes it to the
+        SeedGenerator CR where it runs as executable code during seed
+        generation.
+    liveISO:
       type: object
       additionalProperties: false
       properties:
-        seedImage:
+        releaseImage:
           type: string
-          description: Full pull-spec for the seed container image to publish
           minLength: 1
-          pattern: "^([a-z0-9]+://)?[\\S]+$"
-        seedAuthSecretRef:
-          type: object
-          additionalProperties: false
-          properties:
-            name:
-              type: string
-          required: [name]
-        recertImage:
-          type: string
           description: >
-            Override for the recert tool image used during seed generation.
-            Template-owned (see the security posture and the admission check
-            above): rejected as PR input, and when set it must be an
-            allowlisted, immutable digest reference (repo@sha256:<digest>),
-            because Phase 3 passes it to the SeedGenerator CR where it runs
-            as executable code during seed generation.
-        liveISO:
+            OCP release image to extract openshift-install from — the
+            canonical release pull-spec (redirected by the hub-derived mirror
+            mappings) or a direct mirror pull-spec.
+        installationDisk: { type: string, minLength: 1, description: Disk device path on the target servers }
+        sshKey: { type: string, description: SSH public key for debugging access }
+        uploadSecretRef:
           type: object
           additionalProperties: false
-          properties:
-            releaseImage:
-              type: string
-              description: >
-                OCP release image to extract openshift-install from.
-                In disconnected environments, either the canonical release
-                pull-spec (redirected by the hub-derived mirror mappings)
-                or a direct mirror pull-spec.
-              minLength: 1
-            installationDisk:
-              type: string
-              description: Disk device path on the target servers
-              minLength: 1
-            sshKey:
-              type: string
-              description: SSH public key for debugging access to pre-provisioned servers
-            uploadSecretRef:
-              type: object
-              additionalProperties: false
-              properties:
-                name:
-                  type: string
-              required: [name]
-            urlBase:
-              type: string
-              description: >
-                HTTPS origin plus base path from which the uploaded ISO is
-                served, backed by the same directory tree the upload
-                writes into. The effective per-run ISO URL is computed by
-                the controller as urlBase + the per-run suffix and recorded
-                in status; it is never supplied directly.
-              minLength: 1
-            pullSecretRef:
-              type: object
-              additionalProperties: false
-              properties:
-                name:
-                  type: string
-              required: [name]
-            storageClass:
-              type: string
-              description: >
-                StorageClass for the ISO build workspace PVC (~20GB).
-                Uses the cluster default StorageClass if omitted.
-            imageDigestSources:
-              type: array
-              description: >
-                Mirror mappings for the ISO build. Auto-derived from the
-                hub's ImageDigestMirrorSet/ImageContentSourcePolicy if
-                omitted; set only to target a different mirror.
-              items:
-                type: object
-                additionalProperties: false
-                properties:
-                  source:
-                    type: string
-                  mirrors:
-                    type: array
-                    items:
-                      type: string
-                required: [source, mirrors]
-            additionalTrustBundleConfigMapRef:
-              type: object
-              additionalProperties: false
-              description: >
-                ConfigMap holding the registry CA trust bundle for the
-                mirror. Auto-derived from the hub's image config
-                additionalTrustedCA if omitted.
-              properties:
-                name:
-                  type: string
-              required: [name]
-          required: [releaseImage, installationDisk, uploadSecretRef, urlBase]
-      required: [seedImage, seedAuthSecretRef]
+          properties: { name: { type: string } }
+          required: [name]
+        urlBase:
+          type: string
+          minLength: 1
+          description: >
+            HTTPS origin plus base path from which the uploaded ISO is served.
+            The effective per-run ISO URL is computed as urlBase + the per-run
+            suffix and recorded in status; it is never supplied directly.
+        pullSecretRef:
+          type: object
+          additionalProperties: false
+          properties: { name: { type: string } }
+          required: [name]
+        storageClass: { type: string, description: StorageClass for the ISO build workspace PVC (~20GB); cluster default if omitted }
+        imageDigestSources:
+          type: array
+          description: >
+            Mirror mappings for the ISO build. Auto-derived from the hub's
+            ImageDigestMirrorSet/ImageContentSourcePolicy if omitted.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              source: { type: string }
+              mirrors: { type: array, items: { type: string } }
+            required: [source, mirrors]
+        additionalTrustBundleConfigMapRef:
+          type: object
+          additionalProperties: false
+          description: >
+            ConfigMap holding the registry CA trust bundle for the mirror.
+            Auto-derived from the hub's image config additionalTrustedCA if
+            omitted.
+          properties: { name: { type: string } }
+          required: [name]
+      required: [releaseImage, installationDisk, uploadSecretRef, urlBase]
+  required: [seedImage, seedAuthSecretRef]
 ```
 
 ## Controller Workflow
@@ -1144,57 +1128,21 @@ spec:
           urlBase: https://iso-server.example.com/ibi/
       clusterUpgradeTimeout: "3h"
   templateParameterSchema:
-    # Abbreviated: field types only. The `additionalProperties: false` guard
-    # (required at every object level) and some fields are elided — the canonical
-    # "Schema in templateParameterSchema" is authoritative; copy from there.
+    # PR-facing schema: exposes only the PR-overridable field(s). Every
+    # template-owned field lives in upgradeDefaults and is validated post-merge
+    # by the controller's effective-object schema — see "Schema: PR-facing and
+    # effective-object". additionalProperties: false rejects any other override.
     properties:
       # ... standard provisioning parameters ...
       upgradeParameters:
         properties:
           seedGeneration:
             type: object
+            additionalProperties: false
             properties:
               seedImage:
                 type: string
                 minLength: 1
-              seedAuthSecretRef:
-                type: object
-                properties:
-                  name:
-                    type: string
-                required: [name]
-              recertImage:
-                type: string
-              liveISO:
-                type: object
-                properties:
-                  releaseImage:
-                    type: string
-                    minLength: 1
-                  installationDisk:
-                    type: string
-                    minLength: 1
-                  sshKey:
-                    type: string
-                  uploadSecretRef:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                    required: [name]
-                  urlBase:
-                    type: string
-                    minLength: 1
-                  pullSecretRef:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                    required: [name]
-                  storageClass:
-                    type: string
-                required: [releaseImage, installationDisk, uploadSecretRef, urlBase]
-            required: [seedImage, seedAuthSecretRef]
         type: object
     type: object
 ```

--- a/docs/proposals/automated-seed-image-generation.md
+++ b/docs/proposals/automated-seed-image-generation.md
@@ -262,22 +262,20 @@ override is intentionally partial — the example above supplies only
 set) must therefore run **after** the CT defaults are merged over the PR
 overrides, not against the raw `spec.templateParameters` in isolation.
 
-There is a specific ordering hazard here that the implementation must
-resolve. The admission webhook today calls
-`ValidateTemplateInputMatchesSchema` on the **raw** `spec.templateParameters`
-*before* `ValidateUpgradeInput` runs, and that first call does **not** merge
-`TemplateDefaults.UpgradeDefaults`. If the `seedGeneration` sub-schema
-carries `required: [seedImage, seedAuthSecretRef]` (and the `liveISO`
-required set), a partial override supplying only `seedImage` is rejected at
-that first gate before any merge happens. Two acceptable fixes: (a) merge
-`UpgradeDefaults` into the effective object *before* the schema check so the
-same validated document the controller acts on is what admission sees; or
-(b) keep the raw-params schema check structural only (types/patterns) and
-move the `required` enforcement for `seedGeneration` into the
-post-merge `ValidateUpgradeInput` path. This proposal specifies option (a) —
-validate the merged object — so a partial override is never rejected for
-missing fields the defaults provide, and admission and the controller agree
-on one document. This ordering must be covered by a test that submits a
+There is a specific ordering hazard the implementation must resolve. The
+admission webhook today calls `ValidateTemplateInputMatchesSchema` on the
+**raw** `spec.templateParameters` *before* `ValidateUpgradeInput` runs, and that
+first call does **not** merge `TemplateDefaults.UpgradeDefaults`. If the
+`seedGeneration` sub-schema carries `required: [seedImage, seedAuthSecretRef]`
+(and the `liveISO` required set), a partial override supplying only `seedImage`
+is rejected at that first gate before any merge. Two acceptable fixes: (a) merge
+`UpgradeDefaults` into the effective object *before* the schema check, so
+admission sees the same document the controller acts on; or (b) keep the
+raw-params check structural only (types/patterns) and move `required`
+enforcement into the post-merge `ValidateUpgradeInput` path. This proposal
+specifies option (a) — validate the merged object — so a partial override is
+never rejected for fields the defaults provide, and admission and the controller
+agree on one document. A test must cover this ordering by submitting a
 `seedImage`-only override against defaults that provide the rest.
 
 **Restricting PR-controlled outbound targets and credential selection.**
@@ -303,18 +301,17 @@ of a less-trusted PR author:
   account can read, exfiltrating those credentials into an ISO/Job the
   caller influences.
 
-The default posture is that **all** of these fields are template-owned:
-they are set by trusted authors in `upgradeDefaults` and are **not**
-exposed in `templateParameterSchema.upgradeParameters` (so admission
-rejects any attempt to override them, making them effectively immutable
-from the PR side). The only field expected to be overridable is a benign
-one such as the `seedImage` tag *when* the deployment trusts its PR
-authors. Where a deployment must accept these overrides from less-trusted
-principals, it must enforce admission checks rather than trust the value:
-validate that Secret/ConfigMap references resolve to an allowlisted set,
-that URL schemes are `https`, and that resolved destinations pass an egress
-allowlist rejecting private and link-local addresses after DNS resolution.
-Requiring `https` alone is **not** sufficient SSRF protection.
+The default posture is that **all** of these fields are template-owned: set by
+trusted authors in `upgradeDefaults` and **not** exposed in
+`templateParameterSchema.upgradeParameters`, so admission rejects any override
+attempt, making them effectively immutable from the PR side. The only field
+expected to be overridable is a benign one such as the `seedImage` tag *when*
+the deployment trusts its PR authors. Where a deployment must accept these
+overrides from less-trusted principals, it must enforce admission checks rather
+than trust the value: validate that Secret/ConfigMap references resolve to an
+allowlisted set, that URL schemes are `https`, and that resolved destinations
+pass an egress allowlist rejecting private and link-local addresses after DNS
+resolution. Requiring `https` alone is **not** sufficient SSRF protection.
 
 ### Schema in templateParameterSchema
 
@@ -325,17 +322,16 @@ Two points about this schema, both tied to the security posture above:
 - **Declaring a field here does not make it PR-overridable.** Because the
   design validates the **merged** object (defaults over PR input — option (a)
   above), the schema must describe the full `seedGeneration` shape, including
-  the credential and outbound-target fields, or the merged document (which
-  carries those fields from `upgradeDefaults`) would fail validation. JSON
-  Schema alone therefore cannot express "present in defaults but forbidden
-  from PR input." Template-ownership of `seedAuthSecretRef`, `recertImage`,
-  `liveISO.releaseImage`, `uploadSecretRef`, `urlBase`, `pullSecretRef`,
-  `imageDigestSources`, and `additionalTrustBundleConfigMapRef` is instead
-  enforced by an **admission check on the raw `spec.templateParameters`**
-  that rejects any of these keys appearing in PR input unless the deployment
-  has explicitly opted them in (see the security posture above). The schema's
-  job is structural validation of the merged object; the admission check is
-  what makes these fields effectively immutable from the PR side.
+  the credential and outbound-target fields, or the merged document would fail
+  validation. JSON Schema alone therefore cannot express "present in defaults
+  but forbidden from PR input." Template-ownership of `seedAuthSecretRef`,
+  `recertImage`, `liveISO.releaseImage`, `uploadSecretRef`, `urlBase`,
+  `pullSecretRef`, `imageDigestSources`, and `additionalTrustBundleConfigMapRef`
+  is instead enforced by an **admission check on the raw
+  `spec.templateParameters`** that rejects those keys in PR input unless the
+  deployment has explicitly opted them in. The schema does structural
+  validation of the merged object; the admission check is what makes these
+  fields effectively immutable from the PR side.
 - **`additionalProperties: false` at every object level.** Unknown or
   mistyped keys are rejected rather than silently ignored, so a typo like
   `seedimage` or an attempt to smuggle an unrecognized field fails admission
@@ -477,9 +473,8 @@ The value: a repeatable API operation replaces a manual, expert-only runbook;
 progress and results are visible instead of requiring SSH-and-tail-logs;
 prerequisite and credential problems fail fast before the long image build; and
 air-gapped environments — the primary use case — are handled without extra
-operator effort.
-
-The rest of this section describes how the controller realizes that flow.
+operator effort. The rest of this section describes how the controller realizes
+that flow.
 
 ### Trigger and Dispatch
 
@@ -494,17 +489,16 @@ Gating the predicate on equality would leave an ahead-of-release spoke (`openshi
   Because a `seedGeneration` config is **not** an upgrade config, it is never a valid input to `handleUpgrade` — the reconciler must route it to the seed-generation state machine, not the upgrade switch (which has no seed-generation case and would otherwise return without action).
 - The main reconciler checks `IsSeedGenerationRequested` **before** `IsUpgradeRequested` so a `seedGeneration` request is never misrouted into the upgrade path.
   A new predicate — `IsSeedGenerationRequested` (parallel to `IsUpgradeRequested`) — returns true when the merged upgrade config contains `seedGeneration` and the spoke has reached ZTP Done, **regardless of the version relationship**.
-- **Any version mismatch is a terminal precondition failure, not a stall — fail closed in both directions.** Seed generation requires the cluster to already be *at* `spec.release`; it does not itself perform an upgrade or a downgrade.
-  Phase 1 requires `openshiftVersion == spec.release` and fails terminally with `PreconditionChecksFailed` on either mismatch:
+- **Any version mismatch is a terminal precondition failure, not a stall — fail closed in both directions.** Seed generation requires the cluster to already be *at* `spec.release`; it performs neither an upgrade nor a downgrade.
+  Because the predicate fires on presence alone, a version-mismatched spoke
+  reaches Phase 1, which requires `openshiftVersion == spec.release` and fails
+  terminally with `PreconditionChecksFailed` and a direction-specific message:
   - `openshiftVersion < spec.release` (behind): "seed generation requires the cluster at spec.release; upgrade the cluster first, or configure an upgrade".
   - `openshiftVersion > spec.release` (ahead): "seed generation requires the cluster at spec.release; the cluster is ahead of the template release — align spec.release with the running version".
-  Because the predicate fires on presence alone, a version-mismatched spoke
-  (behind or ahead of `spec.release`) reaches Phase 1 and fails terminally with
-  a clear, direction-specific message. Routing a `seedGeneration`-only config
-  through `IsSeedGenerationRequested` — rather than the upgrade switch, which has
-  no seed case — guarantees the request always reaches a state that makes
-  progress or fails closed, never one that returns without action. Both mismatch
-  directions are covered by tests.
+  Routing a `seedGeneration`-only config through `IsSeedGenerationRequested`
+  rather than the upgrade switch (which has no seed case) thus guarantees the
+  request always reaches a state that makes progress or fails closed, never one
+  that returns without action. Both mismatch directions are covered by tests.
 - The main reconciler dispatches to the seed-generation state machine when `IsSeedGenerationRequested` is true, mutually exclusively with the upgrade path.
 
 #### One-shot semantics
@@ -534,30 +528,27 @@ automatically.
 
 Because a reconcile can be interrupted after a resource is created but before
 its status is flushed, every create in the state machine is **create-or-adopt**,
-not blind create. Deterministic names alone are not enough: a restart that
-re-issues a `create` would hit `AlreadyExists`, and a name collision with an
-unrelated object left by a prior run (or an external actor) could silently
-reuse the wrong resource. For each generated resource — the `seedgen`
-Secret, the ISO-build `Job`, its workspace `PVC`, and the per-run mirror/CA
-`ConfigMap` — the controller:
+not blind create. Deterministic names alone are not enough: a restart re-issuing
+a `create` hits `AlreadyExists`, and a name collision with an unrelated object
+(prior run or external actor) could silently reuse the wrong resource. For each
+generated resource — the `seedgen` Secret, the ISO-build `Job`, its workspace
+`PVC`, and the per-run mirror/CA `ConfigMap` — the controller:
 
 - Stamps a **per-run ownership label** carrying the ProvisioningRequest name
   and UID at creation time.
-- On create, treats `AlreadyExists` as follows: **get** the existing object and
-  compare its ownership label/UID. If it matches this run, **adopt** it (the
-  create is idempotent and reconcile continues). If it does not match — no
-  label, or a different UID — the controller fails closed rather than reusing or
-  mutating an object it does not own (a stale object from a prior run under the
-  same deterministic name is deleted and recreated only when it is provably this
-  PR's own residue).
+- On `AlreadyExists`, **gets** the existing object and compares its ownership
+  label/UID: on a match it **adopts** it (idempotent, reconcile continues); on
+  a mismatch (no label, or a different UID) it fails closed rather than reusing
+  an object it does not own (a stale object under the same deterministic name is
+  deleted and recreated only when provably this PR's own residue).
 - Hub-side resources additionally carry an `ownerReference` to the
   ProvisioningRequest so Kubernetes garbage-collects them if the PR is deleted
   mid-run.
 
-Each create operation has restart-after-create test coverage: kill the
-reconcile immediately after the create and assert the next reconcile adopts
-(not duplicates, not `AlreadyExists`-fails) its own resource, and rejects a
-same-named foreign object.
+Each create has restart-after-create test coverage: kill the reconcile
+immediately after the create and assert the next reconcile adopts (not
+duplicates, not `AlreadyExists`-fails) its own resource and rejects a same-named
+foreign object.
 
 #### Regenerating a seed
 
@@ -570,27 +561,31 @@ attempt.
 
 Rather than silently ignoring a late edit, the validating webhook
 (`provisioningrequest_webhook.go`) is **extended to reject** changes to
-`upgradeParameters.seedGeneration` once `SeedGenerationCompleted` is
-terminal. The existing webhook already allows updates after provisioning
-completes but only compares a disallowed-ClusterInstance-fields set; it does
-not compare `seedGeneration`, so without this addition a changed `seedImage`
-or `urlBase` would be admitted and then dropped by the one-shot dispatch
-gate — an accepted-but-ignored change that misleads the operator. The webhook
-instead returns a validation error directing the operator to submit a new
-ProvisioningRequest. (If in-place regeneration is ever desired, it would
-require an explicit generation-aware retry operation — for example bumping a
-`seedGeneration.generation` counter that the dispatch gate treats as a new
-attempt — which is out of scope here.)
+`upgradeParameters.seedGeneration` once `SeedGenerationCompleted` is terminal.
+The existing webhook allows updates after provisioning completes but only
+compares a disallowed-ClusterInstance-fields set, not `seedGeneration`, so
+without this a changed `seedImage` or `urlBase` would be admitted and then
+dropped by the one-shot dispatch gate — an accepted-but-ignored change that
+misleads the operator. The webhook instead returns a validation error directing
+the operator to submit a new ProvisioningRequest. (In-place regeneration, if
+ever desired, would require an explicit generation-aware retry — e.g. bumping a
+`seedGeneration.generation` counter the dispatch gate treats as a new attempt —
+which is out of scope here.)
 
-The spoke's `ManagedCluster` on the hub is left intact throughout the process — the controller never deletes it, so there is no re-provisioning or ClusterInstance recreation. What must be removed is the spoke-side ACM *agent state* (the klusterlet and all addon agents), because it
-would otherwise be captured in the seed image and cause a clone to register with the original hub on first boot.
-
-Because a proper klusterlet teardown deletes the ACM agent namespaces (`open-cluster-management-agent*`) — where the existing `ManagedServiceAccount` token and its RBAC live — the controller cannot rely on that token during generation. Instead, before any ACM removal, it retrieves the
-spoke's **admin kubeconfig from the hub** (the Secret referenced by the spoke `ClusterDeployment`'s `spec.clusterMetadata.adminKubeconfigSecretRef`) and builds the spoke client from it. That kubeconfig authenticates with an embedded client certificate that is independent of ACM, so it
-survives the full ACM teardown and provides spoke API access for the entire workflow — while writing nothing to the spoke's etcd, so no new credential is captured into the seed. The seed cluster is a disposable factory, so ACM is **not** restored after generation: the controller removes the
-transient workflow artifacts during cleanup, sets a terminal `SeedGenerationCompleted` condition, and the operator deletes the ProvisioningRequest to reclaim the hardware.
-
-Note that lca-cli's own cleanup does **not** strip klusterlet/registration identity, so the controller must remove it explicitly — it cannot defer this to LCA's seed preparation.
+The spoke's `ManagedCluster` on the hub is left intact throughout — the
+controller never deletes it, so there is no re-provisioning or ClusterInstance
+recreation. What must be removed is the spoke-side ACM *agent state* (the
+klusterlet and all addon agents), which would otherwise be captured in the seed
+and cause a clone to register with the original hub on first boot. Because
+klusterlet teardown deletes the agent namespaces (`open-cluster-management-agent*`)
+where the `ManagedServiceAccount` token lives, the controller cannot rely on that
+token; instead it drives generation with the spoke's hub-held admin kubeconfig
+(see Phase 2 and [Challenge 6](#6-spoke-access-after-acm-removal)). The seed
+cluster is a disposable factory, so ACM is **not** restored: cleanup removes the
+transient artifacts, a terminal `SeedGenerationCompleted` condition is set, and
+the operator deletes the ProvisioningRequest to reclaim the hardware. Note that
+lca-cli's own cleanup does **not** strip klusterlet/registration identity, so the
+controller must remove it explicitly rather than defer to LCA's seed preparation.
 
 The workflow is a multi-phase state machine tracked via a new `SeedGenerationCompleted` condition and `SeedGenerationStatus` in the PR status.
 
@@ -615,54 +610,45 @@ The workflow is a multi-phase state machine tracked via a new `SeedGenerationCom
     4.Y.Z but spec.release is 4.Y.W")
   - **Resolve and pin the `releaseImage` digest.** `releaseImage` is often a
     mutable tag (e.g. `...:4.Y.Z-x86_64`). Resolve it to an immutable
-    `repo@sha256:<digest>` during this check (from the same
-    `oc adm release info` call) and persist it in
-    `SeedGenerationStatus.ReleaseImageDigest`, so Phase 4 extracts
+    `repo@sha256:<digest>` from the same `oc adm release info` call and persist
+    it in `SeedGenerationStatus.ReleaseImageDigest`, so Phase 4 extracts
     `openshift-install` from exactly the release validated here rather than
-    re-resolving a tag that could have moved between validation and build.
-    Persisting to status (not an in-memory value) is required so the pin
-    survives a controller restart between Phase 1 and Phase 4. Report
-    `PreconditionChecksFailed` if the digest cannot be resolved.
-    In disconnected environments this resolution has a subtlety: `IDMS`/`ICSP`
-    only redirect **by-digest** pull specs, not tags, so a mutable-tag
-    `releaseImage` will not be redirected to the mirror by the hub's
-    `ImageDigestMirrorSet`/`ImageContentSourcePolicy`. Phase 1 therefore
-    requires one of: a by-digest `releaseImage`, a direct mirror pull-spec, or
-    a hub `ImageTagMirrorSet` covering the tag; if a mutable tag has no
-    tag-mirror or direct-mirror path, resolution fails closed with
-    `PreconditionChecksFailed` rather than silently reaching the (unreachable)
-    upstream registry
+    re-resolving a tag that could have moved. Persisting to status (not an
+    in-memory value) is required so the pin survives a controller restart
+    between Phase 1 and Phase 4. Report `PreconditionChecksFailed` if the digest
+    cannot be resolved. In disconnected environments there is a subtlety:
+    `IDMS`/`ICSP` redirect **by-digest** specs only, not tags, so a mutable-tag
+    `releaseImage` is not redirected to the mirror by the hub's
+    `ImageDigestMirrorSet`/`ImageContentSourcePolicy`. Phase 1 therefore requires
+    one of: a by-digest `releaseImage`, a direct mirror pull-spec, or a hub
+    `ImageTagMirrorSet` covering the tag; a mutable tag with no tag-mirror or
+    direct-mirror path fails closed with `PreconditionChecksFailed` rather than
+    silently reaching the (unreachable) upstream registry
   - **An `ImageTagMirrorSet`-only resolution must be translated into a
     by-digest mapping for Phase 4.** When the tag was reachable *only* through
-    an `ImageTagMirrorSet` (no by-digest `releaseImage`, no direct mirror
-    pull-spec, no covering `IDMS`/`ICSP`), the digest that Phase 1 persists to
-    `ReleaseImageDigest` is a `repo@sha256:<digest>` on the *source* registry
-    — and Phase 4 passes exactly that digest to
-    `oc adm release extract --idms-file`, which honors only `IDMS`/`ICSP`.
-    Because tag mirrors do **not** redirect digest references, Phase 4 would
-    then fail (or reach the unreachable source) despite Phase 1 passing.
-    Phase 1 therefore does not accept ITMS coverage on its own: it must
-    resolve the digest **through the mirror** and record an equivalent
-    by-digest mirror mapping (source repo → mirror repo, keyed on the resolved
-    digest) that is emitted into the generated `idms.yaml` Phase 4 consumes. If
-    no such digest mapping can be derived from the ITMS mirror (i.e. the mirror
-    repo does not actually hold the resolved digest), resolution fails closed
-    with `PreconditionChecksFailed` rather than deferring the failure to
-    Phase 4
+    an `ImageTagMirrorSet` (no by-digest `releaseImage`, direct mirror pull-spec,
+    or covering `IDMS`/`ICSP`), the digest Phase 1 persists to
+    `ReleaseImageDigest` is a `repo@sha256:<digest>` on the *source* registry,
+    and Phase 4 passes it to `oc adm release extract --idms-file`, which honors
+    only `IDMS`/`ICSP`. Because tag mirrors do **not** redirect digest
+    references, Phase 4 would then fail despite Phase 1 passing. Phase 1
+    therefore does not accept ITMS coverage alone: it resolves the digest
+    **through the mirror** and records an equivalent by-digest mapping (source
+    repo → mirror repo, keyed on the resolved digest) emitted into the generated
+    `idms.yaml`. If no such mapping can be derived (the mirror repo does not hold
+    the resolved digest), resolution fails closed with `PreconditionChecksFailed`
+    rather than deferring the failure to Phase 4
   - **Validate the effective ISO-build pull secret against both images.** The
-    pull secret used by the ISO-build Job is not the same credential as
-    `seedAuthSecretRef` (which only needs push access to the seed registry).
-    Resolve the effective pull secret exactly as Phase 4 will — the contents
-    of `liveISO.pullSecretRef` if provided, otherwise the hub cluster pull
-    secret (`openshift-config/pull-secret`) merged with the
-    `seedAuthSecretRef` credentials — and confirm it can authenticate to
-    **both** the `seedImage` registry and the `releaseImage` registry (after
-    mirror redirection). Checking only that the Secret exists is
-    insufficient: a `pullSecretRef` that can reach the release mirror but
-    lacks credentials for the seed mirror (or vice versa) passes a
-    mere-existence check and then fails deep in the ISO build. Report
-    `PreconditionChecksFailed` naming the registry that rejected the
-    credentials.
+    ISO-build pull secret is not the same credential as `seedAuthSecretRef`
+    (which only needs push access to the seed registry). Resolve it exactly as
+    Phase 4 will — `liveISO.pullSecretRef` if provided, else the hub pull secret
+    (`openshift-config/pull-secret`) merged with the `seedAuthSecretRef`
+    credentials — and confirm it can authenticate to **both** the `seedImage`
+    and `releaseImage` registries (after mirror redirection). A mere-existence
+    check is insufficient: a `pullSecretRef` that reaches the release mirror but
+    lacks credentials for the seed mirror (or vice versa) passes it and then
+    fails deep in the ISO build. Report `PreconditionChecksFailed` naming the
+    registry that rejected the credentials.
 - **Condition**: `SeedGenerationCompleted = False / Reason: Validating`
 
 ### Phase 2: ACM Agent Cleanup
@@ -674,36 +660,21 @@ Remove all ACM agent state from the spoke so it doesn't contaminate the seed ima
    the spoke `ClusterDeployment`'s
    `spec.clusterMetadata.adminKubeconfigSecretRef` in the cluster's namespace —
    and build the spoke client from it. This kubeconfig authenticates with an
-   embedded **client certificate** (`system:admin`), not a ServiceAccount
-   token, which is what makes it suitable here:
-   - **It survives ACM teardown.** The client cert is signed by the cluster's
-     admin-kubeconfig-signer at install time and is independent of the
-     klusterlet and the `ManagedServiceAccount` token that live in the
-     `open-cluster-management-agent*` namespaces. Deleting the `Klusterlet` CR
-     (step 4) does not affect it, so it stays valid for the entire operation. It
-     stops working only if the spoke's **API server certificate** is rotated
-     under a new CA — which happens at *restore* time on the target (recert),
-     not during generation on the seed — so it remains valid through Phase 5.
-   - **Using it writes nothing to the spoke's etcd.** No ServiceAccount, token
-     Secret, or RBAC object is created on the spoke, so no new credential is
-     captured into the seed image. This is the decisive difference from minting
-     a spoke-side token: the workflow adds no persisted credential that a clone
-     deployed from the seed would carry (see
-     [Challenge 6](#6-spoke-access-after-acm-removal)). The only object this
-     workflow places on the spoke is the transient `seedgen` Secret in Phase 3,
-     which lca-cli consumes and Phase 5 deletes — the same Secret the manual
-     workflow uses.
-   - **No revocation is required.** Because nothing is minted, there is no
-     standalone credential to delete or leave behind; Phase 5 spoke cleanup is
-     limited to the transient `seedgen` Secret and the `SeedGenerator` CR. The
-     admin kubeconfig is a pre-existing hub Secret the controller only *reads*.
-
-   The trade-off is that the admin kubeconfig is a broad (`cluster-admin`)
-   credential rather than a least-privilege, purpose-scoped one. This is
-   accepted because the credential is (a) used only by the O-Cloud Manager
-   controller during a controlled, one-shot operation, (b) never persisted or
-   copied to the spoke, and (c) never baked into the seed — so its blast radius
-   is bounded by the operation's duration, not by any artifact that outlives it.
+   embedded `system:admin` **client certificate**, not a ServiceAccount token,
+   which is what makes it suitable (see
+   [Challenge 6](#6-spoke-access-after-acm-removal) for the full rationale): it
+   **survives ACM teardown** (the cert is independent of the klusterlet and the
+   `ManagedServiceAccount` token in the `open-cluster-management-agent*`
+   namespaces, breaking only on API-server cert rotation, which happens at
+   *restore* on the target, not generation), **writes nothing to the spoke's
+   etcd** (no ServiceAccount/token/RBAC is created, so no new credential is
+   captured into the seed — the only object placed on the spoke is the transient
+   Phase 3 `seedgen` Secret), and **needs no revocation** (nothing is minted;
+   Phase 5 spoke cleanup is limited to the `seedgen` Secret and `SeedGenerator`
+   CR). The trade-off — a broad `cluster-admin` credential rather than a
+   least-privilege one — is accepted because it is used only during this
+   controlled one-shot operation, never persisted or copied to the spoke, and
+   never baked into the seed.
 
    **Precondition.** If the admin-kubeconfig Secret is absent, malformed, or the
    resulting client cannot reach the spoke API server, Phase 2 fails with
@@ -736,25 +707,21 @@ Using the admin-kubeconfig spoke client established in Phase 2:
    - Seed image generation via lca-cli (`lca_image_builder` container)
    - Image push to registry
    - Cluster operator recovery
-4. **Capture the pushed digest**: On completion, read the digest of the
-   pushed seed image from the SeedGenerator status and record it in
-   `SeedGenerationStatus.SeedImage` as an immutable
+4. **Capture the pushed digest**: On completion, record the pushed seed image
+   digest in `SeedGenerationStatus.SeedImage` as an immutable
    `<repository>@sha256:<digest>` reference. The configured
-   `seedGeneration.seedImage` is a **mutable tag**; between the push in this
-   phase and the ISO build in Phase 4 that tag could be overwritten to point
-   at a different image, so all downstream consumption must pin the digest
-   rather than re-resolving the tag. The digest is taken **only** from the
-   authoritative output of the push itself — the digest the SeedGenerator/LCA
-   reports for the image it just pushed, which is produced atomically with the
-   push and therefore provably identifies this run's image. The controller
-   does **not** fall back to a post-hoc registry tag lookup (a manifest
-   `HEAD`/`GET`): resolving the mutable tag after the fact cannot prove the
-   returned image is the one this run produced — another writer can move the
-   tag before or during the lookup — so a tag lookup would defeat the very
-   integrity guarantee this pin exists to provide. If the SeedGenerator/LCA
-   does not surface an immutable digest for the pushed image, the workflow
-   **fails closed** with a terminal `Failed` rather than building an ISO from
-   an unverifiable tag.
+   `seedGeneration.seedImage` is a **mutable tag** that could be overwritten
+   between this push and the Phase 4 ISO build, so all downstream consumption
+   pins the digest rather than re-resolving the tag. The digest is taken
+   **only** from the authoritative output of the push itself — the digest the
+   SeedGenerator/LCA reports for the image it just pushed, produced atomically
+   with the push and thus provably this run's image. The controller does **not**
+   fall back to a post-hoc registry tag lookup (manifest `HEAD`/`GET`): resolving
+   the tag after the fact cannot prove the returned image is this run's (another
+   writer can move the tag before or during the lookup), defeating the very
+   integrity guarantee the pin exists for. If the SeedGenerator/LCA surfaces no
+   immutable digest, the workflow **fails closed** with a terminal `Failed`
+   rather than building an ISO from an unverifiable tag.
 
 - **Condition**: `SeedGenerationCompleted = False / Reason: InProgress`
 - **Status message**: Reflects the SeedGenerator's condition messages (e.g., `SeedGenInProgress=True` → "Generating seed image", `SeedGenCompleted=True` → generation finished)
@@ -772,10 +739,10 @@ The controller creates a Kubernetes Job on the hub cluster that builds the live 
    - **Mirror mappings**: Read the hub's `ImageDigestMirrorSet` resources (field `spec.imageDigestMirrors`)
      and, if present, legacy `ImageContentSourcePolicy` resources (field `spec.repositoryDigestMirrors` —
      **not** `imageDigestMirrors`, which ICSP does not define). Translate their source → mirrors entries into
-     both IBI `imageDigestSources` entries and an equivalent `idms.yaml` passed to
-     `oc adm release extract --idms-file`. Reading the wrong field for ICSP yields empty mappings and silently breaks disconnected release extraction, so the ICSP-only path must be covered by a dedicated test.
-     **Preserve `mirrorSourcePolicy`.** When an `ImageDigestMirrorSet` entry sets `mirrorSourcePolicy: NeverContactSource`, copy that policy into the generated `idms.yaml` alongside its `source` and `mirrors`.
-     If it is dropped, `oc adm release extract --idms-file` may fall back to the source registry after a mirror miss, causing upstream egress on a connected hub or an extraction failure on a disconnected one. A dedicated test covers the `NeverContactSource` case.
+     both IBI `imageDigestSources` and an equivalent `idms.yaml` passed to `oc adm release extract --idms-file`.
+     Reading the wrong field for ICSP yields empty mappings and silently breaks disconnected release extraction, so a dedicated test covers the ICSP-only path.
+     **Preserve `mirrorSourcePolicy`.** When an entry sets `mirrorSourcePolicy: NeverContactSource`, copy that into the generated `idms.yaml` alongside its `source` and `mirrors`; if dropped,
+     `oc adm release extract` may fall back to the source registry after a mirror miss, causing upstream egress on a connected hub or an extraction failure on a disconnected one. A dedicated test covers this case.
    - **Registry trust**: Read the ConfigMap named by `image.config.openshift.io/cluster` `spec.additionalTrustedCA` (in `openshift-config`) and concatenate its CA values into a single PEM bundle, used as the IBI `additionalTrustBundle` and mounted into the Job pod's trust store so
      `oc` can reach the mirror.
 
@@ -829,73 +796,53 @@ The controller creates a Kubernetes Job on the hub cluster that builds the live 
    mounted SSH private key while a bogus (or malicious) ISO is served to
    the BMCs.
 
-   The upload itself uses SSH (encrypted in transit). The Job computes the
-   ISO's SHA-256 digest locally before upload and records the byte size. After
-   upload, the controller verifies the served artifact is exactly the one it
-   built, not merely that *some* file is reachable:
-   - A HEAD/`Content-Length` check against the effective ISO URL alone is insufficient — it
-     confirms reachability and TLS trust but cannot detect a stale ISO from a
-     previous run, a truncated upload with a matching size, or a same-size
-     substitution.
-   - Uploads therefore target a **unique, per-run remote path** (the
-     `remotePath` from `uploadSecretRef` disambiguated by the
-     ProvisioningRequest name and the seed image digest) so a new build never
-     silently overwrites or is confused with an older ISO at a shared URL.
-   - The controller then confirms **content identity** — this step is
-     **mandatory**, not best-effort. It fetches the digest over the SSH
-     channel it already trusts (`sha256sum` on the remote `remotePath`) and
-     compares it to the locally computed digest; a mismatch or an inability
-     to obtain the remote digest is a terminal `Failed`. Because SSH already
-     gives an authenticated, integrity-checked channel to the exact file just
-     written, this comparison is always available and does not depend on the
-     server exposing anything extra.
-   - The `remotePath` → effective-ISO-URL relationship is **deterministic and
-     explicitly defined**, not merely asserted, so the artifact verified over
-     SSH is provably the same object addressed by the recorded URL. The upload
-     endpoint (`uploadSecretRef.host` + `remotePath`) and the HTTPS origin
-     (`liveISO.urlBase`) must be two views of the **same backing store**; the
-     design derives both sides from a single input and the controller
-     validates the binding before recording `ISOURL`:
-     - `liveISO.urlBase` is the only URL input: the HTTPS origin + base path
-       served from the same directory tree the SSH `remotePath` writes into.
-       Both the SSH target and the effective ISO URL are computed from it plus
-       the per-run suffix (the ProvisioningRequest name + seed image digest +
-       filename) — one rule applied identically to both sides, so there is no
-       independently supplied full URL that could drift from `remotePath`.
-     - Before recording `ISOURL`, the controller validates the binding: the
-       path component of the computed effective ISO URL must equal the
-       served-root-relative form of `remotePath`. A mismatch (e.g. a `urlBase`
-       whose served root does not correspond to where the file was actually
-       written) is a terminal `Failed`, because SSH would otherwise verify one
-       file while status advertises another.
-     - **Path binding is not sufficient on its own, because `uploadSecretRef.host`
-       and the `urlBase` host are independent inputs.** Matching path components
-       do not prove the HTTPS origin and the SSH upload target are the same
-       backing store — an SSH upload to host A and an HTTPS `urlBase` on host B
-       that happen to share a path would pass a path-only check while serving
-       different bytes. The controller therefore binds the hosts as well, in
-       one of two ways, and records `ISOURL` only when one holds:
-       - **Same-host fast path:** the `urlBase` host resolves to the same
-         backing store as `uploadSecretRef.host` (identical host, or an
-         explicitly configured alias mapping the two to one store). Here the
-         mandatory SSH digest verification already covers the served bytes.
-       - **Cross-host path (or any time the same-store relationship cannot be
-         proven): mandatory HTTPS content-digest verification.** The controller
-         fetches the artifact over HTTPS from the computed effective ISO URL
-         (using the `urlBase` `caCert`), hashes it, and requires it to equal the
-         locally computed digest before recording `ISOURL`. In this case the
-         HTTPS check is **not** optional and a HEAD/sidecar is not accepted as a
-         substitute — the actual served bytes at `urlBase` must be hashed. A
-         mismatch or unreachable URL is a terminal `Failed`.
-     - `ISOURL` is recorded **only after** the path binding, the host binding
-       (same-store or mandatory HTTPS content-digest verification), and the
-       mandatory SSH digest verification all pass.
-   - Optionally, if the server publishes a companion `.sha256` sidecar, an
-     HTTPS `GET` of that small file (using the `caCert`) additionally
-     confirms the *publicly served* copy without re-downloading the multi-GB
-     ISO. When present it is compared and must match; when absent the
-     mandatory SSH-side verification above still stands. A plain HEAD is only
-     a "served over HTTPS" liveness probe, never the integrity check.
+   The upload uses SSH (encrypted in transit). The Job computes the ISO's
+   SHA-256 digest locally before upload. After upload the controller verifies
+   the served artifact is exactly the one it built, not merely that *some* file
+   is reachable — a HEAD/`Content-Length` check confirms reachability and TLS
+   trust but cannot detect a stale ISO, a truncated upload with a matching size,
+   or a same-size substitution:
+   - **Unique per-run remote path.** Uploads target the `remotePath` from
+     `uploadSecretRef` disambiguated by the ProvisioningRequest name and seed
+     image digest, so a new build never overwrites or is confused with an older
+     ISO at a shared URL.
+   - **Mandatory SSH content identity.** The controller fetches the digest over
+     the already-trusted SSH channel (`sha256sum` on the remote `remotePath`)
+     and compares it to the local digest; a mismatch or an inability to obtain
+     the remote digest is a terminal `Failed`. SSH gives an authenticated,
+     integrity-checked channel to the exact file just written, so this check is
+     always available without the server exposing anything extra.
+   - **Deterministic `remotePath` → ISO-URL binding.** The upload endpoint
+     (`uploadSecretRef.host` + `remotePath`) and the HTTPS origin
+     (`liveISO.urlBase`) must be two views of the **same backing store**.
+     `liveISO.urlBase` is the only URL input; both the SSH target and the
+     effective ISO URL are computed from it plus the per-run suffix
+     (ProvisioningRequest name + seed image digest + filename), so no
+     independently supplied full URL can drift from `remotePath`. Before
+     recording `ISOURL` the controller validates the binding on two axes:
+     - **Path.** The path component of the computed ISO URL must equal the
+       served-root-relative form of `remotePath`; a mismatch is a terminal
+       `Failed` (SSH would otherwise verify one file while status advertises
+       another).
+     - **Host** — because `uploadSecretRef.host` and the `urlBase` host are
+       independent inputs, matching paths alone do not prove the same backing
+       store (SSH to host A, HTTPS on host B sharing a path would pass a
+       path-only check). Either the **same-host fast path** (identical host or
+       an explicit alias to one store — the mandatory SSH digest check already
+       covers the served bytes), or, when the same-store relationship cannot be
+       proven, **mandatory HTTPS content-digest verification**: the controller
+       fetches the artifact over HTTPS from the computed URL (using the
+       `urlBase` `caCert`), hashes it, and requires equality with the local
+       digest. Here the HTTPS check is **not** optional and a HEAD/sidecar is
+       no substitute — the actual served bytes must be hashed; a mismatch or
+       unreachable URL is a terminal `Failed`.
+     `ISOURL` is recorded **only after** the path binding, the host binding, and
+     the mandatory SSH digest verification all pass.
+   - Optionally, if the server publishes a companion `.sha256` sidecar, an HTTPS
+     `GET` of that small file (using the `caCert`) confirms the publicly served
+     copy without re-downloading the multi-GB ISO; when present it must match,
+     when absent the mandatory SSH-side verification still stands. A plain HEAD
+     is only a "served over HTTPS" liveness probe, never the integrity check.
 
    The verified SHA-256 digest and the resolved per-run effective ISO URL are recorded
    in status (`ISODigest`, `ISOURL`) so downstream consumers can pin the
@@ -904,26 +851,21 @@ The controller creates a Kubernetes Job on the hub cluster that builds the live 
 **Job pod spec considerations:**
 
 - The Job image uses `oc` (available from the OCP CLI tools image) and `openshift-install` (extracted at runtime)
-- **PVC for build workspace**: The controller creates a dedicated PersistentVolumeClaim (~20GB) for the ISO build workspace. The PVC is mounted into the Job pod as the working directory. This is required because the `openshift-install` command pulls the full seed image and generates
-  an ISO, which exceeds typical ephemeral storage limits. The PVC is created before the Job and deleted during Phase 5 cleanup after the ISO has been successfully uploaded. The PVC name is derived from the ProvisioningRequest name (e.g., `<pr-name>-iso-build`). The StorageClass is
-  configurable via an optional `storageClass` field in the `liveISO` config; if omitted, the cluster's default StorageClass is used.
+- **PVC for build workspace**: The controller creates a dedicated PVC (~20GB), mounted into the Job pod as the working directory, because `openshift-install` pulls the full seed image and generates an ISO, exceeding typical ephemeral storage limits. It is created before the Job and deleted
+  during Phase 5 after successful upload. Its name is derived from the ProvisioningRequest name (e.g. `<pr-name>-iso-build`); the StorageClass comes from the optional `liveISO.storageClass` field, or the cluster default if omitted.
 - **Per-run credential copies in the Job namespace.** A pod can only mount
-  Secrets from its own namespace, but the source credentials live elsewhere:
-  `seedAuthSecretRef` resolves in the **ClusterTemplate** namespace and the
-  hub pull secret is `openshift-config/pull-secret`, while the Job runs in the
-  **O-Cloud Manager** namespace. The Job therefore cannot mount either source
-  Secret directly. Before creating the Job, the controller copies the
-  credentials it needs into **short-lived, per-run Secrets in the Job
-  namespace** (named deterministically from the ProvisioningRequest), and the
-  Job references those copies. `uploadSecretRef` and the optional
-  `pullSecretRef` are name-only references that **always resolve in the
-  ClusterTemplate namespace** (the same namespace as `seedAuthSecretRef`),
-  never in the PR or Job namespace — a name-only ref cannot select a Secret
-  the caller controls elsewhere. Because that is not the Job namespace, they
-  are copied into per-run Secrets the same way. These per-run
-  copies are among the credential-bearing artifacts deleted on **every**
-  terminal path (success and failure — see Phase 5), so credentials are not
-  left lingering in the Job namespace.
+  Secrets from its own namespace, but the sources live elsewhere:
+  `seedAuthSecretRef` resolves in the **ClusterTemplate** namespace and the hub
+  pull secret is `openshift-config/pull-secret`, while the Job runs in the
+  **O-Cloud Manager** namespace. Before creating the Job, the controller copies
+  the credentials it needs into **short-lived, per-run Secrets in the Job
+  namespace** (named deterministically from the ProvisioningRequest) that the
+  Job references. `uploadSecretRef` and the optional `pullSecretRef` are
+  name-only references that **always resolve in the ClusterTemplate namespace**
+  (never the PR or Job namespace — a name-only ref cannot select a Secret the
+  caller controls elsewhere) and are copied the same way. These per-run copies
+  are deleted on **every** terminal path (success and failure — see Phase 5),
+  so credentials are not left lingering in the Job namespace.
 - The Job mounts: the build workspace PVC, the per-run copies of
   `seedAuthSecretRef` (registry auth) and the merged/`pullSecretRef` pull
   secret, `uploadSecretRef` (SSH credentials), and the resolved mirror config
@@ -934,20 +876,15 @@ The controller creates a Kubernetes Job on the hub cluster that builds the live 
 - On Job failure, the controller surfaces a **bounded, redacted** summary of
   the pod logs in the condition message. Raw pod logs must not be written
   verbatim into `metav1.Condition.message`: that field is capped at 32768
-  bytes (the API server rejects longer values, which would fail the status
-  update and stall the state machine), and the ISO-build environment has
-  registry pull secrets, SSH credentials, and CA material mounted, so
-  unfiltered logs risk leaking secrets into the PR status. The controller
-  extracts a short tail (e.g. the last few lines / a fixed byte budget well
-  under the limit) and redacts known credential patterns for the condition
-  message. For deeper debugging it retains a **redacted** copy of the pod
-  logs — never the raw logs. Because the ISO-build pod has registry pull
-  secrets, SSH credentials, and CA material mounted, raw logs left with the
-  failed Job/pod would expose those credentials, so the controller redacts
-  before persisting, **deletes the original log-bearing artifacts** (the
-  failed pod and its raw logs are not kept), and retains only the bounded,
-  redacted copy under a diagnostic-retention **TTL** (see Phase 5). The
-  condition message points the operator at that redacted copy.
+  bytes (the API server rejects longer values, failing the status update and
+  stalling the state machine), and the ISO-build environment has registry pull
+  secrets, SSH credentials, and CA material mounted, so unfiltered logs risk
+  leaking secrets into the PR status. The controller extracts a short tail (a
+  fixed byte budget well under the limit) with known credential patterns
+  redacted for the message. For deeper debugging it **deletes the original
+  log-bearing artifacts** (the failed pod and its raw logs are not kept) and
+  retains only a **redacted** copy of the pod logs under a diagnostic-retention
+  **TTL** (see Phase 5), which the condition message points the operator at.
 
 **Hub RBAC contract for the controller.** The operator's hub service account
 needs an explicit set of permissions in the O-Cloud Manager namespace beyond
@@ -978,17 +915,15 @@ in its own namespace:
   `ImageTagMirrorSet`: `get`, `list` (derive mirror config).
 - `operator.openshift.io` `ImageContentSourcePolicy`: `get`, `list`. **ICSP
   lives in a different API group** (`operator.openshift.io`) than IDMS/ITMS
-  (`config.openshift.io`); a single `config.openshift.io` grant cannot
-  authorize reading ICSP, so the ICSP-only mirror-resolution path would fail
-  with `Forbidden` without this separate entry. An authorization test covers
-  the ICSP-only path.
+  (`config.openshift.io`), so a single `config.openshift.io` grant cannot
+  authorize reading ICSP and the ICSP-only mirror-resolution path would fail
+  with `Forbidden` without this separate entry. An authorization test covers it.
 - `addon.open-cluster-management.io` `ManagedClusterAddOn`: `get`, `list`,
-  `delete`, scoped to the managed-cluster namespace. Phase 2 deletes all
-  `ManagedClusterAddOn` CRs there (including `managed-serviceaccount`) as a
-  hub-side operation; a `get`/`list`/`watch`-only grant would fail the delete
-  with `Forbidden` **after** `DetachmentStarted` was already persisted,
-  leaving the spoke half-detached. `list` and `delete` (with the required
-  namespace scope) must be granted before that marker is written.
+  `delete`, scoped to the managed-cluster namespace. Phase 2 deletes all such
+  CRs there (including `managed-serviceaccount`); a read-only grant would fail
+  the delete with `Forbidden` **after** `DetachmentStarted` was persisted,
+  leaving the spoke half-detached, so `list`/`delete` (with the namespace scope)
+  must be granted before that marker is written.
 
 These are enumerated so the manually-maintained controller ClusterRole (see
 the repository RBAC conventions) can be updated in one place; every artifact
@@ -1040,32 +975,26 @@ On failure (at any phase):
    - **Hub**: deletes **every** per-run credential copy created in the Job
      namespace — the `seedAuthSecretRef` copy, the pull-secret copy, and the
      per-run `uploadSecretRef` copy (which holds the SSH **private key** and
-     `knownHosts`) — plus the `idms.yaml`/CA-trust ConfigMap and any Secret
-     projections mounted into the Job pod, and deletes the Job pod's mounted
-     volumes. The upload-credential copy is the most sensitive of the three
-     and is scrubbed on the same immediate failure path as the others, not
-     left behind after the Job and pod are deleted. Every per-run Secret the
-     controller generates is covered by this scrub and by a test.
-     Only *scrubbed* diagnostics are retained: the
-     bounded, redacted log tail (already written to the condition) and, if
-     kept, a copy of pod logs with credential patterns redacted. The build
-     workspace PVC (which may hold the seed image / partial ISO but not the
-     input Secrets) may be retained under a **bounded diagnostic-retention
-     policy** (a TTL after which it is reclaimed), not "until the PR is
-     deleted" indefinitely.
+     `knownHosts`, the most sensitive of the three) — plus the `idms.yaml`/CA-trust
+     ConfigMap and any Secret projections mounted into the Job pod, and deletes
+     the pod's mounted volumes, all on the same immediate failure path. Every
+     per-run Secret the controller generates is covered by this scrub and by a
+     test. Only *scrubbed* diagnostics are retained: the bounded, redacted log
+     tail (already in the condition) and, if kept, credential-redacted pod logs.
+     The build workspace PVC (which may hold the seed image / partial ISO but not
+     the input Secrets) may be retained under a **bounded diagnostic-retention
+     policy** (a TTL after which it is reclaimed), not indefinitely until the PR
+     is deleted.
    - **Spoke**: deletes the transient `seedgen` Secret and the SeedGenerator
-     CR. No standalone credential was minted, so there is no spoke-side
-     ServiceAccount, token Secret, or RBAC to revoke — the admin kubeconfig used
-     for spoke access is a pre-existing hub Secret the controller only read and
-     never copied to the spoke, and nothing about it is baked into the seed. The
-     only sensitive item this workflow places on the spoke is the `seedgen`
-     Secret (registry push credentials); a hub-side finalizer plus a bounded
-     overall operation **deadline** ensure that even a stuck or abandoned run
-     force-runs this spoke cleanup while the spoke is still reachable, rather
-     than leaving the `seedgen` Secret behind. If the spoke is genuinely
-     unreachable at cleanup time (e.g. the controller was down and the spoke was
-     independently torn down), the `seedgen` Secret is the item to purge
-     manually.
+     CR. Nothing was minted, so there is no spoke-side ServiceAccount, token, or
+     RBAC to revoke — the admin kubeconfig is a hub Secret the controller only
+     read, never copied to the spoke, and nothing about it is baked into the
+     seed. The only sensitive item placed on the spoke is the `seedgen` Secret
+     (registry push credentials); a hub-side finalizer plus a bounded operation
+     **deadline** force-run this cleanup even for a stuck or abandoned run while
+     the spoke is still reachable. If the spoke is genuinely unreachable at
+     cleanup time (e.g. the controller was down and the spoke was independently
+     torn down), the `seedgen` Secret is the item to purge manually.
 4. The spoke cluster remains running (detached) for manual intervention. ACM
    is **not** restored automatically; the operator can re-import the cluster
    manually for debugging or delete the ProvisioningRequest to tear it down.
@@ -1094,15 +1023,14 @@ type SeedGenerationStatus struct {
 
     // DetachmentStarted is set to true and flushed to status immediately
     // BEFORE Phase 2 performs the first destructive ACM removal (deleting the
-    // ManagedClusterAddOn CRs, which precedes Klusterlet deletion), i.e. it is
-    // persisted before the point of no return, not after teardown finishes.
-    // This is deliberate: if addon/Klusterlet deletion succeeds but the teardown
-    // poll times out before the status could be updated, a "Detached only
-    // after Phase 2 completes" marker would still read false and ACM-
-    // dependent reconciliation would resume against a spoke that is in fact
+    // ManagedClusterAddOn CRs, which precedes Klusterlet deletion) — before the
+    // point of no return, not after teardown finishes. This is deliberate: if
+    // that deletion succeeds but the teardown poll times out before status is
+    // updated, an "after Phase 2 completes" marker would still read false and
+    // ACM-dependent reconciliation would resume against a spoke that is in fact
     // (partially) detached. Gating suppression on DetachmentStarted instead
-    // means any terminal outcome reached once destruction has begun
-    // suppresses ACM-dependent checks. A pre-Phase-2 terminal failure (e.g.
+    // means any terminal outcome reached once destruction has begun suppresses
+    // ACM-dependent checks; a pre-Phase-2 terminal failure (e.g.
     // PreconditionChecksFailed) leaves this false, so the still-attached
     // cluster reconciles normally. See Challenge 4.
     DetachmentStarted bool `json:"detachmentStarted,omitempty"`
@@ -1136,20 +1064,17 @@ type SeedGenerationStatus struct {
     // ISOURL rather than trusting a mutable URL.
     ISODigest string `json:"isoDigest,omitempty"`
 
-    // ISOServerCACertRef is a typed reference to a ConfigMap the
-    // controller materializes on completion (in the O-Cloud Manager
-    // namespace, named deterministically from the ProvisioningRequest)
-    // holding the PEM CA bundle for the HTTPS ISO server under a
-    // well-known key. It is populated only when uploadSecretRef.caCert
-    // is present. The controller creates the ConfigMap rather than
-    // storing raw PEM here, so downstream consumers (e.g. BMC virtual
-    // media configuration) get a stable object reference instead of
-    // inline certificate data. Because ProvisioningRequest is cluster-
-    // scoped and this ConfigMap is namespaced, Kubernetes garbage
-    // collection cannot delete it via an ownerReference (a namespaced
-    // dependent may not have a cluster-scoped owner). Cleanup is therefore
-    // explicit: handleFinalizer deletes this ConfigMap (by the
-    // deterministic name recorded here) as part of ProvisioningRequest
+    // ISOServerCACertRef is a typed reference to a ConfigMap the controller
+    // materializes on completion (in the O-Cloud Manager namespace, named
+    // deterministically from the ProvisioningRequest) holding the PEM CA bundle
+    // for the HTTPS ISO server under a well-known key. Populated only when
+    // uploadSecretRef.caCert is present. The controller creates the ConfigMap
+    // rather than storing raw PEM here, so downstream consumers (e.g. BMC
+    // virtual media configuration) get a stable object reference, not inline
+    // certificate data. Because ProvisioningRequest is cluster-scoped and this
+    // ConfigMap is namespaced, GC cannot delete it via an ownerReference (a
+    // namespaced dependent may not have a cluster-scoped owner); cleanup is
+    // therefore explicit — handleFinalizer deletes it by the recorded name at
     // teardown. It is not credential-bearing, so it is removed on normal
     // teardown rather than in the immediate Phase 5 credential-scrub path.
     ISOServerCACertRef *ConfigMapKeyRef `json:"isoServerCACertRef,omitempty"`
@@ -1273,30 +1198,29 @@ spec:
 **Mitigation**: The controller removes hub-side addon CRs (stopping reconciliation) and deletes the spoke `Klusterlet` CR, letting the klusterlet operator tear down the agent namespaces and their identity secrets (`bootstrap-hub-kubeconfig`, `hub-kubeconfig-secret`). lca-cli's own
 cleanup does **not** strip klusterlet/registration identity, so this explicit removal is required; lca-cli still handles the remaining cluster-specific artifacts (certificates, node identity) as part of recert.
 
-Observability is handled **preventively rather than by post-hoc cleanup**. RHACM's `multicluster-observability-operator` watches for managed clusters and
-automatically deploys the observability-addon (metrics-collector plus the observability-endpoint-operator) to each one; that addon is what creates hub-specific
-secrets such as `hub-alertmanager-router-ca-*` and `observability-alertmanager-accessor-*` in the `openshift-monitoring` and
-`openshift-user-workload-monitoring` namespaces on the spoke — exactly the kind of hub-coupled artifact that must not be baked into a portable seed image. Because
-the seed cluster is a disposable, purpose-built cluster the operator provisions, the seed `ClusterTemplate` sets the `observability: disabled` label on the
-`ManagedCluster` (via `clusterInstanceDefaults`) so the label is present from the moment the cluster is imported. The observability-operator then never deploys
-the addon to it, so the metrics-collector and the secrets above are never created and cannot contaminate the seed. This is preferable to enumerating and deleting
-those secrets during teardown, whose exact set drifts across RHACM/MCE versions — a hardcoded deletion list is fragile, and preventing the secrets from ever being
-created is more robust than racing to remove them before capture. A residual secret sweep is needed only if a cluster that *already* had observability deployed is
-later repurposed as a seed cluster (not the standard flow); it is called out as a fallback in [Open Question 4](#open-questions), not the default path.
+Observability is handled **preventively rather than by post-hoc cleanup**. RHACM's `multicluster-observability-operator` automatically deploys the
+observability-addon (metrics-collector plus the observability-endpoint-operator) to each managed cluster; that addon creates hub-specific secrets such as
+`hub-alertmanager-router-ca-*` and `observability-alertmanager-accessor-*` in the spoke's `openshift-monitoring` and `openshift-user-workload-monitoring`
+namespaces — exactly the hub-coupled artifact that must not be baked into a portable seed. Because the seed cluster is disposable and purpose-built, the seed
+`ClusterTemplate` sets the `observability: disabled` label on the `ManagedCluster` (via `clusterInstanceDefaults`) from the moment it is imported, so the
+observability-operator never deploys the addon and those secrets are never created. This is preferable to enumerating and deleting them during teardown, whose
+exact set drifts across RHACM/MCE versions — preventing creation is more robust than racing a fragile hardcoded deletion list before capture. A residual secret
+sweep is needed only if a cluster that *already* had observability deployed is later repurposed as a seed (not the standard flow); it is a fallback in
+[Open Question 4](#open-questions), not the default path.
 
 ### 2. Spoke client availability during seed generation
 
 **Challenge**: During Phase 3, the lca-cli shuts down cluster operators on the spoke, which may temporarily affect API server availability and disrupt the spoke client.
 
-**Mitigation**: The controller uses polling with backoff when monitoring the SeedGenerator CR. The spoke API server itself stays running (lca-cli stops operators, not the API server). The admin kubeconfig retrieved in Phase 2 remains valid — its client certificate is independent of ACM and is
-not affected by the klusterlet teardown — so the spoke client keeps working even though the ACM agents are gone. Transient API errors during operator shutdown are retried.
+**Mitigation**: The controller polls the SeedGenerator CR with backoff. The spoke API server stays running (lca-cli stops operators, not the API server), and the Phase 2 admin kubeconfig remains valid — its client certificate is independent of ACM and unaffected by klusterlet teardown — so the
+spoke client keeps working even though the ACM agents are gone. Transient API errors during operator shutdown are retried.
 
 ### 3. ACM self-healing during cleanup phase
 
 **Challenge**: ACM's klusterlet operator may attempt to re-deploy agents while the controller is removing them in Phase 2, creating a race condition.
 
-**Mitigation**: The controller deletes the `Klusterlet` CR itself — not just the agent Deployments — so the klusterlet operator tears the agents down and does not recreate them; the race dissolves because there is no CR left to reconcile. Hub-side `ManagedClusterAddOn` CRs are deleted
-first so the addon framework also stops reconciling. The order is: hub addon CRs → spoke `Klusterlet` CR → wait for namespace/pod teardown. The seed cluster is disposable, so nothing reinstalls the klusterlet afterward.
+**Mitigation**: The controller deletes the `Klusterlet` CR itself — not just the agent Deployments — so the klusterlet operator tears the agents down and does not recreate them; the race dissolves because there is no CR left to reconcile. Hub-side `ManagedClusterAddOn` CRs are deleted first
+so the addon framework also stops. The order is: hub addon CRs → spoke `Klusterlet` CR → wait for namespace/pod teardown. The seed cluster is disposable, so nothing reinstalls the klusterlet afterward.
 
 ### 4. Seed cluster afterlife and PR terminal state
 
@@ -1307,19 +1231,14 @@ compliance via the governance addon) and `NonCompliantAt`. Left unhandled, the P
 whenever the spoke has (begun to) detach and `SeedGenerationCompleted` is terminal. Detachment happens in
 Phase 2, so **any** terminal outcome reached at or after Phase 2 — `True / Completed`, `False / Failed`, or
 `False / TimedOut` — leaves the cluster detached and must suppress those checks; otherwise
-`ConfigurationApplied` and `NonCompliantAt` would report the detached cluster as broken forever. To
-distinguish this from a pre-detachment failure (e.g. `PreconditionChecksFailed` in Phase 1, where the
-cluster is still ACM-attached and should reconcile normally), the controller records a `DetachmentStarted`
-marker in `SeedGenerationStatus` **immediately before** it performs the first destructive ACM removal in
-Phase 2 (deleting the `ManagedClusterAddOn` CRs, which precedes Klusterlet deletion) and gates the
-suppression on it. Persisting the marker before the point of no
-return — rather than after Phase 2 finishes — is deliberate: if that teardown succeeds but the
-teardown poll then times out before status could be written, an "after Phase 2 completes" marker would still
-read false and the controller would resume ACM checks against a spoke that is in fact already (partially)
-detached. On any terminal outcome it
-also stops re-running seed generation. The cluster is left running for the operator to inspect; deleting the
-ProvisioningRequest tears it down via the existing deletion path and reclaims the hardware. This mirrors the
-manual workflow, which also never re-attaches the seed cluster.
+`ConfigurationApplied` and `NonCompliantAt` would report it as broken forever. To distinguish this from a
+pre-detachment failure (e.g. `PreconditionChecksFailed` in Phase 1, where the cluster is still ACM-attached
+and should reconcile normally), the controller records a `DetachmentStarted` marker in
+`SeedGenerationStatus` **immediately before** the first destructive ACM removal and gates the suppression on
+it (the marker's before-the-point-of-no-return placement is detailed in the status-field comment). On any
+terminal outcome it also stops re-running seed generation. The cluster is left running for the operator to
+inspect; deleting the ProvisioningRequest tears it down via the existing deletion path and reclaims the
+hardware. This mirrors the manual workflow, which also never re-attaches the seed cluster.
 
 ### 5. Seed SNO prerequisites
 
@@ -1343,52 +1262,52 @@ operation (2h/3h), and — critically — does **not** end up baked into the see
 - **No revocation is required.** Because nothing is minted, there is no standalone credential to revoke or leak. Phase 5 spoke cleanup is limited to deleting the transient `seedgen` Secret and the `SeedGenerator` CR; a hub-side finalizer plus a bounded operation **deadline** force-run that
   cleanup even for a stuck or abandoned run, so the `seedgen` Secret is not left behind.
 
-The trade-off is that the admin kubeconfig is a broad (`cluster-admin`) credential. This is accepted because it is used only by the controller during a controlled one-shot operation, is never persisted or copied to the spoke, and is never baked into the seed — so its blast radius is bounded by the
-operation's duration, not by any artifact that outlives it. The controller's only new access requirement is a hub-side `get` on the admin-kubeconfig Secret in the cluster's namespace (see the hub RBAC contract); it needs **no spoke-side RBAC at all**. The Phase 2 deletion of `ManagedClusterAddOn` CRs
-is a **hub-side** operation performed with the O-Cloud Manager's own hub client, so it is also covered by the hub RBAC contract, not by any spoke credential.
+The trade-off is that the admin kubeconfig is a broad (`cluster-admin`) credential. This is accepted because it is used only during a controlled one-shot operation, never persisted or copied to the spoke, and never baked into the seed — so its blast radius is bounded by the operation's duration,
+not by any artifact that outlives it. The controller's only new access requirement is a hub-side `get` on the admin-kubeconfig Secret in the cluster's namespace (see the hub RBAC contract); it needs **no spoke-side RBAC at all**. The Phase 2 deletion of `ManagedClusterAddOn` CRs is likewise a
+**hub-side** operation performed with the O-Cloud Manager's own hub client, covered by the hub RBAC contract, not by any spoke credential.
 
 ### 7. ISO generation Job storage requirements
 
 **Challenge**: The `openshift-install image-based create image` command pulls the full seed image and generates an ISO, requiring ~15-20GB of workspace storage. Ephemeral storage on hub nodes is typically insufficient and risks pod eviction.
 
-**Mitigation**: The controller creates a dedicated PVC (~20GB) for the ISO build workspace, mounted into the Job pod. The PVC uses the StorageClass specified in `liveISO.storageClass`, or the cluster's default StorageClass if omitted. The PVC is cleaned up in Phase 5 after successful
-upload. On failure, the PVC is retained for debugging under the **same bounded diagnostic-retention TTL** described in the failure workflow (reclaimed when the TTL elapses or on PR deletion, whichever comes first) —
-it is **not** kept indefinitely until the ProvisioningRequest is deleted, since a ~20GB workspace per failed request would otherwise accumulate and exhaust hub storage. Operators must ensure the hub cluster has a StorageClass with sufficient capacity available.
+**Mitigation**: The controller creates a dedicated PVC (~20GB) for the ISO build workspace, mounted into the Job pod, using `liveISO.storageClass` or the cluster default if omitted. It is cleaned up in Phase 5 after successful upload. On failure it is retained for debugging under the **same
+bounded diagnostic-retention TTL** described in the failure workflow (reclaimed when the TTL elapses or on PR deletion, whichever comes first) — **not** indefinitely, since a ~20GB workspace per failed request would otherwise accumulate and exhaust hub storage. Operators must ensure the hub has a
+StorageClass with sufficient capacity.
 
 ### 8. Disconnected environment registry configuration
 
 **Challenge**: In disconnected environments, the ISO build must pull the seed image and OCP release images from local mirrors. The `openshift-install` binary must also be extracted from a mirrored release image. Misconfigured mirrors cause silent failures deep in the ISO build.
 
-**Mitigation**: The controller **auto-derives the mirror configuration from the hub** (Phase 4, step 1) — mirror mappings from the hub's `ImageDigestMirrorSet`/`ImageContentSourcePolicy` and registry trust from the hub's image-config `additionalTrustedCA` — and injects it into both
-`oc adm release extract` (`--idms-file` + CA trust) and the `ImageBasedInstallationConfig` (`imageDigestSources` + `additionalTrustBundle`). Because the hub already operates in the same disconnected environment as the seed and target clusters, this avoids duplicating mirror config in
-the ClusterTemplate and keeps it from drifting. Optional `liveISO.imageDigestSources` / `liveISO.additionalTrustBundleConfigMapRef` overrides cover the case where the ISO build must target a different mirror. The `releaseImage` field is required (no default fallback to a public
-registry), and the pull secret must include credentials for all mirrors involved. Phase 1 validation checks that the `releaseImage` is reachable using the resolved mirror config and that `oc adm release extract` can authenticate to it. The `seedImage` pull-spec in the
-`ImageBasedInstallationConfig` is the immutable `repo@sha256:<digest>` reference captured from the SeedGenerator status in Phase 3, not the mutable `seedGeneration.seedImage` tag, so the ISO is built from exactly the image that was generated.
+**Mitigation**: The controller **auto-derives the mirror configuration from the hub** (Phase 4, step 1) — mirror mappings from the hub's `ImageDigestMirrorSet`/`ImageContentSourcePolicy` and registry trust from its image-config `additionalTrustedCA` — and injects it into both
+`oc adm release extract` (`--idms-file` + CA trust) and the `ImageBasedInstallationConfig` (`imageDigestSources` + `additionalTrustBundle`). Because the hub already operates in the same disconnected environment as the seed and target clusters, this avoids duplicating and drifting mirror config
+in the ClusterTemplate; optional `liveISO.imageDigestSources` / `liveISO.additionalTrustBundleConfigMapRef` overrides cover targeting a different mirror. `releaseImage` is required (no public-registry fallback) and the pull secret must include credentials for all mirrors involved; Phase 1
+validates that `releaseImage` is reachable and `oc adm release extract` can authenticate using the resolved mirror config. The `seedImage` in the `ImageBasedInstallationConfig` is the immutable `repo@sha256:<digest>` captured in Phase 3, not the mutable tag, so the ISO is built from exactly
+the generated image.
 
 ### 9. HTTPS ISO server certificate management
 
 **Challenge**: In disconnected environments, the HTTPS ISO server uses a private CA. BMCs fetching the ISO via virtual media must trust this CA. Different BMC vendors handle custom CA trust differently — some support injecting a CA cert via the virtual media API, others rely on
 pre-configured trust stores.
 
-**Mitigation**: The `uploadSecretRef` Secret carries an optional `caCert` field containing the PEM-encoded CA
-bundle for the ISO server. Phase 1 validates the certificate chain by performing a TLS handshake against the
-`urlBase` host. On completion, the controller **materializes the PEM bundle into a dedicated ConfigMap** (in the
-O-Cloud Manager namespace, named deterministically from the ProvisioningRequest) and records a typed reference to
-it in `SeedGenerationStatus.ISOServerCACertRef` — a stable object reference, not inline certificate data or a name
-for an object that is never created. Downstream consumers (BMC configuration, hardware manager) resolve that
-reference when mounting the ISO via virtual media. The controller does not configure BMC trust — that is the
-responsibility of the hardware manager or the BMC pre-configuration
-workflow. The controller's role is to validate the cert, use it during pre-flight checks, and surface it via the ConfigMap reference for downstream consumption.
+**Mitigation**: The `uploadSecretRef` Secret carries an optional `caCert` field with the PEM-encoded CA bundle
+for the ISO server. Phase 1 validates the chain via a TLS handshake against the `urlBase` host. On completion the
+controller **materializes the PEM bundle into a dedicated ConfigMap** (in the O-Cloud Manager namespace, named
+deterministically from the ProvisioningRequest) and records a typed reference to it in
+`SeedGenerationStatus.ISOServerCACertRef` — a stable object reference, not inline data or a name for an object
+that is never created. Downstream consumers (BMC configuration, hardware manager) resolve that reference when
+mounting the ISO via virtual media.
 
-BMC-side certificate management proper — for example uploading CA certificates to BMCs via the Redfish `ImportCertificate` action as a day-0/day-2 operation — is intentionally **out of scope** for this proposal and is better handled as a separate
-certificate-management feature (consistent with the Non-Goals). This proposal deliberately stops at validating the ISO server certificate and surfacing it for downstream consumers, rather than taking on BMC trust provisioning.
+The controller's role stops at validating the cert, using it during pre-flight checks, and surfacing it via the
+ConfigMap reference. BMC-side certificate management proper — e.g. uploading CA certificates to BMCs via the
+Redfish `ImportCertificate` action as a day-0/day-2 operation — is intentionally **out of scope** and is better
+handled as a separate certificate-management feature (consistent with the Non-Goals), not taken on here.
 
 ### 10. Registry pre-flight check limitations
 
 **Challenge**: The registry validation in Phase 1 runs from the hub cluster, which may have different network access than the spoke (where the actual image push occurs).
 
-**Mitigation**: The pre-flight check validates credential correctness and basic reachability from the hub. If the hub and spoke have different network paths to the registry (e.g., disconnected environments with different mirrors), the check may pass on the hub but the spoke-side push
-may still fail. In disconnected environments, the `seedImage` pull-spec should reference a mirror accessible to the spoke; the pre-flight check validates what it can and the SeedGenerator reports push failures in its own conditions.
+**Mitigation**: The pre-flight check validates credential correctness and basic reachability from the hub. If hub and spoke have different network paths to the registry (e.g. disconnected environments with different mirrors), the check may pass on the hub while the spoke-side push still
+fails; the `seedImage` pull-spec should therefore reference a mirror accessible to the spoke. The pre-flight check validates what it can, and the SeedGenerator reports push failures in its own conditions.
 
 ## Alternatives Considered
 
@@ -1398,10 +1317,10 @@ Detach the spoke entirely by deleting the ClusterInstance/ManagedCluster, as the
 keeps the `ManagedCluster` intact and removes only the spoke-side ACM agent state (klusterlet + addons), achieving the same seed cleanliness without touching the provisioning lifecycle; the operator reclaims the hardware by deleting the ProvisioningRequest when the seed is captured.
 (Spoke access is obtained the same way either way — the hub-held admin kubeconfig survives klusterlet teardown regardless — so the access credential is not what distinguishes this alternative.)
 
-Taking on spoke cleanup ourselves does add responsibility that deleting the `ManagedCluster` would otherwise leave to ACM, and that responsibility must be bounded so it does not become a maintenance burden as ACM adds features. The design
-deliberately leans on ACM's **own teardown primitives** rather than a hardcoded inventory of agent objects: it deletes the `Klusterlet` CR (so the klusterlet operator tears down *all* of its current and future registration/work agents and
-namespaces) and enumerates and deletes **all** `ManagedClusterAddOn` CRs (so new addons are covered without code changes). The residual risk is limited to spoke state that is neither klusterlet-managed nor modeled as a `ManagedClusterAddOn` — the
-observability secrets in [Challenge 1](#1-incomplete-acm-cleanup-contaminates-the-seed-image) are the known example, and the pattern there (prevent creation at the source via a label rather than chase deletions) is the template for any future such case.
+Taking on spoke cleanup ourselves adds responsibility that deleting the `ManagedCluster` would otherwise leave to ACM, and it must be bounded so it does not become a maintenance burden as ACM adds features. The design deliberately leans on
+ACM's **own teardown primitives** rather than a hardcoded inventory: it deletes the `Klusterlet` CR (so the klusterlet operator tears down *all* current and future registration/work agents and namespaces) and enumerates and deletes **all**
+`ManagedClusterAddOn` CRs (so new addons are covered without code changes). The residual risk is limited to spoke state that is neither klusterlet-managed nor a `ManagedClusterAddOn` — the observability secrets in
+[Challenge 1](#1-incomplete-acm-cleanup-contaminates-the-seed-image) are the known example, and the pattern there (prevent creation at the source via a label rather than chase deletions) is the template for any future case.
 
 ### B. Separate SeedGenerationRequest CRD
 

--- a/docs/proposals/automated-seed-image-generation.md
+++ b/docs/proposals/automated-seed-image-generation.md
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
   - [3. ACM self-healing during cleanup phase](#3-acm-self-healing-during-cleanup-phase)
   - [4. Seed cluster afterlife and PR terminal state](#4-seed-cluster-afterlife-and-pr-terminal-state)
   - [5. Seed SNO prerequisites](#5-seed-sno-prerequisites)
-  - [6. Standalone access token lifetime and cleanup](#6-standalone-access-token-lifetime-and-cleanup)
+  - [6. Spoke access after ACM removal](#6-spoke-access-after-acm-removal)
   - [7. ISO generation Job storage requirements](#7-iso-generation-job-storage-requirements)
   - [8. Disconnected environment registry configuration](#8-disconnected-environment-registry-configuration)
   - [9. HTTPS ISO server certificate management](#9-https-iso-server-certificate-management)
@@ -89,8 +89,10 @@ The manual seed generation workflow has several pain points:
   operators no longer need to SSH and tail logs.
 - Treat the seed cluster as a disposable factory: remove all ACM agent
   state (klusterlet and addons) from the spoke so it does not contaminate
-  the seed, retain spoke access during generation via a standalone
-  long-lived token, and do **not** restore ACM afterward. The controller
+  the seed, retain spoke access during generation via the spoke's admin
+  kubeconfig retrieved from the hub (which survives ACM teardown and writes
+  nothing to the spoke, so nothing is baked into the seed), and do **not**
+  restore ACM afterward. The controller
   never deletes the `ManagedCluster` itself; the operator deletes the
   ProvisioningRequest to reclaim the hardware once the seed is captured.
 - Reuse the existing `upgradeDefaults` / `upgradeParameters`
@@ -529,8 +531,7 @@ its status is flushed, every create in the state machine is **create-or-adopt**,
 not blind create. Deterministic names alone are not enough: a restart that
 re-issues a `create` would hit `AlreadyExists`, and a name collision with an
 unrelated object left by a prior run (or an external actor) could silently
-reuse the wrong resource. For each generated resource — the standalone
-`ServiceAccount` and its token `Secret`, the RBAC objects, the `seedgen`
+reuse the wrong resource. For each generated resource — the `seedgen`
 Secret, the ISO-build `Job`, its workspace `PVC`, and the per-run mirror/CA
 `ConfigMap` — the controller:
 
@@ -578,10 +579,10 @@ attempt — which is out of scope here.)
 The spoke's `ManagedCluster` on the hub is left intact throughout the process — the controller never deletes it, so there is no re-provisioning or ClusterInstance recreation. What must be removed is the spoke-side ACM *agent state* (the klusterlet and all addon agents), because it
 would otherwise be captured in the seed image and cause a clone to register with the original hub on first boot.
 
-Because a proper klusterlet teardown deletes the ACM agent namespaces (`open-cluster-management-agent*`) — where the existing `ManagedServiceAccount` token and its RBAC live — the controller cannot rely on that token during generation. Instead, before any ACM removal, it mints a
-**standalone long-lived token** (a dedicated ServiceAccount, token Secret, and RBAC RoleBinding, named deterministically from the ProvisioningRequest) in a non-ACM namespace on the spoke and rebuilds the spoke client from it. This token survives the full ACM teardown and provides
-spoke API access for the entire workflow. The seed cluster is a disposable factory, so ACM is **not** restored after generation: the controller removes the standalone token and workflow artifacts during cleanup, sets a terminal `SeedGenerationCompleted` condition, and the operator
-deletes the ProvisioningRequest to reclaim the hardware.
+Because a proper klusterlet teardown deletes the ACM agent namespaces (`open-cluster-management-agent*`) — where the existing `ManagedServiceAccount` token and its RBAC live — the controller cannot rely on that token during generation. Instead, before any ACM removal, it retrieves the
+spoke's **admin kubeconfig from the hub** (the Secret referenced by the spoke `ClusterDeployment`'s `spec.clusterMetadata.adminKubeconfigSecretRef`) and builds the spoke client from it. That kubeconfig authenticates with an embedded client certificate that is independent of ACM, so it
+survives the full ACM teardown and provides spoke API access for the entire workflow — while writing nothing to the spoke's etcd, so no new credential is captured into the seed. The seed cluster is a disposable factory, so ACM is **not** restored after generation: the controller removes the
+transient workflow artifacts during cleanup, sets a terminal `SeedGenerationCompleted` condition, and the operator deletes the ProvisioningRequest to reclaim the hardware.
 
 Note that lca-cli's own cleanup does **not** strip klusterlet/registration identity, so the controller must remove it explicitly — it cannot defer this to LCA's seed preparation.
 
@@ -662,90 +663,48 @@ The workflow is a multi-phase state machine tracked via a new `SeedGenerationCom
 
 Remove all ACM agent state from the spoke so it doesn't contaminate the seed image. The `ManagedCluster` on the hub is left intact.
 
-1. **Mint a standalone access token**: Using the current (MSA-based) spoke client, create a dedicated ServiceAccount in a non-ACM namespace on the spoke (e.g. the `openshift-lifecycle-agent` namespace), named deterministically from
-   the ProvisioningRequest, plus a **long-lived token**. Because the token
-   must outlive the whole operation (2h/3h) and survive ACM teardown, it is
-   issued as a **`kubernetes.io/service-account-token`-typed Secret annotated
-   with `kubernetes.io/service-account.name`**, not by relying on
-   auto-mounted tokens (absent since Kubernetes 1.24) or a `TokenRequest`
-   token (bounded by a maximum TTL and thus liable to expire mid-operation).
-   The legacy-style token Secret yields a non-expiring credential the
-   controller can read once and rebuild the spoke client from; if the Secret
-   is not populated with a token within a short poll, Phase 2 fails
-   `PreconditionChecksFailed` before any teardown. Phase 5 deletes the
-   ServiceAccount and Secret (which invalidates the token) on every terminal
-   path.
+1. **Retrieve the spoke admin kubeconfig from the hub**: Before any ACM
+   removal, read the spoke's admin kubeconfig from the hub — the Secret named by
+   the spoke `ClusterDeployment`'s
+   `spec.clusterMetadata.adminKubeconfigSecretRef` in the cluster's namespace —
+   and build the spoke client from it. This kubeconfig authenticates with an
+   embedded **client certificate** (`system:admin`), not a ServiceAccount
+   token, which is what makes it suitable here:
+   - **It survives ACM teardown.** The client cert is signed by the cluster's
+     admin-kubeconfig-signer at install time and is independent of the
+     klusterlet and the `ManagedServiceAccount` token that live in the
+     `open-cluster-management-agent*` namespaces. Deleting the `Klusterlet` CR
+     (step 4) does not affect it, so it stays valid for the entire operation. It
+     stops working only if the spoke's **API server certificate** is rotated
+     under a new CA — which happens at *restore* time on the target (recert),
+     not during generation on the seed — so it remains valid through Phase 5.
+   - **Using it writes nothing to the spoke's etcd.** No ServiceAccount, token
+     Secret, or RBAC object is created on the spoke, so no new credential is
+     captured into the seed image. This is the decisive difference from minting
+     a spoke-side token: the workflow adds no persisted credential that a clone
+     deployed from the seed would carry (see
+     [Challenge 6](#6-spoke-access-after-acm-removal)). The only object this
+     workflow places on the spoke is the transient `seedgen` Secret in Phase 3,
+     which lca-cli consumes and Phase 5 deletes — the same Secret the manual
+     workflow uses.
+   - **No revocation is required.** Because nothing is minted, there is no
+     standalone credential to delete or leave behind; Phase 5 spoke cleanup is
+     limited to the transient `seedgen` Secret and the `SeedGenerator` CR. The
+     admin kubeconfig is a pre-existing hub Secret the controller only *reads*.
 
-   Bind the required RBAC least-privilege:
-   - A namespaced `RoleBinding` for the namespaced `seedgen` Secret in the LCA
-     namespace.
-   - A `ClusterRole`/`ClusterRoleBinding` scoped to **only** the genuinely
-     cluster-scoped needs: `create`/`get`/`list`/`watch`/`delete` on the
-     cluster-scoped `SeedGenerator` resource (the LCA `SeedGenerator` is the
-     cluster-scoped singleton `seedimage`, so a namespaced `RoleBinding` cannot
-     authorize creating, monitoring, or deleting it); `delete` **and
-     `get`/`list`/`watch`** on the cluster-scoped `Klusterlet` resource (a
-     namespaced `RoleBinding` cannot authorize either operation on a
-     cluster-scoped object, and the teardown poll in step 5 needs read access to
-     observe the `Klusterlet` disappear), plus `get`/`list`/`watch` on
-     `namespaces` (inherently cluster-scoped, so it cannot be limited by a
-     `RoleBinding`).
-   - **Pod read permissions are bound per-namespace, not cluster-wide:**
-     `get`/`list`/`watch` on `pods` is granted through `RoleBinding` objects
-     in the specific agent namespaces the poll watches
-     (`open-cluster-management-agent*`), so the standalone token cannot read
-     pod specs in unrelated namespaces.
-   - **Self-cleanup permissions (so Phase 5 can revoke this very
-     credential).** After ACM/MSA teardown, the standalone token is the *only*
-     path back to the spoke, so it must be able to delete its own artifacts.
-     The grants therefore also include `delete` on the namespaced `seedgen`
-     Secret (via the LCA-namespace `RoleBinding`) and on the cluster-scoped
-     `SeedGenerator` CR (via the `ClusterRole`/`ClusterRoleBinding` above),
-     `delete` on the credential's own `ServiceAccount` and token `Secret`
-     (namespaced), and `delete` on its namespaced `RoleBinding`s. `delete` is
-     not escalation, so this needs no additional `escalate`/`bind`.
-   - **The token does not delete its own `ClusterRole`/`ClusterRoleBinding` —
-     that self-deletion is unsound.** A `ClusterRoleBinding` confers the very
-     permissions the token would use to delete it: removing the binding first
-     immediately revokes the `delete` verb, so the paired `ClusterRole` can no
-     longer be removed; removing the `ClusterRole` first strips the same verb
-     and orphans the binding. Either order leaves one cluster-scoped object
-     behind, so a credential cannot reliably remove the RBAC that grants it.
-     Instead, Phase 5 deletes the `ServiceAccount` and token `Secret` **last**;
-     once the subject `ServiceAccount` is gone the residual
-     `ClusterRole`/`ClusterRoleBinding` grant nothing to anyone (the binding's
-     subject no longer resolves). These two **inert** cluster-scoped objects are
-     reclaimed when the disposable seed cluster is torn down (PR deletion). If
-     the cluster is instead retained for diagnostics, the still-attached hub
-     removes them out of band using an independently granted identity — never
-     the standalone token itself. Because the token never needs cluster-scoped
-     `delete`, that grant is dropped entirely, further shrinking its blast
-     radius.
+   The trade-off is that the admin kubeconfig is a broad (`cluster-admin`)
+   credential rather than a least-privilege, purpose-scoped one. This is
+   accepted because the credential is (a) used only by the O-Cloud Manager
+   controller during a controlled, one-shot operation, (b) never persisted or
+   copied to the spoke, and (c) never baked into the seed — so its blast radius
+   is bounded by the operation's duration, not by any artifact that outlives it.
 
-   Rebuild the spoke client from this token. All subsequent phases use this
-   client, which survives the ACM teardown below. Phase 5 removes the
-   namespaced `RoleBinding`s and, last, the credential itself; the inert
-   cluster-scoped `ClusterRole`/`ClusterRoleBinding` are reclaimed with the
-   disposable cluster (or by the hub out of band) as described above.
-
-   **MSA bootstrap authority (precondition).** The MSA-based client performs
-   the entire bootstrap of the standalone credential, so it needs more than the
-   RBAC-creation verbs. Specifically it requires, on the spoke:
-   - `create` on `serviceaccounts` and `secrets` in the LCA namespace (to make
-     the standalone `ServiceAccount` and its token `Secret`) and `get` on that
-     `Secret` (to read the token the token-controller populates).
-   - `create` on `rolebindings` in each namespace where a namespaced
-     `RoleBinding` is bound (the LCA namespace and the
-     `open-cluster-management-agent*` agent namespaces for pod reads).
-   - `create` on the cluster-scoped `ClusterRole`/`ClusterRoleBinding` **plus
-     `escalate`/`bind`** (or an aggregated role already granting them) —
-     Kubernetes escalation prevention allows creating an RBAC object only if the
-     creator already holds the verbs it confers.
-
-   All of this is a **precondition**: if the MSA client lacks any of these
-   verbs — or the agent namespaces do not yet exist — Phase 2 fails with
+   **Precondition.** If the admin-kubeconfig Secret is absent, malformed, or the
+   resulting client cannot reach the spoke API server, Phase 2 fails with
    `PreconditionChecksFailed` **before** any destructive ACM removal, so the
-   spoke is never left partially detached without a working access path.
+   spoke is never left partially detached without a working access path. This
+   needs only a hub-side `get` on the admin-kubeconfig Secret in the cluster's
+   namespace (see the hub RBAC contract) — no spoke-side RBAC at all.
 2. **Record detachment intent**: Persist
    `SeedGenerationStatus.DetachmentStarted = true` (and flush the status
    update) **before** step 3 performs the first destructive ACM removal. This
@@ -753,7 +712,7 @@ Remove all ACM agent state from the spoke so it doesn't contaminate the seed ima
    a controller restart mid-detachment still treats the spoke as (partially)
    detached — see [Challenge 4](#4-seed-cluster-afterlife-and-pr-terminal-state).
 3. **Delete hub-side addon CRs**: Delete all `ManagedClusterAddOn` resources from the spoke's namespace on the hub (including `managed-serviceaccount`). This tells the ACM addon framework to stop reconciling them.
-4. **Delete the klusterlet**: Delete the `Klusterlet` CR on the spoke (via the standalone-token client). The klusterlet operator tears down the registration and work agents and their namespaces (`open-cluster-management-agent*`) — including the identity secrets
+4. **Delete the klusterlet**: Delete the `Klusterlet` CR on the spoke (via the admin-kubeconfig client). The klusterlet operator tears down the registration and work agents and their namespaces (`open-cluster-management-agent*`) — including the identity secrets
    (`bootstrap-hub-kubeconfig`, `hub-kubeconfig-secret`) that would otherwise be captured in the seed. Deleting only the klusterlet Deployment is **not** sufficient: those secrets persist in etcd and on disk.
 5. **Wait for teardown**: Poll the spoke until the klusterlet and addon agent namespaces/pods are gone.
 
@@ -761,7 +720,7 @@ Remove all ACM agent state from the spoke so it doesn't contaminate the seed ima
 
 ### Phase 3: Trigger Seed Generation
 
-Using the standalone-token spoke client established in Phase 2:
+Using the admin-kubeconfig spoke client established in Phase 2:
 
 1. **Create the seedgen Secret**: Deliver the `seedgen` Secret to the `openshift-lifecycle-agent` namespace on the spoke, reading credentials from the hub Secret referenced by `seedAuthSecretRef`.
 2. **Create the SeedGenerator CR**: Apply the singleton `seedimage` SeedGenerator CR with the configured `seedImage` (and optionally `recertImage`).
@@ -995,8 +954,12 @@ in its own namespace:
 - `core/persistentvolumeclaims`: `create`, `get`, `delete` (the ~20GB build
   workspace PVC).
 - `core/secrets`: `create`, `get`, `delete` (per-run credential copies) and
-  `get` on the source Secrets in the ClusterTemplate namespace and
-  `openshift-config/pull-secret`.
+  `get` on the source Secrets in the ClusterTemplate namespace,
+  `openshift-config/pull-secret`, and the spoke's admin-kubeconfig Secret
+  (named by the `ClusterDeployment`'s `adminKubeconfigSecretRef`) in the
+  cluster's namespace — the credential Phase 2 uses to reach the spoke. This
+  `get` is the **only** access the workflow needs to obtain spoke API access;
+  no spoke-side RBAC is created.
 - `core/configmaps`: `create`, `get`, `delete` (the per-run mirror/CA
   ConfigMap), `get` on the hub image-config `additionalTrustedCA`, and `get` on
   the ConfigMap named by `liveISO.additionalTrustBundleConfigMapRef` in the
@@ -1042,12 +1005,8 @@ The seed cluster is a disposable factory, so there is no ACM restoration. Once t
 On success (seed generation complete, and ISO generation complete if configured):
 
 1. **Record results**: Store the seed image digest reference in `SeedGenerationStatus.SeedImage` and, if ISO was built, the resolved per-run URL in `SeedGenerationStatus.ISOURL` and the verified digest in `SeedGenerationStatus.ISODigest`.
-2. **Clean up workflow artifacts**: On the spoke, delete the SeedGenerator CR and seedgen Secret first, then the standalone credential's namespaced `RoleBinding`s, and **last** the credential-bearing `ServiceAccount` and token `Secret` —
-   deleting the credential last so the token stays valid for every preceding spoke delete (see the self-cleanup permissions in Phase 2).
-   The token does **not** delete its own `ClusterRole`/`ClusterRoleBinding`
-   (that self-deletion is unsound — Phase 2); once the `ServiceAccount` is gone
-   they are inert and are reclaimed when the disposable cluster is torn down, or
-   removed by the hub out of band if the cluster is retained.
+2. **Clean up workflow artifacts**: On the spoke, delete the SeedGenerator CR and the transient `seedgen` Secret (using the admin-kubeconfig client from Phase 2). No standalone credential was minted, so there is nothing else to
+   revoke on the spoke — the admin kubeconfig is a hub Secret the controller only read and never copied to the spoke.
    Delete the ISO generation Job, its build workspace PVC, the per-run credential Secret copies created in the Job namespace, and associated resources from the hub.
 3. **Update conditions**: `SeedGenerationCompleted = True / Reason: Completed`. This is a **terminal** condition — the controller does not re-run seed generation, and it suppresses the PR's ACM-dependent reconciliation (see [Challenge 4](#4-seed-cluster-afterlife-and-pr-terminal-state)).
 
@@ -1088,30 +1047,19 @@ On failure (at any phase):
      input Secrets) may be retained under a **bounded diagnostic-retention
      policy** (a TTL after which it is reclaimed), not "until the PR is
      deleted" indefinitely.
-   - **Spoke**: deletes the `seedgen` Secret, the SeedGenerator CR, and the
-     standalone credential (ServiceAccount, token Secret, and namespaced
-     RoleBindings), the ServiceAccount and token Secret last. The inert
-     cluster-scoped `ClusterRole`/`ClusterRoleBinding` are reclaimed with the
-     disposable cluster (or removed by the hub out of band), not self-deleted by
-     the token — see Phase 2. The standalone token
-     is a **non-expiring** `kubernetes.io/service-account-token` Secret (chosen
-     precisely so it cannot lapse mid-operation), so there is **no token TTL**
-     and revocation is explicit: deleting the ServiceAccount and its token
-     Secret immediately invalidates the credential. Because the token never
-     expires on its own, the design must **not** rely on expiry to bound a
-     leaked credential — an abandoned workflow that never reached Phase 5 would
-     otherwise leave a permanently valid spoke credential. Revocation is
-     therefore driven by two mechanisms, both independent of any TTL: (1) spoke
-     scrubbing runs as part of reaching every terminal state, not lazily on PR
-     deletion; and (2) a hub-side finalizer plus a bounded overall operation
-     **deadline** — after the deadline the controller force-runs Phase 5
-     revocation even for a stuck/abandoned run, deleting the SA and token
-     Secret while the spoke is still reachable. The deadline bounds *when
-     revocation happens*; it is not a lifetime on the token itself. If the
-     spoke is genuinely unreachable at cleanup time (e.g. the controller was
-     down and the spoke was independently torn down), the residual credential
-     is documented as requiring manual removal, and the `seedgen` Secret is the
-     sensitive item to purge.
+   - **Spoke**: deletes the transient `seedgen` Secret and the SeedGenerator
+     CR. No standalone credential was minted, so there is no spoke-side
+     ServiceAccount, token Secret, or RBAC to revoke — the admin kubeconfig used
+     for spoke access is a pre-existing hub Secret the controller only read and
+     never copied to the spoke, and nothing about it is baked into the seed. The
+     only sensitive item this workflow places on the spoke is the `seedgen`
+     Secret (registry push credentials); a hub-side finalizer plus a bounded
+     overall operation **deadline** ensure that even a stuck or abandoned run
+     force-runs this spoke cleanup while the spoke is still reachable, rather
+     than leaving the `seedgen` Secret behind. If the spoke is genuinely
+     unreachable at cleanup time (e.g. the controller was down and the spoke was
+     independently torn down), the `seedgen` Secret is the item to purge
+     manually.
 4. The spoke cluster remains running (detached) for manual intervention. ACM
    is **not** restored automatically; the operator can re-import the cluster
    manually for debugging or delete the ProvisioningRequest to tear it down.
@@ -1325,18 +1273,17 @@ secrets such as `hub-alertmanager-router-ca-*` and `observability-alertmanager-a
 `openshift-user-workload-monitoring` namespaces on the spoke — exactly the kind of hub-coupled artifact that must not be baked into a portable seed image. Because
 the seed cluster is a disposable, purpose-built cluster the operator provisions, the seed `ClusterTemplate` sets the `observability: disabled` label on the
 `ManagedCluster` (via `clusterInstanceDefaults`) so the label is present from the moment the cluster is imported. The observability-operator then never deploys
-the addon to it, so the metrics-collector and the secrets above are never created and cannot contaminate the seed. This is strictly preferable to enumerating and
-deleting those secrets during teardown: the exact secret set drifts across RHACM/MCE versions, and spoke-side deletion would require broadening the standalone
-credential's RBAC into `openshift-monitoring`/`openshift-user-workload-monitoring` — enlarging its blast radius for no benefit. A residual secret sweep is needed
-only if a cluster that *already* had observability deployed is later repurposed as a seed cluster (not the standard flow); it is called out as a fallback in
-[Open Question 4](#open-questions), not the default path.
+the addon to it, so the metrics-collector and the secrets above are never created and cannot contaminate the seed. This is preferable to enumerating and deleting
+those secrets during teardown, whose exact set drifts across RHACM/MCE versions — a hardcoded deletion list is fragile, and preventing the secrets from ever being
+created is more robust than racing to remove them before capture. A residual secret sweep is needed only if a cluster that *already* had observability deployed is
+later repurposed as a seed cluster (not the standard flow); it is called out as a fallback in [Open Question 4](#open-questions), not the default path.
 
 ### 2. Spoke client availability during seed generation
 
 **Challenge**: During Phase 3, the lca-cli shuts down cluster operators on the spoke, which may temporarily affect API server availability and disrupt the spoke client.
 
-**Mitigation**: The controller uses polling with backoff when monitoring the SeedGenerator CR. The spoke API server itself stays running (lca-cli stops operators, not the API server). The standalone token minted in Phase 2 remains valid — it is long-lived and independent of ACM — so
-the spoke client keeps working even though the ACM agents are gone. Transient API errors during operator shutdown are retried.
+**Mitigation**: The controller uses polling with backoff when monitoring the SeedGenerator CR. The spoke API server itself stays running (lca-cli stops operators, not the API server). The admin kubeconfig retrieved in Phase 2 remains valid — its client certificate is independent of ACM and is
+not affected by the klusterlet teardown — so the spoke client keeps working even though the ACM agents are gone. Transient API errors during operator shutdown are retried.
 
 ### 3. ACM self-healing during cleanup phase
 
@@ -1375,26 +1322,24 @@ manual workflow, which also never re-attaches the seed cluster.
 **Mitigation**: The controller validates what it can (OCP version, `var-lib-containers` partition, LCA operator presence, OADP operator presence, registry credentials). Hardware prerequisites are the cluster template author's responsibility — they must ensure the ClusterTemplate's
 `clusterInstanceDefaults` and `policyTemplateDefaults` produce a seed SNO that meets the documented prerequisites.
 
-### 6. Standalone access token lifetime and cleanup
+### 6. Spoke access after ACM removal
 
-**Challenge**: With ACM fully removed, spoke access depends entirely on the standalone credential minted in Phase 2. It must not expire mid-operation; and if the workflow is abandoned, a valid credential could be left behind on the spoke.
+**Challenge**: The klusterlet teardown in Phase 2 deletes the ACM agent namespaces where the `ManagedServiceAccount` token lives, so the controller cannot use that token to drive the rest of seed generation. It needs a spoke credential that survives ACM removal, stays valid for the whole
+operation (2h/3h), and — critically — does **not** end up baked into the seed image, since anything present in the spoke's etcd at capture time is cloned into every cluster deployed from that seed.
 
-**Mitigation**: The credential is a **non-expiring** `kubernetes.io/service-account-token` Secret (not a TTL-bounded `TokenRequest` token), so it cannot lapse mid-operation.
-Because it never expires on its own, a bounded credential lifetime is enforced by *revocation*, not by a token TTL: its ServiceAccount, token Secret, RoleBinding, and cluster-scoped `ClusterRole`/`ClusterRoleBinding` are named deterministically from the ProvisioningRequest.
-Phase 5 can therefore always find and delete them on both the success and failure paths (deletion immediately invalidates the token).
-The PR finalizer plus a bounded overall operation **deadline** force-runs this revocation if the operation is abandoned, so a leaked credential is bounded by *when cleanup runs*, not by an expiry on the token.
-The RBAC is scoped to only the permissions the workflow needs on the spoke and must be **repeated identically wherever this contract is summarized** (see Phase 2 for the authoritative statement):
+**Mitigation**: The controller uses the spoke's **admin kubeconfig, retrieved from the hub** (the Secret named by the spoke `ClusterDeployment`'s `spec.clusterMetadata.adminKubeconfigSecretRef`), rather than minting a new spoke-side credential. This kubeconfig authenticates with an embedded
+`system:admin` **client certificate** signed at install time, which has three properties that fit this workflow exactly:
 
-- A namespaced `RoleBinding` for the namespaced `seedgen` Secret in the LCA namespace.
-- A `ClusterRole`/`ClusterRoleBinding` for the genuinely cluster-scoped needs:
-  `create`/`get`/`list`/`watch`/`delete` on the cluster-scoped `SeedGenerator`
-  (the singleton `seedimage` CR is cluster-scoped); `delete` **and
-  `get`/`list`/`watch`** on the cluster-scoped `Klusterlet` (read verbs are
-  needed so the teardown poll can observe it disappear), plus
-  `get`/`list`/`watch` on `namespaces`.
-- Per-namespace `RoleBinding`s granting `get`/`list`/`watch` on `pods` in the `open-cluster-management-agent*` namespaces (not a cluster-wide pod-read grant).
+- **It survives ACM teardown.** The client cert is independent of the klusterlet and the `ManagedServiceAccount`; deleting the `Klusterlet` CR does not affect it. It stops working only if the spoke's API server certificate is rotated under a new CA, which happens at *restore* time on the
+  target (recert), not during generation on the seed — so it remains valid through Phase 5.
+- **Using it writes nothing to the spoke.** No ServiceAccount, token Secret, or RBAC object is created on the spoke, so **no new credential is captured into the seed image**. This directly resolves the concern that a minted credential would become part of the seed and would need to be found and
+  deleted after every IBI/IBU: there is nothing to find. The only object this workflow places on the spoke is the transient `seedgen` Secret in Phase 3 (the same Secret the manual LCA workflow uses), which lca-cli consumes and Phase 5 deletes.
+- **No revocation is required.** Because nothing is minted, there is no standalone credential to revoke or leak. Phase 5 spoke cleanup is limited to deleting the transient `seedgen` Secret and the `SeedGenerator` CR; a hub-side finalizer plus a bounded operation **deadline** force-run that
+  cleanup even for a stuck or abandoned run, so the `seedgen` Secret is not left behind.
 
-The Phase 2 deletion of `ManagedClusterAddOn` CRs is a **hub-side** operation performed with the O-Cloud Manager's own hub client, so it is covered by the hub RBAC contract (see the hub RBAC contract earlier in this document), not by this spoke credential.
+The trade-off is that the admin kubeconfig is a broad (`cluster-admin`) credential. This is accepted because it is used only by the controller during a controlled one-shot operation, is never persisted or copied to the spoke, and is never baked into the seed — so its blast radius is bounded by the
+operation's duration, not by any artifact that outlives it. The controller's only new access requirement is a hub-side `get` on the admin-kubeconfig Secret in the cluster's namespace (see the hub RBAC contract); it needs **no spoke-side RBAC at all**. The Phase 2 deletion of `ManagedClusterAddOn` CRs
+is a **hub-side** operation performed with the O-Cloud Manager's own hub client, so it is also covered by the hub RBAC contract, not by any spoke credential.
 
 ### 7. ISO generation Job storage requirements
 
@@ -1442,7 +1387,7 @@ may still fail. In disconnected environments, the `seedImage` pull-spec should r
 
 Detach the spoke entirely by deleting the ClusterInstance/ManagedCluster, as the manual workflow does today. Rejected because deleting the ClusterInstance risks triggering deprovisioning of the running spoke and discards the hub-side record of the cluster. The chosen approach instead
 keeps the `ManagedCluster` intact and removes only the spoke-side ACM agent state (klusterlet + addons), achieving the same seed cleanliness without touching the provisioning lifecycle; the operator reclaims the hardware by deleting the ProvisioningRequest when the seed is captured.
-(A standalone spoke token is minted either way — klusterlet teardown removes the MSA token regardless — so token pre-provisioning is not what distinguishes this alternative.)
+(Spoke access is obtained the same way either way — the hub-held admin kubeconfig survives klusterlet teardown regardless — so the access credential is not what distinguishes this alternative.)
 
 ### B. Separate SeedGenerationRequest CRD
 
@@ -1488,9 +1433,9 @@ const DefaultSeedGenerationWithISOTimeout = 3 * time.Hour
 | `IsSeedGenerationRequested` predicate + reconciler dispatch (separate trigger from `IsUpgradeRequested`) | 1 file | ~40 | Medium |
 | CT validation — seedGen defaults, registry pre-flight, release image check, TLS handshake, upload Secret validation | 1 file | ~150 | Medium |
 | Seed generation controller — Phases 1-3 + Phase 5 state machine (ACM cleanup, SeedGenerator lifecycle, spoke client, terminal state) | 1 new file | ~600 | High |
-| ACM removal helpers — standalone token mint, `Klusterlet` CR delete + wait, hub addon-CR delete (no restore) | 1 new file | ~180 | Medium |
+| ACM removal helpers — admin-kubeconfig retrieval + spoke client build, `Klusterlet` CR delete + wait, hub addon-CR delete (no restore) | 1 new file | ~140 | Medium |
 | ISO generation Phase 4 — PVC creation, Job template (extract `openshift-install`, build config, build ISO, SCP upload, HTTPS verification), Job lifecycle monitoring, pull secret merging, hub mirror-config derivation from IDMS/ICSP and `additionalTrustedCA` | 1 new file | ~420 | High |
-| RBAC — spoke (`RoleBinding` for seedgen Secret + per-ns pod read; `ClusterRole` for the cluster-scoped `SeedGenerator`, `Klusterlet` and `namespaces` verbs; self-cleanup deletes — full contract in Phase 2) and hub (see **hub RBAC contract** above) | 2 files | ~40 | Low |
+| RBAC — hub only (`get` on the admin-kubeconfig Secret for spoke access, plus the **hub RBAC contract** above); no spoke-side RBAC is created | 1 file | ~20 | Low |
 | Tests — seed gen controller, ACM helpers, ISO Job lifecycle, validation, TLS checks | 2-3 new files | ~1200 | High |
 | Samples — ClusterTemplate YAML, upload Secret | 2 files | ~80 | Low |
 | Docs — update ibi-based-cluster-provisioning.md | 1 file | ~120 | Low |
@@ -1499,7 +1444,7 @@ const DefaultSeedGenerationWithISOTimeout = 3 * time.Hour
 Roughly 4 working sessions to implement:
 
 - **Session 1**: API types, constants, conditions, `parseUpgradeConfig` extension, CT validation (registry pre-flight, release image check, TLS handshake, upload Secret validation), sample YAMLs
-- **Session 2**: Core seed generation state machine (Phases 1-3, 5), ACM removal helpers (standalone token mint, `Klusterlet` CR delete, addon-CR delete), terminal-state / config-reconcile suppression, spoke and hub RBAC, wiring into the main reconciler
+- **Session 2**: Core seed generation state machine (Phases 1-3, 5), ACM removal helpers (admin-kubeconfig retrieval + spoke client, `Klusterlet` CR delete, addon-CR delete), terminal-state / config-reconcile suppression, hub RBAC, wiring into the main reconciler
 - **Session 3**: ISO generation — hub mirror-config derivation, PVC creation, Job template (release image extract, config generation, ISO build, SCP upload, HTTPS post-upload verification), pull secret merging, Job lifecycle monitoring, cleanup
 - **Session 4**: Tests, edge cases, docs update, `make ci-job` pass
 

--- a/docs/proposals/automated-seed-image-generation.md
+++ b/docs/proposals/automated-seed-image-generation.md
@@ -169,7 +169,8 @@ upgradeDefaults:
     # docker/podman auth JSON (same format as LCA's seedgen Secret).
     seedAuthSecretRef:
       name: seed-registry-credentials
-    # Optional: custom recert image override (LCA default used if omitted)
+    # Optional: custom recert image selected by the trusted template author
+    # (LCA default used if omitted); not exposed to PR authors.
     recertImage: ""
     # Optional: live ISO generation configuration. When present, the
     # controller builds a live installation ISO after seed generation
@@ -296,8 +297,11 @@ less-trusted PR author, so none of them appears there:
   generation: `recertImage`. Phase 3 passes `recertImage` to the
   `SeedGenerator` CR, and the LCA runs it (the recert tool) on the spoke, so
   a PR-supplied value would let an untrusted author run an arbitrary image on
-  the seed cluster. When resolved from `upgradeDefaults` it must be an
-  allowlisted, immutable (`repo@sha256:<digest>`) reference.
+  the seed cluster. `recertImage` is therefore template-owned and is only
+  selected by a trusted template author. This proposal does not require the
+  operator to enforce a digest or registry allowlist for that trusted input;
+  deployments that impose such a policy may enforce it through their normal
+  platform or admission controls.
 - **Credential references** that select which hub Secret/ConfigMap the
   workflow reads and mounts into the ISO-build Job: `seedAuthSecretRef`,
   `liveISO.uploadSecretRef`, `liveISO.pullSecretRef`. Overriding these lets
@@ -331,7 +335,10 @@ benign `seedImage` tag:
 
 ```yaml
 # templateParameterSchema.upgradeParameters
+type: object
+additionalProperties: false
 properties:
+  # Existing upgrade-parameter properties are omitted from this excerpt.
   seedGeneration:
     type: object
     additionalProperties: false
@@ -355,77 +362,82 @@ level so a typo in `upgradeDefaults` (e.g. `seedimage`) fails validation:
 
 ```yaml
 # Controller-internal; not part of templateParameterSchema.
-seedGeneration:
-  type: object
-  additionalProperties: false
-  properties:
-    seedImage: { type: string, minLength: 1, pattern: "^([a-z0-9]+://)?[\\S]+$" }
-    seedAuthSecretRef:
-      type: object
-      additionalProperties: false
-      properties: { name: { type: string } }
-      required: [name]
-    recertImage:
-      type: string
-      description: >
-        Template-owned; when set it must be an allowlisted, immutable digest
-        reference (repo@sha256:<digest>), because Phase 3 passes it to the
-        SeedGenerator CR where it runs as executable code during seed
-        generation.
-    liveISO:
-      type: object
-      additionalProperties: false
-      properties:
-        releaseImage:
-          type: string
-          minLength: 1
-          description: >
-            OCP release image to extract openshift-install from — the
-            canonical release pull-spec (redirected by the hub-derived mirror
-            mappings) or a direct mirror pull-spec.
-        installationDisk: { type: string, minLength: 1, description: Disk device path on the target servers }
-        sshKey: { type: string, description: SSH public key for debugging access }
-        uploadSecretRef:
-          type: object
-          additionalProperties: false
-          properties: { name: { type: string } }
-          required: [name]
-        urlBase:
-          type: string
-          minLength: 1
-          description: >
-            HTTPS origin plus base path from which the uploaded ISO is served.
-            The effective per-run ISO URL is computed as urlBase + the per-run
-            suffix and recorded in status; it is never supplied directly.
-        pullSecretRef:
-          type: object
-          additionalProperties: false
-          properties: { name: { type: string } }
-          required: [name]
-        storageClass: { type: string, description: StorageClass for the ISO build workspace PVC (~20GB); cluster default if omitted }
-        imageDigestSources:
-          type: array
-          description: >
-            Mirror mappings for the ISO build. Auto-derived from the hub's
-            ImageDigestMirrorSet/ImageContentSourcePolicy if omitted.
-          items:
+type: object
+additionalProperties: false
+properties:
+  # Existing upgrade-parameter properties are omitted from this excerpt.
+  seedGeneration:
+    type: object
+    additionalProperties: false
+    properties:
+      seedImage: { type: string, minLength: 1, pattern: "^([a-z0-9]+://)?[\\S]+$" }
+      seedAuthSecretRef:
+        type: object
+        additionalProperties: false
+        properties: { name: { type: string } }
+        required: [name]
+      recertImage:
+        type: string
+        description: >
+          Template-owned and selected only by a trusted template author. The
+          operator passes it to the SeedGenerator CR, where LCA runs it as the
+          recert tool during seed generation. It is not exposed to PR authors;
+          any deployment-specific digest or registry policy is enforced by
+          the deployment's normal platform or admission controls.
+      liveISO:
+        type: object
+        additionalProperties: false
+        properties:
+          releaseImage:
+            type: string
+            minLength: 1
+            description: >
+              OCP release image to extract openshift-install from — the
+              canonical release pull-spec (redirected by the hub-derived mirror
+              mappings) or a direct mirror pull-spec.
+          installationDisk: { type: string, minLength: 1, description: Disk device path on the target servers }
+          sshKey: { type: string, description: SSH public key for debugging access }
+          uploadSecretRef:
             type: object
             additionalProperties: false
-            properties:
-              source: { type: string }
-              mirrors: { type: array, items: { type: string } }
-            required: [source, mirrors]
-        additionalTrustBundleConfigMapRef:
-          type: object
-          additionalProperties: false
-          description: >
-            ConfigMap holding the registry CA trust bundle for the mirror.
-            Auto-derived from the hub's image config additionalTrustedCA if
-            omitted.
-          properties: { name: { type: string } }
-          required: [name]
-      required: [releaseImage, installationDisk, uploadSecretRef, urlBase]
-  required: [seedImage, seedAuthSecretRef]
+            properties: { name: { type: string } }
+            required: [name]
+          urlBase:
+            type: string
+            minLength: 1
+            description: >
+              HTTPS origin plus base path from which the uploaded ISO is served.
+              The effective per-run ISO URL is computed as urlBase + the per-run
+              suffix and recorded in status; it is never supplied directly.
+          pullSecretRef:
+            type: object
+            additionalProperties: false
+            properties: { name: { type: string } }
+            required: [name]
+          storageClass: { type: string, description: StorageClass for the ISO build workspace PVC (~20GB); cluster default if omitted }
+          imageDigestSources:
+            type: array
+            description: >
+              Mirror mappings for the ISO build. Auto-derived from the hub's
+              ImageDigestMirrorSet/ImageContentSourcePolicy if omitted.
+            items:
+              type: object
+              additionalProperties: false
+              properties:
+                source: { type: string }
+                mirrors: { type: array, items: { type: string } }
+              required: [source, mirrors]
+          additionalTrustBundleConfigMapRef:
+            type: object
+            additionalProperties: false
+            description: >
+              ConfigMap holding the registry CA trust bundle for the mirror.
+              Auto-derived from the hub's image config additionalTrustedCA if
+              omitted.
+            properties: { name: { type: string } }
+            required: [name]
+        required: [releaseImage, installationDisk, uploadSecretRef, urlBase]
+    required: [seedImage, seedAuthSecretRef]
 ```
 
 ## Controller Workflow
@@ -1151,7 +1163,10 @@ spec:
     properties:
       # ... standard provisioning parameters ...
       upgradeParameters:
+        type: object
+        additionalProperties: false
         properties:
+          # Existing upgrade-parameter properties are omitted from this excerpt.
           seedGeneration:
             type: object
             additionalProperties: false

--- a/docs/proposals/automated-seed-image-generation.md
+++ b/docs/proposals/automated-seed-image-generation.md
@@ -757,12 +757,28 @@ The controller creates a Kubernetes Job on the hub cluster that builds the live 
    additionalTrustBundle: |      # hub-derived (or liveISO override); omitted when empty
      -----BEGIN CERTIFICATE-----
      ...
+   ignitionConfigOverride: <generated generic IBI pre-provisioning callback Ignition JSON>
    ```
 
    The pull secret is constructed by merging the hub cluster pull secret (`openshift-config/pull-secret`) with the `seedAuthSecretRef` credentials. If `liveISO.pullSecretRef` is provided, its contents are used directly instead of the auto-merged secret. In disconnected environments,
    the pull secret must include credentials for both the local seed image mirror and the OCP release image mirror.
 
-4. **Build the ISO**: Run `openshift-install image-based create image --dir <workdir>`. This pulls the seed image, generates ignition configuration, and produces the `rhcos-ibi.iso` file. This step requires significant workspace storage (~15-20GB for seed image pull + ISO generation).
+   When pre-provisioning is enabled, `ignitionConfigOverride` contains the
+   generic IBI pre-provisioning callback client: the
+   `ibi-prep-callback.service` unit and `/usr/local/bin/ibi-prep-callback`
+   script. The client is identical across hosts and reads its per-host data
+   from `/etc/ibi-callback/env` and `/etc/ibi-callback/auth.cfg`, which are
+   delivered by the per-attempt carrier described in the
+   [IBI pre-provisioning proposal](./ibi-server-pre-provisioning.md#1-callback-ignition-override).
+   The override must not contain a per-host callback URL, attempt ID, or token.
+
+4. **Build the ISO**: Populate `ImageBasedInstallationConfig.ignitionConfigOverride`
+   with the generic callback client described above, then run
+   `openshift-install image-based create image --dir <workdir>`. This pulls the
+   seed image, generates ignition configuration (merging the override), and
+   produces the `rhcos-ibi.iso` file. Because the override carries no per-host
+   data, the ISO stays reusable across IBI deployments. This step requires
+   significant workspace storage (~15-20GB for seed image pull + ISO generation).
 
 5. **Upload the ISO**: SCP the ISO to the HTTPS server using the SSH credentials from `uploadSecretRef`, pinning the server host key from `knownHosts` with strict checking:
 

--- a/docs/proposals/ibi-server-pre-provisioning.md
+++ b/docs/proposals/ibi-server-pre-provisioning.md
@@ -11,18 +11,17 @@ SPDX-License-Identifier: Apache-2.0
 The IBI-based cluster provisioning workflow (documented in
 `docs/user-guide/ibi-based-cluster-provisioning.md`) is split into two stages:
 
-1. **Factory preparation** — done once per hardware/software configuration:
-   generate a seed image, build a live ISO, and pre-provision servers by
-   booting them from the ISO via BMC virtual media.
-2. **Site deployment** — done per cluster via ProvisioningRequest: since
-   servers arrive pre-provisioned, cluster provisioning skips OS installation
-   and image pull.
+1. **Factory preparation** — once per hardware/software configuration: generate a
+   seed image, build a live ISO, and pre-provision servers by booting them from
+   the ISO via BMC virtual media.
+2. **Site deployment** — per cluster via ProvisioningRequest: since servers arrive
+   pre-provisioned, cluster provisioning skips OS installation and image pull.
 
 The [automated seed image and live ISO generation proposal](./automated-seed-image-generation.md)
 automates the seed image and ISO creation. This proposal automates the final
 factory step: **pre-provisioning servers by booting them from the IBI live ISO**.
 
-Today, pre-provisioning is a manual process. An operator must:
+Today, pre-provisioning is manual. An operator must:
 
 1. Mount the live ISO to each target server via BMC virtual media
 2. Set a one-time boot override to boot from the virtual CD/ISO
@@ -36,38 +35,35 @@ to handle the ISO boot and preparation lifecycle natively.
 
 ## Problem Statement
 
-- **Manual BMC interaction**: Operators must manually mount the ISO via each
+- **Manual BMC interaction**: operators must manually mount the ISO via each
   server's BMC console (Redfish, iDRAC, iLO, etc.)
-- **Unmonitored**: No status reporting through the O-Cloud Manager API;
+- **Unmonitored**: no status reporting through the O-Cloud Manager API;
   operators must SSH and tail logs on each server
-- **Serial execution**: Without automation, operators typically pre-provision
+- **Serial execution**: without automation, operators typically pre-provision
   servers one at a time rather than in parallel
-- **Error-prone handoff**: The boundary between "pre-provisioned" and "ready
-  for IBI deployment" is manual — operators must remember to label BMHs
-  and set the correct state
+- **Error-prone handoff**: the boundary between "pre-provisioned" and "ready for
+  IBI deployment" is manual — operators must remember to label BMHs and set the
+  correct state
 
 ## Architecture
 
 ### Why the IBI Operator
 
-The pre-provisioning step is best integrated into the IBI Operator
-(`stolostron/image-based-install-operator`) rather than the O-Cloud Manager
-controller for several reasons:
+The pre-provisioning step is best integrated into the IBI Operator rather than
+the O-Cloud Manager controller for several reasons:
 
-- **Already owns BMH lifecycle for IBI**: The IBI Operator creates
-  `DataImage` CRs, manages BMH annotations (`detached`, `reboot`,
-  `image-based-install-managed`), sets `externallyProvisioned`, and
-  handles power management. Adding a "boot from ISO first" phase is a
-  natural extension.
-- **Already serves an HTTP endpoint**: The IBI Operator runs an image
-  server (`internal/imageserver/`) that serves config ISOs to BMHs. This
-  existing HTTP infrastructure can be extended to receive completion
-  callbacks from pre-provisioned servers.
-- **Reusable**: Other consumers of the IBI Operator (not just
-  ProvisioningRequest users) would benefit from automated pre-provisioning.
+- **Already owns BMH lifecycle for IBI**: it creates `DataImage` CRs, manages
+  BMH annotations (`detached`, `reboot`, `image-based-install-managed`), sets
+  `externallyProvisioned`, and handles power management. Adding a "boot from ISO
+  first" phase is a natural extension.
+- **Already serves an HTTP endpoint**: it runs an image server
+  (`internal/imageserver/`) serving config ISOs to BMHs; this HTTP
+  infrastructure can be extended to receive completion callbacks.
+- **Reusable**: other consumers of the IBI Operator (not just
+  ProvisioningRequest users) benefit from automated pre-provisioning.
 - **Clean separation**: O-Cloud Manager handles orchestration (what to
-  provision), the IBI Operator handles mechanics (how to provision).
-  Pre-provisioning is a "how" concern.
+  provision), the IBI Operator the mechanics (how) — pre-provisioning is a
+  "how" concern.
 
 ### Monitoring Approach: HTTP Callback
 
@@ -90,24 +86,21 @@ access, SSH key management, and IP discovery), the IBI Operator uses an
 
 This approach:
 
-- **Requires no SSH**: No SSH keys to manage, no IP discovery needed, and
-  no hub → server connectivity. It does **not** eliminate the network
-  dependency — it inverts its direction: the model requires
-  **server → hub** reachability instead.
+- **Requires no SSH**: no SSH keys, IP discovery, or hub → server
+  connectivity. It does **not** eliminate the network dependency — it
+  inverts its direction to **server → hub**.
 - **Aligns with existing egress, not "works behind any firewall"**: the
-  server must reach the hub's callback endpoint over HTTPS (DNS resolution
-  of the endpoint hostname, IP routing from the provisioning network to the
-  hub Route/Service, and TLS trust of the hub certificate). This is the
-  same *direction* of connectivity already needed for the server to pull
-  images from the hub, but it is a concrete precondition, not a given —
-  an environment that blocks arbitrary provisioning-network → hub egress,
-  or that resolves/routes the endpoint differently from the image
-  registries, will drop callbacks. The reachability contract is therefore
-  made explicit: the IBI Operator validates that the callback endpoint is
-  resolvable, routable, and TLS-trusted from the target's network **before**
-  booting the ISO (see [Challenge 1](#1-callback-url-must-be-reachable-from-the-pre-provisioned-server)),
-  and a `PreProvisioningTimedOut` is treated as a possible reachability
-  failure, not only a preparation failure.
+  server must reach the hub's callback endpoint over HTTPS (DNS, IP routing
+  from the provisioning network to the hub Route/Service, and TLS trust of
+  the hub certificate) — the same *direction* already needed to pull images
+  from the hub, but a concrete precondition, not a given: an environment that
+  blocks provisioning-network → hub egress, or resolves/routes the endpoint
+  differently from the image registries, will drop callbacks. The IBI
+  Operator therefore validates that the callback endpoint is resolvable,
+  routable, and TLS-trusted from the target's network **before** booting the
+  ISO (see [Challenge 1](#1-callback-url-must-be-reachable-from-the-pre-provisioned-server)),
+  and treats a `PreProvisioningTimedOut` as a possible reachability failure,
+  not only a preparation failure.
 - **Leverages existing infrastructure**: The IBI Operator already serves
   HTTP; adding a callback handler is minimal
 - **Scales naturally**: Callbacks are event-driven, not poll-based — no
@@ -174,13 +167,12 @@ type PreProvisioningConfig struct {
     // a caller cannot direct the operator's pre-fetch at an arbitrary host.
     ISOURL string `json:"isoURL"`
 
-    // ISODigest is the expected SHA-256 digest ("sha256:<hex>") of the
-    // live ISO served at ISOURL. The operator verifies the fetched ISO against
-    // it before setting the BMH image so a mutated or stale artifact at that URL
-    // cannot be booted. This is the same digest the seed-generation workflow
-    // records in SeedGenerationStatus.ISODigest; wiring it through pins the
-    // pre-provisioning boot to the exact artifact that was built and verified.
-    // Required for automated boot: admission rejects a pre-provisioning config
+    // ISODigest is the expected SHA-256 digest ("sha256:<hex>") of the live ISO
+    // served at ISOURL. The operator verifies the fetched ISO against it before
+    // setting the BMH image, so a mutated or stale artifact at that URL cannot be
+    // booted. Same digest the seed-generation workflow records in
+    // SeedGenerationStatus.ISODigest, pinning the boot to the exact built and
+    // verified artifact. Required for automated boot: admission rejects a config
     // that omits it (PreProvisioningConfigInvalid) rather than falling back to
     // URL-only trust. The json tag keeps omitempty only so the zero value is
     // caught by the required-field check, not silently defaulted.
@@ -197,20 +189,18 @@ type PreProvisioningConfig struct {
     // +optional
     Timeout *metav1.Duration `json:"timeout,omitempty"`
 
-    // CallbackBaseURL is the externally-reachable base URL that the
-    // booted host uses to reach the IBI Operator's callback endpoint,
-    // e.g. "https://ibi-callback.example.com:8443". The operator appends
-    // "/callbacks/<namespace>/<name>/status" to form the full endpoint
-    // that is injected into the ISO's ignition. This must be set to an
-    // address reachable from the *provisioning network the booted host
-    // is on*, which is frequently NOT the in-cluster Service DNS name
-    // (`<svc>.<ns>.svc`): that name resolves only inside the hub cluster,
-    // while the callback originates from the bare-metal host. When unset,
-    // the operator falls back to the in-cluster Service URL, which is
-    // only correct when the host shares the hub's cluster network.
-    // The operator validates that the resolved host is reachable from the
-    // target network before booting the ISO (see Challenge 1); a value
-    // that only resolves in-cluster is treated as a configuration error.
+    // CallbackBaseURL is the externally-reachable base URL the booted host
+    // uses to reach the IBI Operator's callback endpoint, e.g.
+    // "https://ibi-callback.example.com:8443". The operator appends
+    // "/callbacks/<namespace>/<name>/status" to form the endpoint injected
+    // into the ISO's ignition. It must be reachable from the *provisioning
+    // network the booted host is on*, which is frequently NOT the in-cluster
+    // Service DNS name (`<svc>.<ns>.svc`) — that resolves only inside the hub,
+    // while the callback originates from the bare-metal host. When unset, the
+    // operator falls back to the in-cluster Service URL, correct only when the
+    // host shares the hub's cluster network. The operator validates the
+    // resolved host is reachable from the target network before booting the ISO
+    // (see Challenge 1); an in-cluster-only value is a configuration error.
     // +optional
     CallbackBaseURL string `json:"callbackBaseURL,omitempty"`
 
@@ -284,28 +274,25 @@ type ImageClusterInstallStatus struct {
     // +optional
     PreProvisioningAttempt string `json:"preProvisioningAttempt,omitempty"`
 
-    // PreProvisioningResult records the result received via HTTP callback
-    // from the pre-provisioned server for a specific attempt. The operator
-    // clears this (sets it to nil) atomically in the same pre-boot status
-    // update that records a new PreProvisioningAttempt (NOT
-    // PreProvisioningBootTime, which is written later — see that field), so a
-    // stale result from a prior boot can never be mistaken for the outcome of
-    // the current one. A callback is accepted only if its Attempt matches the
-    // current PreProvisioningAttempt; callbacks for any other attempt are
-    // rejected.
+    // PreProvisioningResult records the result received via HTTP callback for a
+    // specific attempt. The operator clears it (nil) atomically in the same
+    // pre-boot status update that records a new PreProvisioningAttempt (NOT
+    // PreProvisioningBootTime, written later — see that field), so a stale
+    // result from a prior boot can never be read as the current one's outcome.
+    // A callback is accepted only if its Attempt matches the current
+    // PreProvisioningAttempt; all others are rejected.
     // +optional
     PreProvisioningResult *PreProvisioningResult `json:"preProvisioningResult,omitempty"`
 
-    // PreProvisioningTeardownComplete gates cessation of teardown retries for
-    // a terminal (failed/timed-out) attempt. When the operator claims the
-    // terminal state it writes this as false in the same update; teardown
-    // (clear image, remove DataImage, power off, delete the per-attempt token
-    // Secret) is then idempotently re-driven on every reconcile until all
-    // actions succeed, at which point this flips to true — the ONLY state that
-    // stops teardown retries. It survives restarts so a crash mid-teardown
-    // cannot leave a terminal ICI with cleanup still owed. Reset to false (or
-    // cleared) when a retry mints a fresh attempt; meaningful only once a
-    // terminal reason (PreProvisioningFailed/PreProvisioningTimedOut) is set.
+    // PreProvisioningTeardownComplete gates cessation of teardown retries for a
+    // terminal (failed/timed-out) attempt. The operator writes it false in the
+    // same update that claims the terminal state; teardown (clear image, remove
+    // DataImage, power off, delete the per-attempt token Secret) is then
+    // idempotently re-driven every reconcile until all actions succeed, when it
+    // flips to true — the ONLY state that stops teardown retries. It survives
+    // restarts so a crash mid-teardown cannot leave a terminal ICI with cleanup
+    // owed. Reset to false (or cleared) when a retry mints a fresh attempt;
+    // meaningful only once a terminal reason is set.
     // +optional
     PreProvisioningTeardownComplete bool `json:"preProvisioningTeardownComplete,omitempty"`
 }
@@ -328,16 +315,14 @@ type PreProvisioningResult struct {
 ```
 
 The IBI Operator reports pre-provisioning progress via the existing
-`RequirementsMet` condition before proceeding to its normal `configureHost`
-flow. **`RequirementsMet` is the single authoritative status field for the
-handoff** — the design deliberately does *not* introduce a separate
-`PreProvisioningCompleted` condition, so producer (IBI Operator) and consumer
-(O-Cloud Manager) agree on exactly one field and cannot end up watching
-different conditions (which would advance only after timeout). The
-pre-provisioning phase is distinguished by the condition `reason`
-(`PreProvisioning*`), not by a different condition `type`. This one contract
-is used consistently by the IBI Operator, the O-Cloud Manager mapping, and the
-integration tests.
+`RequirementsMet` condition before its normal `configureHost` flow.
+**`RequirementsMet` is the single authoritative status field for the handoff** —
+the design deliberately does *not* add a separate `PreProvisioningCompleted`
+condition, so producer (IBI Operator) and consumer (O-Cloud Manager) agree on
+exactly one field and cannot watch different conditions (which would advance only
+after timeout). The phase is distinguished by the condition `reason`
+(`PreProvisioning*`), not a different `type`. This one contract is used
+consistently by the IBI Operator, the O-Cloud Manager mapping, and the tests.
 
 ### O-Cloud Manager: ClusterTemplate Configuration
 
@@ -400,43 +385,40 @@ applies this mapping when rendering the ICI:
 | `retryBackoff` | `retryBackoff` |
 
 `callbackBaseURL` on the ICI is **not** sourced from `hwMgmtDefaults`; the
-operator derives it from operator-level configuration (the externally-
-reachable callback address is an environment property, not a per-template
-input). This is a **security boundary, not just a naming choice**: the
-callback client sends the per-attempt **bearer token** to whatever host
-`callbackBaseURL` resolves to, so a template or ProvisioningRequest author who
-could set it freely could redirect the token to a host they control and then
-forge a success callback. The field is therefore **operator-owned**:
+operator derives it from operator-level configuration (the externally-reachable
+callback address is an environment property, not a per-template input). This is a
+**security boundary, not just a naming choice**: the callback client sends the
+per-attempt **bearer token** to whatever host `callbackBaseURL` resolves to, so a
+template or ProvisioningRequest author who could set it freely could redirect the
+token to a host they control and forge a success callback. The field is therefore
+**operator-owned**:
 
-1. The IBI Operator's own configuration: an `IBI_CALLBACK_BASE_URL` value
-   sourced from the operator Deployment environment (populated from the
-   O-Cloud Manager `Inventory` CR's externally-reachable ingress/route
-   configuration). This is the normal way to set it fleet-wide.
+1. The IBI Operator's own configuration: an `IBI_CALLBACK_BASE_URL` from the
+   operator Deployment environment (populated from the O-Cloud Manager
+   `Inventory` CR's externally-reachable ingress/route config). The normal
+   fleet-wide setting.
 2. Otherwise the in-cluster Service URL (`<svc>.<ns>.svc`) — usable **only**
    when the host shares the hub cluster network.
 
-`PreProvisioningConfig.CallbackBaseURL` on the ICI is **not** a
-template/ProvisioningRequest input. It is not surfaced in
-`hwMgmtParameters`, and write access to `ImageClusterInstall.spec.preProvisioning.callbackBaseURL`
-is restricted by RBAC to the operator's own service account (template and PR
-authors cannot set it). If a value is present, it is accepted **only** when it
+It is not a template/ProvisioningRequest input, not surfaced in
+`hwMgmtParameters`, and write access to
+`ImageClusterInstall.spec.preProvisioning.callbackBaseURL` is RBAC-restricted to
+the operator's own service account. A present value is accepted **only** when it
 matches an operator-maintained **allowlist** of callback origins (the same
 `Inventory`-derived hosts); any off-allowlist origin is rejected at admission
-with `PreProvisioningConfigInvalid` and the ISO is never booted. An admission
-test covers a spoofed off-allowlist origin.
+with `PreProvisioningConfigInvalid` and the ISO is never booted (an admission
+test covers a spoofed off-allowlist origin).
 
-If none of these yields a URL reachable from the target provisioning
-network, the operator **fails closed**: it does not boot the ISO and reports
-a configuration error (`PreProvisioningConfigInvalid`), rather than booting a
-host that can never call back and then timing out 60 minutes later. In
-particular the in-cluster fallback is accepted only when the reachability
-check in Challenge 1 confirms the host is on the hub cluster network.
+If none of these yields a URL reachable from the target provisioning network,
+the operator **fails closed**: it does not boot the ISO and reports
+`PreProvisioningConfigInvalid`, rather than booting a host that can never call
+back and timing out 60 minutes later. The in-cluster fallback is accepted only
+when the Challenge 1 reachability check confirms the host is on the hub network.
 
-Keeping the names distinct on each side is intentional:
-`preProvisioningTimeout` reads clearly in the hardware-timeouts block
-alongside `hardwareProvisioningTimeout`, while `timeout` is scoped by its
-`preProvisioning` parent on the ICI. The mapping table above is the
-authoritative contract between the two field sets.
+Keeping the names distinct is intentional: `preProvisioningTimeout` reads clearly
+alongside `hardwareProvisioningTimeout` in the hardware-timeouts block, while
+`timeout` is scoped by its `preProvisioning` parent on the ICI. The mapping table
+above is the authoritative contract between the two field sets.
 
 ### Schema in templateParameterSchema
 
@@ -483,20 +465,20 @@ hwMgmtParameters:
   type: object
 ```
 
-Validation mirrors the schema: `maxRetries` must be a non-negative integer
-and `retryBackoff` must parse as a non-negative Go `time.Duration`. Both the
-admission webhook and the ICI passthrough reject out-of-range values so a bad
-override is caught at write time rather than surfacing as a stuck attempt. When
-omitted, the controller applies the `PreProvisioningConfig` defaults
-(`maxRetries: 0`, `retryBackoff: 5m`).
+Validation mirrors the schema: `maxRetries` must be a non-negative integer and
+`retryBackoff` must parse as a non-negative Go `time.Duration`. Both the admission
+webhook and the ICI passthrough reject out-of-range values so a bad override is
+caught at write time rather than surfacing as a stuck attempt. When omitted, the
+controller applies the `PreProvisioningConfig` defaults (`maxRetries: 0`,
+`retryBackoff: 5m`).
 
 Because `isoURL` and `isoDigest` are caller-overridable through
-`hwMgmtParameters`, validation also enforces the two artifact-trust checks
-before the operator ever fetches the URL (see "Restricting `ISOURL`"): `isoURL`
-must resolve to an operator-owned or allowlisted origin, and `isoDigest` is
-required (the schema marks it required; the webhook and passthrough re-check it,
-rejecting a missing or off-allowlist value with `PreProvisioningConfigInvalid`).
-The allowlist is operator configuration and cannot be widened by a template or
+`hwMgmtParameters`, validation also enforces the two artifact-trust checks before
+the operator fetches the URL (see "Restricting `ISOURL`"): `isoURL` must resolve
+to an operator-owned or allowlisted origin, and `isoDigest` is required (schema
+marks it required; the webhook and passthrough re-check, rejecting a missing or
+off-allowlist value with `PreProvisioningConfigInvalid`). The allowlist is
+operator configuration and cannot be widened by a template or
 `ProvisioningRequest`.
 
 ## IBI Operator Workflow Changes
@@ -529,14 +511,14 @@ ImageClusterInstall created (with spec.preProvisioning set)
   → NEW: preProvisionHost (ordered so every write is recoverable — see
     "Crash-safety of the boot handoff" below; each step is idempotent and the
     next reconcile resumes from the first incomplete one):
-      # RECOVERY: classify the current state before doing anything:
-      #   (a) Status.PreProvisioningAttempt set        → in-flight attempt:
-      #       resume it. Do NOT mint a new id/token; reuse the existing attempt
-      #       and its token Secret and re-drive the remaining steps idempotently.
-      #   (b) attempt unset, but a pending token Secret owned by this ICI and
-      #       carrying the ibi.openshift.io/attempt label exists → the status
-      #       write in step 2 was lost after step 1; ADOPT that Secret's attempt
-      #       id (do NOT mint a second one) and continue at step 2.
+      # RECOVERY: classify the current state first:
+      #   (a) Status.PreProvisioningAttempt set → in-flight attempt: resume it.
+      #       Do NOT mint a new id/token; reuse the attempt and its token Secret
+      #       and re-drive the remaining steps idempotently.
+      #   (b) attempt unset, but a pending token Secret owned by this ICI with
+      #       the ibi.openshift.io/attempt label exists → the step-2 write was
+      #       lost after step 1; ADOPT that Secret's attempt id (do NOT mint a
+      #       second) and continue at step 2.
       #   (c) attempt unset, no pending Secret, Status.RetryNotBefore set → a
       #       retired attempt is in backoff: wait until now >= RetryNotBefore
       #       (RequeueAfter = the remainder, recomputed here so a restart that
@@ -544,20 +526,18 @@ ImageClusterInstall created (with spec.preProvisioning set)
       #   (d) none of the above → first attempt: mint.
       → 1. mint intent (only in cases (c)-after-backoff and (d)):
           → mint attempt id + per-attempt token
-          → write the token to its own Secret, named deterministically from
-            the attempt id, OWNED by this ICI (ownerReference) and labelled
+          → write the token to its own Secret, named deterministically from the
+            attempt id, OWNED by this ICI (ownerReference) and labelled
             ibi.openshift.io/attempt=<id> (create-or-adopt). The token lives
-            here, NOT in status, so it must be persisted BEFORE the attempt id
-            is recorded. The owner + label make a written-but-not-yet-recorded
-            Secret discoverable (case (b)), so a lost step-2 write is adopted
-            rather than orphaned — the attempt id is recoverable from the Secret
-            even when it is absent from status.
+            here, NOT in status, so it must be persisted BEFORE the attempt id is
+            recorded. The owner + label make a written-but-not-yet-recorded
+            Secret discoverable (case (b)), so a lost step-2 write is adopted, not
+            orphaned — the attempt id is recoverable even when absent from status.
       → 2. record the attempt (ONE status update, flushed):
           → set Status.PreProvisioningAttempt = <id>
-          → clear Status.PreProvisioningResult (a stale result from a prior
-            attempt must not be read as this attempt's outcome)
-          → clear Status.RetryNotBefore (this attempt is now in flight, not
-            pending)
+          → clear Status.PreProvisioningResult (a stale result must not be read
+            as this attempt's outcome)
+          → clear Status.RetryNotBefore (this attempt is now in flight)
           → condition: RequirementsMet = False / PreProvisioningBooting
           → do NOT set PreProvisioningBootTime yet (see step 5)
       → 3. deliver the per-host callback data (URL, attempt id, token,
@@ -565,15 +545,14 @@ ImageClusterInstall created (with spec.preProvisioning set)
          preprovisioningNetworkDataName (that field is an nmstate network-data
          Secret and does not inject callback config into a live-iso boot — see
          Challenge 4). The DataImage MUST be named and namespaced after the
-         BareMetalHost (same name + namespace): BMO v0.13.2's
-         DataImageReconciler resolves the owning host by matching the DataImage
-         request name/namespace to a BareMetalHost, so an attempt-id-named
-         DataImage would never attach. The attempt id is bound instead through
-         carrier content and a label (e.g. `ibi.openshift.io/attempt: <id>`),
-         which the create-or-adopt step also uses to detect and replace a stale
-         carrier from a prior attempt. The generic callback client is already
-         baked into the live ISO via ignitionConfigOverride at build time
-         (identical for every host).
+         BareMetalHost: BMO v0.13.2's DataImageReconciler resolves the owning
+         host by matching the request name/namespace to a BareMetalHost, so an
+         attempt-id-named DataImage would never attach. The attempt id is bound
+         instead through carrier content and a label (e.g.
+         `ibi.openshift.io/attempt: <id>`), which the create-or-adopt step also
+         uses to detect and replace a stale carrier from a prior attempt. The
+         generic callback client is already baked into the live ISO via
+         ignitionConfigOverride at build time (identical for every host).
       → 4. mutate the BMH (idempotent patch):
           → set BMH spec.image.url = isoURL, spec.image.format = "live-iso"
           → set BMH spec.online = true
@@ -600,12 +579,12 @@ ImageClusterInstall created (with spec.preProvisioning set)
               → increment Status.PreProvisioningRetryCount
               → set Status.RetryNotBefore = now + RetryBackoff, and in the SAME
                 update CLEAR Status.PreProvisioningAttempt, PreProvisioningResult
-                and PreProvisioningBootTime. Clearing the attempt id is what
-                stops the recovery rule from re-driving the retired attempt with
-                its now-invalidated token; RetryNotBefore is the durable
-                retry-pending marker that survives a restart (the next reconcile
-                recomputes the remaining backoff from it rather than relying on
-                an in-memory RequeueAfter that a crash would lose).
+                and PreProvisioningBootTime. Clearing the attempt id stops the
+                recovery rule from re-driving the retired attempt with its now-
+                invalidated token; RetryNotBefore is the durable retry-pending
+                marker that survives a restart (the next reconcile recomputes the
+                remaining backoff from it, not an in-memory RequeueAfter a crash
+                would lose).
               → condition: RequirementsMet = False / PreProvisioningRetrying
                 (NON-terminal — the ProvisioningRequest keeps progressing)
               → RequeueAfter = RetryBackoff. A fresh attempt (new id + token) is
@@ -633,31 +612,30 @@ invariants:
 - **Token before attempt id, and discoverable.** The per-attempt token is
   persisted in its own deterministically-named Secret — owned by the ICI and
   labelled `ibi.openshift.io/attempt=<id>` — before the attempt id is written to
-  status. An attempt id can therefore never reference a token that was never
-  stored. If the status write in step 2 is lost after the Secret exists, the
-  next reconcile finds the pending Secret by owner + label and **adopts its
-  attempt id** rather than minting a second token, so the "token written, status
-  not" window resumes the same attempt (no orphaned Secret, no duplicate token).
+  status, so an attempt id can never reference a token that was never stored. If
+  the step-2 status write is lost after the Secret exists, the next reconcile
+  finds the pending Secret by owner + label and **adopts its attempt id** rather
+  than minting a second token (no orphaned Secret, no duplicate token).
 - **Attempt id is the recovery key for an in-flight attempt.** Once
   `PreProvisioningAttempt` is set, every subsequent reconcile **resumes the same
-  attempt** — it reuses the existing id and token Secret and re-drives steps 3-5
+  attempt** — reusing the existing id and token Secret and re-driving steps 3-5
   idempotently (create-or-adopt the BMH-named DataImage whose attempt-id label
-  identifies the current attempt, idempotent BMH patch), rather than minting a
+  identifies the current attempt, idempotent BMH patch) — rather than minting a
   fresh attempt while the previous ISO may still be booting.
 - **A retired attempt is never resumed.** On a retry, the failed attempt's
   `PreProvisioningAttempt` is cleared in the same update that sets
-  `RetryNotBefore`, so recovery can never mistake the retired attempt (whose
-  token is already invalidated) for an in-flight one. Recovery distinguishes
-  three post-failure states purely from persisted status: attempt set = resume;
+  `RetryNotBefore`, so recovery cannot mistake the retired attempt (token
+  already invalidated) for an in-flight one. Recovery distinguishes three
+  post-failure states purely from persisted status: attempt set = resume;
   attempt unset + `RetryNotBefore` in the future = wait out the backoff;
   attempt unset + `RetryNotBefore` reached = mint the next attempt. The backoff
-  remainder is recomputed from `RetryNotBefore` on every reconcile, so a restart
+  remainder is recomputed from `RetryNotBefore` each reconcile, so a restart
   that loses the in-memory `RequeueAfter` still honors it.
 - **BootTime marks a real boot, and is written last.** `PreProvisioningBootTime`
-  — the timeout anchor — is stamped only after the BMH boot request is
-  confirmed applied. A resumed attempt with steps 3-4 complete but no BootTime
-  verifies the BMH is booting the expected ISO, then stamps it; the timeout
-  clock cannot start before the host was actually asked to boot.
+  — the timeout anchor — is stamped only after the BMH boot request is confirmed
+  applied. A resumed attempt with steps 3-4 complete but no BootTime verifies the
+  BMH is booting the expected ISO, then stamps it; the clock cannot start before
+  the host was actually asked to boot.
 - **Timeout still bounds a stuck resume.** An in-flight attempt whose
   `PreProvisioningBootTime` + `timeout` has elapsed is treated as timed out and
   enters the retry/terminal branch — never a silent re-mint.
@@ -665,32 +643,31 @@ invariants:
 Each partial-write window — "token Secret written, status not" (asserts the
 pending Secret is adopted by owner + label, not re-minted); "status written,
 DataImage not"; "DataImage created, BMH not patched"; "BMH patched, BootTime not
-stamped"; and "retry recorded (`RetryNotBefore` set, attempt cleared), process
-restarted mid-backoff" (asserts the remaining backoff is honored and exactly one
-fresh attempt is then minted) — is covered by its own **fault-injection test**
-that kills the reconcile at that point and asserts the next reconcile resumes
-the same attempt (no new token, no duplicate boot, exactly one booting ISO).
+stamped"; and "retry recorded (`RetryNotBefore` set, attempt cleared), restarted
+mid-backoff" (asserts the remaining backoff is honored and exactly one fresh
+attempt is then minted) — is covered by its own **fault-injection test** that
+kills the reconcile at that point and asserts the next reconcile resumes the same
+attempt (no new token, no duplicate boot, exactly one booting ISO).
 
 ### Key Implementation Details in the IBI Operator
 
 #### 1. Callback Ignition Override
 
-The IBI Operator generates an ignition config snippet containing a systemd
-unit that runs after `install-rhcos-and-restore-seed.service` completes.
-This unit reports the result back to the hub via HTTP.
+The IBI Operator generates an ignition config snippet containing a systemd unit
+that runs after `install-rhcos-and-restore-seed.service` completes and reports
+the result back to the hub via HTTP.
 
 **This depends on `install-rhcos-and-restore-seed.service` being a
 `Type=oneshot` unit** (which the IBI seed-restore service is): a oneshot unit
-does not reach `active`/exit until its `ExecStart` has finished, so its
-`Result` property is a *terminal* success/failure verdict by the time the
-reporter reads it. `After=` only orders start-up — it does **not** wait for a
-`Type=simple` (or other long-running) unit to finish, so if the referenced unit
-were not oneshot the reporter could read a non-failure `Result` while
-preparation is still running and send a premature "success". If a future base
-changes that unit's type, the design must instead gate on an explicit
-completion sentinel (a dedicated oneshot unit ordered `After=` the prep service,
-whose own terminal `Result` the reporter reads) rather than the prep service's
-live state. The reporter contract is: read a terminal result, never a
+does not reach `active`/exit until its `ExecStart` finishes, so its `Result`
+property is a *terminal* verdict by the time the reporter reads it. `After=` only
+orders start-up — it does **not** wait for a `Type=simple` (or other
+long-running) unit to finish, so a non-oneshot unit could let the reporter read a
+non-failure `Result` while preparation is still running and send a premature
+"success". If a future base changes that unit's type, the design must gate on an
+explicit completion sentinel (a dedicated oneshot unit ordered `After=` the prep
+service, whose own terminal `Result` the reporter reads) rather than the prep
+service's live state. The reporter contract: read a terminal result, never a
 mid-flight one.
 
 ```yaml
@@ -702,89 +679,75 @@ systemd:
       contents: |
         [Unit]
         Description=Report IBI preparation result to hub
-        # Order AFTER the prep service, and use Wants= (NOT Requires=). The
-        # whole point of this unit is to report BOTH success and failure, so
-        # it must run even when the prep service fails. With Requires=, a
-        # failed prep service would cause systemd to skip this reporter's job
-        # entirely, no failure callback would be sent, and the hub would wait
-        # out the full PreProvisioningTimedOut. Wants= keeps the ordering
-        # dependency without cancelling the reporter when the prep service
-        # fails. Requires=/After= on the data unit below is different: that
-        # data must exist for the reporter to work at all, so it stays
-        # Requires=. After= alone only orders start-up; it does not wait for
-        # the prep service to finish, so it is paired with the current-boot
-        # result check in ExecStart (the prep service reaches a terminal
-        # success/failure state, so the result is deterministic when read).
+        # Order AFTER the prep service, and use Wants= (NOT Requires=): this
+        # unit must report BOTH success and failure, so it must run even when
+        # the prep service fails. With Requires=, a failed prep service would
+        # make systemd skip this reporter's job entirely — no failure callback,
+        # and the hub waits out the full PreProvisioningTimedOut. Wants= keeps
+        # the ordering without cancelling the reporter on prep failure. After=
+        # only orders start-up; it does not wait for the prep service to finish,
+        # so it is paired with the current-boot result check in ExecStart (the
+        # prep service reaches a terminal state, so the result is deterministic
+        # when read).
         After=install-rhcos-and-restore-seed.service
         Wants=install-rhcos-and-restore-seed.service
         # Runtime dependency on the per-host data (see Challenge 4): the
-        # reporter cannot run without its URL/token/attempt files. The data
-        # unit is Type=oneshot with RemainAfterExit=yes, so it stays
-        # active (exited) after materializing the files; without that this
-        # Requires= would drop as soon as the data unit's ExecStart returned
-        # and systemd could stop the reporter before it ran.
+        # reporter cannot run without its URL/token/attempt files. The data unit
+        # is Type=oneshot with RemainAfterExit=yes, so it stays active (exited)
+        # after materializing the files; without that, this Requires= would drop
+        # as soon as the data unit's ExecStart returned and systemd could stop
+        # the reporter before it ran.
         Requires=ibi-callback-data.service
         After=ibi-callback-data.service
-        # StartLimit* live in [Unit] (moved here from [Service] in systemd
-        # v230). Backstop only — the real retry budget is the script's
-        # absolute deadline.
+        # StartLimit* live in [Unit] (moved from [Service] in systemd v230).
+        # Backstop only — the real retry budget is the script's absolute deadline.
         StartLimitIntervalSec=660
         StartLimitBurst=3
 
         [Service]
-        # Type=oneshot with Restart=on-failure requires systemd v244 or
-        # later (before v244 Restart= is silently ignored for oneshot
-        # units, so the callback would never be retried). RHCOS ships
-        # systemd 252+, so this is satisfied; the dependency is called out
-        # here because the retry semantics below are load-bearing, not
-        # decorative. On any older base the ExecStart must instead wrap the
-        # send in its own bounded retry loop.
+        # Type=oneshot with Restart=on-failure requires systemd v244+ (before
+        # v244 Restart= is silently ignored for oneshot units, so the callback
+        # would never be retried). RHCOS ships systemd 252+, so this holds; on
+        # any older base the ExecStart must wrap the send in its own retry loop.
         Type=oneshot
         ExecStart=/usr/local/bin/ibi-prep-callback
-        # The retry budget is enforced as an ABSOLUTE deadline inside the
-        # script (a wall-clock loop), not by per-attempt timers, and it is
-        # sized from the operator's PreProvisioningConfig.Timeout (default 60m,
-        # delivered as CALLBACK_BUDGET_SECS) so callbacks stay alive for the
-        # whole window the operator waits — see the script below.
-        # TimeoutStartSec/Restart alone cannot bound total effort:
-        # TimeoutStartSec caps a SINGLE start attempt, and Restart=on-failure
-        # would keep re-launching the unit (subject to start-rate limits)
-        # with no ceiling on cumulative time. So the script owns the budget:
-        # it retries curl until it succeeds or the deadline passes, then
-        # exits (0 on delivery, non-zero if the deadline elapsed).
-        # TimeoutStartSec is DISABLED (infinity) because the budget is now
-        # host-specific and can be up to the operator timeout; a fixed cap
-        # baked into the shared ISO would truncate it. The script's persisted
-        # deadline is the real bound. Restart + StartLimit remain only as a
-        # backstop for an outright script crash.
+        # The retry budget is an ABSOLUTE deadline inside the script (a
+        # wall-clock loop), not per-attempt timers, sized from the operator's
+        # PreProvisioningConfig.Timeout (default 60m, delivered as
+        # CALLBACK_BUDGET_SECS) so callbacks stay alive for the whole window the
+        # operator waits. TimeoutStartSec/Restart alone cannot bound total
+        # effort: TimeoutStartSec caps a SINGLE start, and Restart=on-failure
+        # would relaunch with no ceiling on cumulative time. So the script owns
+        # the budget (retries curl until success or deadline, then exits). It is
+        # DISABLED here (infinity) because a fixed cap baked into the shared ISO
+        # would truncate a host-specific budget; the script's persisted deadline
+        # is the real bound. Restart + StartLimit remain a crash backstop only.
         TimeoutStartSec=infinity
         Restart=on-failure
         RestartSec=30
-        # Non-secret callback parameters (URL, attempt id). The bearer token
-        # is NOT here — it is delivered in a root-only curl config file (see
-        # below) so it never lands in an environment variable, the unit
-        # contents, or the process argument list.
+        # Non-secret callback parameters (URL, attempt id). The bearer token is
+        # NOT here — it is delivered in a root-only curl config file (see below)
+        # so it never lands in an env var, the unit contents, or argv.
         EnvironmentFile=/etc/ibi-callback/env
 
         [Install]
         WantedBy=multi-user.target
 ```
 
-The reporter logic is delivered as a small script (`/usr/local/bin/ibi-prep-callback`,
-also injected via the ignition overlay) rather than an inline `bash -c`,
-so the JSON body can be serialized safely and the token kept out of argv:
+The reporter logic is a small script (`/usr/local/bin/ibi-prep-callback`, also
+injected via the ignition overlay) rather than an inline `bash -c`, so the JSON
+body can be serialized safely and the token kept out of argv:
 
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
 
 # Determine the prep service result for THIS boot/attempt only. Use the
-# systemd-tracked result (Result property) rather than grepping the journal,
-# and scope any journal read to the current boot (-b 0). An unscoped
-# `journalctl -u ...` would also match a "finished successfully" line left
-# over from an earlier boot or a previous pre-provisioning attempt on the
-# same disk, producing a false success. After= ordering alone does NOT
-# disambiguate attempts.
+# systemd-tracked Result property rather than grepping the journal, and scope any
+# journal read to the current boot (-b 0). An unscoped `journalctl -u ...` would
+# also match a "finished successfully" line from an earlier boot or a previous
+# attempt on the same disk, producing a false success. After= ordering alone does
+# NOT disambiguate attempts.
 RESULT=$(systemctl show -p Result --value install-rhcos-and-restore-seed.service)
 if [ "${RESULT}" = "success" ]; then
   STATUS="success"
@@ -796,13 +759,12 @@ else
 fi
 
 # Serialize the body with a real JSON encoder. MSG is arbitrary journal text
-# containing newlines, double quotes, and backslashes; hand-built
-# "{\"message\": \"${MSG}\"}" produces invalid JSON and can be used to
-# inject fields. Use jq (shipped in RHCOS) rather than python3 (NOT present
-# in the RHCOS live ISO — invoking it would fail and, under `set -e`, exit
-# before curl, turning every callback into a timeout). --arg passes each
-# value as a literal string so no field injection is possible. The attempt
-# id ties this callback to the exact boot the operator is waiting on (see
+# (newlines, quotes, backslashes); a hand-built "{\"message\": \"${MSG}\"}"
+# produces invalid JSON and enables field injection. Use jq (shipped in RHCOS)
+# not python3 (NOT present in the RHCOS live ISO — invoking it would fail and,
+# under `set -e`, exit before curl, turning every callback into a timeout).
+# --arg passes each value as a literal string, so no field injection. The
+# attempt id ties this callback to the exact boot the operator waits on (see
 # PreProvisioningAttempt); the operator rejects any mismatch.
 PAYLOAD=$(jq -nc \
   --arg attempt "${CALLBACK_ATTEMPT}" \
@@ -810,39 +772,34 @@ PAYLOAD=$(jq -nc \
   --arg message "${MSG}" \
   '{attempt: $attempt, status: $status, message: $message}')
 
-# Retry against an ABSOLUTE wall-clock deadline, not a per-attempt timer.
-# This bounds cumulative effort regardless of how many individual attempts
-# fail, which neither TimeoutStartSec nor Restart= can do on their own. On the
-# first successful delivery, exit 0 immediately; if the deadline passes without
-# success, exit non-zero (systemd's Restart is only a crash backstop, bounded
-# by StartLimit).
+# Retry against an ABSOLUTE wall-clock deadline, not a per-attempt timer. This
+# bounds cumulative effort regardless of how many attempts fail, which neither
+# TimeoutStartSec nor Restart= can do alone. Exit 0 on first success; exit
+# non-zero if the deadline passes (Restart is a crash backstop only, bounded by
+# StartLimit).
 #
 # The budget MUST cover the operator's whole wait window. The operator waits up
-# to PreProvisioningConfig.Timeout (default 60m) for a callback; if the host
-# stopped retrying after a fixed ~10m, a hub that is unreachable for 10-59m
-# after prep succeeds would never receive the (already-produced) result and the
-# operator would time out a host that actually succeeded. So the operator
-# delivers CALLBACK_BUDGET_SECS per-host in the env file, derived from the
-# effective timeout (timeout minus a small margin so the last send precedes the
-# operator's own deadline). The script uses that as its budget instead of a
-# hardcoded constant.
+# to PreProvisioningConfig.Timeout (default 60m); if the host stopped retrying
+# after a fixed ~10m, a hub unreachable for 10-59m after prep succeeds would
+# never receive the already-produced result and the operator would time out a
+# host that actually succeeded. So the operator delivers CALLBACK_BUDGET_SECS
+# per-host (effective timeout minus a small margin so the last send precedes the
+# operator's own deadline); the script uses that, not a hardcoded constant.
 #
-# CALLBACK_BUDGET_SECS is a REQUIRED per-host value (see env file below). There
-# is deliberately NO silent fallback: a missing budget is a delivery bug, and
-# defaulting to a short window would reintroduce the very "host stops before the
-# operator's timeout" failure this value exists to prevent. Fail loudly instead.
+# CALLBACK_BUDGET_SECS is REQUIRED (see env file below) with deliberately NO
+# silent fallback: a missing budget is a delivery bug, and defaulting to a short
+# window would reintroduce the "host stops before the operator's timeout"
+# failure this value prevents. Fail loudly instead.
 : "${CALLBACK_BUDGET_SECS:?CALLBACK_BUDGET_SECS not delivered}"
 #
-# Anchor the deadline to the host's BOOT time, not to this script's first-run
-# time. The operator's timeout starts at PreProvisioningBootTime (≈ when the
-# host was asked to boot), but this reporter only starts after preparation
-# finishes, which can be many minutes later. Computing `now + budget` here would
-# hand a late-starting reporter a fresh full budget and push its window past the
-# operator's deadline. Using boot time keeps the two clocks aligned.
-#
-# The deadline is also PERSISTED to a tmpfs file so it survives a
-# Restart=on-failure relaunch (a crash + re-exec must not restart the budget);
-# the first invocation stamps it, later invocations read it back.
+# Anchor the deadline to the host's BOOT time, not this script's first-run time.
+# The operator's timeout starts at PreProvisioningBootTime (≈ when the host was
+# asked to boot), but this reporter starts only after preparation finishes,
+# possibly many minutes later. `now + budget` would hand a late-starting reporter
+# a fresh full budget and push its window past the operator's deadline; boot time
+# keeps the two clocks aligned. The deadline is PERSISTED to a tmpfs file so it
+# survives a Restart=on-failure relaunch (a crash must not restart the budget):
+# the first invocation stamps it, later ones read it back.
 DEADLINE_FILE=/run/ibi-callback/deadline   # tmpfs, cleared on reboot
 mkdir -p "$(dirname "${DEADLINE_FILE}")"
 if [ -s "${DEADLINE_FILE}" ]; then
@@ -854,11 +811,10 @@ else
   printf '%s' "${DEADLINE}" > "${DEADLINE_FILE}"
 fi
 ATTEMPT_TIMEOUT=20                   # per-curl cap so one hang can't eat the budget
-# --config points at a root-only (0600) file that carries ONLY the
-# Authorization header:  header = "Authorization: Bearer <token>"
-# This keeps the token out of argv (visible via ps / /proc/*/cmdline) and
-# out of the environment. The endpoint is header-authenticated only; the
-# token is never placed in the URL query string.
+# --config points at a root-only (0600) file carrying ONLY the Authorization
+# header:  header = "Authorization: Bearer <token>". This keeps the token out of
+# argv (visible via ps / /proc/*/cmdline) and the environment. The endpoint is
+# header-authenticated only; the token is never in the URL query string.
 while :; do
   if curl -sf -X POST \
       --max-time "${ATTEMPT_TIMEOUT}" \
@@ -874,102 +830,91 @@ while :; do
 done
 ```
 
-The ignition overlay therefore delivers three per-server files, all as data
-(not baked into the shared ISO — see [Challenge 4](#4-callback-url-injection-into-the-iso)):
+The ignition overlay therefore delivers three per-server files, all as data (not
+baked into the shared ISO — see [Challenge 4](#4-callback-url-injection-into-the-iso)):
 
-- `/etc/ibi-callback/env` (0644): `CALLBACK_URL=...`, `CALLBACK_ATTEMPT=...`,
-  and `CALLBACK_BUDGET_SECS=...` (the callback retry budget in seconds, derived
-  by the operator from the effective `PreProvisioningConfig.Timeout` minus a
-  margin so the host keeps resending for the entire window the operator waits)
-  — all non-secret.
-- `/etc/ibi-callback/auth.cfg` (0600, root-only): a curl config file whose
-  sole line is `header = "Authorization: Bearer <per-attempt-token>"`.
+- `/etc/ibi-callback/env` (0644): `CALLBACK_URL=...`, `CALLBACK_ATTEMPT=...`, and
+  `CALLBACK_BUDGET_SECS=...` (the retry budget in seconds, derived from the
+  effective `PreProvisioningConfig.Timeout` minus a margin so the host keeps
+  resending for the whole window the operator waits) — all non-secret.
+- `/etc/ibi-callback/auth.cfg` (0600, root-only): a curl config file whose sole
+  line is `header = "Authorization: Bearer <per-attempt-token>"`.
 - `/usr/local/bin/ibi-prep-callback` (0755): the script above (identical for
   every server; safe to bake into the shared ISO).
 
 `CALLBACK_URL` is the operator's `callbackBaseURL` (see
 `PreProvisioningConfig.CallbackBaseURL`) with
-`/callbacks/<ici-namespace>/<ici-name>/status` appended — an externally-
-reachable address, not the in-cluster `<service>.<namespace>.svc` name,
-which resolves only inside the hub. In disconnected environments the server
-typically reaches the hub via an external route, so `callbackBaseURL` is
-that route hostname.
+`/callbacks/<ici-namespace>/<ici-name>/status` appended — an externally-reachable
+address, not the in-cluster `<service>.<namespace>.svc` name, which resolves only
+inside the hub. In disconnected environments the server typically reaches the hub
+via an external route, so `callbackBaseURL` is that route hostname.
 
 The operator builds `CALLBACK_URL` with **URL-aware joining**, not string
-concatenation: it parses `callbackBaseURL`, rejects any value carrying a
-query or fragment, and collapses a trailing slash so
-`https://host/` and `https://host` both yield exactly one separator before
-`/callbacks/...` (naive concatenation would produce `https://host//callbacks`
-or splice the path into a query/fragment and never reach the endpoint). The
-admission-time validation below enforces the same constraints so a malformed
-base is rejected at write time rather than surfacing 60 minutes later as a
-`PreProvisioningTimedOut`.
+concatenation: it parses `callbackBaseURL`, rejects any value with a query or
+fragment, and collapses a trailing slash so `https://host/` and `https://host`
+both yield exactly one separator before `/callbacks/...` (naive concatenation
+would produce `https://host//callbacks` or splice the path into a query/fragment
+and never reach the endpoint). The admission-time validation below enforces the
+same constraints so a malformed base is rejected at write time rather than
+surfacing 60 minutes later as a `PreProvisioningTimedOut`.
 
-Delivering the snippet to a **live-iso** boot is the subtle part, and the
-mechanism must be chosen against what BMO/Ironic actually honor for
-`DiskFormat: live-iso`, not against what is available for a normal
-provisioned boot:
+Delivering the snippet to a **live-iso** boot is the subtle part; the mechanism
+must be chosen against what BMO/Ironic actually honor for `DiskFormat: live-iso`,
+not what a normal provisioned boot offers:
 
 - **`ignitionConfigOverride` baked into the ISO (authoritative path).** The
   live ISO's embedded Ignition is the one delivery surface Ironic reliably
-  applies for a live-iso boot. The `ImageBasedInstallationConfig` supports
-  `ignitionConfigOverride`, so the callback systemd unit can be merged into
-  the ISO at build time. The cost is that the callback target must be known
-  at build time — which conflicts with a per-ICI URL/token baked into a
-  shared ISO (see [Challenge 4](#4-callback-url-injection-into-the-iso)).
-  The resolution is to bake only a **generic** callback client into the ISO
-  that reads its per-server URL and token from a well-known location, and
-  deliver only that small per-server data at boot.
-- **`DataImage` is not an ignition overlay.** A `DataImage` attaches an
-  extra virtual-media device; BMO does **not** merge its contents into the
-  live environment's Ignition, so it cannot be relied on to *inject* the
-  callback systemd unit. It can only carry data that the ISO's baked-in
-  generic client explicitly mounts and reads (e.g. a config drive the
-  client looks for).
+  applies for a live-iso boot; `ImageBasedInstallationConfig` supports
+  `ignitionConfigOverride`, so the callback systemd unit can be merged in at
+  build time. The cost is the callback target must be known at build time —
+  which conflicts with a per-ICI URL/token in a shared ISO (see
+  [Challenge 4](#4-callback-url-injection-into-the-iso)). The resolution:
+  bake only a **generic** callback client that reads its per-server URL and
+  token from a well-known location, and deliver that small data at boot.
+- **`DataImage` is not an ignition overlay.** It attaches an extra
+  virtual-media device; BMO does **not** merge its contents into the live
+  environment's Ignition, so it cannot *inject* the callback systemd unit — it
+  can only carry data the ISO's baked-in generic client explicitly mounts and
+  reads (e.g. a config drive).
 - **`spec.preprovisioningNetworkDataName` / `userData` / `networkData` /
-  `metaData` are not a safe assumption for live-iso.** For a live-iso boot
-  BMO/Ironic do not process these the way they do for a normal deploy, so
-  the design must not depend on them to carry the ignition override.
+  `metaData` are not safe for live-iso.** BMO/Ironic do not process these for
+  a live-iso boot as they do for a normal deploy, so the design must not depend
+  on them to carry the ignition override.
 
 **Recommended path:** bake a generic callback client into the ISO via
-`ignitionConfigOverride` at build time, and deliver the per-server callback
-URL + token at boot through a mechanism the client reads itself. Because the
-exact behavior of `live-iso` + `DataImage` + config-drive discovery is
-version-dependent in BMO/Ironic, this path **must be covered by a
-version-pinned integration test** against the supported BMO/Ironic version
-rather than assumed; if that test cannot be made to pass, the fallback is a
-unique per-ICI ISO with the URL/token baked directly into
-`ignitionConfigOverride`. This tension is tracked in
-[Open Question 2](#open-questions).
+`ignitionConfigOverride` at build time, and deliver the per-server callback URL +
+token at boot through a mechanism the client reads itself. Because the exact
+behavior of `live-iso` + `DataImage` + config-drive discovery is version-dependent
+in BMO/Ironic, this path **must be covered by a version-pinned integration test**
+against the supported version rather than assumed; if that test cannot pass, the
+fallback is a unique per-ICI ISO with the URL/token baked directly into
+`ignitionConfigOverride`. Tracked in [Open Question 2](#open-questions).
 
 #### Host network configuration for the callback
 
-Everything above assumes the live-ISO host can already reach
-`CALLBACK_URL` over the network. That is not automatic: the callback carrier
-(`DataImage`) delivers only the URL/token/attempt data, and — as noted above —
-`preprovisioningNetworkDataName` / `networkData` are **not** reliably honored
-for a live-iso boot, so they cannot be assumed to configure the host's IP,
-route, and DNS. Without a defined network path the callback never leaves the
-host and the operator times the (possibly successful) preparation out. The
-design therefore requires one of two explicit modes, selected per template:
+Everything above assumes the live-ISO host can already reach `CALLBACK_URL`.
+That is not automatic: the callback carrier (`DataImage`) delivers only the
+URL/token/attempt data, and — as noted above — `preprovisioningNetworkDataName`
+/ `networkData` are **not** reliably honored for a live-iso boot, so they cannot
+be assumed to configure the host's IP, route, and DNS. Without a defined network
+path the callback never leaves the host and the operator times the (possibly
+successful) preparation out. The design requires one of two explicit modes,
+selected per template:
 
-- **DHCP (default, must be validated).** DHCP on the provisioning network is
-  the assumed baseline. It is stated as an explicit prerequisite, and the
-  reachability check in
+- **DHCP (default, must be validated).** DHCP on the provisioning network is the
+  assumed baseline, stated as an explicit prerequisite; the reachability check in
   [Challenge 1](#1-callback-url-must-be-reachable-from-the-pre-provisioned-server)
-  is the gate: if the host cannot obtain an address and reach
-  `callbackBaseURL`, the
-  operator fails closed with `PreProvisioningConfigInvalid` rather than booting
-  a host that can never call back.
-- **Static networking (DHCP-less environments).** When DHCP is unavailable,
-  the host IP/route/DNS are supplied at ISO build time — as dracut
-  `ip=`/`nameserver=` kernel arguments and/or NetworkManager keyfiles injected
-  into the ISO via `coreos-installer iso customize`, carried in the same
-  `ignitionConfigOverride`/ISO-build path that bakes the generic callback
-  client. Because this configuration is baked, a static-network deployment
-  needs its own per-host or per-site ISO variant (it cannot ride the shared
-  ISO's per-host data files), which is called out as a cost of DHCP-less
-  operation.
+  is the gate: if the host cannot obtain an address and reach `callbackBaseURL`,
+  the operator fails closed with `PreProvisioningConfigInvalid` rather than
+  booting a host that can never call back.
+- **Static networking (DHCP-less environments).** When DHCP is unavailable, the
+  host IP/route/DNS are supplied at ISO build time — dracut `ip=`/`nameserver=`
+  kernel arguments and/or NetworkManager keyfiles injected via
+  `coreos-installer iso customize`, in the same `ignitionConfigOverride`/ISO-build
+  path that bakes the generic callback client. Because this is baked, a
+  static-network deployment needs its own per-host or per-site ISO variant (it
+  cannot ride the shared ISO's per-host data files) — a called-out cost of
+  DHCP-less operation.
 
 The supported live-ISO network path (whichever mode) is exercised by the same
 version-pinned integration test, so "the host can reach the hub" is verified,
@@ -996,37 +941,32 @@ On receiving a callback:
 1. Look up the `ImageClusterInstall` by namespace/name
 2. Verify the ICI has `spec.preProvisioning` set and is in the
    `PreProvisioningBooting` or `PreProvisioningInProgress` state
-3. Verify the payload `attempt` equals `status.preProvisioningAttempt` (and
-   that the bearer token is the one minted for that attempt); reject with
-   409/401 otherwise. This drops late callbacks from a superseded boot.
-4. Reject if `status.preProvisioningResult` for this attempt is **already
-   set** — only the **first** terminal callback wins.
+3. Verify the payload `attempt` equals `status.preProvisioningAttempt` (and the
+   bearer token is the one minted for that attempt); reject with 409/401
+   otherwise. This drops late callbacks from a superseded boot.
+4. Reject if `status.preProvisioningResult` for this attempt is **already set** —
+   only the **first** terminal callback wins.
 5. Store the result in `status.preProvisioningResult` (with its `attempt`)
-   using an **atomic compare-and-swap on the ICI `resourceVersion`** (a
-   status update with the read `resourceVersion` set as precondition). If the
-   update is rejected with a conflict, re-read and re-apply step 4: a
-   concurrent callback (e.g. duplicate retries from the host, or a
-   success/failure race) that already recorded a terminal result causes this
-   one to be dropped with 409. This guarantees exactly one terminal result is
-   recorded even under concurrent POSTs, rather than a last-writer-wins
-   overwrite.
+   using an **atomic compare-and-swap on the ICI `resourceVersion`** (a status
+   update with the read `resourceVersion` as precondition). On a conflict,
+   re-read and re-apply step 4: a concurrent callback (duplicate host retries,
+   or a success/failure race) that already recorded a terminal result drops this
+   one with 409. This guarantees exactly one terminal result even under
+   concurrent POSTs, rather than last-writer-wins.
 6. Trigger a reconciliation of the ICI (the reconciler picks up the
    result and proceeds with the BMH state transition)
 
-The endpoint is authenticated using a **per-attempt** bearer token
-generated by the IBI Operator when the pre-provisioning phase starts. The
-token is presented in an HTTP `Authorization: Bearer <token>` header (not
-in the URL as a query parameter or path segment), so it does not leak into
-image-server access logs, proxy logs, or the ISO's cloud-init/journal
-output. The token is stored only in a per-ICI Secret owned by the ICI
-(not in `status`, which is world-readable to anyone with `get` on the ICI),
-delivered to the server inside the ignition overlay, compared in constant
-time on receipt, and invalidated once a terminal callback is accepted or
-the attempt times out. A fresh token is minted on every boot attempt so a
-token captured from an earlier attempt cannot drive a later one. Where the
-deployment can support it, mutual TLS (a client certificate provisioned
-into the ignition overlay) is preferred over the bearer token. See
-[Challenge 3](#3-callback-authentication-and-security).
+The endpoint is authenticated with a **per-attempt** bearer token generated when
+the pre-provisioning phase starts. It is presented in an `Authorization: Bearer
+<token>` header (not in the URL query or path), so it does not leak into
+image-server access logs, proxy logs, or the ISO's cloud-init/journal output. The
+token is stored only in a per-ICI Secret owned by the ICI (not in `status`, which
+is readable by anyone with `get` on the ICI), delivered inside the ignition
+overlay, compared in constant time on receipt, and invalidated once a terminal
+callback is accepted or the attempt times out. A fresh token is minted every boot
+attempt so one captured from an earlier attempt cannot drive a later one. Where
+supported, mutual TLS (a client certificate in the ignition overlay) is preferred
+over the bearer token. See [Challenge 3](#3-callback-authentication-and-security).
 
 #### 3. BMH Image Configuration for ISO Boot
 
@@ -1051,77 +991,70 @@ media (Redfish `VirtualMedia.InsertMedia`) and boot from it. The IBI
 preparation service within the ISO handles the actual disk installation.
 
 **Binding the boot to an immutable artifact.** When
-`PreProvisioningConfig.ISODigest` is set, the operator ensures the ISO
-actually booted is the exact artifact that was built and verified — a
-mutable HTTPS URL alone can be swapped for a stale or tampered ISO between
-build and boot. Because Ironic's `live-iso` path does **not** reliably
-enforce the BMH `Image.Checksum` the way the normal deploy path does, the
-operator does not depend solely on populating `Checksum` above: before
-setting `spec.image`, it **streams the ISO bytes from `ISOURL`** over an HTTPS
-channel and computes the SHA-256 **over those bytes**, comparing the result to
+`PreProvisioningConfig.ISODigest` is set, the operator ensures the booted ISO is
+the exact artifact built and verified — a mutable HTTPS URL alone can be swapped
+for a stale or tampered ISO between build and boot. Because Ironic's `live-iso`
+path does **not** reliably enforce the BMH `Image.Checksum` the way the normal
+deploy path does, the operator does not rely solely on populating `Checksum`
+above: before setting `spec.image`, it **streams the ISO bytes from `ISOURL`**
+over HTTPS and computes the SHA-256 **over those bytes**, comparing to
 `ISODigest` and failing closed with `PreProvisioningConfigInvalid` on mismatch.
-A published `.sha256` **sidecar is explicitly not trusted** as the verification
-source: comparing sidecar text to `ISODigest` only checks that two pieces of
-metadata agree, not that `ISOURL` actually returns those bytes — a stale or
-mispublished sidecar would pass while the URL serves an ISO that was never
-hashed. The bytes the operator will hand to the BMC are the bytes that must be
-hashed. This digest is the same value the seed-generation workflow records in
-`SeedGenerationStatus.ISODigest`, so the two proposals pin to one artifact
-end to end.
+A published `.sha256` **sidecar is explicitly not trusted**: comparing sidecar
+text to `ISODigest` only checks that two pieces of metadata agree, not that
+`ISOURL` returns those bytes — a stale or mispublished sidecar would pass while
+the URL serves an ISO that was never hashed. The bytes handed to the BMC are the
+bytes that must be hashed. This digest is the same value the seed-generation
+workflow records in `SeedGenerationStatus.ISODigest`, so the two proposals pin to
+one artifact end to end.
 
 **Restricting `ISOURL` before the operator fetches it.** Because `isoURL` is
-overridable through `hwMgmtParameters` on a `ProvisioningRequest`, an untrusted
-caller could otherwise point the operator's pre-fetch at an arbitrary HTTPS
-endpoint. Requiring HTTPS is not sufficient: a valid HTTPS URL can still name an
-internal service, making the operator's fetch a server-side request forgery
-(SSRF) vector. The operator therefore enforces two checks, **both before any
-byte of `ISOURL` is fetched**, failing closed with `PreProvisioningConfigInvalid`:
+overridable through `hwMgmtParameters`, an untrusted caller could otherwise point
+the operator's pre-fetch at an arbitrary HTTPS endpoint. Requiring HTTPS is not
+enough: a valid HTTPS URL can still name an internal service, making the fetch a
+server-side request forgery (SSRF) vector. The operator therefore enforces two
+checks **before any byte of `ISOURL` is fetched**, failing closed with
+`PreProvisioningConfigInvalid`:
 
 - **Origin allowlist.** `ISOURL` must resolve to an operator-owned or
-  explicitly allowlisted ISO origin (the origins configured for the
-  seed-generation upload target, plus any operator-configured additions). A URL
-  outside that set is rejected before the fetch — the operator never issues a
-  request to a caller-chosen host. The allowlist is operator configuration, not
-  template or `ProvisioningRequest` input, so a request author cannot widen it.
+  allowlisted ISO origin (the seed-generation upload origins plus any
+  operator-configured additions); a URL outside that set is rejected before the
+  fetch, so the operator never requests a caller-chosen host. The allowlist is
+  operator configuration, not template/`ProvisioningRequest` input, so a request
+  author cannot widen it.
 - **Mandatory digest for automated boot.** `ISODigest` is **required** whenever
   the operator drives an automated boot from a caller-influenceable `ISOURL`;
-  URL-only trust is not accepted for that path. A missing digest is rejected up
-  front rather than silently falling back to URL-only trust, so the bytes handed
-  to the BMC are always pinned to a verified artifact.
+  URL-only trust is not accepted. A missing digest is rejected up front, so the
+  bytes handed to the BMC are always pinned to a verified artifact.
 
 **The operator's pre-fetch is necessary but not sufficient on its own — the
 `ISOURL` must also be immutable.** There is an unavoidable time-of-check /
 time-of-use gap: the operator verifies the bytes at `ISOURL` *before* setting
-`spec.image`, but the BMC (via Ironic) fetches the bytes *later*, and BMO's
+`spec.image`, but the BMC (via Ironic) fetches them *later*, and BMO's
 `live-iso` path passes only `imageData.URL` as the Ironic `boot_iso` while
 clearing the checksum fields — so nothing in the boot path re-binds what the
-BMC actually pulls. If the content at `ISOURL` changes after the operator's
-check, the BMC can boot different bytes than were verified. The design
-therefore **requires `ISOURL` to be an immutable, content-addressed reference**
-(a per-run URL that never has its bytes rewritten), not a mutable "latest"
-URL. The seed-generation workflow already satisfies this: it uploads to a
-**unique per-run path** (ProvisioningRequest name + seed image digest +
-filename) that is written once and never overwritten, so the URL effectively
-addresses one immutable artifact. Immutability of `ISOURL` is a
-**producer-side contract** (the seed workflow guarantees it; a generic webhook
-cannot reliably prove a URL is immutable), and the operator's pre-fetch
-verification then confirms that immutable artifact matches `ISODigest`.
-Immutability closes the TOCTOU window; the pre-fetch confirms identity. Because
-`ISODigest` is mandatory for automated boot (above), the operator always
-verifies identity at check time; what a non-immutable `ISOURL` costs is the
-guarantee that the BMC's *later* fetch pulls those same verified bytes. A
-deployment that cannot guarantee an immutable, allowlisted URL therefore cannot
-offer automated IBI pre-provisioning through this path — it is rejected up
-front, not silently downgraded to URL-only trust.
+BMC actually pulls. If the content at `ISOURL` changes after the check, the BMC
+can boot different bytes than were verified. The design therefore **requires
+`ISOURL` to be an immutable, content-addressed reference** (a per-run URL whose
+bytes are never rewritten), not a mutable "latest" URL. The seed-generation
+workflow already satisfies this: it uploads to a **unique per-run path**
+(ProvisioningRequest name + seed image digest + filename), written once and
+never overwritten. Immutability is a **producer-side contract** (the seed
+workflow guarantees it; a generic webhook cannot prove a URL immutable), and the
+pre-fetch then confirms that artifact matches `ISODigest` — immutability closes
+the TOCTOU window, the pre-fetch confirms identity. Because `ISODigest` is
+mandatory for automated boot (above), identity is always verified at check time;
+what a non-immutable `ISOURL` costs is the guarantee that the BMC's *later* fetch
+pulls those same bytes. A deployment that cannot guarantee an immutable,
+allowlisted URL therefore cannot offer automated IBI pre-provisioning through
+this path — it is rejected up front, not silently downgraded to URL-only trust.
 
-The HTTPS client used for this fetch trusts the **same private CA as the
-boot**: when `ISOServerCACertRef` is set, the operator reads the
-`ca-bundle.crt` key from that ConfigMap (resolved in the ICI's namespace,
-requiring `get` on `configmaps` there) and uses it as the root pool for the
-verification request; otherwise it uses the system trust store. Without this,
-digest verification against a private-CA ISO server would fail the TLS
-handshake before the BMH ever boots. This is distinct from the BMC's own
-trust of the ISO server (a pre-installed prerequisite, out of scope here) —
+The HTTPS client used for this fetch trusts the **same private CA as the boot**:
+when `ISOServerCACertRef` is set, the operator reads the `ca-bundle.crt` key from
+that ConfigMap (resolved in the ICI's namespace, requiring `get` on `configmaps`)
+and uses it as the root pool for the verification request; otherwise the system
+trust store. Without this, digest verification against a private-CA ISO server
+would fail the TLS handshake before the BMH boots. This is distinct from the
+BMC's own trust of the ISO server (a pre-installed prerequisite, out of scope) —
 `ISOServerCACertRef` configures the *operator's* client, not the BMC's.
 
 #### 4. BMH State Transition After Pre-Provisioning
@@ -1136,10 +1069,9 @@ bmh.Spec.Online = false                 // power off until cluster install
 err := r.Patch(ctx, bmh, patch)
 ```
 
-The BMH is now in the same state it would be if it had been manually
-pre-provisioned. The IBI Operator's existing `configureHost` flow proceeds
-unchanged — it creates the config DataImage, sets the reboot annotation,
-and monitors cluster installation.
+The BMH is now in the same state as a manually pre-provisioned host. The IBI
+Operator's existing `configureHost` flow proceeds unchanged — it creates the
+config DataImage, sets the reboot annotation, and monitors cluster installation.
 
 #### 5. Condition Reporting
 
@@ -1157,63 +1089,60 @@ condition type for this handoff (see above); the phase is carried in the
 | Failure with retry budget exhausted | `RequirementsMet = False` | `PreProvisioningFailed` | Yes |
 | Timeout with retry budget exhausted | `RequirementsMet = False` | `PreProvisioningTimedOut` | Yes |
 
-`PreProvisioningRetrying` is a **non-terminal** state: while it is set the
+`PreProvisioningRetrying` is a **non-terminal** state: while set, the
 `ProvisioningRequest` keeps progressing (it does **not** map to `failed`).
 `PreProvisioningFailed`/`PreProvisioningTimedOut` are emitted **only** once the
 retry budget is exhausted, so the terminal-failure contract is never entered
 while a retry is still owed.
 
-The O-Cloud Manager must map these ICI conditions into
-`ProvisioningRequest` status; this is **not** covered by existing monitoring
-(see [O-Cloud Manager Changes](#o-cloud-manager-changes) for the required
-handoff — the PR controller today watches only a fixed set of
-`ClusterInstance` conditions and would otherwise ignore pre-provisioning
-state entirely).
+The O-Cloud Manager must map these ICI conditions into `ProvisioningRequest`
+status; this is **not** covered by existing monitoring (see
+[O-Cloud Manager Changes](#o-cloud-manager-changes) — the PR controller today
+watches only a fixed set of `ClusterInstance` conditions and would otherwise
+ignore pre-provisioning state).
 
 #### 6. Timeout Handling
 
 The reconciler checks `Status.PreProvisioningBootTime` against the
 configured `Timeout` (default: 60m) on each reconciliation.
 
-**The timeout must be self-triggering.** A callback is the only external
-event that wakes the reconciler; if no callback ever arrives, nothing would
-re-enqueue the ICI and it would remain `PreProvisioningInProgress` forever.
-While an attempt is in flight, every reconcile therefore returns
-`RequeueAfter` set to the remaining time until
-`PreProvisioningBootTime + Timeout` (bounded to a minimum floor so clock
-skew cannot produce a zero/negative delay and a tight requeue loop). This
-guarantees a reconcile fires at — or just after — the deadline even with no
-callback, no BMH change, and no other watched event. The no-callback path
-is explicitly covered by an envtest that advances the fake clock past the
-deadline and asserts the transition to `PreProvisioningTimedOut`.
+**The timeout must be self-triggering.** A callback is the only external event
+that wakes the reconciler; if none arrives, nothing would re-enqueue the ICI and
+it would remain `PreProvisioningInProgress` forever. While an attempt is in
+flight, every reconcile therefore returns `RequeueAfter` set to the remaining
+time until `PreProvisioningBootTime + Timeout` (bounded to a minimum floor so
+clock skew cannot produce a zero/negative delay and a tight requeue loop),
+guaranteeing a reconcile fires at — or just after — the deadline even with no
+callback, no BMH change, and no other watched event. The no-callback path is
+covered by an envtest that advances the fake clock past the deadline and asserts
+the transition to `PreProvisioningTimedOut`.
 
 **Timeout and callback compete for the same terminal state.** The timeout
 teardown uses the **same resourceVersion compare-and-swap** on
-`preProvisioningResult` as the callback handler (see the callback flow
-above): it re-reads the ICI, and only if the attempt is still non-terminal
-does it write the terminal result, guarded by `resourceVersion`. A callback
-that lands in the same instant either wins the CAS (the timeout write then
-gets a conflict and is dropped) or loses it (the timeout wins and the late
-callback is rejected against the invalidated token). Exactly one of the two
-paths becomes the terminal writer, and **only that winner performs the
-teardown** below — the loser observes the already-terminal state and does
-nothing. This prevents double teardown and a torn state where, e.g., the
-token is invalidated by timeout while the callback is concurrently accepted.
+`preProvisioningResult` as the callback handler: it re-reads the ICI and, only if
+the attempt is still non-terminal, writes the terminal result guarded by
+`resourceVersion`. A callback landing in the same instant either wins the CAS
+(the timeout write then conflicts and is dropped) or loses it (the timeout wins
+and the late callback is rejected against the invalidated token). Exactly one
+path becomes the terminal writer, and **only that winner performs the teardown**
+below — the loser observes the already-terminal state and does nothing. This
+prevents double teardown and a torn state where, e.g., the token is invalidated
+by timeout while the callback is concurrently accepted.
 
-The winning timeout path then performs teardown. Because teardown spans
-several resources (ICI status, BMH spec, DataImage, token Secret), it must be
+The winning timeout path then performs teardown. Because teardown spans several
+resources (ICI status, BMH spec, DataImage, token Secret), it must be
 **restart-safe**: a crash partway through must not leave a terminal ICI with
-live cleanup still owed. Two rules make it safe:
+cleanup owed. Two rules make it safe:
 
 - **Claiming the terminal state and *finishing* teardown are distinct.**
   Winning the CAS records the terminal **reason** (`PreProvisioningTimedOut`)
-  *and* a `PreProvisioningTeardownComplete = false` marker in the same write.
-  The condition is reported as terminal, but the reconciler treats the attempt
-  as **not done** until the marker flips to `true`.
+  *and* `PreProvisioningTeardownComplete = false` in the same write. The
+  condition is reported as terminal, but the reconciler treats the attempt as
+  **not done** until the marker flips to `true`.
 - **Teardown is idempotent and re-driven until every action succeeds.** While
   `PreProvisioningTeardownComplete` is `false`, each reconcile re-runs all
-  teardown actions (each a no-op if already applied) and only sets the marker
-  `true` once every one is confirmed:
+  teardown actions (each a no-op if already applied) and sets the marker `true`
+  only once every one is confirmed:
   1. Clear the ISO image (`spec.image = nil`)
   2. Remove the per-attempt pre-provisioning DataImage
   3. Power off the BMH (`spec.online = false`)
@@ -1223,13 +1152,13 @@ live cleanup still owed. Two rules make it safe:
 
 Only step 5 stops the retries; a failure in any of steps 1-4 leaves the marker
 `false` and the next reconcile resumes teardown. This is the **same teardown as
-the failure-callback path** (see the flow above), which uses the same
-marker-gated loop: a completed teardown leaves no live ISO, no DataImage
-carrier, and no usable token behind, so a late or replayed callback for the
-abandoned attempt cannot be accepted. A **fault-injection test** kills the
-reconcile after the terminal claim but before teardown completes and asserts
-the next reconcile drives cleanup to completion. The ProvisioningRequest fails,
-and the server can be manually investigated.
+the failure-callback path** (see the flow above), using the same marker-gated
+loop: a completed teardown leaves no live ISO, no DataImage carrier, and no
+usable token behind, so a late or replayed callback for the abandoned attempt
+cannot be accepted. A **fault-injection test** kills the reconcile after the
+terminal claim but before teardown completes and asserts the next reconcile
+drives cleanup to completion. The ProvisioningRequest fails, and the server can
+be manually investigated.
 
 ## O-Cloud Manager Changes
 
@@ -1237,32 +1166,29 @@ The O-Cloud Manager changes are minimal:
 
 1. **Configuration passthrough**: Read `ibiPreProvisioning` from
    `hwMgmtDefaults` / `hwMgmtParameters` and populate the
-   `ImageClusterInstall.spec.preProvisioning` fields. The **preferred** path
-   is for SiteConfig to render `preProvisioning` into the ICI at creation
-   time, so the field is present before the IBI Operator ever reconciles the
-   ICI. If instead the field must be patched onto an ICI that SiteConfig
-   already created, the patch introduces a race: the IBI Operator could
-   reconcile the ICI (and begin a normal, non-pre-provisioning install)
-   before the patch lands. The design therefore requires that when the
-   patch-after-create path is used, IBI reconciliation is **gated** until
-   `preProvisioning` is present — e.g. the ICI is created paused/annotated and
-   the O-Cloud Manager clears the gate only after the patch is applied — so
-   the operator never observes a pre-provisioning ICI without its
-   `preProvisioning` spec.
+   `ImageClusterInstall.spec.preProvisioning` fields. The **preferred** path is
+   for SiteConfig to render `preProvisioning` into the ICI at creation time, so
+   the field is present before the IBI Operator reconciles the ICI. If instead it
+   must be patched onto an ICI SiteConfig already created, the patch introduces a
+   race: the IBI Operator could reconcile the ICI (and begin a normal,
+   non-pre-provisioning install) before the patch lands. The design therefore
+   requires that on the patch-after-create path, IBI reconciliation is **gated**
+   until `preProvisioning` is present — e.g. the ICI is created paused/annotated
+   and the O-Cloud Manager clears the gate only after the patch is applied — so
+   the operator never observes a pre-provisioning ICI without its spec.
 2. **Validation**: Verify ConfigMaps referenced by `ibiPreProvisioning`
    exist and are valid during ClusterTemplate validation.
 3. **Status handoff (new controller logic)**: define how the ICI's
    pre-provisioning status maps onto `ProvisioningRequest` conditions and
-   `provisioningStatus`. This is a real gap, not a no-op: the
-   ProvisioningRequest controller today gates cluster-install progress on a
-   fixed set of `ClusterInstance` conditions
-   (`ClusterInstanceValidated`, `RenderedTemplates`,
+   `provisioningStatus`. This is a real gap: the ProvisioningRequest controller
+   today gates cluster-install progress on a fixed set of `ClusterInstance`
+   conditions (`ClusterInstanceValidated`, `RenderedTemplates`,
    `RenderedTemplatesValidated`, `RenderedTemplatesApplied`) and does **not**
-   look at `ImageClusterInstall` status. Without an explicit handoff the
+   look at `ImageClusterInstall` status, so without an explicit handoff the
    request could advance to (or report) cluster installation while
    pre-provisioning is still pending or has failed. The controller must
-   therefore, **before** it treats hardware as ready, block on the ICI
-   pre-provisioning state and translate it as follows:
+   therefore, **before** treating hardware as ready, block on the ICI
+   pre-provisioning state and translate it:
 
    | ICI pre-provisioning reason | PR `HardwareProvisioned` condition | PR `provisioningStatus.provisioningPhase` |
    | --- | --- | --- |
@@ -1272,38 +1198,38 @@ The O-Cloud Manager changes are minimal:
    | `PreProvisioningFailed` | `False`, reason `Failed` | `failed` |
    | `PreProvisioningTimedOut` | `False`, reason `TimedOut` | `failed` |
 
-   Pre-provisioning is modelled as part of the hardware-provisioning gate:
-   the PR does not proceed to (or report) cluster installation until the ICI
-   reports `PreProvisioningSucceeded`. Crucially, `PreProvisioningRetrying` is
+   Pre-provisioning is modelled as part of the hardware-provisioning gate: the
+   PR does not proceed to (or report) cluster installation until the ICI reports
+   `PreProvisioningSucceeded`. Crucially, `PreProvisioningRetrying` is
    **non-terminal** — the PR keeps `progressing` across a failed attempt's
-   backoff, so the configured `MaxRetries`/`RetryBackoff` budget can actually
-   be used without the PR prematurely latching `failed`. Only
-   `PreProvisioningFailed`/`PreProvisioningTimedOut` (emitted after the retry
-   budget is exhausted) drive the PR to a terminal `failed` `provisioningStatus`
-   with the ICI message surfaced. `MaxRetries` and `RetryBackoff` are carried
-   in `ibiPreProvisioning` (the same `hwMgmtDefaults`/`hwMgmtParameters`
-   passthrough as the other fields, and present in the ClusterTemplate schema).
-   This mapping is the contract between the two controllers and must be covered
-   by an integration test, including the retry path.
+   backoff, so the configured `MaxRetries`/`RetryBackoff` budget can be used
+   without the PR prematurely latching `failed`. Only
+   `PreProvisioningFailed`/`PreProvisioningTimedOut` (emitted after the budget is
+   exhausted) drive the PR to a terminal `failed` `provisioningStatus` with the
+   ICI message surfaced. `MaxRetries` and `RetryBackoff` are carried in
+   `ibiPreProvisioning` (same `hwMgmtDefaults`/`hwMgmtParameters` passthrough as
+   the other fields, present in the ClusterTemplate schema). This mapping is the
+   contract between the two controllers and must be covered by an integration
+   test, including the retry path.
 4. **Watch `ImageClusterInstall` to enqueue the owning
-   `ProvisioningRequest`.** The mapping in item 3 only runs when the PR
-   reconciles, and pre-provisioning transitions (callback success/failure,
-   timeout, retry) update **`ImageClusterInstall` status and nothing else**.
-   The `ProvisioningRequestReconciler` today watches `NodeAllocationRequest`
-   and `ClusterInstance` but **not** `ImageClusterInstall`, so without a new
-   watch a callback- or timeout-driven ICI status change would not wake the PR,
-   and the request would sit stale — never advancing on success nor reporting
-   failure — until some unrelated event happened to requeue it. The reconciler
-   therefore adds a watch on `ImageClusterInstall` with a mapper that enqueues
-   the owning `ProvisioningRequest` (resolved via the ICI→ClusterInstance→PR
-   ownership chain, or a field index on the PR name). Consistent with **DD-002**,
-   the enqueued `NamespacedName` omits the namespace because
-   `ProvisioningRequest` is cluster-scoped. An integration test asserts that a
-   callback-only and a timeout-only ICI status change — with no NAR or
-   ClusterInstance change — each wake the PR and drive the item-3 transition.
+   `ProvisioningRequest`.** The item-3 mapping only runs when the PR reconciles,
+   and pre-provisioning transitions (callback success/failure, timeout, retry)
+   update **`ImageClusterInstall` status and nothing else**. The
+   `ProvisioningRequestReconciler` today watches `NodeAllocationRequest` and
+   `ClusterInstance` but **not** `ImageClusterInstall`, so without a new watch a
+   callback- or timeout-driven ICI status change would not wake the PR, and the
+   request would sit stale — never advancing on success nor reporting failure —
+   until some unrelated event requeued it. The reconciler therefore adds a watch
+   on `ImageClusterInstall` with a mapper that enqueues the owning
+   `ProvisioningRequest` (resolved via the ICI→ClusterInstance→PR ownership
+   chain, or a field index on the PR name). Consistent with **DD-002**, the
+   enqueued `NamespacedName` omits the namespace because `ProvisioningRequest` is
+   cluster-scoped. An integration test asserts that a callback-only and a
+   timeout-only ICI status change — with no NAR or ClusterInstance change — each
+   wake the PR and drive the item-3 transition.
 
-No hub-side Jobs and no SSH infrastructure are introduced, but the status
-handoff above is new controller logic on the O-Cloud Manager side.
+No hub-side Jobs and no SSH infrastructure are introduced, but the status handoff
+above is new controller logic on the O-Cloud Manager side.
 
 ## Integration with Seed Generation Proposal
 
@@ -1387,28 +1313,25 @@ to reach the IBI Operator's HTTP endpoint on the hub cluster. In
 disconnected environments, the server may be on a different network
 (provisioning/BMC network) than the hub's service network.
 
-**Mitigation**: The IBI Operator's image server is already exposed via a
-Route or NodePort for serving config ISOs to BMHs. The same network path
-that allows BMH/Ironic to fetch ISOs from the hub can be used for the
-callback. The callback URL uses the same externally-reachable hostname. If
-the provisioning network is isolated, a Route or LoadBalancer service
-exposes the callback endpoint — this is the same requirement that exists
-for DataImage ISO serving.
+**Mitigation**: The IBI Operator's image server is already exposed via a Route
+or NodePort for serving config ISOs to BMHs; the same network path that lets
+BMH/Ironic fetch ISOs from the hub can carry the callback, using the same
+externally-reachable hostname. If the provisioning network is isolated, a Route
+or LoadBalancer service exposes the callback endpoint — the same requirement as
+DataImage ISO serving.
 
-This reachability is an explicit **precondition**, not an assumption. Note
-that BMH/Ironic fetches ISOs from the hub's *service* network via the BMC,
-whereas the callback originates from the *booted host* on the provisioning
-network — these can differ, so "Ironic can pull the ISO" does not by itself
-prove "the host can reach the callback." Before booting the ISO, the IBI
-Operator validates that the resolved callback endpoint is DNS-resolvable and
-its hostname is one the target network can route to, and that its TLS
+This reachability is an explicit **precondition**, not an assumption. BMH/Ironic
+fetches ISOs from the hub's *service* network via the BMC, whereas the callback
+originates from the *booted host* on the provisioning network — these can differ,
+so "Ironic can pull the ISO" does not prove "the host can reach the callback."
+Before booting, the IBI Operator validates that the resolved callback endpoint is
+DNS-resolvable, its hostname is routable from the target network, and its TLS
 certificate chains to a CA the host will trust (the same bundle injected via
 `additionalTrustBundle`, see [Challenge 7](#7-hub-ca-trust-on-the-pre-provisioned-server)).
-If these checks fail, the ICI reports a configuration error up front rather
-than booting a server that can never call back. A `PreProvisioningTimedOut`
-is documented as ambiguous between "preparation never finished" and
-"callback could not be delivered," and the operator surfaces both
-possibilities.
+If these fail, the ICI reports a configuration error up front rather than booting
+a server that can never call back. A `PreProvisioningTimedOut` is documented as
+ambiguous between "preparation never finished" and "callback could not be
+delivered," and the operator surfaces both possibilities.
 
 ### 2. Callback delivery reliability
 
@@ -1418,25 +1341,22 @@ temporarily unavailable. A missed callback would leave the ICI stuck in
 `PreProvisioningInProgress` until timeout.
 
 **Mitigation**: The `ibi-prep-callback` script retries curl against an
-**absolute wall-clock deadline derived from `CALLBACK_BUDGET_SECS`** (a loop
-with a per-attempt `--max-time`), so cumulative retry effort is bounded
-regardless of how many individual attempts fail — something `TimeoutStartSec`
-(per single start) and `Restart=on-failure` (unbounded relaunches) cannot
-guarantee on their own. `CALLBACK_BUDGET_SECS` is the per-host budget delivered
-on the data carrier, derived by the operator from
-`PreProvisioningConfig.Timeout` (default 60m) anchored to `PreProvisioningBootTime`,
-so the host's retry window always tracks the operator's timeout rather than a
-fixed value that could expire before it (a hard-coded 10m deadline, for
-instance, would give up ~50m early on a default-timeout host and mark a prepared
+**absolute wall-clock deadline derived from `CALLBACK_BUDGET_SECS`** (a loop with
+a per-attempt `--max-time`), so cumulative retry effort is bounded regardless of
+how many individual attempts fail — something `TimeoutStartSec` (per single
+start) and `Restart=on-failure` (unbounded relaunches) cannot guarantee alone.
+`CALLBACK_BUDGET_SECS` is the per-host budget delivered on the data carrier,
+derived from `PreProvisioningConfig.Timeout` (default 60m) anchored to
+`PreProvisioningBootTime`, so the host's retry window tracks the operator's
+timeout rather than a fixed value that could expire before it (a hard-coded 10m
+deadline would give up ~50m early on a default-timeout host and mark a prepared
 server as timed out). The script fails closed if `CALLBACK_BUDGET_SECS` is
-absent rather than substituting a default. `Restart=on-failure` plus
-`StartLimitIntervalSec`/`StartLimitBurst` remain only as a bounded backstop for
-an outright script crash. This covers
-transient network issues during boot. Additionally, the IBI Operator's
-reconcile loop checks the timeout — if no callback is received within the
-configured timeout, the ICI transitions to `PreProvisioningTimedOut`. The
-operator can distinguish "callback never arrived" (timeout) from
-"preparation failed" (failure callback).
+absent. `Restart=on-failure` plus `StartLimitIntervalSec`/`StartLimitBurst`
+remain only a bounded backstop for an outright script crash. This covers
+transient network issues during boot. Additionally, the operator's reconcile
+loop checks the timeout — if no callback arrives within it, the ICI transitions
+to `PreProvisioningTimedOut` — so the operator can distinguish "callback never
+arrived" (timeout) from "preparation failed" (failure callback).
 
 ### 3. Callback authentication and security
 
@@ -1448,26 +1368,23 @@ IBI Operator to proceed with cluster installation on an unprepared server.
 token (cryptographically random, or an HMAC over the ICI identity + attempt
 marker) when each pre-provisioning boot starts. Key properties:
 
-- **Header, not URL**: the token is sent in an `Authorization: Bearer`
-  header and verified with a constant-time comparison. It is never placed
-  in the URL (query parameter or path segment), where it would be captured
-  by image-server logs, intermediary proxies, and the server's own journal.
-- **Secret, not status**: the token is stored in a per-ICI Secret owned by
-  the ICI, not in `status.preProvisioningResult` or any status field —
-  status is readable by any principal with `get` on the ICI, which would
-  expose the shared secret needed to forge a success callback.
-- **Per-attempt and expiring**: a new token is minted on every boot attempt
-  and invalidated as soon as a terminal callback is accepted or the attempt
-  times out, so a token observed during one attempt cannot authorize a
-  callback for a later attempt (see also [Challenge 6](#6-server-state-after-failed-pre-provisioning)
-  on per-attempt binding).
-- **State check as defense in depth**: the handler additionally requires the
-  ICI to be in `PreProvisioningBooting` / `PreProvisioningInProgress` and
-  the token to match the *current* attempt before accepting the callback.
-- **mTLS preferred where available**: provisioning a short-lived client
-  certificate into the ignition overlay and requiring mutual TLS at the
-  endpoint is stronger than a bearer token and is the recommended option
-  when the environment supports it.
+- **Header, not URL**: sent in an `Authorization: Bearer` header and verified
+  with a constant-time comparison, never in the URL (query or path), where it
+  would be captured by image-server logs, proxies, and the server's journal.
+- **Secret, not status**: stored in a per-ICI Secret owned by the ICI, not in
+  any status field — status is readable by any principal with `get` on the ICI,
+  which would expose the secret needed to forge a success callback.
+- **Per-attempt and expiring**: a new token is minted every boot attempt and
+  invalidated as soon as a terminal callback is accepted or the attempt times
+  out, so a token observed during one attempt cannot authorize a later one (see
+  also [Challenge 6](#6-server-state-after-failed-pre-provisioning) on
+  per-attempt binding).
+- **State check as defense in depth**: the handler additionally requires the ICI
+  to be in `PreProvisioningBooting` / `PreProvisioningInProgress` and the token
+  to match the *current* attempt before accepting the callback.
+- **mTLS preferred where available**: a short-lived client certificate in the
+  ignition overlay with mutual TLS at the endpoint is stronger than a bearer
+  token and recommended when the environment supports it.
 
 ### 4. Callback URL injection into the ISO
 
@@ -1475,76 +1392,65 @@ marker) when each pre-provisioning boot starts. Key properties:
 name). If the ISO is built once and reused across multiple servers, the
 callback URL cannot be baked into the ISO at build time.
 
-**Mitigation**: The design must account for the fact that, for a
-`live-iso` boot, BMO does **not** merge `DataImage` contents (or
-`userData`/`networkData`/`metaData`) into the live environment's Ignition —
-only the ISO's baked-in Ignition (`ignitionConfigOverride`) is reliably
-applied (see [ISO ignition delivery](#1-callback-ignition-override)). So a
-DataImage cannot be used to *inject* the callback systemd unit into a shared
-ISO. Two viable options remain:
+**Mitigation**: For a `live-iso` boot, BMO does **not** merge `DataImage`
+contents (or `userData`/`networkData`/`metaData`) into the live environment's
+Ignition — only the ISO's baked-in Ignition (`ignitionConfigOverride`) is
+reliably applied (see [ISO ignition delivery](#1-callback-ignition-override)).
+So a DataImage cannot *inject* the callback systemd unit into a shared ISO. Two
+viable options remain:
 
-- **Generic client baked in + per-server data read at boot (recommended
-  when validated).** The ISO carries, via `ignitionConfigOverride`, the
-  generic callback client (the `ibi-prep-callback` script and its
-  `ibi-prep-callback.service` unit — identical for every server). The
-  per-server data (`/etc/ibi-callback/env` and the root-only
-  `/etc/ibi-callback/auth.cfg`) is delivered at boot through a concrete,
-  specified carrier rather than "a well-known location":
+- **Generic client baked in + per-server data read at boot (recommended when
+  validated).** The ISO carries, via `ignitionConfigOverride`, the generic
+  callback client (the `ibi-prep-callback` script and its
+  `ibi-prep-callback.service` unit — identical for every server). The per-server
+  data (`/etc/ibi-callback/env` and the root-only `/etc/ibi-callback/auth.cfg`)
+  is delivered at boot through a concrete carrier, not "a well-known location":
 
   - **Carrier**: a per-ICI `DataImage` (a tiny ISO9660/FAT image the IBI
-    Operator builds and attaches as an additional virtual-media device),
-    used **purely as a data device**, not as an ignition overlay. The
-    `DataImage` resource is **named and namespaced after the BareMetalHost**
-    (BMO v0.13.2's `DataImageReconciler` resolves the owning host by matching
-    the request name/namespace to a `BareMetalHost`, so a differently named
-    carrier never attaches); the attempt id it carries is bound through the
-    carrier content and an `ibi.openshift.io/attempt` label, not the resource
-    name. Its filesystem is labelled `ibi-callback` so it is addressable by
-    label regardless of device enumeration order. An integration test verifies
-    BMO attaches the image and the guest sees the `ibi-callback` device label.
+    Operator builds and attaches as an additional virtual-media device), used
+    **purely as a data device**, not as an ignition overlay. The `DataImage` is
+    **named and namespaced after the BareMetalHost** (BMO v0.13.2's
+    `DataImageReconciler` resolves the owning host by matching the request
+    name/namespace to a `BareMetalHost`, so a differently named carrier never
+    attaches); the attempt id is bound through the carrier content and an
+    `ibi.openshift.io/attempt` label, not the resource name. Its filesystem is
+    labelled `ibi-callback` so it is addressable by label regardless of device
+    enumeration order. An integration test verifies BMO attaches the image and
+    the guest sees the `ibi-callback` device label.
   - **Mount + materialize**: a baked-in `ibi-callback-data.service`
     (`Type=oneshot` **with `RemainAfterExit=yes`**) mounts
     `/dev/disk/by-label/ibi-callback` read-only, copies `env` to
-    `/etc/ibi-callback/env` (0644) and `auth.cfg` to
-    `/etc/ibi-callback/auth.cfg` (0600, root-only), then unmounts. Copying
-    to a root-only path — rather than reading the token off the shared
-    virtual-media device directly — keeps the 0600 permission guarantee.
-    `RemainAfterExit=yes` is load-bearing: without it a `Type=oneshot` unit
-    goes `inactive` the moment `ExecStart` returns, and because the reporter
-    declares `Requires=` on it, systemd would consider the dependency no longer
-    active and could stop the reporter before it runs. With
-    `RemainAfterExit=yes` the data unit stays `active (exited)` after
-    materialization, so the `Requires=`/`After=` pair holds for the whole boot.
-  - **Ordering and dependency (runtime, not `[Install]`)**: the dependency
-    must be expressed as a **runtime** relationship in the reporter's
-    `[Unit]` section — `ibi-prep-callback.service` declares
-    `Requires=ibi-callback-data.service` and
-    `After=ibi-callback-data.service`. It is a mistake to rely on
-    `RequiredBy=`/`WantedBy=` in the *data* unit's `[Install]` section for
-    this: `[Install]` directives take effect only when the unit is
-    `enable`d, so if enablement is ever missed the reporter would run before
-    (or without) its data files. Both units are additionally marked
-    `enabled: true` in the ignition so they are active on first boot, but the
-    correctness guarantee comes from the runtime `Requires=`/`After=`, not
-    from enablement. With `Requires=`, if the data mount fails (device
-    absent) the reporter is not started, surfacing as a timeout rather than a
-    callback with an empty URL/token. This enablement-plus-runtime-dependency
-    behavior must be covered by a systemd integration test that asserts the data
-    unit stays `active (exited)` after materialization and the reporter then
-    actually runs (not just that ordering is declared).
+    `/etc/ibi-callback/env` (0644) and `auth.cfg` to `/etc/ibi-callback/auth.cfg`
+    (0600, root-only), then unmounts. Copying to a root-only path — rather than
+    reading the token off the shared virtual-media device — keeps the 0600
+    guarantee. `RemainAfterExit=yes` is load-bearing: without it a `Type=oneshot`
+    unit goes `inactive` the moment `ExecStart` returns, and since the reporter
+    declares `Requires=` on it, systemd would treat the dependency as inactive
+    and could stop the reporter before it runs. With it, the data unit stays
+    `active (exited)`, so the `Requires=`/`After=` pair holds for the whole boot.
+  - **Ordering and dependency (runtime, not `[Install]`)**: the dependency is a
+    **runtime** relationship in the reporter's `[Unit]` section —
+    `ibi-prep-callback.service` declares `Requires=ibi-callback-data.service` and
+    `After=ibi-callback-data.service`. Relying on `RequiredBy=`/`WantedBy=` in the
+    *data* unit's `[Install]` section is a mistake: `[Install]` directives take
+    effect only when the unit is `enable`d, so a missed enablement would let the
+    reporter run before (or without) its data files. Both units are also marked
+    `enabled: true` so they are active on first boot, but the correctness
+    guarantee comes from the runtime `Requires=`/`After=`, not enablement. With
+    `Requires=`, if the data mount fails (device absent) the reporter never starts,
+    surfacing as a timeout rather than a callback with an empty URL/token. A
+    systemd integration test must assert the data unit stays `active (exited)`
+    after materialization and the reporter then actually runs (not just that
+    ordering is declared).
 
   This keeps the ISO reusable. It depends on version-specific `live-iso` +
   DataImage behavior in BMO/Ironic and therefore **must be backed by a
   version-pinned integration test**.
 - **Unique per-ICI ISO (fallback).** If the generic-client path cannot be
-  validated on the supported BMO/Ironic version, the IBI Operator (or the
-  ISO build step) bakes the ICI-specific callback URL and token directly
-  into `ignitionConfigOverride`, producing one ISO per ICI. This is simpler
-  and robust but sacrifices ISO reuse.
-
-Using DataImage as an ignition overlay is not viable: BMO does not merge
-DataImage contents into live-iso Ignition, so a per-ICI callback URL and
-token cannot be injected that way.
+  validated on the supported BMO/Ironic version, the IBI Operator (or the ISO
+  build step) bakes the ICI-specific callback URL and token directly into
+  `ignitionConfigOverride`, producing one ISO per ICI. Simpler and robust but
+  sacrifices ISO reuse.
 
 ### 5. BMC CA trust for HTTPS virtual media
 
@@ -1552,48 +1458,35 @@ token cannot be injected that way.
 must trust the CA certificate to fetch the ISO via virtual media. BMC CA
 trust configuration is vendor-specific.
 
-**Mitigation**: The `isoServerCACertRef` provides the CA cert, but supplying
-the cert is not the same as establishing BMC trust, and that trust must
-exist **before** `spec.image` is set (Ironic mounts the virtual media
-immediately). The design defines two concrete, ordered paths rather than
-leaving the flow implicit:
+**Mitigation**: The `isoServerCACertRef` provides the CA cert, but supplying the
+cert is not the same as establishing BMC trust, and that trust must exist
+**before** `spec.image` is set (Ironic mounts the virtual media immediately).
+There is also **no portable contract** — across BMO, Ironic, and vendor BMC
+drivers — by which the IBI Operator can query whether a BMC already trusts a CA:
+neither the `BareMetalHost` status, the Ironic node, nor any capability
+annotation exposes the BMC's virtual-media trust store, and Redfish
+certificate-management support is optional and vendor-specific. The design
+therefore does **not** claim the operator validates BMC trust before booting;
+asserting a precondition it cannot check would be false assurance. It defines two
+concrete paths instead:
 
-- **Runtime injection (only where actually supported).** For BMCs whose
+- **Pre-installed BMC trust is the single documented prerequisite** (the portable
+  default) when the ISO server uses a private CA. The private CA must already be
+  present in the BMC trust store; establishing it (via the BMC's own management
+  interface, out of band) is the integrator's responsibility and an explicit
+  prerequisite — pre-provisioning does not silently proceed assuming HTTPS works.
+- **Runtime injection, only where actually supported.** For BMCs whose
   Redfish/vendor API exposes a certificate-management endpoint, trust can be
   established at runtime **before** the virtual-media insert. This is *not*
-  something the IBI Operator implements generically here — BMO/Ironic and
-  the BMC driver own certificate handling, and support is vendor- and
-  firmware-specific. The IBI Operator relies on the underlying stack's
-  existing capability and does not attempt ad-hoc BMC certificate pushes.
-- **Pre-installed trust (the portable default).** Where runtime injection is
-  not available or not verifiable, the private CA must already be present in
-  the BMC trust store. This is documented as an explicit **prerequisite**,
-  and pre-provisioning does not silently proceed assuming HTTPS will work.
-
-There is **no portable contract** — across BMO, Ironic, and vendor BMC
-drivers — by which the IBI Operator can query whether a given BMC already
-trusts a given CA. Neither the `BareMetalHost` status, the Ironic node, nor
-any capability annotation exposes the BMC's virtual-media trust store, and
-Redfish certificate-management support is optional and vendor-specific. The
-design therefore does **not** claim the operator validates BMC trust before
-booting; asserting a precondition it cannot actually check would be false
-assurance. Instead:
-
-- **Pre-installed BMC trust is the single documented prerequisite** when the
-  ISO server uses a private CA. Establishing that trust (via the BMC's own
-  management interface, out of band) is the integrator's responsibility and
-  is stated as an explicit prerequisite of enabling pre-provisioning with an
-  HTTPS+private-CA ISO server.
-- If runtime injection *is* available on a given stack (the "Runtime
-  injection" path above), it is handled entirely by BMO/Ironic/the BMC
-  driver — outside this design — and remains subject to the same
-  prerequisite from the IBI Operator's perspective.
+  implemented generically by the IBI Operator — BMO/Ironic and the BMC driver own
+  certificate handling (vendor- and firmware-specific), so it is handled entirely
+  outside this design, with no ad-hoc BMC certificate pushes, and remains subject
+  to the same prerequisite from the IBI Operator's perspective.
 
 Consequently, a BMC that does not trust the CA manifests as the ISO fetch
 failing and the flow reaching `PreProvisioningTimedOut`; the timeout message
 explicitly names "BMC could not fetch the ISO — verify the ISO server CA is
-present in the BMC trust store" so the failure is diagnosable rather than
-mysterious. The corresponding
+present in the BMC trust store" so the failure is diagnosable. The
 [seed-generation proposal](./automated-seed-image-generation.md) surfaces the
 ISO server CA in status precisely so this reference is available to whoever
 configures BMC trust out of band.
@@ -1603,73 +1496,66 @@ configures BMC trust out of band.
 **Challenge**: If pre-provisioning fails mid-way, the server may be in an
 inconsistent state (partial RHCOS installation, incomplete seed image pull).
 
-**Mitigation**: The IBI preparation is idempotent — rebooting from the ISO
-restarts the process. On failure callback (or timeout), the IBI Operator
-first tears the attempt down cleanly (clears `spec.image`, removes the
-per-attempt data carrier, powers the BMH off, invalidates the per-attempt
-token — the host is left **not** `externallyProvisioned`), records the
-retry-pending marker (`Status.RetryNotBefore`) while **clearing** the retired
-`PreProvisioningAttempt` so the invalidated token is never re-driven, then can
-retry by re-triggering the ISO boot with a **fresh attempt**: a new per-attempt
-token and marker, and `Status.PreProvisioningBootTime` reset so the per-attempt
-timeout is measured from the new boot.
+**Mitigation**: IBI preparation is idempotent — rebooting from the ISO restarts
+the process. On failure callback (or timeout), the IBI Operator first tears the
+attempt down cleanly (clears `spec.image`, removes the per-attempt data carrier,
+powers the BMH off, invalidates the per-attempt token — leaving the host **not**
+`externallyProvisioned`), records the retry-pending marker
+(`Status.RetryNotBefore`) while **clearing** the retired `PreProvisioningAttempt`
+so the invalidated token is never re-driven, then retries with a **fresh
+attempt**: new token and marker, and `Status.PreProvisioningBootTime` reset so
+the timeout is measured from the new boot.
 
 **Retry is explicitly bounded — there is no infinite retry and no retry
 after a terminal result.** `PreProvisioningConfig` carries the retry policy
 so the operator does not have to invent unbounded behavior:
 
-- `MaxRetries` (default: `0`, i.e. a single attempt) caps the number of
-  additional attempts after the first. Retries stop as soon as this budget
-  is exhausted.
-- `RetryBackoff` (default: `5m`) is the delay between a failed attempt's
-  teardown and the next boot. It is persisted durably as
-  `Status.RetryNotBefore` (= failure time + `RetryBackoff`) in the same update
-  that clears the retired `PreProvisioningAttempt`, and also applied as a
-  `RequeueAfter` so the retry is self-triggering. The `RequeueAfter` is only a
-  wake-up hint; `RetryNotBefore` is the source of truth, so an operator restart
-  that loses the in-memory timer still waits out the remaining backoff and never
-  re-drives the retired attempt.
-- The per-attempt `Timeout` bounds each individual boot; the operator also
-  enforces an overall ceiling of
-  `(MaxRetries + 1) × Timeout + MaxRetries × RetryBackoff` so total retry
-  effort is finite even in the worst case.
+- `MaxRetries` (default: `0`, a single attempt) caps additional attempts after
+  the first; retries stop once this budget is exhausted.
+- `RetryBackoff` (default: `5m`) is the delay between a failed attempt's teardown
+  and the next boot. It is persisted durably as `Status.RetryNotBefore` (=
+  failure time + `RetryBackoff`) in the same update that clears the retired
+  `PreProvisioningAttempt`, and also applied as a `RequeueAfter` so the retry is
+  self-triggering. The `RequeueAfter` is only a wake-up hint; `RetryNotBefore` is
+  the source of truth, so an operator restart that loses the in-memory timer
+  still waits out the remaining backoff and never re-drives the retired attempt.
+- The per-attempt `Timeout` bounds each boot; the operator also enforces an
+  overall ceiling of `(MaxRetries + 1) × Timeout + MaxRetries × RetryBackoff` so
+  total retry effort is finite even in the worst case.
 
 **A failed attempt with budget remaining is a distinct, non-terminal state —
 `PreProvisioningFailed`/`PreProvisioningTimedOut` are *not* recorded until the
-budget is exhausted.** This matters because those two reasons are terminal and
-map the `ProvisioningRequest` to `failed`; recording them on a failed attempt
-that still owes a retry would make the configured budget unusable (the PR would
-latch `failed` before the retry ever ran). Instead, a failed/timed-out attempt
-with `PreProvisioningRetryCount < MaxRetries` transitions to the non-terminal
+budget is exhausted.** Those two reasons are terminal and map the
+`ProvisioningRequest` to `failed`; recording them on an attempt that still owes
+a retry would make the configured budget unusable (the PR would latch `failed`
+before the retry ran). Instead, a failed/timed-out attempt with
+`PreProvisioningRetryCount < MaxRetries` transitions to the non-terminal
 `PreProvisioningRetrying` reason, the PR keeps `progressing`, and the operator
-re-boots a fresh attempt after `RetryBackoff`. Only when the budget is
-exhausted does the operator write the terminal `PreProvisioningFailed` (or
-`PreProvisioningTimedOut`) result — via the compare-and-swap above — and let
-the PR map to `failed`.
+re-boots a fresh attempt after `RetryBackoff`. Only once the budget is exhausted
+does the operator write the terminal result — via the compare-and-swap above —
+and let the PR map to `failed`.
 
 `Status.PreProvisioningRetryCount` records attempts consumed so the budget
-survives operator restarts. A retry is scheduled **only** from the
-non-terminal `PreProvisioningRetrying` state (reached only after a clean
-teardown) and **only** while the budget remains; once a terminal result
-(`PreProvisioningSucceeded` / `PreProvisioningFailed` /
-`PreProvisioningTimedOut`) has been written via the compare-and-swap above, no
-further attempt is booted.
+survives operator restarts. A retry is scheduled **only** from the non-terminal
+`PreProvisioningRetrying` state (reached only after a clean teardown) and **only**
+while budget remains; once a terminal result has been written via the
+compare-and-swap above, no further attempt is booted.
 
-Each attempt is explicitly bound so a stale signal cannot be mistaken for
-the current one:
+Each attempt is explicitly bound so a stale signal cannot be mistaken for the
+current one:
 
-- The callback carries the **current attempt's** token; the handler rejects
-  a callback whose token does not match the active attempt, so a late
-  callback from a prior boot cannot complete a new attempt.
-- The on-host reporter reads the prep service's result for the **current
-  boot only** (see [the ignition unit](#1-callback-ignition-override)), so a
-  "finished successfully" record left on disk from an earlier attempt does
-  not produce a false success.
+- The callback carries the **current attempt's** token; the handler rejects a
+  callback whose token does not match the active attempt, so a late callback from
+  a prior boot cannot complete a new attempt.
+- The on-host reporter reads the prep service's result for the **current boot
+  only** (see [the ignition unit](#1-callback-ignition-override)), so a "finished
+  successfully" record left on disk from an earlier attempt does not produce a
+  false success.
 
 Once the last attempt's timeout is exceeded and the `MaxRetries` budget is
-exhausted (see above), the operator reports `PreProvisioningTimedOut` and
-the ProvisioningRequest fails. The server can be manually investigated or
-released for re-allocation.
+exhausted, the operator reports `PreProvisioningTimedOut` and the
+ProvisioningRequest fails. The server can be manually investigated or released
+for re-allocation.
 
 ### 7. Hub CA trust on the pre-provisioned server
 
@@ -1706,15 +1592,14 @@ repository:
   `PreProvisioningAttempt` on a budgeted failure, so recovery distinguishes a
   retired attempt in backoff from an in-flight one; the remaining backoff is
   recomputed from it after a restart. Cleared when the next attempt is recorded
-  (never set at the same time as `PreProvisioningAttempt`)
+  (never set alongside `PreProvisioningAttempt`)
 - Add `PreProvisioningResult` struct to `ImageClusterInstallStatus`
 - Add `PreProvisioningTeardownComplete bool` to `ImageClusterInstallStatus`:
-  gates cessation of teardown retries for a terminal attempt. Written `false`
-  in the same update that claims a terminal reason; flipped to `true` only
-  once every teardown action (clear image, remove DataImage, power off,
-  delete the per-attempt token Secret) has succeeded. Reset to `false` (or
-  cleared) when a retry mints a fresh attempt; meaningful only once a
-  terminal reason is set
+  gates cessation of teardown retries for a terminal attempt. Written `false` in
+  the same update that claims a terminal reason; flipped to `true` only once every
+  teardown action (clear image, remove DataImage, power off, delete the
+  per-attempt token Secret) has succeeded. Reset (or cleared) when a retry mints a
+  fresh attempt; meaningful only once a terminal reason is set
 - Add condition reason constants: `PreProvisioningPendingReason`,
   `PreProvisioningBootingReason`, `PreProvisioningInProgressReason`,
   `PreProvisioningRetryingReason`, `PreProvisioningSucceededReason`,
@@ -1770,13 +1655,13 @@ repository:
 ### 4. Ignition Package (`internal/ignition/` — new)
 
 - New package for generating ignition config snippets, split along the
-  **build-time vs per-attempt** boundary so per-attempt secrets never enter
-  the shared, build-time ISO surface (see the recommended path in Challenge 4):
+  **build-time vs per-attempt** boundary so per-attempt secrets never enter the
+  shared, build-time ISO surface (see the recommended path in Challenge 4):
   - `GenerateCallbackClient() ([]byte, error)` — the **build-time**,
     attempt-independent surface baked into the shared ISO via
-    `ignitionConfigOverride`: the `ibi-prep-callback.service` systemd unit,
-    the `/usr/local/bin/ibi-prep-callback` script, and the generic callback
-    client. Identical for every server, contains no URL/token/attempt.
+    `ignitionConfigOverride`: the `ibi-prep-callback.service` unit, the
+    `/usr/local/bin/ibi-prep-callback` script, and the generic callback client.
+    Identical for every server, contains no URL/token/attempt.
   - `GenerateCallbackData(callbackURL, attempt, token string, budget time.Duration) ([]byte, error)`
     — the **per-attempt** surface delivered at boot through the `DataImage`
     carrier: the non-secret `/etc/ibi-callback/env` (`CALLBACK_URL`,
@@ -1785,18 +1670,17 @@ repository:
     `budget` is the callback retry window, derived from the effective
     `PreProvisioningConfig.Timeout` minus a margin, so the host keeps resending
     for the whole window the operator waits (see below). It is a **required**
-    part of the contract — the script does **not** silently fall back to a
-    fixed budget when it is absent — and a unit test asserts the generated
-    `env` file contains a non-empty `CALLBACK_BUDGET_SECS` matching the
-    requested budget. Regenerated per boot attempt; never baked into the shared
-    ISO.
+    part of the contract — the script does **not** silently fall back to a fixed
+    budget when absent — and a unit test asserts the generated `env` file
+    contains a non-empty `CALLBACK_BUDGET_SECS` matching the requested budget.
+    Regenerated per boot attempt; never baked into the shared ISO.
 
     Note the two clocks: the operator's timeout is anchored at
-    `PreProvisioningBootTime`, while the on-host callback loop can only start
-    once preparation finishes. To keep them aligned, the script anchors its
-    deadline to the host's **boot** time (via `/proc/uptime`), not to its own
-    first-run time — so a long preparation can neither push the host's retry
-    window past the operator's timeout nor collapse it to a short window.
+    `PreProvisioningBootTime`, while the on-host callback loop starts only once
+    preparation finishes. To keep them aligned, the script anchors its deadline
+    to the host's **boot** time (via `/proc/uptime`), not its own first-run time
+    — so a long preparation can neither push the host's retry window past the
+    operator's timeout nor collapse it to a short window.
 
 ### 5. Webhook (`api/v1alpha1/imageclusterinstall_webhook.go`)
 
@@ -1858,69 +1742,64 @@ are minimal:
 
 **Total O-Cloud Manager: ~365 lines, roughly 1 working session.**
 
-Combined with the upstream IBI Operator changes (~1000 lines), the total
-effort is ~1365 lines.
+Combined with the upstream IBI Operator changes (~1000 lines), total effort is
+~1365 lines.
 
 ## Alternatives Considered
 
 ### A. SSH-based monitoring from the IBI Operator
 
-The IBI Operator SSHs into each server to poll the preparation service
-status. Rejected because it requires SSH key management, hub-to-server
-network access (often blocked by firewalls in edge environments), IP
-discovery for live-booted servers, and an SSH client library dependency
-in the operator.
+The IBI Operator SSHs into each server to poll the preparation service status.
+Rejected: requires SSH key management, hub-to-server network access (often
+firewall-blocked at the edge), IP discovery for live-booted servers, and an SSH
+client library dependency in the operator.
 
 ### B. Pre-provisioning entirely in the O-Cloud Manager controller
 
-The O-Cloud Manager patches BMH `spec.image`, boots the server, and creates
-a hub-side SSH monitoring Job. Rejected because it duplicates BMH lifecycle
-management that the IBI Operator already owns, requires SSH-from-a-Job
-plumbing on the hub, and is not reusable by other IBI Operator consumers.
+The O-Cloud Manager patches BMH `spec.image`, boots the server, and creates a
+hub-side SSH monitoring Job. Rejected: duplicates BMH lifecycle management the IBI
+Operator already owns, needs SSH-from-a-Job plumbing on the hub, and is not
+reusable by other IBI Operator consumers.
 
 ### C. Pre-provisioning as part of the hardware manager / NAR flow
 
-Integrate pre-provisioning into the NAR controller. Rejected because the
-NAR controller handles hardware allocation and firmware updates, not
-image-based installation. The pre-provisioning step is logically part of the
-IBI installation lifecycle.
+Integrate pre-provisioning into the NAR controller. Rejected: the NAR controller
+handles hardware allocation and firmware updates, not image-based installation.
+Pre-provisioning is logically part of the IBI installation lifecycle.
 
 ### D. Pre-provisioning without monitoring (timeout-based)
 
-Wait a fixed duration then assume pre-provisioning succeeded. Rejected
-because it provides no failure detection, wastes time on fast completions,
-and risks proceeding to cluster installation on servers that failed
-pre-provisioning.
+Wait a fixed duration then assume success. Rejected: no failure detection, wastes
+time on fast completions, and risks proceeding to cluster installation on servers
+that failed pre-provisioning.
 
 ### E. BMH provisioning state as completion signal
 
-Detect completion by monitoring BMH state transitions after the live-iso
-boot. Rejected because BMH transitions to `provisioned` when the boot
-*starts*, not when the preparation *finishes*. BMO has no visibility into
-the preparation service running inside the live environment.
+Detect completion by monitoring BMH state transitions after the live-iso boot.
+Rejected: BMH transitions to `provisioned` when the boot *starts*, not when
+preparation *finishes*. BMO has no visibility into the preparation service inside
+the live environment.
 
 ## Open Questions
 
-1. **Condition type for the status handoff — resolved.** The design
-   standardizes on the existing `RequirementsMet` condition with new
-   `PreProvisioning*` reason codes rather than adding a dedicated
-   `PreProvisioningCompleted` condition. A single authoritative field keeps the
-   IBI Operator (producer) and O-Cloud Manager (consumer) from watching
-   different conditions; the mild overloading of `RequirementsMet`'s meaning is
-   accepted in exchange for one unambiguous cross-layer contract (see
+1. **Condition type for the status handoff — resolved.** The design standardizes
+   on the existing `RequirementsMet` condition with new `PreProvisioning*` reason
+   codes rather than a dedicated `PreProvisioningCompleted` condition. A single
+   authoritative field keeps the IBI Operator (producer) and O-Cloud Manager
+   (consumer) from watching different conditions; the mild overloading of
+   `RequirementsMet` is accepted for one unambiguous cross-layer contract (see
    [Condition Reporting](#5-condition-reporting)).
 
-2. **Does the recommended carrier (generic client baked in +
-   per-server data on a labelled `DataImage`, read at boot — see
-   [Challenge 4](#4-callback-url-injection-into-the-iso)) work on the
-   supported BMO/Ironic version?** This must be settled by a version-pinned
-   integration test. Note the DataImage is used **purely as a data device**,
-   never as an ignition overlay (BMO does not merge DataImage contents into
-   live-iso Ignition). If the test cannot be made to pass, the fallback is a
-   unique per-ICI ISO with the URL/token baked directly into
-   `ignitionConfigOverride`, sacrificing ISO reuse.
+2. **Does the recommended carrier (generic client baked in + per-server data on
+   a labelled `DataImage`, read at boot — see
+   [Challenge 4](#4-callback-url-injection-into-the-iso)) work on the supported
+   BMO/Ironic version?** Must be settled by a version-pinned integration test. The
+   DataImage is used **purely as a data device**, never as an ignition overlay
+   (BMO does not merge DataImage contents into live-iso Ignition). If the test
+   cannot pass, the fallback is a unique per-ICI ISO with the URL/token baked
+   directly into `ignitionConfigOverride`, sacrificing ISO reuse.
 
-3. **Should the SiteConfig Operator's IBI templates be updated to support
-   the `preProvisioning` field natively?** If so, the config flows through
-   ClusterInstance → ICI cleanly. If not, the O-Cloud Manager needs to
-   patch the ICI after SiteConfig creates it — functional but less elegant.
+3. **Should the SiteConfig Operator's IBI templates support the `preProvisioning`
+   field natively?** If so, the config flows through ClusterInstance → ICI
+   cleanly. If not, the O-Cloud Manager patches the ICI after SiteConfig creates
+   it — functional but less elegant.

--- a/docs/proposals/ibi-server-pre-provisioning.md
+++ b/docs/proposals/ibi-server-pre-provisioning.md
@@ -1,0 +1,1926 @@
+<!--
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Proposal: Automated IBI Server Pre-Provisioning via ProvisioningRequest API
+
+## Background
+
+The IBI-based cluster provisioning workflow (documented in
+`docs/user-guide/ibi-based-cluster-provisioning.md`) is split into two stages:
+
+1. **Factory preparation** — done once per hardware/software configuration:
+   generate a seed image, build a live ISO, and pre-provision servers by
+   booting them from the ISO via BMC virtual media.
+2. **Site deployment** — done per cluster via ProvisioningRequest: since
+   servers arrive pre-provisioned, cluster provisioning skips OS installation
+   and image pull.
+
+The [automated seed image and live ISO generation proposal](./automated-seed-image-generation.md)
+automates the seed image and ISO creation. This proposal automates the final
+factory step: **pre-provisioning servers by booting them from the IBI live ISO**.
+
+Today, pre-provisioning is a manual process. An operator must:
+
+1. Mount the live ISO to each target server via BMC virtual media
+2. Set a one-time boot override to boot from the virtual CD/ISO
+3. Power on the server and monitor the `install-rhcos-and-restore-seed.service`
+   logs via SSH until "IBI preparation process finished successfully!" appears
+4. Power off or leave the server running
+
+This proposal adds an optional pre-provisioning phase to the ProvisioningRequest
+workflow by extending the IBI Operator (`stolostron/image-based-install-operator`)
+to handle the ISO boot and preparation lifecycle natively.
+
+## Problem Statement
+
+- **Manual BMC interaction**: Operators must manually mount the ISO via each
+  server's BMC console (Redfish, iDRAC, iLO, etc.)
+- **Unmonitored**: No status reporting through the O-Cloud Manager API;
+  operators must SSH and tail logs on each server
+- **Serial execution**: Without automation, operators typically pre-provision
+  servers one at a time rather than in parallel
+- **Error-prone handoff**: The boundary between "pre-provisioned" and "ready
+  for IBI deployment" is manual — operators must remember to label BMHs
+  and set the correct state
+
+## Architecture
+
+### Why the IBI Operator
+
+The pre-provisioning step is best integrated into the IBI Operator
+(`stolostron/image-based-install-operator`) rather than the O-Cloud Manager
+controller for several reasons:
+
+- **Already owns BMH lifecycle for IBI**: The IBI Operator creates
+  `DataImage` CRs, manages BMH annotations (`detached`, `reboot`,
+  `image-based-install-managed`), sets `externallyProvisioned`, and
+  handles power management. Adding a "boot from ISO first" phase is a
+  natural extension.
+- **Already serves an HTTP endpoint**: The IBI Operator runs an image
+  server (`internal/imageserver/`) that serves config ISOs to BMHs. This
+  existing HTTP infrastructure can be extended to receive completion
+  callbacks from pre-provisioned servers.
+- **Reusable**: Other consumers of the IBI Operator (not just
+  ProvisioningRequest users) would benefit from automated pre-provisioning.
+- **Clean separation**: O-Cloud Manager handles orchestration (what to
+  provision), the IBI Operator handles mechanics (how to provision).
+  Pre-provisioning is a "how" concern.
+
+### Monitoring Approach: HTTP Callback
+
+Rather than SSH-based monitoring (which requires hub-to-server network
+access, SSH key management, and IP discovery), the IBI Operator uses an
+**HTTP callback** pattern:
+
+1. The IBI Operator generates a small ignition config override containing a
+   systemd unit that calls back to the hub after the IBI preparation service
+   completes (success or failure).
+2. This callback unit is injected into the ISO via the
+   `ignitionConfigOverride` field already supported by the
+   `ImageBasedInstallationConfig`.
+3. The IBI Operator's existing HTTP server exposes a callback endpoint
+   (e.g., `/callbacks/<ici-namespace>/<ici-name>/status`).
+4. When the preparation service finishes, the callback unit `curl`s the
+   hub endpoint with the result.
+5. The IBI Operator receives the callback, updates the ICI condition, and
+   proceeds with the BMH state transition.
+
+This approach:
+
+- **Requires no SSH**: No SSH keys to manage, no IP discovery needed, and
+  no hub → server connectivity. It does **not** eliminate the network
+  dependency — it inverts its direction: the model requires
+  **server → hub** reachability instead.
+- **Aligns with existing egress, not "works behind any firewall"**: the
+  server must reach the hub's callback endpoint over HTTPS (DNS resolution
+  of the endpoint hostname, IP routing from the provisioning network to the
+  hub Route/Service, and TLS trust of the hub certificate). This is the
+  same *direction* of connectivity already needed for the server to pull
+  images from the hub, but it is a concrete precondition, not a given —
+  an environment that blocks arbitrary provisioning-network → hub egress,
+  or that resolves/routes the endpoint differently from the image
+  registries, will drop callbacks. The reachability contract is therefore
+  made explicit: the IBI Operator validates that the callback endpoint is
+  resolvable, routable, and TLS-trusted from the target's network **before**
+  booting the ISO (see [Challenge 1](#1-callback-url-must-be-reachable-from-the-pre-provisioned-server)),
+  and a `PreProvisioningTimedOut` is treated as a possible reachability
+  failure, not only a preparation failure.
+- **Leverages existing infrastructure**: The IBI Operator already serves
+  HTTP; adding a callback handler is minimal
+- **Scales naturally**: Callbacks are event-driven, not poll-based — no
+  per-server reconcile loops
+
+### Component Responsibilities
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│ O-Cloud Manager (ProvisioningRequest Controller)                │
+│                                                                 │
+│  1. Hardware allocation (NAR)                                   │
+│  2. Populate ImageClusterInstall with pre-provisioning config   │
+│  3. Create ClusterInstance (triggers SiteConfig → ICI creation) │
+│  4. Monitor ICI conditions for pre-provisioning + install       │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│ SiteConfig Operator                                             │
+│                                                                 │
+│  Renders ClusterInstance → creates ImageClusterInstall CR       │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│ IBI Operator (upstream changes required)                        │
+│                                                                 │
+│  1. NEW: Generate callback ignition override                    │
+│  2. NEW: Boot BMH from live ISO via spec.image (live-iso)       │
+│  3. NEW: Receive HTTP callback on preparation completion        │
+│  4. NEW: Transition BMH to IBI-ready state                      │
+│  5. Existing: Create config DataImage, reboot from disk,        │
+│     monitor cluster installation                                │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│ Metal3 / Ironic (BMO)                                           │
+│                                                                 │
+│  Handles BMH spec.image (live-iso) → virtual media mount + boot │
+│  Handles DataImage → virtual media attach for config ISO        │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Proposed API Changes
+
+### IBI Operator: ImageClusterInstall CRD Changes
+
+New optional fields in `ImageClusterInstallSpec`:
+
+```go
+type ImageClusterInstallSpec struct {
+    // ... existing fields ...
+
+    // PreProvisioning configures optional server pre-provisioning.
+    // When set, the IBI Operator boots the BMH from the specified
+    // live ISO and monitors the IBI preparation process via HTTP
+    // callback before proceeding to cluster installation.
+    // +optional
+    PreProvisioning *PreProvisioningConfig `json:"preProvisioning,omitempty"`
+}
+
+type PreProvisioningConfig struct {
+    // ISOURL is the HTTPS URL of the IBI live ISO accessible from
+    // the BMC management network. It must resolve to an operator-owned or
+    // explicitly allowlisted ISO origin; the operator rejects any off-allowlist
+    // URL at admission (PreProvisioningConfigInvalid) and never fetches it, so
+    // a caller cannot direct the operator's pre-fetch at an arbitrary host.
+    ISOURL string `json:"isoURL"`
+
+    // ISODigest is the expected SHA-256 digest ("sha256:<hex>") of the
+    // live ISO served at ISOURL. The operator verifies the fetched ISO against
+    // it before setting the BMH image so a mutated or stale artifact at that URL
+    // cannot be booted. This is the same digest the seed-generation workflow
+    // records in SeedGenerationStatus.ISODigest; wiring it through pins the
+    // pre-provisioning boot to the exact artifact that was built and verified.
+    // Required for automated boot: admission rejects a pre-provisioning config
+    // that omits it (PreProvisioningConfigInvalid) rather than falling back to
+    // URL-only trust. The json tag keeps omitempty only so the zero value is
+    // caught by the required-field check, not silently defaulted.
+    ISODigest string `json:"isoDigest,omitempty"`
+
+    // ISOServerCACertRef is a reference to a ConfigMap containing the
+    // CA certificate bundle ('ca-bundle.crt' key) for the HTTPS ISO
+    // server. Required when the server uses a private CA.
+    // +optional
+    ISOServerCACertRef *corev1.LocalObjectReference `json:"isoServerCACertRef,omitempty"`
+
+    // Timeout is the maximum duration to wait for the IBI preparation
+    // to complete. Default: 60m.
+    // +optional
+    Timeout *metav1.Duration `json:"timeout,omitempty"`
+
+    // CallbackBaseURL is the externally-reachable base URL that the
+    // booted host uses to reach the IBI Operator's callback endpoint,
+    // e.g. "https://ibi-callback.example.com:8443". The operator appends
+    // "/callbacks/<namespace>/<name>/status" to form the full endpoint
+    // that is injected into the ISO's ignition. This must be set to an
+    // address reachable from the *provisioning network the booted host
+    // is on*, which is frequently NOT the in-cluster Service DNS name
+    // (`<svc>.<ns>.svc`): that name resolves only inside the hub cluster,
+    // while the callback originates from the bare-metal host. When unset,
+    // the operator falls back to the in-cluster Service URL, which is
+    // only correct when the host shares the hub's cluster network.
+    // The operator validates that the resolved host is reachable from the
+    // target network before booting the ISO (see Challenge 1); a value
+    // that only resolves in-cluster is treated as a configuration error.
+    // +optional
+    CallbackBaseURL string `json:"callbackBaseURL,omitempty"`
+
+    // MaxRetries caps the number of ADDITIONAL boot attempts after the
+    // first, when an attempt fails or times out. 0 (the default) means a
+    // single attempt with no retry. Retries stop once this budget is
+    // exhausted, after which the result is terminal. There is no infinite
+    // retry and no retry after a terminal result.
+    // +optional
+    // +kubebuilder:default=0
+    MaxRetries int `json:"maxRetries,omitempty"`
+
+    // RetryBackoff is the delay between a failed attempt's teardown and the
+    // next boot, applied as a self-triggering RequeueAfter. Default: 5m.
+    // The operator enforces an overall ceiling of
+    // (MaxRetries+1)*Timeout + MaxRetries*RetryBackoff so total retry effort
+    // is finite.
+    // +optional
+    RetryBackoff *metav1.Duration `json:"retryBackoff,omitempty"`
+}
+```
+
+New condition and status fields:
+
+```go
+const (
+    PreProvisioningPendingReason    = "PreProvisioningPending"
+    PreProvisioningBootingReason    = "PreProvisioningBooting"
+    PreProvisioningInProgressReason = "PreProvisioningInProgress"
+    PreProvisioningRetryingReason   = "PreProvisioningRetrying"
+    PreProvisioningSucceededReason  = "PreProvisioningSucceeded"
+    PreProvisioningFailedReason     = "PreProvisioningFailed"
+    PreProvisioningTimedOutReason   = "PreProvisioningTimedOut"
+)
+
+type ImageClusterInstallStatus struct {
+    // ... existing fields ...
+
+    // PreProvisioningBootTime indicates when the BMH was booted from the
+    // live ISO for pre-provisioning, and is the anchor for the timeout. It is
+    // set ONLY after the BMH boot request has been applied (NOT in the
+    // pre-boot status update that records PreProvisioningAttempt), so the
+    // timeout clock cannot start before the host was actually asked to boot.
+    // See the preProvisionHost ordering in "IBI Operator Workflow Changes."
+    // +optional
+    PreProvisioningBootTime *metav1.Time `json:"preProvisioningBootTime,omitempty"`
+
+    // PreProvisioningRetryCount records the number of additional attempts
+    // already consumed against the MaxRetries budget. It is persisted so the
+    // budget survives operator restarts; a retry is scheduled only while
+    // this remains below MaxRetries.
+    // +optional
+    PreProvisioningRetryCount int `json:"preProvisioningRetryCount,omitempty"`
+
+    // RetryNotBefore is the durable retry-pending marker. When a failed attempt
+    // still has retry budget, the operator sets this (now + RetryBackoff) in the
+    // SAME update that clears PreProvisioningAttempt, so recovery can tell a
+    // retired attempt in backoff (attempt unset, RetryNotBefore set) from an
+    // in-flight one (attempt set). The remaining backoff is recomputed from this
+    // value on every reconcile, so a restart that loses the in-memory
+    // RequeueAfter still honors the delay. Cleared when the next attempt is
+    // recorded (RetryNotBefore and PreProvisioningAttempt are never both set).
+    // +optional
+    RetryNotBefore *metav1.Time `json:"retryNotBefore,omitempty"`
+
+    // PreProvisioningAttempt identifies the current boot attempt. The
+    // operator increments (or regenerates) it each time it boots the BMH
+    // for pre-provisioning, and mints the per-attempt callback token bound
+    // to this value (the token embeds the attempt id as a claim). It is
+    // the single source of truth for "which boot are we waiting on."
+    // +optional
+    PreProvisioningAttempt string `json:"preProvisioningAttempt,omitempty"`
+
+    // PreProvisioningResult records the result received via HTTP callback
+    // from the pre-provisioned server for a specific attempt. The operator
+    // clears this (sets it to nil) atomically in the same pre-boot status
+    // update that records a new PreProvisioningAttempt (NOT
+    // PreProvisioningBootTime, which is written later — see that field), so a
+    // stale result from a prior boot can never be mistaken for the outcome of
+    // the current one. A callback is accepted only if its Attempt matches the
+    // current PreProvisioningAttempt; callbacks for any other attempt are
+    // rejected.
+    // +optional
+    PreProvisioningResult *PreProvisioningResult `json:"preProvisioningResult,omitempty"`
+
+    // PreProvisioningTeardownComplete gates cessation of teardown retries for
+    // a terminal (failed/timed-out) attempt. When the operator claims the
+    // terminal state it writes this as false in the same update; teardown
+    // (clear image, remove DataImage, power off, delete the per-attempt token
+    // Secret) is then idempotently re-driven on every reconcile until all
+    // actions succeed, at which point this flips to true — the ONLY state that
+    // stops teardown retries. It survives restarts so a crash mid-teardown
+    // cannot leave a terminal ICI with cleanup still owed. Reset to false (or
+    // cleared) when a retry mints a fresh attempt; meaningful only once a
+    // terminal reason (PreProvisioningFailed/PreProvisioningTimedOut) is set.
+    // +optional
+    PreProvisioningTeardownComplete bool `json:"preProvisioningTeardownComplete,omitempty"`
+}
+
+type PreProvisioningResult struct {
+    // Attempt is the PreProvisioningAttempt this result belongs to. The
+    // operator records it from the (token-verified) callback and compares
+    // it to Status.PreProvisioningAttempt; a mismatch means the result is
+    // for a superseded boot and is discarded.
+    Attempt string `json:"attempt"`
+    // Status is "success" or "failure".
+    Status string `json:"status"`
+    // Message contains the completion or error message from the
+    // preparation service.
+    // +optional
+    Message string `json:"message,omitempty"`
+    // ReceivedAt is the timestamp when the callback was received.
+    ReceivedAt metav1.Time `json:"receivedAt"`
+}
+```
+
+The IBI Operator reports pre-provisioning progress via the existing
+`RequirementsMet` condition before proceeding to its normal `configureHost`
+flow. **`RequirementsMet` is the single authoritative status field for the
+handoff** — the design deliberately does *not* introduce a separate
+`PreProvisioningCompleted` condition, so producer (IBI Operator) and consumer
+(O-Cloud Manager) agree on exactly one field and cannot end up watching
+different conditions (which would advance only after timeout). The
+pre-provisioning phase is distinguished by the condition `reason`
+(`PreProvisioning*`), not by a different condition `type`. This one contract
+is used consistently by the IBI Operator, the O-Cloud Manager mapping, and the
+integration tests.
+
+### O-Cloud Manager: ClusterTemplate Configuration
+
+The pre-provisioning configuration is placed in `hwMgmtDefaults` (and
+overridable via `hwMgmtParameters`) since it describes how the hardware
+should be prepared:
+
+```yaml
+# In ClusterTemplate spec.templateDefaults.hwMgmtDefaults
+hwMgmtDefaults:
+  hardwareProvisioningTimeout: "120m"
+  nodeGroupData:
+    - name: controller
+      role: master
+      resourceSelector:
+        resourceselector.clcm.openshift.io/server-type: XR8620t
+  # Optional: IBI pre-provisioning configuration.
+  # Passed through to ImageClusterInstall.spec.preProvisioning.
+  ibiPreProvisioning:
+    # Required: HTTPS URL of the live IBI ISO accessible from the BMC
+    # management network.
+    isoURL: https://iso-server.example.com/ibi/rhcos-ibi-4.Y.Z.iso
+    # Optional (recommended): expected SHA-256 digest of the ISO, verified
+    # before boot to pin the exact artifact. Matches
+    # SeedGenerationStatus.ISODigest from the seed-generation workflow.
+    isoDigest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+    # Optional: reference to a ConfigMap containing the CA certificate
+    # bundle for the HTTPS ISO server.
+    isoServerCACertRef:
+      name: iso-server-ca-cert
+    # Optional: timeout for pre-provisioning a single server.
+    # Default: 60m.
+    preProvisioningTimeout: "60m"
+    # Optional: number of automatic re-boot attempts after a failed/timed-out
+    # attempt before the phase is terminal. Default: 0 (single attempt).
+    maxRetries: 2
+    # Optional: delay between a failed attempt and the next boot.
+    # Default: 5m.
+    retryBackoff: "5m"
+```
+
+The O-Cloud Manager controller passes these values through to the
+`ImageClusterInstall` CR when rendering the ClusterInstance. The IBI
+templates in the SiteConfig Operator would need to support the new
+`preProvisioning` fields (or the O-Cloud Manager patches the ICI directly
+after SiteConfig creates it).
+
+The `hwMgmtDefaults` field names are hardware-management-oriented and do not
+match the `ImageClusterInstall.spec.preProvisioning` field names one-to-one;
+the passthrough is an explicit mapping, not a verbatim copy. The controller
+applies this mapping when rendering the ICI:
+
+| `hwMgmtDefaults.ibiPreProvisioning` | `ImageClusterInstall.spec.preProvisioning` |
+| --- | --- |
+| `isoURL` | `isoURL` |
+| `isoDigest` | `isoDigest` |
+| `isoServerCACertRef` | `isoServerCACertRef` |
+| `preProvisioningTimeout` | `timeout` |
+| `maxRetries` | `maxRetries` |
+| `retryBackoff` | `retryBackoff` |
+
+`callbackBaseURL` on the ICI is **not** sourced from `hwMgmtDefaults`; the
+operator derives it from operator-level configuration (the externally-
+reachable callback address is an environment property, not a per-template
+input). This is a **security boundary, not just a naming choice**: the
+callback client sends the per-attempt **bearer token** to whatever host
+`callbackBaseURL` resolves to, so a template or ProvisioningRequest author who
+could set it freely could redirect the token to a host they control and then
+forge a success callback. The field is therefore **operator-owned**:
+
+1. The IBI Operator's own configuration: an `IBI_CALLBACK_BASE_URL` value
+   sourced from the operator Deployment environment (populated from the
+   O-Cloud Manager `Inventory` CR's externally-reachable ingress/route
+   configuration). This is the normal way to set it fleet-wide.
+2. Otherwise the in-cluster Service URL (`<svc>.<ns>.svc`) — usable **only**
+   when the host shares the hub cluster network.
+
+`PreProvisioningConfig.CallbackBaseURL` on the ICI is **not** a
+template/ProvisioningRequest input. It is not surfaced in
+`hwMgmtParameters`, and write access to `ImageClusterInstall.spec.preProvisioning.callbackBaseURL`
+is restricted by RBAC to the operator's own service account (template and PR
+authors cannot set it). If a value is present, it is accepted **only** when it
+matches an operator-maintained **allowlist** of callback origins (the same
+`Inventory`-derived hosts); any off-allowlist origin is rejected at admission
+with `PreProvisioningConfigInvalid` and the ISO is never booted. An admission
+test covers a spoofed off-allowlist origin.
+
+If none of these yields a URL reachable from the target provisioning
+network, the operator **fails closed**: it does not boot the ISO and reports
+a configuration error (`PreProvisioningConfigInvalid`), rather than booting a
+host that can never call back and then timing out 60 minutes later. In
+particular the in-cluster fallback is accepted only when the reachability
+check in Challenge 1 confirms the host is on the hub cluster network.
+
+Keeping the names distinct on each side is intentional:
+`preProvisioningTimeout` reads clearly in the hardware-timeouts block
+alongside `hardwareProvisioningTimeout`, while `timeout` is scoped by its
+`preProvisioning` parent on the ICI. The mapping table above is the
+authoritative contract between the two field sets.
+
+### Schema in templateParameterSchema
+
+```yaml
+hwMgmtParameters:
+  properties:
+    ibiPreProvisioning:
+      type: object
+      properties:
+        isoURL:
+          type: string
+          description: >
+            HTTPS URL of the IBI live ISO. Must resolve to an operator-owned
+            or allowlisted ISO origin; off-allowlist URLs are rejected before
+            any fetch.
+          minLength: 1
+        isoDigest:
+          type: string
+          description: >
+            Expected SHA-256 digest ("sha256:<hex>") of the live ISO;
+            verified before boot to pin the exact artifact. Required for
+            automated boot.
+          pattern: '^sha256:[a-f0-9]{64}$'
+        isoServerCACertRef:
+          type: object
+          properties:
+            name:
+              type: string
+          required: [name]
+        preProvisioningTimeout:
+          type: string
+          description: Timeout for pre-provisioning (e.g., "60m")
+        maxRetries:
+          type: integer
+          minimum: 0
+          description: >
+            Automatic re-boot attempts after a failed/timed-out attempt
+            before the phase is terminal (default 0 = single attempt).
+        retryBackoff:
+          type: string
+          description: >
+            Delay before the next attempt, as a Go duration (e.g., "5m").
+      required: [isoURL, isoDigest]
+  type: object
+```
+
+Validation mirrors the schema: `maxRetries` must be a non-negative integer
+and `retryBackoff` must parse as a non-negative Go `time.Duration`. Both the
+admission webhook and the ICI passthrough reject out-of-range values so a bad
+override is caught at write time rather than surfacing as a stuck attempt. When
+omitted, the controller applies the `PreProvisioningConfig` defaults
+(`maxRetries: 0`, `retryBackoff: 5m`).
+
+Because `isoURL` and `isoDigest` are caller-overridable through
+`hwMgmtParameters`, validation also enforces the two artifact-trust checks
+before the operator ever fetches the URL (see "Restricting `ISOURL`"): `isoURL`
+must resolve to an operator-owned or allowlisted origin, and `isoDigest` is
+required (the schema marks it required; the webhook and passthrough re-check it,
+rejecting a missing or off-allowlist value with `PreProvisioningConfigInvalid`).
+The allowlist is operator configuration and cannot be widened by a template or
+`ProvisioningRequest`.
+
+## IBI Operator Workflow Changes
+
+### Current Flow (no pre-provisioning)
+
+```text
+ImageClusterInstall created
+  → validateBMH (check BMH state, hardware details)
+  → writeInputData (generate config ISO)
+  → configureHost:
+      → ensureBMHDataImage (attach config ISO via DataImage)
+      → updateBMHProvisioningState (set online, reboot annotation)
+      → set Status.BootTime
+  → monitor cluster installation
+  → installation complete
+```
+
+### New Flow (with pre-provisioning)
+
+```text
+ImageClusterInstall created (with spec.preProvisioning set)
+  → validateBMH (check BMH state)
+      # IMPORTANT: when spec.preProvisioning is set, validateBMH/validateHost
+      # must NOT set BMH spec.externallyProvisioned. The host is not yet
+      # prepared; marking it externallyProvisioned here would tell BMO the OS
+      # is already installed and skip/short-circuit the very boot we need.
+      # externallyProvisioned is set ONLY on a verified success callback,
+      # in transitionToIBIReady below.
+  → NEW: preProvisionHost (ordered so every write is recoverable — see
+    "Crash-safety of the boot handoff" below; each step is idempotent and the
+    next reconcile resumes from the first incomplete one):
+      # RECOVERY: classify the current state before doing anything:
+      #   (a) Status.PreProvisioningAttempt set        → in-flight attempt:
+      #       resume it. Do NOT mint a new id/token; reuse the existing attempt
+      #       and its token Secret and re-drive the remaining steps idempotently.
+      #   (b) attempt unset, but a pending token Secret owned by this ICI and
+      #       carrying the ibi.openshift.io/attempt label exists → the status
+      #       write in step 2 was lost after step 1; ADOPT that Secret's attempt
+      #       id (do NOT mint a second one) and continue at step 2.
+      #   (c) attempt unset, no pending Secret, Status.RetryNotBefore set → a
+      #       retired attempt is in backoff: wait until now >= RetryNotBefore
+      #       (RequeueAfter = the remainder, recomputed here so a restart that
+      #       lost the in-memory timer still honors the backoff), then mint.
+      #   (d) none of the above → first attempt: mint.
+      → 1. mint intent (only in cases (c)-after-backoff and (d)):
+          → mint attempt id + per-attempt token
+          → write the token to its own Secret, named deterministically from
+            the attempt id, OWNED by this ICI (ownerReference) and labelled
+            ibi.openshift.io/attempt=<id> (create-or-adopt). The token lives
+            here, NOT in status, so it must be persisted BEFORE the attempt id
+            is recorded. The owner + label make a written-but-not-yet-recorded
+            Secret discoverable (case (b)), so a lost step-2 write is adopted
+            rather than orphaned — the attempt id is recoverable from the Secret
+            even when it is absent from status.
+      → 2. record the attempt (ONE status update, flushed):
+          → set Status.PreProvisioningAttempt = <id>
+          → clear Status.PreProvisioningResult (a stale result from a prior
+            attempt must not be read as this attempt's outcome)
+          → clear Status.RetryNotBefore (this attempt is now in flight, not
+            pending)
+          → condition: RequirementsMet = False / PreProvisioningBooting
+          → do NOT set PreProvisioningBootTime yet (see step 5)
+      → 3. deliver the per-host callback data (URL, attempt id, token,
+         CALLBACK_BUDGET_SECS) on a DataImage carrier (create-or-adopt), NOT via
+         preprovisioningNetworkDataName (that field is an nmstate network-data
+         Secret and does not inject callback config into a live-iso boot — see
+         Challenge 4). The DataImage MUST be named and namespaced after the
+         BareMetalHost (same name + namespace): BMO v0.13.2's
+         DataImageReconciler resolves the owning host by matching the DataImage
+         request name/namespace to a BareMetalHost, so an attempt-id-named
+         DataImage would never attach. The attempt id is bound instead through
+         carrier content and a label (e.g. `ibi.openshift.io/attempt: <id>`),
+         which the create-or-adopt step also uses to detect and replace a stale
+         carrier from a prior attempt. The generic callback client is already
+         baked into the live ISO via ignitionConfigOverride at build time
+         (identical for every host).
+      → 4. mutate the BMH (idempotent patch):
+          → set BMH spec.image.url = isoURL, spec.image.format = "live-iso"
+          → set BMH spec.online = true
+      → 5. set Status.PreProvisioningBootTime = now, ONLY after the BMH boot
+         request in step 4 is confirmed applied. BootTime is the timeout
+         anchor, so it must mark an actual boot request, not merely recorded
+         intent; a resumed attempt whose steps 3-4 completed but whose BootTime
+         is unset verifies the BMH is booting the expected ISO and then stamps
+         BootTime.
+  → NEW: waitForCallback:
+      → IBI Operator HTTP server receives POST to
+        /callbacks/<namespace>/<name>/status
+      → callback payload: {"attempt": "<n>", "status": "success|failure", "message": "..."}
+      → on success:
+          → clear BMH spec.image
+          → set BMH spec.externallyProvisioned = true
+          → set BMH spec.online = false (power off)
+          → set Status.PreProvisioningResult
+          → condition: RequirementsMet = True / PreProvisioningSucceeded
+      → on failure (or timeout): tear the attempt down (clear image,
+        remove DataImage, power off, invalidate the per-attempt token),
+        then branch on the retry budget — do NOT set externallyProvisioned:
+          → if PreProvisioningRetryCount < MaxRetries (budget remains):
+              → increment Status.PreProvisioningRetryCount
+              → set Status.RetryNotBefore = now + RetryBackoff, and in the SAME
+                update CLEAR Status.PreProvisioningAttempt, PreProvisioningResult
+                and PreProvisioningBootTime. Clearing the attempt id is what
+                stops the recovery rule from re-driving the retired attempt with
+                its now-invalidated token; RetryNotBefore is the durable
+                retry-pending marker that survives a restart (the next reconcile
+                recomputes the remaining backoff from it rather than relying on
+                an in-memory RequeueAfter that a crash would lose).
+              → condition: RequirementsMet = False / PreProvisioningRetrying
+                (NON-terminal — the ProvisioningRequest keeps progressing)
+              → RequeueAfter = RetryBackoff. A fresh attempt (new id + token) is
+                minted only once now >= RetryNotBefore, via the mint path above —
+                never inline here, so the boot is driven from one place and a
+                restart mid-backoff still waits out the remainder.
+          → else (budget exhausted): this is the terminal attempt
+              → set Status.PreProvisioningResult (status=failure)
+              → condition: RequirementsMet = False /
+                PreProvisioningFailed (timeout → PreProvisioningTimedOut)
+                — terminal; only now does the PR map to failed
+  → writeInputData (generate config ISO) — existing flow
+  → configureHost — existing flow (BMH is now externallyProvisioned)
+  → monitor cluster installation — existing flow
+  → installation complete
+```
+
+**Crash-safety of the boot handoff.** A single attempt spans four durable
+resources — the **token Secret**, the ICI **status** (`PreProvisioningAttempt`,
+`PreProvisioningResult`, `PreProvisioningBootTime`), the **DataImage** carrier,
+and the **BMH** spec — so "one atomic status update" is not enough on its own;
+the write *ordering* above is what makes the whole handoff recoverable. The
+invariants:
+
+- **Token before attempt id, and discoverable.** The per-attempt token is
+  persisted in its own deterministically-named Secret — owned by the ICI and
+  labelled `ibi.openshift.io/attempt=<id>` — before the attempt id is written to
+  status. An attempt id can therefore never reference a token that was never
+  stored. If the status write in step 2 is lost after the Secret exists, the
+  next reconcile finds the pending Secret by owner + label and **adopts its
+  attempt id** rather than minting a second token, so the "token written, status
+  not" window resumes the same attempt (no orphaned Secret, no duplicate token).
+- **Attempt id is the recovery key for an in-flight attempt.** Once
+  `PreProvisioningAttempt` is set, every subsequent reconcile **resumes the same
+  attempt** — it reuses the existing id and token Secret and re-drives steps 3-5
+  idempotently (create-or-adopt the BMH-named DataImage whose attempt-id label
+  identifies the current attempt, idempotent BMH patch), rather than minting a
+  fresh attempt while the previous ISO may still be booting.
+- **A retired attempt is never resumed.** On a retry, the failed attempt's
+  `PreProvisioningAttempt` is cleared in the same update that sets
+  `RetryNotBefore`, so recovery can never mistake the retired attempt (whose
+  token is already invalidated) for an in-flight one. Recovery distinguishes
+  three post-failure states purely from persisted status: attempt set = resume;
+  attempt unset + `RetryNotBefore` in the future = wait out the backoff;
+  attempt unset + `RetryNotBefore` reached = mint the next attempt. The backoff
+  remainder is recomputed from `RetryNotBefore` on every reconcile, so a restart
+  that loses the in-memory `RequeueAfter` still honors it.
+- **BootTime marks a real boot, and is written last.** `PreProvisioningBootTime`
+  — the timeout anchor — is stamped only after the BMH boot request is
+  confirmed applied. A resumed attempt with steps 3-4 complete but no BootTime
+  verifies the BMH is booting the expected ISO, then stamps it; the timeout
+  clock cannot start before the host was actually asked to boot.
+- **Timeout still bounds a stuck resume.** An in-flight attempt whose
+  `PreProvisioningBootTime` + `timeout` has elapsed is treated as timed out and
+  enters the retry/terminal branch — never a silent re-mint.
+
+Each partial-write window — "token Secret written, status not" (asserts the
+pending Secret is adopted by owner + label, not re-minted); "status written,
+DataImage not"; "DataImage created, BMH not patched"; "BMH patched, BootTime not
+stamped"; and "retry recorded (`RetryNotBefore` set, attempt cleared), process
+restarted mid-backoff" (asserts the remaining backoff is honored and exactly one
+fresh attempt is then minted) — is covered by its own **fault-injection test**
+that kills the reconcile at that point and asserts the next reconcile resumes
+the same attempt (no new token, no duplicate boot, exactly one booting ISO).
+
+### Key Implementation Details in the IBI Operator
+
+#### 1. Callback Ignition Override
+
+The IBI Operator generates an ignition config snippet containing a systemd
+unit that runs after `install-rhcos-and-restore-seed.service` completes.
+This unit reports the result back to the hub via HTTP.
+
+**This depends on `install-rhcos-and-restore-seed.service` being a
+`Type=oneshot` unit** (which the IBI seed-restore service is): a oneshot unit
+does not reach `active`/exit until its `ExecStart` has finished, so its
+`Result` property is a *terminal* success/failure verdict by the time the
+reporter reads it. `After=` only orders start-up — it does **not** wait for a
+`Type=simple` (or other long-running) unit to finish, so if the referenced unit
+were not oneshot the reporter could read a non-failure `Result` while
+preparation is still running and send a premature "success". If a future base
+changes that unit's type, the design must instead gate on an explicit
+completion sentinel (a dedicated oneshot unit ordered `After=` the prep service,
+whose own terminal `Result` the reporter reads) rather than the prep service's
+live state. The reporter contract is: read a terminal result, never a
+mid-flight one.
+
+```yaml
+# Generated by the IBI Operator, injected as ignition override
+systemd:
+  units:
+    - name: ibi-prep-callback.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Report IBI preparation result to hub
+        # Order AFTER the prep service, and use Wants= (NOT Requires=). The
+        # whole point of this unit is to report BOTH success and failure, so
+        # it must run even when the prep service fails. With Requires=, a
+        # failed prep service would cause systemd to skip this reporter's job
+        # entirely, no failure callback would be sent, and the hub would wait
+        # out the full PreProvisioningTimedOut. Wants= keeps the ordering
+        # dependency without cancelling the reporter when the prep service
+        # fails. Requires=/After= on the data unit below is different: that
+        # data must exist for the reporter to work at all, so it stays
+        # Requires=. After= alone only orders start-up; it does not wait for
+        # the prep service to finish, so it is paired with the current-boot
+        # result check in ExecStart (the prep service reaches a terminal
+        # success/failure state, so the result is deterministic when read).
+        After=install-rhcos-and-restore-seed.service
+        Wants=install-rhcos-and-restore-seed.service
+        # Runtime dependency on the per-host data (see Challenge 4): the
+        # reporter cannot run without its URL/token/attempt files. The data
+        # unit is Type=oneshot with RemainAfterExit=yes, so it stays
+        # active (exited) after materializing the files; without that this
+        # Requires= would drop as soon as the data unit's ExecStart returned
+        # and systemd could stop the reporter before it ran.
+        Requires=ibi-callback-data.service
+        After=ibi-callback-data.service
+        # StartLimit* live in [Unit] (moved here from [Service] in systemd
+        # v230). Backstop only — the real retry budget is the script's
+        # absolute deadline.
+        StartLimitIntervalSec=660
+        StartLimitBurst=3
+
+        [Service]
+        # Type=oneshot with Restart=on-failure requires systemd v244 or
+        # later (before v244 Restart= is silently ignored for oneshot
+        # units, so the callback would never be retried). RHCOS ships
+        # systemd 252+, so this is satisfied; the dependency is called out
+        # here because the retry semantics below are load-bearing, not
+        # decorative. On any older base the ExecStart must instead wrap the
+        # send in its own bounded retry loop.
+        Type=oneshot
+        ExecStart=/usr/local/bin/ibi-prep-callback
+        # The retry budget is enforced as an ABSOLUTE deadline inside the
+        # script (a wall-clock loop), not by per-attempt timers, and it is
+        # sized from the operator's PreProvisioningConfig.Timeout (default 60m,
+        # delivered as CALLBACK_BUDGET_SECS) so callbacks stay alive for the
+        # whole window the operator waits — see the script below.
+        # TimeoutStartSec/Restart alone cannot bound total effort:
+        # TimeoutStartSec caps a SINGLE start attempt, and Restart=on-failure
+        # would keep re-launching the unit (subject to start-rate limits)
+        # with no ceiling on cumulative time. So the script owns the budget:
+        # it retries curl until it succeeds or the deadline passes, then
+        # exits (0 on delivery, non-zero if the deadline elapsed).
+        # TimeoutStartSec is DISABLED (infinity) because the budget is now
+        # host-specific and can be up to the operator timeout; a fixed cap
+        # baked into the shared ISO would truncate it. The script's persisted
+        # deadline is the real bound. Restart + StartLimit remain only as a
+        # backstop for an outright script crash.
+        TimeoutStartSec=infinity
+        Restart=on-failure
+        RestartSec=30
+        # Non-secret callback parameters (URL, attempt id). The bearer token
+        # is NOT here — it is delivered in a root-only curl config file (see
+        # below) so it never lands in an environment variable, the unit
+        # contents, or the process argument list.
+        EnvironmentFile=/etc/ibi-callback/env
+
+        [Install]
+        WantedBy=multi-user.target
+```
+
+The reporter logic is delivered as a small script (`/usr/local/bin/ibi-prep-callback`,
+also injected via the ignition overlay) rather than an inline `bash -c`,
+so the JSON body can be serialized safely and the token kept out of argv:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine the prep service result for THIS boot/attempt only. Use the
+# systemd-tracked result (Result property) rather than grepping the journal,
+# and scope any journal read to the current boot (-b 0). An unscoped
+# `journalctl -u ...` would also match a "finished successfully" line left
+# over from an earlier boot or a previous pre-provisioning attempt on the
+# same disk, producing a false success. After= ordering alone does NOT
+# disambiguate attempts.
+RESULT=$(systemctl show -p Result --value install-rhcos-and-restore-seed.service)
+if [ "${RESULT}" = "success" ]; then
+  STATUS="success"
+  MSG="IBI preparation process finished successfully"
+else
+  STATUS="failure"
+  MSG=$(journalctl -b 0 -u install-rhcos-and-restore-seed.service \
+    --no-pager -n 20 | tail -5)
+fi
+
+# Serialize the body with a real JSON encoder. MSG is arbitrary journal text
+# containing newlines, double quotes, and backslashes; hand-built
+# "{\"message\": \"${MSG}\"}" produces invalid JSON and can be used to
+# inject fields. Use jq (shipped in RHCOS) rather than python3 (NOT present
+# in the RHCOS live ISO — invoking it would fail and, under `set -e`, exit
+# before curl, turning every callback into a timeout). --arg passes each
+# value as a literal string so no field injection is possible. The attempt
+# id ties this callback to the exact boot the operator is waiting on (see
+# PreProvisioningAttempt); the operator rejects any mismatch.
+PAYLOAD=$(jq -nc \
+  --arg attempt "${CALLBACK_ATTEMPT}" \
+  --arg status "${STATUS}" \
+  --arg message "${MSG}" \
+  '{attempt: $attempt, status: $status, message: $message}')
+
+# Retry against an ABSOLUTE wall-clock deadline, not a per-attempt timer.
+# This bounds cumulative effort regardless of how many individual attempts
+# fail, which neither TimeoutStartSec nor Restart= can do on their own. On the
+# first successful delivery, exit 0 immediately; if the deadline passes without
+# success, exit non-zero (systemd's Restart is only a crash backstop, bounded
+# by StartLimit).
+#
+# The budget MUST cover the operator's whole wait window. The operator waits up
+# to PreProvisioningConfig.Timeout (default 60m) for a callback; if the host
+# stopped retrying after a fixed ~10m, a hub that is unreachable for 10-59m
+# after prep succeeds would never receive the (already-produced) result and the
+# operator would time out a host that actually succeeded. So the operator
+# delivers CALLBACK_BUDGET_SECS per-host in the env file, derived from the
+# effective timeout (timeout minus a small margin so the last send precedes the
+# operator's own deadline). The script uses that as its budget instead of a
+# hardcoded constant.
+#
+# CALLBACK_BUDGET_SECS is a REQUIRED per-host value (see env file below). There
+# is deliberately NO silent fallback: a missing budget is a delivery bug, and
+# defaulting to a short window would reintroduce the very "host stops before the
+# operator's timeout" failure this value exists to prevent. Fail loudly instead.
+: "${CALLBACK_BUDGET_SECS:?CALLBACK_BUDGET_SECS not delivered}"
+#
+# Anchor the deadline to the host's BOOT time, not to this script's first-run
+# time. The operator's timeout starts at PreProvisioningBootTime (≈ when the
+# host was asked to boot), but this reporter only starts after preparation
+# finishes, which can be many minutes later. Computing `now + budget` here would
+# hand a late-starting reporter a fresh full budget and push its window past the
+# operator's deadline. Using boot time keeps the two clocks aligned.
+#
+# The deadline is also PERSISTED to a tmpfs file so it survives a
+# Restart=on-failure relaunch (a crash + re-exec must not restart the budget);
+# the first invocation stamps it, later invocations read it back.
+DEADLINE_FILE=/run/ibi-callback/deadline   # tmpfs, cleared on reboot
+mkdir -p "$(dirname "${DEADLINE_FILE}")"
+if [ -s "${DEADLINE_FILE}" ]; then
+  DEADLINE=$(cat "${DEADLINE_FILE}")
+else
+  UPTIME=$(cut -d. -f1 /proc/uptime)              # seconds since boot
+  BOOT_EPOCH=$(( $(date +%s) - UPTIME ))          # ≈ operator's boot request
+  DEADLINE=$(( BOOT_EPOCH + CALLBACK_BUDGET_SECS ))
+  printf '%s' "${DEADLINE}" > "${DEADLINE_FILE}"
+fi
+ATTEMPT_TIMEOUT=20                   # per-curl cap so one hang can't eat the budget
+# --config points at a root-only (0600) file that carries ONLY the
+# Authorization header:  header = "Authorization: Bearer <token>"
+# This keeps the token out of argv (visible via ps / /proc/*/cmdline) and
+# out of the environment. The endpoint is header-authenticated only; the
+# token is never placed in the URL query string.
+while :; do
+  if curl -sf -X POST \
+      --max-time "${ATTEMPT_TIMEOUT}" \
+      --cacert /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+      --config /etc/ibi-callback/auth.cfg \
+      -H "Content-Type: application/json" \
+      -d "${PAYLOAD}" \
+      "${CALLBACK_URL}"; then
+    exit 0
+  fi
+  [ "$(date +%s)" -ge "${DEADLINE}" ] && exit 1
+  sleep 30
+done
+```
+
+The ignition overlay therefore delivers three per-server files, all as data
+(not baked into the shared ISO — see [Challenge 4](#4-callback-url-injection-into-the-iso)):
+
+- `/etc/ibi-callback/env` (0644): `CALLBACK_URL=...`, `CALLBACK_ATTEMPT=...`,
+  and `CALLBACK_BUDGET_SECS=...` (the callback retry budget in seconds, derived
+  by the operator from the effective `PreProvisioningConfig.Timeout` minus a
+  margin so the host keeps resending for the entire window the operator waits)
+  — all non-secret.
+- `/etc/ibi-callback/auth.cfg` (0600, root-only): a curl config file whose
+  sole line is `header = "Authorization: Bearer <per-attempt-token>"`.
+- `/usr/local/bin/ibi-prep-callback` (0755): the script above (identical for
+  every server; safe to bake into the shared ISO).
+
+`CALLBACK_URL` is the operator's `callbackBaseURL` (see
+`PreProvisioningConfig.CallbackBaseURL`) with
+`/callbacks/<ici-namespace>/<ici-name>/status` appended — an externally-
+reachable address, not the in-cluster `<service>.<namespace>.svc` name,
+which resolves only inside the hub. In disconnected environments the server
+typically reaches the hub via an external route, so `callbackBaseURL` is
+that route hostname.
+
+The operator builds `CALLBACK_URL` with **URL-aware joining**, not string
+concatenation: it parses `callbackBaseURL`, rejects any value carrying a
+query or fragment, and collapses a trailing slash so
+`https://host/` and `https://host` both yield exactly one separator before
+`/callbacks/...` (naive concatenation would produce `https://host//callbacks`
+or splice the path into a query/fragment and never reach the endpoint). The
+admission-time validation below enforces the same constraints so a malformed
+base is rejected at write time rather than surfacing 60 minutes later as a
+`PreProvisioningTimedOut`.
+
+Delivering the snippet to a **live-iso** boot is the subtle part, and the
+mechanism must be chosen against what BMO/Ironic actually honor for
+`DiskFormat: live-iso`, not against what is available for a normal
+provisioned boot:
+
+- **`ignitionConfigOverride` baked into the ISO (authoritative path).** The
+  live ISO's embedded Ignition is the one delivery surface Ironic reliably
+  applies for a live-iso boot. The `ImageBasedInstallationConfig` supports
+  `ignitionConfigOverride`, so the callback systemd unit can be merged into
+  the ISO at build time. The cost is that the callback target must be known
+  at build time — which conflicts with a per-ICI URL/token baked into a
+  shared ISO (see [Challenge 4](#4-callback-url-injection-into-the-iso)).
+  The resolution is to bake only a **generic** callback client into the ISO
+  that reads its per-server URL and token from a well-known location, and
+  deliver only that small per-server data at boot.
+- **`DataImage` is not an ignition overlay.** A `DataImage` attaches an
+  extra virtual-media device; BMO does **not** merge its contents into the
+  live environment's Ignition, so it cannot be relied on to *inject* the
+  callback systemd unit. It can only carry data that the ISO's baked-in
+  generic client explicitly mounts and reads (e.g. a config drive the
+  client looks for).
+- **`spec.preprovisioningNetworkDataName` / `userData` / `networkData` /
+  `metaData` are not a safe assumption for live-iso.** For a live-iso boot
+  BMO/Ironic do not process these the way they do for a normal deploy, so
+  the design must not depend on them to carry the ignition override.
+
+**Recommended path:** bake a generic callback client into the ISO via
+`ignitionConfigOverride` at build time, and deliver the per-server callback
+URL + token at boot through a mechanism the client reads itself. Because the
+exact behavior of `live-iso` + `DataImage` + config-drive discovery is
+version-dependent in BMO/Ironic, this path **must be covered by a
+version-pinned integration test** against the supported BMO/Ironic version
+rather than assumed; if that test cannot be made to pass, the fallback is a
+unique per-ICI ISO with the URL/token baked directly into
+`ignitionConfigOverride`. This tension is tracked in
+[Open Question 2](#open-questions).
+
+#### Host network configuration for the callback
+
+Everything above assumes the live-ISO host can already reach
+`CALLBACK_URL` over the network. That is not automatic: the callback carrier
+(`DataImage`) delivers only the URL/token/attempt data, and — as noted above —
+`preprovisioningNetworkDataName` / `networkData` are **not** reliably honored
+for a live-iso boot, so they cannot be assumed to configure the host's IP,
+route, and DNS. Without a defined network path the callback never leaves the
+host and the operator times the (possibly successful) preparation out. The
+design therefore requires one of two explicit modes, selected per template:
+
+- **DHCP (default, must be validated).** DHCP on the provisioning network is
+  the assumed baseline. It is stated as an explicit prerequisite, and the
+  reachability check in
+  [Challenge 1](#1-callback-url-must-be-reachable-from-the-pre-provisioned-server)
+  is the gate: if the host cannot obtain an address and reach
+  `callbackBaseURL`, the
+  operator fails closed with `PreProvisioningConfigInvalid` rather than booting
+  a host that can never call back.
+- **Static networking (DHCP-less environments).** When DHCP is unavailable,
+  the host IP/route/DNS are supplied at ISO build time — as dracut
+  `ip=`/`nameserver=` kernel arguments and/or NetworkManager keyfiles injected
+  into the ISO via `coreos-installer iso customize`, carried in the same
+  `ignitionConfigOverride`/ISO-build path that bakes the generic callback
+  client. Because this configuration is baked, a static-network deployment
+  needs its own per-host or per-site ISO variant (it cannot ride the shared
+  ISO's per-host data files), which is called out as a cost of DHCP-less
+  operation.
+
+The supported live-ISO network path (whichever mode) is exercised by the same
+version-pinned integration test, so "the host can reach the hub" is verified,
+not assumed.
+
+#### 2. HTTP Callback Endpoint
+
+The IBI Operator's image server (`internal/imageserver/`) is extended with
+a callback handler:
+
+```go
+// POST /callbacks/{namespace}/{name}/status
+// The bearer token is carried ONLY in the Authorization header; the
+// endpoint accepts no ?token= query parameter (see auth notes below).
+type CallbackPayload struct {
+    Attempt string `json:"attempt"` // must equal status.preProvisioningAttempt
+    Status  string `json:"status"`  // "success" or "failure"
+    Message string `json:"message"` // detail message
+}
+```
+
+On receiving a callback:
+
+1. Look up the `ImageClusterInstall` by namespace/name
+2. Verify the ICI has `spec.preProvisioning` set and is in the
+   `PreProvisioningBooting` or `PreProvisioningInProgress` state
+3. Verify the payload `attempt` equals `status.preProvisioningAttempt` (and
+   that the bearer token is the one minted for that attempt); reject with
+   409/401 otherwise. This drops late callbacks from a superseded boot.
+4. Reject if `status.preProvisioningResult` for this attempt is **already
+   set** — only the **first** terminal callback wins.
+5. Store the result in `status.preProvisioningResult` (with its `attempt`)
+   using an **atomic compare-and-swap on the ICI `resourceVersion`** (a
+   status update with the read `resourceVersion` set as precondition). If the
+   update is rejected with a conflict, re-read and re-apply step 4: a
+   concurrent callback (e.g. duplicate retries from the host, or a
+   success/failure race) that already recorded a terminal result causes this
+   one to be dropped with 409. This guarantees exactly one terminal result is
+   recorded even under concurrent POSTs, rather than a last-writer-wins
+   overwrite.
+6. Trigger a reconciliation of the ICI (the reconciler picks up the
+   result and proceeds with the BMH state transition)
+
+The endpoint is authenticated using a **per-attempt** bearer token
+generated by the IBI Operator when the pre-provisioning phase starts. The
+token is presented in an HTTP `Authorization: Bearer <token>` header (not
+in the URL as a query parameter or path segment), so it does not leak into
+image-server access logs, proxy logs, or the ISO's cloud-init/journal
+output. The token is stored only in a per-ICI Secret owned by the ICI
+(not in `status`, which is world-readable to anyone with `get` on the ICI),
+delivered to the server inside the ignition overlay, compared in constant
+time on receipt, and invalidated once a terminal callback is accepted or
+the attempt times out. A fresh token is minted on every boot attempt so a
+token captured from an earlier attempt cannot drive a later one. Where the
+deployment can support it, mutual TLS (a client certificate provisioned
+into the ignition overlay) is preferred over the bearer token. See
+[Challenge 3](#3-callback-authentication-and-security).
+
+#### 3. BMH Image Configuration for ISO Boot
+
+The IBI Operator sets `spec.image` on the BMH to trigger Ironic's virtual
+media boot:
+
+```go
+patch := client.MergeFrom(bmh.DeepCopy())
+bmh.Spec.Image = &bmh_v1alpha1.Image{
+    URL:        preProvisioning.ISOURL,
+    DiskFormat: pointer.String("live-iso"),
+    // Populated from PreProvisioningConfig.ISODigest when set.
+    Checksum:     preProvisioning.ISODigest, // "sha256:<hex>"
+    ChecksumType: bmh_v1alpha1.SHA256,
+}
+bmh.Spec.Online = true
+err := r.Patch(ctx, bmh, patch)
+```
+
+The `live-iso` format instructs Ironic to mount the ISO via BMC virtual
+media (Redfish `VirtualMedia.InsertMedia`) and boot from it. The IBI
+preparation service within the ISO handles the actual disk installation.
+
+**Binding the boot to an immutable artifact.** When
+`PreProvisioningConfig.ISODigest` is set, the operator ensures the ISO
+actually booted is the exact artifact that was built and verified — a
+mutable HTTPS URL alone can be swapped for a stale or tampered ISO between
+build and boot. Because Ironic's `live-iso` path does **not** reliably
+enforce the BMH `Image.Checksum` the way the normal deploy path does, the
+operator does not depend solely on populating `Checksum` above: before
+setting `spec.image`, it **streams the ISO bytes from `ISOURL`** over an HTTPS
+channel and computes the SHA-256 **over those bytes**, comparing the result to
+`ISODigest` and failing closed with `PreProvisioningConfigInvalid` on mismatch.
+A published `.sha256` **sidecar is explicitly not trusted** as the verification
+source: comparing sidecar text to `ISODigest` only checks that two pieces of
+metadata agree, not that `ISOURL` actually returns those bytes — a stale or
+mispublished sidecar would pass while the URL serves an ISO that was never
+hashed. The bytes the operator will hand to the BMC are the bytes that must be
+hashed. This digest is the same value the seed-generation workflow records in
+`SeedGenerationStatus.ISODigest`, so the two proposals pin to one artifact
+end to end.
+
+**Restricting `ISOURL` before the operator fetches it.** Because `isoURL` is
+overridable through `hwMgmtParameters` on a `ProvisioningRequest`, an untrusted
+caller could otherwise point the operator's pre-fetch at an arbitrary HTTPS
+endpoint. Requiring HTTPS is not sufficient: a valid HTTPS URL can still name an
+internal service, making the operator's fetch a server-side request forgery
+(SSRF) vector. The operator therefore enforces two checks, **both before any
+byte of `ISOURL` is fetched**, failing closed with `PreProvisioningConfigInvalid`:
+
+- **Origin allowlist.** `ISOURL` must resolve to an operator-owned or
+  explicitly allowlisted ISO origin (the origins configured for the
+  seed-generation upload target, plus any operator-configured additions). A URL
+  outside that set is rejected before the fetch — the operator never issues a
+  request to a caller-chosen host. The allowlist is operator configuration, not
+  template or `ProvisioningRequest` input, so a request author cannot widen it.
+- **Mandatory digest for automated boot.** `ISODigest` is **required** whenever
+  the operator drives an automated boot from a caller-influenceable `ISOURL`;
+  URL-only trust is not accepted for that path. A missing digest is rejected up
+  front rather than silently falling back to URL-only trust, so the bytes handed
+  to the BMC are always pinned to a verified artifact.
+
+**The operator's pre-fetch is necessary but not sufficient on its own — the
+`ISOURL` must also be immutable.** There is an unavoidable time-of-check /
+time-of-use gap: the operator verifies the bytes at `ISOURL` *before* setting
+`spec.image`, but the BMC (via Ironic) fetches the bytes *later*, and BMO's
+`live-iso` path passes only `imageData.URL` as the Ironic `boot_iso` while
+clearing the checksum fields — so nothing in the boot path re-binds what the
+BMC actually pulls. If the content at `ISOURL` changes after the operator's
+check, the BMC can boot different bytes than were verified. The design
+therefore **requires `ISOURL` to be an immutable, content-addressed reference**
+(a per-run URL that never has its bytes rewritten), not a mutable "latest"
+URL. The seed-generation workflow already satisfies this: it uploads to a
+**unique per-run path** (ProvisioningRequest name + seed image digest +
+filename) that is written once and never overwritten, so the URL effectively
+addresses one immutable artifact. Immutability of `ISOURL` is a
+**producer-side contract** (the seed workflow guarantees it; a generic webhook
+cannot reliably prove a URL is immutable), and the operator's pre-fetch
+verification then confirms that immutable artifact matches `ISODigest`.
+Immutability closes the TOCTOU window; the pre-fetch confirms identity. Because
+`ISODigest` is mandatory for automated boot (above), the operator always
+verifies identity at check time; what a non-immutable `ISOURL` costs is the
+guarantee that the BMC's *later* fetch pulls those same verified bytes. A
+deployment that cannot guarantee an immutable, allowlisted URL therefore cannot
+offer automated IBI pre-provisioning through this path — it is rejected up
+front, not silently downgraded to URL-only trust.
+
+The HTTPS client used for this fetch trusts the **same private CA as the
+boot**: when `ISOServerCACertRef` is set, the operator reads the
+`ca-bundle.crt` key from that ConfigMap (resolved in the ICI's namespace,
+requiring `get` on `configmaps` there) and uses it as the root pool for the
+verification request; otherwise it uses the system trust store. Without this,
+digest verification against a private-CA ISO server would fail the TLS
+handshake before the BMH ever boots. This is distinct from the BMC's own
+trust of the ISO server (a pre-installed prerequisite, out of scope here) —
+`ISOServerCACertRef` configures the *operator's* client, not the BMC's.
+
+#### 4. BMH State Transition After Pre-Provisioning
+
+When the callback reports success:
+
+```go
+patch := client.MergeFrom(bmh.DeepCopy())
+bmh.Spec.Image = nil                    // clear ISO boot
+bmh.Spec.ExternallyProvisioned = true   // mark as pre-provisioned
+bmh.Spec.Online = false                 // power off until cluster install
+err := r.Patch(ctx, bmh, patch)
+```
+
+The BMH is now in the same state it would be if it had been manually
+pre-provisioned. The IBI Operator's existing `configureHost` flow proceeds
+unchanged — it creates the config DataImage, sets the reboot annotation,
+and monitors cluster installation.
+
+#### 5. Condition Reporting
+
+Pre-provisioning progress is reported via the ICI `RequirementsMet`
+condition (already used for pending states) — the **single** authoritative
+condition type for this handoff (see above); the phase is carried in the
+`reason`, not a separate condition type:
+
+| Phase | Condition | Reason | Terminal? |
+|---|---|---|---|
+| Booting from ISO | `RequirementsMet = False` | `PreProvisioningBooting` | No |
+| Waiting for callback | `RequirementsMet = False` | `PreProvisioningInProgress` | No |
+| Attempt failed/timed out, retry budget remains | `RequirementsMet = False` | `PreProvisioningRetrying` | No (backoff, then re-boot) |
+| Callback received (success) | `RequirementsMet = True` | `PreProvisioningSucceeded` | Yes |
+| Failure with retry budget exhausted | `RequirementsMet = False` | `PreProvisioningFailed` | Yes |
+| Timeout with retry budget exhausted | `RequirementsMet = False` | `PreProvisioningTimedOut` | Yes |
+
+`PreProvisioningRetrying` is a **non-terminal** state: while it is set the
+`ProvisioningRequest` keeps progressing (it does **not** map to `failed`).
+`PreProvisioningFailed`/`PreProvisioningTimedOut` are emitted **only** once the
+retry budget is exhausted, so the terminal-failure contract is never entered
+while a retry is still owed.
+
+The O-Cloud Manager must map these ICI conditions into
+`ProvisioningRequest` status; this is **not** covered by existing monitoring
+(see [O-Cloud Manager Changes](#o-cloud-manager-changes) for the required
+handoff — the PR controller today watches only a fixed set of
+`ClusterInstance` conditions and would otherwise ignore pre-provisioning
+state entirely).
+
+#### 6. Timeout Handling
+
+The reconciler checks `Status.PreProvisioningBootTime` against the
+configured `Timeout` (default: 60m) on each reconciliation.
+
+**The timeout must be self-triggering.** A callback is the only external
+event that wakes the reconciler; if no callback ever arrives, nothing would
+re-enqueue the ICI and it would remain `PreProvisioningInProgress` forever.
+While an attempt is in flight, every reconcile therefore returns
+`RequeueAfter` set to the remaining time until
+`PreProvisioningBootTime + Timeout` (bounded to a minimum floor so clock
+skew cannot produce a zero/negative delay and a tight requeue loop). This
+guarantees a reconcile fires at — or just after — the deadline even with no
+callback, no BMH change, and no other watched event. The no-callback path
+is explicitly covered by an envtest that advances the fake clock past the
+deadline and asserts the transition to `PreProvisioningTimedOut`.
+
+**Timeout and callback compete for the same terminal state.** The timeout
+teardown uses the **same resourceVersion compare-and-swap** on
+`preProvisioningResult` as the callback handler (see the callback flow
+above): it re-reads the ICI, and only if the attempt is still non-terminal
+does it write the terminal result, guarded by `resourceVersion`. A callback
+that lands in the same instant either wins the CAS (the timeout write then
+gets a conflict and is dropped) or loses it (the timeout wins and the late
+callback is rejected against the invalidated token). Exactly one of the two
+paths becomes the terminal writer, and **only that winner performs the
+teardown** below — the loser observes the already-terminal state and does
+nothing. This prevents double teardown and a torn state where, e.g., the
+token is invalidated by timeout while the callback is concurrently accepted.
+
+The winning timeout path then performs teardown. Because teardown spans
+several resources (ICI status, BMH spec, DataImage, token Secret), it must be
+**restart-safe**: a crash partway through must not leave a terminal ICI with
+live cleanup still owed. Two rules make it safe:
+
+- **Claiming the terminal state and *finishing* teardown are distinct.**
+  Winning the CAS records the terminal **reason** (`PreProvisioningTimedOut`)
+  *and* a `PreProvisioningTeardownComplete = false` marker in the same write.
+  The condition is reported as terminal, but the reconciler treats the attempt
+  as **not done** until the marker flips to `true`.
+- **Teardown is idempotent and re-driven until every action succeeds.** While
+  `PreProvisioningTeardownComplete` is `false`, each reconcile re-runs all
+  teardown actions (each a no-op if already applied) and only sets the marker
+  `true` once every one is confirmed:
+  1. Clear the ISO image (`spec.image = nil`)
+  2. Remove the per-attempt pre-provisioning DataImage
+  3. Power off the BMH (`spec.online = false`)
+  4. Invalidate/delete the per-attempt callback token Secret
+  5. Set `PreProvisioningTeardownComplete = true` (the **only** state that
+     stops teardown retries)
+
+Only step 5 stops the retries; a failure in any of steps 1-4 leaves the marker
+`false` and the next reconcile resumes teardown. This is the **same teardown as
+the failure-callback path** (see the flow above), which uses the same
+marker-gated loop: a completed teardown leaves no live ISO, no DataImage
+carrier, and no usable token behind, so a late or replayed callback for the
+abandoned attempt cannot be accepted. A **fault-injection test** kills the
+reconcile after the terminal claim but before teardown completes and asserts
+the next reconcile drives cleanup to completion. The ProvisioningRequest fails,
+and the server can be manually investigated.
+
+## O-Cloud Manager Changes
+
+The O-Cloud Manager changes are minimal:
+
+1. **Configuration passthrough**: Read `ibiPreProvisioning` from
+   `hwMgmtDefaults` / `hwMgmtParameters` and populate the
+   `ImageClusterInstall.spec.preProvisioning` fields. The **preferred** path
+   is for SiteConfig to render `preProvisioning` into the ICI at creation
+   time, so the field is present before the IBI Operator ever reconciles the
+   ICI. If instead the field must be patched onto an ICI that SiteConfig
+   already created, the patch introduces a race: the IBI Operator could
+   reconcile the ICI (and begin a normal, non-pre-provisioning install)
+   before the patch lands. The design therefore requires that when the
+   patch-after-create path is used, IBI reconciliation is **gated** until
+   `preProvisioning` is present — e.g. the ICI is created paused/annotated and
+   the O-Cloud Manager clears the gate only after the patch is applied — so
+   the operator never observes a pre-provisioning ICI without its
+   `preProvisioning` spec.
+2. **Validation**: Verify ConfigMaps referenced by `ibiPreProvisioning`
+   exist and are valid during ClusterTemplate validation.
+3. **Status handoff (new controller logic)**: define how the ICI's
+   pre-provisioning status maps onto `ProvisioningRequest` conditions and
+   `provisioningStatus`. This is a real gap, not a no-op: the
+   ProvisioningRequest controller today gates cluster-install progress on a
+   fixed set of `ClusterInstance` conditions
+   (`ClusterInstanceValidated`, `RenderedTemplates`,
+   `RenderedTemplatesValidated`, `RenderedTemplatesApplied`) and does **not**
+   look at `ImageClusterInstall` status. Without an explicit handoff the
+   request could advance to (or report) cluster installation while
+   pre-provisioning is still pending or has failed. The controller must
+   therefore, **before** it treats hardware as ready, block on the ICI
+   pre-provisioning state and translate it as follows:
+
+   | ICI pre-provisioning reason | PR `HardwareProvisioned` condition | PR `provisioningStatus.provisioningPhase` |
+   | --- | --- | --- |
+   | `PreProvisioningBooting` / `PreProvisioningInProgress` | `False`, reason `InProgress` | `progressing` |
+   | `PreProvisioningRetrying` | `False`, reason `InProgress` | `progressing` (attempt failed, backing off to retry) |
+   | `PreProvisioningSucceeded` | `True`, reason `Completed` | `progressing` (proceed to cluster install) |
+   | `PreProvisioningFailed` | `False`, reason `Failed` | `failed` |
+   | `PreProvisioningTimedOut` | `False`, reason `TimedOut` | `failed` |
+
+   Pre-provisioning is modelled as part of the hardware-provisioning gate:
+   the PR does not proceed to (or report) cluster installation until the ICI
+   reports `PreProvisioningSucceeded`. Crucially, `PreProvisioningRetrying` is
+   **non-terminal** — the PR keeps `progressing` across a failed attempt's
+   backoff, so the configured `MaxRetries`/`RetryBackoff` budget can actually
+   be used without the PR prematurely latching `failed`. Only
+   `PreProvisioningFailed`/`PreProvisioningTimedOut` (emitted after the retry
+   budget is exhausted) drive the PR to a terminal `failed` `provisioningStatus`
+   with the ICI message surfaced. `MaxRetries` and `RetryBackoff` are carried
+   in `ibiPreProvisioning` (the same `hwMgmtDefaults`/`hwMgmtParameters`
+   passthrough as the other fields, and present in the ClusterTemplate schema).
+   This mapping is the contract between the two controllers and must be covered
+   by an integration test, including the retry path.
+4. **Watch `ImageClusterInstall` to enqueue the owning
+   `ProvisioningRequest`.** The mapping in item 3 only runs when the PR
+   reconciles, and pre-provisioning transitions (callback success/failure,
+   timeout, retry) update **`ImageClusterInstall` status and nothing else**.
+   The `ProvisioningRequestReconciler` today watches `NodeAllocationRequest`
+   and `ClusterInstance` but **not** `ImageClusterInstall`, so without a new
+   watch a callback- or timeout-driven ICI status change would not wake the PR,
+   and the request would sit stale — never advancing on success nor reporting
+   failure — until some unrelated event happened to requeue it. The reconciler
+   therefore adds a watch on `ImageClusterInstall` with a mapper that enqueues
+   the owning `ProvisioningRequest` (resolved via the ICI→ClusterInstance→PR
+   ownership chain, or a field index on the PR name). Consistent with **DD-002**,
+   the enqueued `NamespacedName` omits the namespace because
+   `ProvisioningRequest` is cluster-scoped. An integration test asserts that a
+   callback-only and a timeout-only ICI status change — with no NAR or
+   ClusterInstance change — each wake the PR and drive the item-3 transition.
+
+No hub-side Jobs and no SSH infrastructure are introduced, but the status
+handoff above is new controller logic on the O-Cloud Manager side.
+
+## Integration with Seed Generation Proposal
+
+When both proposals are implemented, the full automated pipeline is:
+
+```text
+ProvisioningRequest (seed gen CT)     ProvisioningRequest (IBI CT)
+  ├─ Phase 1: Validation               ├─ Pre-provisioning (NAR)
+  ├─ Phase 2: ACM Cleanup              ├─ Hardware provisioning
+  ├─ Phase 3: Seed Generation          ├─ Cluster installation (IBI):
+  ├─ Phase 4: ISO Generation           │    ├─ ICI created with preProvisioning
+  ├─ Phase 5: Completion + Cleanup     │    ├─ IBI Operator: boot from ISO
+  └─ Status: seedImage + isoURL        │    ├─ IBI Operator: receive callback
+                                        │    ├─ IBI Operator: transition BMH
+                                        │    ├─ IBI Operator: config + install
+                                        │    └─ Cluster provisioned
+                                        └─ Post-provisioning (policies)
+```
+
+## Sample: ClusterTemplate with IBI Pre-Provisioning
+
+```yaml
+apiVersion: clcm.openshift.io/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: sno-ran-du-ibi.v4-Y-Z-1
+  namespace: sno-ran-du-v4-Y-Z
+spec:
+  name: sno-ran-du-ibi
+  version: v4-Y-Z-1
+  release: 4.Y.Z
+  templateDefaults:
+    hwMgmtDefaults:
+      hardwareProvisioningTimeout: "120m"
+      nodeGroupData:
+        - name: controller
+          role: master
+          resourceSelector:
+            resourceselector.clcm.openshift.io/server-type: XR8620t
+      ibiPreProvisioning:
+        isoURL: https://iso-server.example.com/ibi/rhcos-ibi-4.Y.Z.iso
+        isoDigest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+        isoServerCACertRef:
+          name: iso-server-ca-cert
+        preProvisioningTimeout: "60m"
+    clusterInstanceDefaults: clusterinstance-defaults-ibi-v1
+    policyTemplateDefaults: policytemplate-defaults-v1
+  templateParameterSchema:
+    properties:
+      # ... standard provisioning parameters ...
+      hwMgmtParameters:
+        properties:
+          ibiPreProvisioning:
+            type: object
+            properties:
+              isoURL:
+                type: string
+                minLength: 1
+              isoDigest:
+                type: string
+                pattern: '^sha256:[a-f0-9]{64}$'
+              isoServerCACertRef:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required: [name]
+              preProvisioningTimeout:
+                type: string
+            required: [isoURL]
+        type: object
+    type: object
+```
+
+## Challenges and Mitigations
+
+### 1. Callback URL must be reachable from the pre-provisioned server
+
+**Challenge**: The server running the IBI preparation service must be able
+to reach the IBI Operator's HTTP endpoint on the hub cluster. In
+disconnected environments, the server may be on a different network
+(provisioning/BMC network) than the hub's service network.
+
+**Mitigation**: The IBI Operator's image server is already exposed via a
+Route or NodePort for serving config ISOs to BMHs. The same network path
+that allows BMH/Ironic to fetch ISOs from the hub can be used for the
+callback. The callback URL uses the same externally-reachable hostname. If
+the provisioning network is isolated, a Route or LoadBalancer service
+exposes the callback endpoint — this is the same requirement that exists
+for DataImage ISO serving.
+
+This reachability is an explicit **precondition**, not an assumption. Note
+that BMH/Ironic fetches ISOs from the hub's *service* network via the BMC,
+whereas the callback originates from the *booted host* on the provisioning
+network — these can differ, so "Ironic can pull the ISO" does not by itself
+prove "the host can reach the callback." Before booting the ISO, the IBI
+Operator validates that the resolved callback endpoint is DNS-resolvable and
+its hostname is one the target network can route to, and that its TLS
+certificate chains to a CA the host will trust (the same bundle injected via
+`additionalTrustBundle`, see [Challenge 7](#7-hub-ca-trust-on-the-pre-provisioned-server)).
+If these checks fail, the ICI reports a configuration error up front rather
+than booting a server that can never call back. A `PreProvisioningTimedOut`
+is documented as ambiguous between "preparation never finished" and
+"callback could not be delivered," and the operator surfaces both
+possibilities.
+
+### 2. Callback delivery reliability
+
+**Challenge**: The callback `curl` command may fail due to transient
+network issues, DNS resolution delays during boot, or the hub being
+temporarily unavailable. A missed callback would leave the ICI stuck in
+`PreProvisioningInProgress` until timeout.
+
+**Mitigation**: The `ibi-prep-callback` script retries curl against an
+**absolute wall-clock deadline derived from `CALLBACK_BUDGET_SECS`** (a loop
+with a per-attempt `--max-time`), so cumulative retry effort is bounded
+regardless of how many individual attempts fail — something `TimeoutStartSec`
+(per single start) and `Restart=on-failure` (unbounded relaunches) cannot
+guarantee on their own. `CALLBACK_BUDGET_SECS` is the per-host budget delivered
+on the data carrier, derived by the operator from
+`PreProvisioningConfig.Timeout` (default 60m) anchored to `PreProvisioningBootTime`,
+so the host's retry window always tracks the operator's timeout rather than a
+fixed value that could expire before it (a hard-coded 10m deadline, for
+instance, would give up ~50m early on a default-timeout host and mark a prepared
+server as timed out). The script fails closed if `CALLBACK_BUDGET_SECS` is
+absent rather than substituting a default. `Restart=on-failure` plus
+`StartLimitIntervalSec`/`StartLimitBurst` remain only as a bounded backstop for
+an outright script crash. This covers
+transient network issues during boot. Additionally, the IBI Operator's
+reconcile loop checks the timeout — if no callback is received within the
+configured timeout, the ICI transitions to `PreProvisioningTimedOut`. The
+operator can distinguish "callback never arrived" (timeout) from
+"preparation failed" (failure callback).
+
+### 3. Callback authentication and security
+
+**Challenge**: The callback endpoint is publicly reachable (same as the
+image server). An attacker could send a fake success callback, causing the
+IBI Operator to proceed with cluster installation on an unprepared server.
+
+**Mitigation**: The IBI Operator generates a **per-attempt** authentication
+token (cryptographically random, or an HMAC over the ICI identity + attempt
+marker) when each pre-provisioning boot starts. Key properties:
+
+- **Header, not URL**: the token is sent in an `Authorization: Bearer`
+  header and verified with a constant-time comparison. It is never placed
+  in the URL (query parameter or path segment), where it would be captured
+  by image-server logs, intermediary proxies, and the server's own journal.
+- **Secret, not status**: the token is stored in a per-ICI Secret owned by
+  the ICI, not in `status.preProvisioningResult` or any status field —
+  status is readable by any principal with `get` on the ICI, which would
+  expose the shared secret needed to forge a success callback.
+- **Per-attempt and expiring**: a new token is minted on every boot attempt
+  and invalidated as soon as a terminal callback is accepted or the attempt
+  times out, so a token observed during one attempt cannot authorize a
+  callback for a later attempt (see also [Challenge 6](#6-server-state-after-failed-pre-provisioning)
+  on per-attempt binding).
+- **State check as defense in depth**: the handler additionally requires the
+  ICI to be in `PreProvisioningBooting` / `PreProvisioningInProgress` and
+  the token to match the *current* attempt before accepting the callback.
+- **mTLS preferred where available**: provisioning a short-lived client
+  certificate into the ignition overlay and requiring mutual TLS at the
+  endpoint is stronger than a bearer token and is the recommended option
+  when the environment supports it.
+
+### 4. Callback URL injection into the ISO
+
+**Challenge**: The callback URL is ICI-specific (contains namespace and
+name). If the ISO is built once and reused across multiple servers, the
+callback URL cannot be baked into the ISO at build time.
+
+**Mitigation**: The design must account for the fact that, for a
+`live-iso` boot, BMO does **not** merge `DataImage` contents (or
+`userData`/`networkData`/`metaData`) into the live environment's Ignition —
+only the ISO's baked-in Ignition (`ignitionConfigOverride`) is reliably
+applied (see [ISO ignition delivery](#1-callback-ignition-override)). So a
+DataImage cannot be used to *inject* the callback systemd unit into a shared
+ISO. Two viable options remain:
+
+- **Generic client baked in + per-server data read at boot (recommended
+  when validated).** The ISO carries, via `ignitionConfigOverride`, the
+  generic callback client (the `ibi-prep-callback` script and its
+  `ibi-prep-callback.service` unit — identical for every server). The
+  per-server data (`/etc/ibi-callback/env` and the root-only
+  `/etc/ibi-callback/auth.cfg`) is delivered at boot through a concrete,
+  specified carrier rather than "a well-known location":
+
+  - **Carrier**: a per-ICI `DataImage` (a tiny ISO9660/FAT image the IBI
+    Operator builds and attaches as an additional virtual-media device),
+    used **purely as a data device**, not as an ignition overlay. The
+    `DataImage` resource is **named and namespaced after the BareMetalHost**
+    (BMO v0.13.2's `DataImageReconciler` resolves the owning host by matching
+    the request name/namespace to a `BareMetalHost`, so a differently named
+    carrier never attaches); the attempt id it carries is bound through the
+    carrier content and an `ibi.openshift.io/attempt` label, not the resource
+    name. Its filesystem is labelled `ibi-callback` so it is addressable by
+    label regardless of device enumeration order. An integration test verifies
+    BMO attaches the image and the guest sees the `ibi-callback` device label.
+  - **Mount + materialize**: a baked-in `ibi-callback-data.service`
+    (`Type=oneshot` **with `RemainAfterExit=yes`**) mounts
+    `/dev/disk/by-label/ibi-callback` read-only, copies `env` to
+    `/etc/ibi-callback/env` (0644) and `auth.cfg` to
+    `/etc/ibi-callback/auth.cfg` (0600, root-only), then unmounts. Copying
+    to a root-only path — rather than reading the token off the shared
+    virtual-media device directly — keeps the 0600 permission guarantee.
+    `RemainAfterExit=yes` is load-bearing: without it a `Type=oneshot` unit
+    goes `inactive` the moment `ExecStart` returns, and because the reporter
+    declares `Requires=` on it, systemd would consider the dependency no longer
+    active and could stop the reporter before it runs. With
+    `RemainAfterExit=yes` the data unit stays `active (exited)` after
+    materialization, so the `Requires=`/`After=` pair holds for the whole boot.
+  - **Ordering and dependency (runtime, not `[Install]`)**: the dependency
+    must be expressed as a **runtime** relationship in the reporter's
+    `[Unit]` section — `ibi-prep-callback.service` declares
+    `Requires=ibi-callback-data.service` and
+    `After=ibi-callback-data.service`. It is a mistake to rely on
+    `RequiredBy=`/`WantedBy=` in the *data* unit's `[Install]` section for
+    this: `[Install]` directives take effect only when the unit is
+    `enable`d, so if enablement is ever missed the reporter would run before
+    (or without) its data files. Both units are additionally marked
+    `enabled: true` in the ignition so they are active on first boot, but the
+    correctness guarantee comes from the runtime `Requires=`/`After=`, not
+    from enablement. With `Requires=`, if the data mount fails (device
+    absent) the reporter is not started, surfacing as a timeout rather than a
+    callback with an empty URL/token. This enablement-plus-runtime-dependency
+    behavior must be covered by a systemd integration test that asserts the data
+    unit stays `active (exited)` after materialization and the reporter then
+    actually runs (not just that ordering is declared).
+
+  This keeps the ISO reusable. It depends on version-specific `live-iso` +
+  DataImage behavior in BMO/Ironic and therefore **must be backed by a
+  version-pinned integration test**.
+- **Unique per-ICI ISO (fallback).** If the generic-client path cannot be
+  validated on the supported BMO/Ironic version, the IBI Operator (or the
+  ISO build step) bakes the ICI-specific callback URL and token directly
+  into `ignitionConfigOverride`, producing one ISO per ICI. This is simpler
+  and robust but sacrifices ISO reuse.
+
+Using DataImage as an ignition overlay is not viable: BMO does not merge
+DataImage contents into live-iso Ignition, so a per-ICI callback URL and
+token cannot be injected that way.
+
+### 5. BMC CA trust for HTTPS virtual media
+
+**Challenge**: When the ISO server uses HTTPS with a private CA, the BMC
+must trust the CA certificate to fetch the ISO via virtual media. BMC CA
+trust configuration is vendor-specific.
+
+**Mitigation**: The `isoServerCACertRef` provides the CA cert, but supplying
+the cert is not the same as establishing BMC trust, and that trust must
+exist **before** `spec.image` is set (Ironic mounts the virtual media
+immediately). The design defines two concrete, ordered paths rather than
+leaving the flow implicit:
+
+- **Runtime injection (only where actually supported).** For BMCs whose
+  Redfish/vendor API exposes a certificate-management endpoint, trust can be
+  established at runtime **before** the virtual-media insert. This is *not*
+  something the IBI Operator implements generically here — BMO/Ironic and
+  the BMC driver own certificate handling, and support is vendor- and
+  firmware-specific. The IBI Operator relies on the underlying stack's
+  existing capability and does not attempt ad-hoc BMC certificate pushes.
+- **Pre-installed trust (the portable default).** Where runtime injection is
+  not available or not verifiable, the private CA must already be present in
+  the BMC trust store. This is documented as an explicit **prerequisite**,
+  and pre-provisioning does not silently proceed assuming HTTPS will work.
+
+There is **no portable contract** — across BMO, Ironic, and vendor BMC
+drivers — by which the IBI Operator can query whether a given BMC already
+trusts a given CA. Neither the `BareMetalHost` status, the Ironic node, nor
+any capability annotation exposes the BMC's virtual-media trust store, and
+Redfish certificate-management support is optional and vendor-specific. The
+design therefore does **not** claim the operator validates BMC trust before
+booting; asserting a precondition it cannot actually check would be false
+assurance. Instead:
+
+- **Pre-installed BMC trust is the single documented prerequisite** when the
+  ISO server uses a private CA. Establishing that trust (via the BMC's own
+  management interface, out of band) is the integrator's responsibility and
+  is stated as an explicit prerequisite of enabling pre-provisioning with an
+  HTTPS+private-CA ISO server.
+- If runtime injection *is* available on a given stack (the "Runtime
+  injection" path above), it is handled entirely by BMO/Ironic/the BMC
+  driver — outside this design — and remains subject to the same
+  prerequisite from the IBI Operator's perspective.
+
+Consequently, a BMC that does not trust the CA manifests as the ISO fetch
+failing and the flow reaching `PreProvisioningTimedOut`; the timeout message
+explicitly names "BMC could not fetch the ISO — verify the ISO server CA is
+present in the BMC trust store" so the failure is diagnosable rather than
+mysterious. The corresponding
+[seed-generation proposal](./automated-seed-image-generation.md) surfaces the
+ISO server CA in status precisely so this reference is available to whoever
+configures BMC trust out of band.
+
+### 6. Server state after failed pre-provisioning
+
+**Challenge**: If pre-provisioning fails mid-way, the server may be in an
+inconsistent state (partial RHCOS installation, incomplete seed image pull).
+
+**Mitigation**: The IBI preparation is idempotent — rebooting from the ISO
+restarts the process. On failure callback (or timeout), the IBI Operator
+first tears the attempt down cleanly (clears `spec.image`, removes the
+per-attempt data carrier, powers the BMH off, invalidates the per-attempt
+token — the host is left **not** `externallyProvisioned`), records the
+retry-pending marker (`Status.RetryNotBefore`) while **clearing** the retired
+`PreProvisioningAttempt` so the invalidated token is never re-driven, then can
+retry by re-triggering the ISO boot with a **fresh attempt**: a new per-attempt
+token and marker, and `Status.PreProvisioningBootTime` reset so the per-attempt
+timeout is measured from the new boot.
+
+**Retry is explicitly bounded — there is no infinite retry and no retry
+after a terminal result.** `PreProvisioningConfig` carries the retry policy
+so the operator does not have to invent unbounded behavior:
+
+- `MaxRetries` (default: `0`, i.e. a single attempt) caps the number of
+  additional attempts after the first. Retries stop as soon as this budget
+  is exhausted.
+- `RetryBackoff` (default: `5m`) is the delay between a failed attempt's
+  teardown and the next boot. It is persisted durably as
+  `Status.RetryNotBefore` (= failure time + `RetryBackoff`) in the same update
+  that clears the retired `PreProvisioningAttempt`, and also applied as a
+  `RequeueAfter` so the retry is self-triggering. The `RequeueAfter` is only a
+  wake-up hint; `RetryNotBefore` is the source of truth, so an operator restart
+  that loses the in-memory timer still waits out the remaining backoff and never
+  re-drives the retired attempt.
+- The per-attempt `Timeout` bounds each individual boot; the operator also
+  enforces an overall ceiling of
+  `(MaxRetries + 1) × Timeout + MaxRetries × RetryBackoff` so total retry
+  effort is finite even in the worst case.
+
+**A failed attempt with budget remaining is a distinct, non-terminal state —
+`PreProvisioningFailed`/`PreProvisioningTimedOut` are *not* recorded until the
+budget is exhausted.** This matters because those two reasons are terminal and
+map the `ProvisioningRequest` to `failed`; recording them on a failed attempt
+that still owes a retry would make the configured budget unusable (the PR would
+latch `failed` before the retry ever ran). Instead, a failed/timed-out attempt
+with `PreProvisioningRetryCount < MaxRetries` transitions to the non-terminal
+`PreProvisioningRetrying` reason, the PR keeps `progressing`, and the operator
+re-boots a fresh attempt after `RetryBackoff`. Only when the budget is
+exhausted does the operator write the terminal `PreProvisioningFailed` (or
+`PreProvisioningTimedOut`) result — via the compare-and-swap above — and let
+the PR map to `failed`.
+
+`Status.PreProvisioningRetryCount` records attempts consumed so the budget
+survives operator restarts. A retry is scheduled **only** from the
+non-terminal `PreProvisioningRetrying` state (reached only after a clean
+teardown) and **only** while the budget remains; once a terminal result
+(`PreProvisioningSucceeded` / `PreProvisioningFailed` /
+`PreProvisioningTimedOut`) has been written via the compare-and-swap above, no
+further attempt is booted.
+
+Each attempt is explicitly bound so a stale signal cannot be mistaken for
+the current one:
+
+- The callback carries the **current attempt's** token; the handler rejects
+  a callback whose token does not match the active attempt, so a late
+  callback from a prior boot cannot complete a new attempt.
+- The on-host reporter reads the prep service's result for the **current
+  boot only** (see [the ignition unit](#1-callback-ignition-override)), so a
+  "finished successfully" record left on disk from an earlier attempt does
+  not produce a false success.
+
+Once the last attempt's timeout is exceeded and the `MaxRetries` budget is
+exhausted (see above), the operator reports `PreProvisioningTimedOut` and
+the ProvisioningRequest fails. The server can be manually investigated or
+released for re-allocation.
+
+### 7. Hub CA trust on the pre-provisioned server
+
+**Challenge**: The callback URL uses HTTPS (the IBI Operator's image server
+is TLS-enabled). The pre-provisioned server needs to trust the hub's TLS
+certificate to send the callback.
+
+**Mitigation**: The callback systemd unit uses
+`--cacert /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` which
+includes the system trust bundle. If the hub uses a private CA, the CA cert
+must be included in the ISO's `additionalTrustBundle` field (already
+supported by `ImageBasedInstallationConfig`). This is the same requirement
+that exists for the server to pull images from the hub's registries.
+
+## Required Upstream Changes (IBI Operator)
+
+### Summary
+
+The following changes are required in the `stolostron/image-based-install-operator`
+repository:
+
+### 1. API Types (`api/v1alpha1/imageclusterinstall_types.go`)
+
+- Add `PreProvisioning *PreProvisioningConfig` to `ImageClusterInstallSpec`
+- Add `PreProvisioningConfig` struct with fields: `ISOURL`, `ISODigest`,
+  `ISOServerCACertRef`, `Timeout`, `CallbackBaseURL`, `MaxRetries`,
+  `RetryBackoff`
+- Add `PreProvisioningBootTime *metav1.Time` to `ImageClusterInstallStatus`
+  (written only after the BMH boot request has been applied — never in the
+  pre-boot status update that records a new `PreProvisioningAttempt`)
+- Add `PreProvisioningRetryCount int` to `ImageClusterInstallStatus`
+- Add `RetryNotBefore *metav1.Time` to `ImageClusterInstallStatus`: durable
+  retry-pending marker set (now + `RetryBackoff`) in the same update that clears
+  `PreProvisioningAttempt` on a budgeted failure, so recovery distinguishes a
+  retired attempt in backoff from an in-flight one; the remaining backoff is
+  recomputed from it after a restart. Cleared when the next attempt is recorded
+  (never set at the same time as `PreProvisioningAttempt`)
+- Add `PreProvisioningResult` struct to `ImageClusterInstallStatus`
+- Add `PreProvisioningTeardownComplete bool` to `ImageClusterInstallStatus`:
+  gates cessation of teardown retries for a terminal attempt. Written `false`
+  in the same update that claims a terminal reason; flipped to `true` only
+  once every teardown action (clear image, remove DataImage, power off,
+  delete the per-attempt token Secret) has succeeded. Reset to `false` (or
+  cleared) when a retry mints a fresh attempt; meaningful only once a
+  terminal reason is set
+- Add condition reason constants: `PreProvisioningPendingReason`,
+  `PreProvisioningBootingReason`, `PreProvisioningInProgressReason`,
+  `PreProvisioningRetryingReason`, `PreProvisioningSucceededReason`,
+  `PreProvisioningFailedReason`, `PreProvisioningTimedOutReason`
+
+### 2. Controller (`controllers/imageclusterinstall_controller.go`)
+
+- Add `preProvisionHost()` method:
+  - Generates the callback ignition override with a fresh per-attempt auth
+    token, stored in a per-ICI Secret (not in status)
+  - Delivers the per-server callback URL + token to the generic client baked
+    into the ISO (config-drive / data-carrier read at boot), or bakes a
+    unique per-ICI ISO as the fallback — it does **not** rely on a DataImage
+    as an ignition overlay (BMO does not merge DataImage contents into
+    live-iso Ignition)
+  - Patches BMH `spec.image` with the ISO URL and `live-iso` format
+  - Sets BMH `spec.online = true`
+  - Records `Status.PreProvisioningBootTime`
+  - Sets `RequirementsMet` condition with `PreProvisioningBooting` reason
+
+- Add `handlePreProvisioningCallback()` method:
+  - Called when a callback is received via the HTTP handler
+  - Validates the auth token
+  - Stores the result in `Status.PreProvisioningResult`
+  - Triggers ICI reconciliation
+
+- Add `transitionToIBIReady()` method:
+  - Clears BMH `spec.image`
+  - Sets BMH `spec.externallyProvisioned = true` (only here, after a
+    verified success callback — never in `validateBMH`/`validateHost`)
+  - Sets BMH `spec.online = false`
+  - Removes any per-attempt pre-provisioning data carrier and invalidates
+    the per-attempt callback token
+  - Sets condition with `PreProvisioningSucceeded` reason
+
+- Modify the main `Reconcile()` flow to:
+  - Insert the pre-provisioning phase before `configureHost()` when
+    `spec.preProvisioning` is set
+  - Check `Status.PreProvisioningResult` for callback results
+  - Handle timeout when no callback is received
+
+### 3. Image Server (`internal/imageserver/imageserver.go`)
+
+- Add callback HTTP handler:
+  - `POST /callbacks/{namespace}/{name}/status` (bearer token in the
+    `Authorization` header only — no `?token=` query parameter, so the
+    token never lands in access/proxy logs)
+  - Parse `CallbackPayload` from request body
+  - Look up ICI, verify the bearer token against the active attempt, verify
+    `payload.attempt == status.preProvisioningAttempt`, store result
+  - Trigger reconciliation via channel or annotation update
+
+### 4. Ignition Package (`internal/ignition/` — new)
+
+- New package for generating ignition config snippets, split along the
+  **build-time vs per-attempt** boundary so per-attempt secrets never enter
+  the shared, build-time ISO surface (see the recommended path in Challenge 4):
+  - `GenerateCallbackClient() ([]byte, error)` — the **build-time**,
+    attempt-independent surface baked into the shared ISO via
+    `ignitionConfigOverride`: the `ibi-prep-callback.service` systemd unit,
+    the `/usr/local/bin/ibi-prep-callback` script, and the generic callback
+    client. Identical for every server, contains no URL/token/attempt.
+  - `GenerateCallbackData(callbackURL, attempt, token string, budget time.Duration) ([]byte, error)`
+    — the **per-attempt** surface delivered at boot through the `DataImage`
+    carrier: the non-secret `/etc/ibi-callback/env` (`CALLBACK_URL`,
+    `CALLBACK_ATTEMPT`, and **`CALLBACK_BUDGET_SECS`**) and the root-only
+    `/etc/ibi-callback/auth.cfg` curl config carrying the bearer token.
+    `budget` is the callback retry window, derived from the effective
+    `PreProvisioningConfig.Timeout` minus a margin, so the host keeps resending
+    for the whole window the operator waits (see below). It is a **required**
+    part of the contract — the script does **not** silently fall back to a
+    fixed budget when it is absent — and a unit test asserts the generated
+    `env` file contains a non-empty `CALLBACK_BUDGET_SECS` matching the
+    requested budget. Regenerated per boot attempt; never baked into the shared
+    ISO.
+
+    Note the two clocks: the operator's timeout is anchored at
+    `PreProvisioningBootTime`, while the on-host callback loop can only start
+    once preparation finishes. To keep them aligned, the script anchors its
+    deadline to the host's **boot** time (via `/proc/uptime`), not to its own
+    first-run time — so a long preparation can neither push the host's retry
+    window past the operator's timeout nor collapse it to a short window.
+
+### 5. Webhook (`api/v1alpha1/imageclusterinstall_webhook.go`)
+
+- Validate `PreProvisioning` fields when set:
+  - `ISOURL` must be a valid HTTPS URL
+  - `ISODigest`, when set, must match `^sha256:[a-f0-9]{64}$`
+  - `Timeout` must be a valid duration if provided
+  - `MaxRetries` must be `>= 0`; `RetryBackoff`, when set, must be a valid
+    non-negative duration
+  - `CallbackBaseURL`, when set, must be an **absolute HTTPS URL with a valid
+    host** (reject `http://`, relative values, and empty/malformed hosts) and
+    must carry **no query or fragment** (a base path is allowed but is joined
+    URL-aware, collapsing any trailing slash). A
+    non-HTTPS base would transmit the per-attempt bearer token without TLS,
+    and a malformed base silently breaks callback delivery (surfacing only as
+    a `PreProvisioningTimedOut`), so this is rejected at admission rather than
+    discovered at boot. When `CallbackBaseURL` is instead sourced from
+    operator configuration (its fallback), the operator applies the **same**
+    validation at startup and refuses to run pre-provisioning with an invalid
+    value.
+
+### 6. RBAC
+
+- No new CRD permissions needed — the IBI Operator already manages BMH
+  objects, DataImages, and Secrets
+
+### 7. Tests
+
+- Unit tests for callback ignition generation
+- Unit tests for the pre-provisioning state machine
+- Unit tests for the callback HTTP handler (with mock HTTP client)
+- Integration tests for the full pre-provisioning → cluster installation
+  flow
+
+### Estimated Upstream Effort
+
+| Area | Est. lines |
+|---|---|
+| API types + webhook validation | ~70 |
+| Pre-provisioning controller methods | ~250 |
+| Callback HTTP handler | ~100 |
+| Ignition generation package | ~80 |
+| Tests | ~500 |
+| **Total** | **~1000** |
+
+## O-Cloud Manager Effort Estimate
+
+With the IBI Operator handling the mechanics, the O-Cloud Manager changes
+are minimal:
+
+| Area | Files | Est. lines | Complexity |
+|---|---|---|---|
+| API types — `IBIPreProvisioning` in `HwMgmtDefaults` | 1 file | ~25 | Low |
+| CT validation — ConfigMap checks, ISO URL validation | 1 file | ~40 | Low |
+| ClusterInstance rendering — pass preProvisioning config to ICI | 1 file | ~40 | Low |
+| Condition mapping — map ICI pre-provisioning reasons to PR status | 1 file | ~30 | Low |
+| Tests | 1 file | ~150 | Low |
+| Samples and docs | 2 files | ~80 | Low |
+
+**Total O-Cloud Manager: ~365 lines, roughly 1 working session.**
+
+Combined with the upstream IBI Operator changes (~1000 lines), the total
+effort is ~1365 lines.
+
+## Alternatives Considered
+
+### A. SSH-based monitoring from the IBI Operator
+
+The IBI Operator SSHs into each server to poll the preparation service
+status. Rejected because it requires SSH key management, hub-to-server
+network access (often blocked by firewalls in edge environments), IP
+discovery for live-booted servers, and an SSH client library dependency
+in the operator.
+
+### B. Pre-provisioning entirely in the O-Cloud Manager controller
+
+The O-Cloud Manager patches BMH `spec.image`, boots the server, and creates
+a hub-side SSH monitoring Job. Rejected because it duplicates BMH lifecycle
+management that the IBI Operator already owns, requires SSH-from-a-Job
+plumbing on the hub, and is not reusable by other IBI Operator consumers.
+
+### C. Pre-provisioning as part of the hardware manager / NAR flow
+
+Integrate pre-provisioning into the NAR controller. Rejected because the
+NAR controller handles hardware allocation and firmware updates, not
+image-based installation. The pre-provisioning step is logically part of the
+IBI installation lifecycle.
+
+### D. Pre-provisioning without monitoring (timeout-based)
+
+Wait a fixed duration then assume pre-provisioning succeeded. Rejected
+because it provides no failure detection, wastes time on fast completions,
+and risks proceeding to cluster installation on servers that failed
+pre-provisioning.
+
+### E. BMH provisioning state as completion signal
+
+Detect completion by monitoring BMH state transitions after the live-iso
+boot. Rejected because BMH transitions to `provisioned` when the boot
+*starts*, not when the preparation *finishes*. BMO has no visibility into
+the preparation service running inside the live environment.
+
+## Open Questions
+
+1. **Condition type for the status handoff — resolved.** The design
+   standardizes on the existing `RequirementsMet` condition with new
+   `PreProvisioning*` reason codes rather than adding a dedicated
+   `PreProvisioningCompleted` condition. A single authoritative field keeps the
+   IBI Operator (producer) and O-Cloud Manager (consumer) from watching
+   different conditions; the mild overloading of `RequirementsMet`'s meaning is
+   accepted in exchange for one unambiguous cross-layer contract (see
+   [Condition Reporting](#5-condition-reporting)).
+
+2. **Does the recommended carrier (generic client baked in +
+   per-server data on a labelled `DataImage`, read at boot — see
+   [Challenge 4](#4-callback-url-injection-into-the-iso)) work on the
+   supported BMO/Ironic version?** This must be settled by a version-pinned
+   integration test. Note the DataImage is used **purely as a data device**,
+   never as an ignition overlay (BMO does not merge DataImage contents into
+   live-iso Ignition). If the test cannot be made to pass, the fallback is a
+   unique per-ICI ISO with the URL/token baked directly into
+   `ignitionConfigOverride`, sacrificing ISO reuse.
+
+3. **Should the SiteConfig Operator's IBI templates be updated to support
+   the `preProvisioning` field natively?** If so, the config flows through
+   ClusterInstance → ICI cleanly. If not, the O-Cloud Manager needs to
+   patch the ICI after SiteConfig creates it — functional but less elegant.

--- a/docs/proposals/ibi-server-pre-provisioning.md
+++ b/docs/proposals/ibi-server-pre-provisioning.md
@@ -388,7 +388,10 @@ hwMgmtDefaults:
   # Passed through to ImageClusterInstall.spec.preProvisioning.
   ibiPreProvisioning:
     # Required: HTTPS URL of the live IBI ISO reachable from the BMC network.
-    isoURL: https://iso-server.example.com/ibi/rhcos-ibi-4.Y.Z.iso
+    # Must be an immutable, content-addressed per-run URL (see "Restricting
+    # ISOURL"), not a mutable "latest" path — here the seed workflow's per-run
+    # path (ProvisioningRequest name + seed image digest).
+    isoURL: https://iso-server.example.com/ibi/example-pr/sha256-abc123/rhcos-ibi.iso
     # Required: expected SHA-256 digest, verified before boot to pin the exact
     # artifact (admission rejects a config that omits it). Matches
     # SeedGenerationStatus.ISODigest from seed generation.
@@ -553,6 +556,10 @@ ImageClusterInstall created (with spec.preProvisioning set)
   → NEW: preProvisionHost (ordered so every write is recoverable — see
     "Crash-safety of the boot handoff" below; each step is idempotent and the
     next reconcile resumes from the first incomplete one):
+      # On the first reconcile where spec.preProvisioning is set but no attempt
+      # is yet in flight (case (c)-in-backoff or (d)-before-mint below), the
+      # condition is RequirementsMet = False / PreProvisioningPending
+      # (recognized, not yet booting) until step 2 records an attempt.
       # RECOVERY: classify the current state first:
       #   (a) Status.PreProvisioningAttempt set → in-flight attempt: resume it.
       #       Do NOT mint a new id/token; reuse the attempt and its token Secret
@@ -584,17 +591,15 @@ ImageClusterInstall created (with spec.preProvisioning set)
           → do NOT set PreProvisioningBootTime yet (see step 5)
       → 3. deliver the per-host callback data (URL, attempt id, token,
          CALLBACK_BUDGET_SECS) on a DataImage carrier (create-or-adopt), NOT via
-         preprovisioningNetworkDataName (that field is an nmstate network-data
-         Secret and does not inject callback config into a live-iso boot — see
-         Challenge 4). The DataImage MUST be named and namespaced after the
-         BareMetalHost: BMO v0.13.2's DataImageReconciler resolves the owning
-         host by matching the request name/namespace to a BareMetalHost, so an
-         attempt-id-named DataImage would never attach. The attempt id is bound
-         instead through carrier content and a label (e.g.
-         `ibi.openshift.io/attempt: <id>`), which the create-or-adopt step also
-         uses to detect and replace a stale carrier from a prior attempt. The
-         generic callback client is already baked into the live ISO via
-         ignitionConfigOverride at build time (identical for every host).
+         preprovisioningNetworkDataName (an nmstate network-data Secret that a
+         live-iso boot ignores — see Challenge 4). The DataImage MUST be named and
+         namespaced after the BareMetalHost (BMO v0.13.2's DataImageReconciler
+         matches request name/namespace to a BareMetalHost, so any other name
+         never attaches); the attempt id is bound through carrier content and an
+         `ibi.openshift.io/attempt` label, which create-or-adopt also uses to
+         replace a stale carrier from a prior attempt. The generic callback client
+         is already baked into the live ISO via ignitionConfigOverride (identical
+         for every host).
       → 4. mutate the BMH (idempotent patch):
           → set BMH spec.image.url = isoURL, spec.image.format = "live-iso"
           → set BMH spec.online = true
@@ -603,7 +608,9 @@ ImageClusterInstall created (with spec.preProvisioning set)
          anchor, so it must mark an actual boot request, not merely recorded
          intent; a resumed attempt whose steps 3-4 completed but whose BootTime
          is unset verifies the BMH is booting the expected ISO and then stamps
-         BootTime.
+         BootTime. In the SAME update, advance the condition to
+         RequirementsMet = False / PreProvisioningInProgress (boot confirmed; now
+         waiting for the callback) — the Booting→InProgress transition.
   → NEW: waitForCallback:
       → IBI Operator HTTP server receives POST to
         /callbacks/<namespace>/<name>/status
@@ -888,22 +895,18 @@ not what a normal provisioned boot offers:
 
 - **`ignitionConfigOverride` baked into the ISO (authoritative path).** The
   live ISO's embedded Ignition is the one delivery surface Ironic reliably
-  applies for a live-iso boot; `ImageBasedInstallationConfig` supports
-  `ignitionConfigOverride`, so the callback systemd unit can be merged in at
-  build time. The cost is the callback target must be known at build time —
-  which conflicts with a per-ICI URL/token in a shared ISO (see
-  [Challenge 4](#4-callback-url-injection-into-the-iso)). The resolution:
-  bake only a **generic** callback client that reads its per-server URL and
-  token from a well-known location, and deliver that small data at boot.
-- **`DataImage` is not an ignition overlay.** It attaches an extra
-  virtual-media device; BMO does **not** merge its contents into the live
-  environment's Ignition, so it cannot *inject* the callback systemd unit — it
-  can only carry data the ISO's baked-in generic client explicitly mounts and
-  reads (e.g. a config drive).
-- **`spec.preprovisioningNetworkDataName` / `userData` / `networkData` /
-  `metaData` are not safe for live-iso.** BMO/Ironic do not process these for
-  a live-iso boot as they do for a normal deploy, so the design must not depend
-  on them to carry the ignition override.
+  applies for a live-iso boot, and `ImageBasedInstallationConfig` supports
+  `ignitionConfigOverride`, so the callback systemd unit is merged in at build
+  time. Since a per-ICI URL/token cannot be baked into a shared ISO (see
+  [Challenge 4](#4-callback-url-injection-into-the-iso)), only a **generic**
+  callback client is baked in; it reads its per-server URL and token from a
+  well-known location delivered at boot.
+- **Other surfaces cannot inject ignition.** A `DataImage` attaches an extra
+  virtual-media device but BMO does **not** merge its contents into the live
+  Ignition (it can only carry data the baked-in client mounts and reads);
+  `spec.preprovisioningNetworkDataName` / `userData` / `networkData` / `metaData`
+  are likewise not processed for a live-iso boot as they are for a normal deploy.
+  The design must not depend on any of them to carry the ignition override.
 
 Because the exact behavior of `live-iso` + `DataImage` + config-drive discovery
 is version-dependent in BMO/Ironic, this recommended path **must be covered by a
@@ -994,7 +997,9 @@ patch := client.MergeFrom(bmh.DeepCopy())
 bmh.Spec.Image = &bmh_v1alpha1.Image{
     URL:        preProvisioning.ISOURL,
     DiskFormat: pointer.String("live-iso"),
-    // Populated from PreProvisioningConfig.ISODigest when set.
+    // Best-effort only: Ironic's live-iso path does NOT reliably enforce these
+    // and BMO clears them before passing boot_iso (see prose below). The real
+    // guarantee is the operator's stream-and-verify of ISOURL before this patch.
     Checksum:     preProvisioning.ISODigest, // "sha256:<hex>"
     ChecksumType: bmh_v1alpha1.SHA256,
 }
@@ -1097,8 +1102,9 @@ condition type for this handoff (see above); the phase is carried in the
 
 | Phase | Condition | Reason | Terminal? |
 |---|---|---|---|
-| Booting from ISO | `RequirementsMet = False` | `PreProvisioningBooting` | No |
-| Waiting for callback | `RequirementsMet = False` | `PreProvisioningInProgress` | No |
+| Recognized, no attempt in flight yet | `RequirementsMet = False` | `PreProvisioningPending` | No |
+| Boot request being applied (BootTime not yet stamped) | `RequirementsMet = False` | `PreProvisioningBooting` | No |
+| Boot confirmed, waiting for callback | `RequirementsMet = False` | `PreProvisioningInProgress` | No |
 | Attempt failed/timed out, retry budget remains | `RequirementsMet = False` | `PreProvisioningRetrying` | No (backoff, then re-boot) |
 | Callback received (success) | `RequirementsMet = True` | `PreProvisioningSucceeded` | Yes |
 | Failure with retry budget exhausted | `RequirementsMet = False` | `PreProvisioningFailed` | Yes |
@@ -1133,15 +1139,14 @@ the transition to `PreProvisioningTimedOut`.
 
 **Timeout and callback compete for the same terminal state.** The timeout
 teardown uses the **same resourceVersion compare-and-swap** on
-`preProvisioningResult` as the callback handler: it re-reads the ICI and, only if
-the attempt is still non-terminal, writes the terminal result guarded by
-`resourceVersion`. A callback landing in the same instant either wins the CAS
-(the timeout write then conflicts and is dropped) or loses it (the timeout wins
-and the late callback is rejected against the invalidated token). Exactly one
-path becomes the terminal writer, and **only that winner performs the teardown**
-below — the loser observes the already-terminal state and does nothing. This
-prevents double teardown and a torn state where, e.g., the token is invalidated
-by timeout while the callback is concurrently accepted.
+`preProvisioningResult` as the callback handler: it writes the terminal result
+only if the attempt is still non-terminal, guarded by `resourceVersion`. A
+callback landing in the same instant either wins the CAS (the timeout write
+conflicts and is dropped) or loses it (the timeout wins and the late callback is
+rejected against the invalidated token). Exactly one path becomes the terminal
+writer, and **only that winner performs the teardown** below — the loser observes
+the already-terminal state and does nothing, preventing double teardown and a torn
+state.
 
 The winning timeout path then performs teardown. Because teardown spans several
 resources (ICI status, BMH spec, DataImage, token Secret), it must be
@@ -1204,7 +1209,7 @@ The O-Cloud Manager changes are minimal:
 
    | ICI pre-provisioning reason | PR `HardwareProvisioned` condition | PR `provisioningStatus.provisioningPhase` |
    | --- | --- | --- |
-   | `PreProvisioningBooting` / `PreProvisioningInProgress` | `False`, reason `InProgress` | `progressing` |
+   | `PreProvisioningPending` / `PreProvisioningBooting` / `PreProvisioningInProgress` | `False`, reason `InProgress` | `progressing` |
    | `PreProvisioningRetrying` | `False`, reason `InProgress` | `progressing` (attempt failed, backing off to retry) |
    | `PreProvisioningSucceeded` | `True`, reason `Completed` | `progressing` (proceed to cluster install) |
    | `PreProvisioningFailed` | `False`, reason `Failed` | `failed` |
@@ -1281,7 +1286,8 @@ spec:
           resourceSelector:
             resourceselector.clcm.openshift.io/server-type: XR8620t
       ibiPreProvisioning:
-        isoURL: https://iso-server.example.com/ibi/rhcos-ibi-4.Y.Z.iso
+        # Immutable, content-addressed per-run URL (see "Restricting ISOURL").
+        isoURL: https://iso-server.example.com/ibi/example-pr/sha256-abc123/rhcos-ibi.iso
         isoDigest: sha256:0000000000000000000000000000000000000000000000000000000000000000
         isoServerCACertRef:
           name: iso-server-ca-cert
@@ -1330,24 +1336,22 @@ disconnected environments, the server may be on a different network
 (provisioning/BMC network) than the hub's service network.
 
 **Mitigation**: The IBI Operator's image server is already exposed via a Route
-or NodePort for serving config ISOs to BMHs; the same network path that lets
-BMH/Ironic fetch ISOs from the hub can carry the callback over the same
-externally-reachable hostname. If the provisioning network is isolated, a Route
-or LoadBalancer exposes the callback endpoint — the same requirement as DataImage
-ISO serving.
+or NodePort for serving config ISOs to BMHs; the same externally-reachable
+hostname that lets BMH/Ironic fetch ISOs carries the callback. If the
+provisioning network is isolated, a Route or LoadBalancer exposes the callback
+endpoint — the same requirement as DataImage ISO serving.
 
 This reachability is an explicit **precondition**, not an assumption. BMH/Ironic
 fetches ISOs from the hub's *service* network via the BMC, whereas the callback
 originates from the *booted host* on the provisioning network — these can differ,
 so "Ironic can pull the ISO" does not prove "the host can reach the callback."
 Before booting, the IBI Operator validates that the resolved callback endpoint is
-DNS-resolvable, its hostname routable from the target network, and its TLS
-certificate chains to a CA the host will trust (the bundle injected via
-`additionalTrustBundle`, see [Challenge 7](#7-hub-ca-trust-on-the-pre-provisioned-server)).
-If these fail, the ICI reports a configuration error up front rather than booting
-a server that can never call back. `PreProvisioningTimedOut` is documented as
-ambiguous between "preparation never finished" and "callback could not be
-delivered," and the operator surfaces both possibilities.
+DNS-resolvable, routable from the target network, and TLS-trusted by the host
+(the bundle injected via `additionalTrustBundle`, see
+[Challenge 7](#7-hub-ca-trust-on-the-pre-provisioned-server)), failing closed with
+a configuration error rather than booting a server that can never call back.
+`PreProvisioningTimedOut` is documented as ambiguous between "preparation never
+finished" and "callback could not be delivered," and the operator surfaces both.
 
 ### 2. Callback delivery reliability
 
@@ -1358,20 +1362,16 @@ temporarily unavailable. A missed callback would leave the ICI stuck in
 
 **Mitigation**: The `ibi-prep-callback` script retries curl against an
 **absolute wall-clock deadline derived from `CALLBACK_BUDGET_SECS`** (a loop with
-a per-attempt `--max-time`), so cumulative retry effort is bounded regardless of
-how many attempts fail — something `TimeoutStartSec` (per single start) and
-`Restart=on-failure` (unbounded relaunches) cannot guarantee alone.
-`CALLBACK_BUDGET_SECS` is the per-host budget delivered on the data carrier,
-derived from `PreProvisioningConfig.Timeout` (default 60m) anchored to
-`PreProvisioningBootTime`, so the host's retry window tracks the operator's
-timeout rather than a fixed value that could expire before it (a hard-coded 10m
-deadline would give up ~50m early on a default-timeout host). The script fails
-closed if `CALLBACK_BUDGET_SECS` is absent; `Restart=on-failure` plus
-`StartLimitIntervalSec`/`StartLimitBurst` remain only a bounded backstop for an
-outright script crash. Additionally, the operator's reconcile loop checks the
-timeout — if no callback arrives within it, the ICI transitions to
-`PreProvisioningTimedOut` — so it can distinguish "callback never arrived"
-(timeout) from "preparation failed" (failure callback).
+a per-attempt `--max-time`), so cumulative retry effort is bounded — something
+`TimeoutStartSec` and `Restart=on-failure` cannot guarantee alone (see
+[the reporter script](#1-callback-ignition-override)). The budget is the per-host
+value delivered on the data carrier, derived from `PreProvisioningConfig.Timeout`
+(default 60m) and anchored to `PreProvisioningBootTime`, so the host's retry
+window tracks the operator's timeout rather than a fixed value that could expire
+before it. The script fails closed if `CALLBACK_BUDGET_SECS` is absent. The
+operator's reconcile loop independently enforces the timeout, so it can
+distinguish "callback never arrived" (timeout) from "preparation failed" (failure
+callback).
 
 ### 3. Callback authentication and security
 

--- a/docs/proposals/ibi-server-pre-provisioning.md
+++ b/docs/proposals/ibi-server-pre-provisioning.md
@@ -6,6 +6,52 @@ SPDX-License-Identifier: Apache-2.0
 
 # Proposal: Automated IBI Server Pre-Provisioning via ProvisioningRequest API
 
+## Table of Contents
+
+- [Background](#background)
+- [Problem Statement](#problem-statement)
+- [Architecture](#architecture)
+  - [Why the IBI Operator](#why-the-ibi-operator)
+  - [Monitoring Approach: HTTP Callback](#monitoring-approach-http-callback)
+  - [Component Responsibilities](#component-responsibilities)
+- [Proposed API Changes](#proposed-api-changes)
+  - [IBI Operator: ImageClusterInstall CRD Changes](#ibi-operator-imageclusterinstall-crd-changes)
+  - [O-Cloud Manager: ClusterTemplate Configuration](#o-cloud-manager-clustertemplate-configuration)
+  - [Schema in templateParameterSchema](#schema-in-templateparameterschema)
+- [IBI Operator Workflow Changes](#ibi-operator-workflow-changes)
+  - [Current Flow (no pre-provisioning)](#current-flow-no-pre-provisioning)
+  - [New Flow (with pre-provisioning)](#new-flow-with-pre-provisioning)
+  - [Key Implementation Details in the IBI Operator](#key-implementation-details-in-the-ibi-operator)
+- [O-Cloud Manager Changes](#o-cloud-manager-changes)
+- [Integration with Seed Generation Proposal](#integration-with-seed-generation-proposal)
+- [Sample: ClusterTemplate with IBI Pre-Provisioning](#sample-clustertemplate-with-ibi-pre-provisioning)
+- [Challenges and Mitigations](#challenges-and-mitigations)
+  - [1. Callback URL must be reachable from the pre-provisioned server](#1-callback-url-must-be-reachable-from-the-pre-provisioned-server)
+  - [2. Callback delivery reliability](#2-callback-delivery-reliability)
+  - [3. Callback authentication and security](#3-callback-authentication-and-security)
+  - [4. Callback URL injection into the ISO](#4-callback-url-injection-into-the-iso)
+  - [5. BMC CA trust for HTTPS virtual media](#5-bmc-ca-trust-for-https-virtual-media)
+  - [6. Server state after failed pre-provisioning](#6-server-state-after-failed-pre-provisioning)
+  - [7. Hub CA trust on the pre-provisioned server](#7-hub-ca-trust-on-the-pre-provisioned-server)
+- [Required Upstream Changes (IBI Operator)](#required-upstream-changes-ibi-operator)
+  - [Summary](#summary)
+  - [1. API Types](#1-api-types-apiv1alpha1imageclusterinstall_typesgo)
+  - [2. Controller](#2-controller-controllersimageclusterinstall_controllergo)
+  - [3. Image Server](#3-image-server-internalimageserverimageservergo)
+  - [4. Ignition Package](#4-ignition-package-internalignition--new)
+  - [5. Webhook](#5-webhook-apiv1alpha1imageclusterinstall_webhookgo)
+  - [6. RBAC](#6-rbac)
+  - [7. Tests](#7-tests)
+  - [Estimated Upstream Effort](#estimated-upstream-effort)
+- [O-Cloud Manager Effort Estimate](#o-cloud-manager-effort-estimate)
+- [Alternatives Considered](#alternatives-considered)
+  - [A. SSH-based monitoring from the IBI Operator](#a-ssh-based-monitoring-from-the-ibi-operator)
+  - [B. Pre-provisioning entirely in the O-Cloud Manager controller](#b-pre-provisioning-entirely-in-the-o-cloud-manager-controller)
+  - [C. Pre-provisioning as part of the hardware manager / NAR flow](#c-pre-provisioning-as-part-of-the-hardware-manager--nar-flow)
+  - [D. Pre-provisioning without monitoring (timeout-based)](#d-pre-provisioning-without-monitoring-timeout-based)
+  - [E. BMH provisioning state as completion signal](#e-bmh-provisioning-state-as-completion-signal)
+- [Open Questions](#open-questions)
+
 ## Background
 
 The IBI-based cluster provisioning workflow (documented in
@@ -93,8 +139,8 @@ This approach:
   server must reach the hub's callback endpoint over HTTPS (DNS, IP routing
   from the provisioning network to the hub Route/Service, and TLS trust of
   the hub certificate) — the same *direction* already needed to pull images
-  from the hub, but a concrete precondition, not a given: an environment that
-  blocks provisioning-network → hub egress, or resolves/routes the endpoint
+  from the hub, but a concrete precondition: an environment that blocks
+  provisioning-network → hub egress, or resolves/routes the endpoint
   differently from the image registries, will drop callbacks. The IBI
   Operator therefore validates that the callback endpoint is resolvable,
   routable, and TLS-trusted from the target's network **before** booting the
@@ -168,14 +214,13 @@ type PreProvisioningConfig struct {
     ISOURL string `json:"isoURL"`
 
     // ISODigest is the expected SHA-256 digest ("sha256:<hex>") of the live ISO
-    // served at ISOURL. The operator verifies the fetched ISO against it before
-    // setting the BMH image, so a mutated or stale artifact at that URL cannot be
-    // booted. Same digest the seed-generation workflow records in
-    // SeedGenerationStatus.ISODigest, pinning the boot to the exact built and
-    // verified artifact. Required for automated boot: admission rejects a config
-    // that omits it (PreProvisioningConfigInvalid) rather than falling back to
-    // URL-only trust. The json tag keeps omitempty only so the zero value is
-    // caught by the required-field check, not silently defaulted.
+    // at ISOURL. The operator verifies the fetched ISO against it before setting
+    // the BMH image, so a mutated or stale artifact cannot be booted. Same digest
+    // the seed-generation workflow records in SeedGenerationStatus.ISODigest,
+    // pinning the boot to the exact verified artifact. Required for automated
+    // boot: admission rejects a config that omits it (PreProvisioningConfigInvalid)
+    // rather than falling back to URL-only trust. omitempty is kept only so the
+    // zero value is caught by the required-field check, not silently defaulted.
     ISODigest string `json:"isoDigest,omitempty"`
 
     // ISOServerCACertRef is a reference to a ConfigMap containing the
@@ -342,15 +387,13 @@ hwMgmtDefaults:
   # Optional: IBI pre-provisioning configuration.
   # Passed through to ImageClusterInstall.spec.preProvisioning.
   ibiPreProvisioning:
-    # Required: HTTPS URL of the live IBI ISO accessible from the BMC
-    # management network.
+    # Required: HTTPS URL of the live IBI ISO reachable from the BMC network.
     isoURL: https://iso-server.example.com/ibi/rhcos-ibi-4.Y.Z.iso
-    # Optional (recommended): expected SHA-256 digest of the ISO, verified
-    # before boot to pin the exact artifact. Matches
-    # SeedGenerationStatus.ISODigest from the seed-generation workflow.
+    # Required: expected SHA-256 digest, verified before boot to pin the exact
+    # artifact (admission rejects a config that omits it). Matches
+    # SeedGenerationStatus.ISODigest from seed generation.
     isoDigest: sha256:0000000000000000000000000000000000000000000000000000000000000000
-    # Optional: reference to a ConfigMap containing the CA certificate
-    # bundle for the HTTPS ISO server.
+    # Optional: ConfigMap (key ca-bundle.crt) with the ISO server CA.
     isoServerCACertRef:
       name: iso-server-ca-cert
     # Optional: timeout for pre-provisioning a single server.
@@ -409,16 +452,16 @@ matches an operator-maintained **allowlist** of callback origins (the same
 with `PreProvisioningConfigInvalid` and the ISO is never booted (an admission
 test covers a spoofed off-allowlist origin).
 
-If none of these yields a URL reachable from the target provisioning network,
-the operator **fails closed**: it does not boot the ISO and reports
-`PreProvisioningConfigInvalid`, rather than booting a host that can never call
-back and timing out 60 minutes later. The in-cluster fallback is accepted only
-when the Challenge 1 reachability check confirms the host is on the hub network.
+If none yields a URL reachable from the target provisioning network, the operator
+**fails closed**: it reports `PreProvisioningConfigInvalid` rather than booting a
+host that can never call back and times out 60 minutes later. The in-cluster
+fallback is accepted only when the Challenge 1 reachability check confirms the
+host is on the hub network.
 
-Keeping the names distinct is intentional: `preProvisioningTimeout` reads clearly
-alongside `hardwareProvisioningTimeout` in the hardware-timeouts block, while
-`timeout` is scoped by its `preProvisioning` parent on the ICI. The mapping table
-above is the authoritative contract between the two field sets.
+The names are kept distinct intentionally: `preProvisioningTimeout` reads clearly
+alongside `hardwareProvisioningTimeout`, while `timeout` is scoped by its
+`preProvisioning` parent on the ICI; the mapping table above is the authoritative
+contract.
 
 ### Schema in templateParameterSchema
 
@@ -473,13 +516,12 @@ controller applies the `PreProvisioningConfig` defaults (`maxRetries: 0`,
 `retryBackoff: 5m`).
 
 Because `isoURL` and `isoDigest` are caller-overridable through
-`hwMgmtParameters`, validation also enforces the two artifact-trust checks before
-the operator fetches the URL (see "Restricting `ISOURL`"): `isoURL` must resolve
-to an operator-owned or allowlisted origin, and `isoDigest` is required (schema
-marks it required; the webhook and passthrough re-check, rejecting a missing or
-off-allowlist value with `PreProvisioningConfigInvalid`). The allowlist is
-operator configuration and cannot be widened by a template or
-`ProvisioningRequest`.
+`hwMgmtParameters`, validation enforces the two artifact-trust checks before the
+operator fetches the URL (see "Restricting `ISOURL`"): `isoURL` must resolve to an
+operator-owned or allowlisted origin, and `isoDigest` is required (schema, webhook
+and passthrough all re-check, rejecting a missing or off-allowlist value with
+`PreProvisioningConfigInvalid`). The allowlist is operator configuration and
+cannot be widened by a template or `ProvisioningRequest`.
 
 ## IBI Operator Workflow Changes
 
@@ -615,39 +657,36 @@ invariants:
   status, so an attempt id can never reference a token that was never stored. If
   the step-2 status write is lost after the Secret exists, the next reconcile
   finds the pending Secret by owner + label and **adopts its attempt id** rather
-  than minting a second token (no orphaned Secret, no duplicate token).
+  than minting a second token.
 - **Attempt id is the recovery key for an in-flight attempt.** Once
-  `PreProvisioningAttempt` is set, every subsequent reconcile **resumes the same
-  attempt** — reusing the existing id and token Secret and re-driving steps 3-5
-  idempotently (create-or-adopt the BMH-named DataImage whose attempt-id label
-  identifies the current attempt, idempotent BMH patch) — rather than minting a
-  fresh attempt while the previous ISO may still be booting.
-- **A retired attempt is never resumed.** On a retry, the failed attempt's
+  `PreProvisioningAttempt` is set, every reconcile **resumes the same attempt** —
+  reusing the id and token Secret and re-driving steps 3-5 idempotently
+  (create-or-adopt the BMH-named DataImage whose attempt-id label identifies the
+  current attempt, idempotent BMH patch) — rather than minting a fresh attempt
+  while the previous ISO may still be booting.
+- **A retired attempt is never resumed.** On retry, the failed attempt's
   `PreProvisioningAttempt` is cleared in the same update that sets
-  `RetryNotBefore`, so recovery cannot mistake the retired attempt (token
-  already invalidated) for an in-flight one. Recovery distinguishes three
-  post-failure states purely from persisted status: attempt set = resume;
-  attempt unset + `RetryNotBefore` in the future = wait out the backoff;
-  attempt unset + `RetryNotBefore` reached = mint the next attempt. The backoff
-  remainder is recomputed from `RetryNotBefore` each reconcile, so a restart
-  that loses the in-memory `RequeueAfter` still honors it.
+  `RetryNotBefore`, so recovery cannot mistake the retired attempt (token already
+  invalidated) for an in-flight one — it falls to the backoff/mint cases above.
+  The backoff remainder is recomputed from `RetryNotBefore` each reconcile, so a
+  restart that loses the in-memory `RequeueAfter` still honors it.
 - **BootTime marks a real boot, and is written last.** `PreProvisioningBootTime`
   — the timeout anchor — is stamped only after the BMH boot request is confirmed
   applied. A resumed attempt with steps 3-4 complete but no BootTime verifies the
   BMH is booting the expected ISO, then stamps it; the clock cannot start before
-  the host was actually asked to boot.
+  the host was asked to boot.
 - **Timeout still bounds a stuck resume.** An in-flight attempt whose
   `PreProvisioningBootTime` + `timeout` has elapsed is treated as timed out and
   enters the retry/terminal branch — never a silent re-mint.
 
-Each partial-write window — "token Secret written, status not" (asserts the
-pending Secret is adopted by owner + label, not re-minted); "status written,
-DataImage not"; "DataImage created, BMH not patched"; "BMH patched, BootTime not
-stamped"; and "retry recorded (`RetryNotBefore` set, attempt cleared), restarted
-mid-backoff" (asserts the remaining backoff is honored and exactly one fresh
-attempt is then minted) — is covered by its own **fault-injection test** that
-kills the reconcile at that point and asserts the next reconcile resumes the same
-attempt (no new token, no duplicate boot, exactly one booting ISO).
+Each partial-write window — "token Secret written, status not" (pending Secret
+adopted by owner + label, not re-minted); "status written, DataImage not";
+"DataImage created, BMH not patched"; "BMH patched, BootTime not stamped"; and
+"retry recorded (`RetryNotBefore` set, attempt cleared), restarted mid-backoff"
+(remaining backoff honored, exactly one fresh attempt minted) — is covered by its
+own **fault-injection test** that kills the reconcile at that point and asserts
+the next reconcile resumes the same attempt (no new token, no duplicate boot,
+exactly one booting ISO).
 
 ### Key Implementation Details in the IBI Operator
 
@@ -659,16 +698,14 @@ the result back to the hub via HTTP.
 
 **This depends on `install-rhcos-and-restore-seed.service` being a
 `Type=oneshot` unit** (which the IBI seed-restore service is): a oneshot unit
-does not reach `active`/exit until its `ExecStart` finishes, so its `Result`
-property is a *terminal* verdict by the time the reporter reads it. `After=` only
-orders start-up — it does **not** wait for a `Type=simple` (or other
-long-running) unit to finish, so a non-oneshot unit could let the reporter read a
-non-failure `Result` while preparation is still running and send a premature
-"success". If a future base changes that unit's type, the design must gate on an
-explicit completion sentinel (a dedicated oneshot unit ordered `After=` the prep
-service, whose own terminal `Result` the reporter reads) rather than the prep
-service's live state. The reporter contract: read a terminal result, never a
-mid-flight one.
+does not reach `active`/exit until its `ExecStart` finishes, so its `Result` is a
+*terminal* verdict when the reporter reads it. `After=` only orders start-up — it
+does **not** wait for a `Type=simple` unit to finish, so a non-oneshot prep unit
+could let the reporter read a non-failure `Result` mid-flight and send a
+premature "success". If a future base changes that unit's type, the design must
+gate on an explicit completion sentinel (a dedicated oneshot unit ordered
+`After=` the prep service, whose terminal `Result` the reporter reads) rather
+than the prep service's live state.
 
 ```yaml
 # Generated by the IBI Operator, injected as ignition override
@@ -711,17 +748,12 @@ systemd:
         # any older base the ExecStart must wrap the send in its own retry loop.
         Type=oneshot
         ExecStart=/usr/local/bin/ibi-prep-callback
-        # The retry budget is an ABSOLUTE deadline inside the script (a
-        # wall-clock loop), not per-attempt timers, sized from the operator's
-        # PreProvisioningConfig.Timeout (default 60m, delivered as
-        # CALLBACK_BUDGET_SECS) so callbacks stay alive for the whole window the
-        # operator waits. TimeoutStartSec/Restart alone cannot bound total
-        # effort: TimeoutStartSec caps a SINGLE start, and Restart=on-failure
-        # would relaunch with no ceiling on cumulative time. So the script owns
-        # the budget (retries curl until success or deadline, then exits). It is
-        # DISABLED here (infinity) because a fixed cap baked into the shared ISO
-        # would truncate a host-specific budget; the script's persisted deadline
-        # is the real bound. Restart + StartLimit remain a crash backstop only.
+        # TimeoutStartSec is DISABLED (infinity): a fixed cap baked into the
+        # shared ISO would truncate a host-specific budget. The real bound is the
+        # script's ABSOLUTE wall-clock deadline (CALLBACK_BUDGET_SECS, from
+        # PreProvisioningConfig.Timeout, default 60m); TimeoutStartSec caps only
+        # a single start and Restart alone can't bound cumulative time. Restart +
+        # StartLimit remain a crash backstop only.
         TimeoutStartSec=infinity
         Restart=on-failure
         RestartSec=30
@@ -772,24 +804,16 @@ PAYLOAD=$(jq -nc \
   --arg message "${MSG}" \
   '{attempt: $attempt, status: $status, message: $message}')
 
-# Retry against an ABSOLUTE wall-clock deadline, not a per-attempt timer. This
-# bounds cumulative effort regardless of how many attempts fail, which neither
-# TimeoutStartSec nor Restart= can do alone. Exit 0 on first success; exit
-# non-zero if the deadline passes (Restart is a crash backstop only, bounded by
-# StartLimit).
-#
-# The budget MUST cover the operator's whole wait window. The operator waits up
-# to PreProvisioningConfig.Timeout (default 60m); if the host stopped retrying
-# after a fixed ~10m, a hub unreachable for 10-59m after prep succeeds would
-# never receive the already-produced result and the operator would time out a
-# host that actually succeeded. So the operator delivers CALLBACK_BUDGET_SECS
-# per-host (effective timeout minus a small margin so the last send precedes the
-# operator's own deadline); the script uses that, not a hardcoded constant.
-#
-# CALLBACK_BUDGET_SECS is REQUIRED (see env file below) with deliberately NO
-# silent fallback: a missing budget is a delivery bug, and defaulting to a short
-# window would reintroduce the "host stops before the operator's timeout"
-# failure this value prevents. Fail loudly instead.
+# Retry against an ABSOLUTE wall-clock deadline (not a per-attempt timer): this
+# bounds cumulative effort, which neither TimeoutStartSec nor Restart= can do
+# alone. Exit 0 on first success; exit non-zero past the deadline (Restart is a
+# crash backstop only). The budget MUST cover the operator's whole wait window
+# (PreProvisioningConfig.Timeout, default 60m); a shorter fixed cap would let a
+# host that succeeded but couldn't reach a briefly-unreachable hub get timed out.
+# So the operator delivers CALLBACK_BUDGET_SECS per-host (effective timeout minus
+# a small margin) and the script uses that, not a hardcoded constant. It is
+# REQUIRED with deliberately NO silent fallback — a missing budget is a delivery
+# bug, and a short default would reintroduce the very failure it prevents.
 : "${CALLBACK_BUDGET_SECS:?CALLBACK_BUDGET_SECS not delivered}"
 #
 # Anchor the deadline to the host's BOOT time, not this script's first-run time.
@@ -881,13 +905,10 @@ not what a normal provisioned boot offers:
   a live-iso boot as they do for a normal deploy, so the design must not depend
   on them to carry the ignition override.
 
-**Recommended path:** bake a generic callback client into the ISO via
-`ignitionConfigOverride` at build time, and deliver the per-server callback URL +
-token at boot through a mechanism the client reads itself. Because the exact
-behavior of `live-iso` + `DataImage` + config-drive discovery is version-dependent
-in BMO/Ironic, this path **must be covered by a version-pinned integration test**
-against the supported version rather than assumed; if that test cannot pass, the
-fallback is a unique per-ICI ISO with the URL/token baked directly into
+Because the exact behavior of `live-iso` + `DataImage` + config-drive discovery
+is version-dependent in BMO/Ironic, this recommended path **must be covered by a
+version-pinned integration test** rather than assumed; if that test cannot pass,
+the fallback is a unique per-ICI ISO with the URL/token baked directly into
 `ignitionConfigOverride`. Tracked in [Open Question 2](#open-questions).
 
 #### Host network configuration for the callback
@@ -956,17 +977,12 @@ On receiving a callback:
 6. Trigger a reconciliation of the ICI (the reconciler picks up the
    result and proceeds with the BMH state transition)
 
-The endpoint is authenticated with a **per-attempt** bearer token generated when
-the pre-provisioning phase starts. It is presented in an `Authorization: Bearer
-<token>` header (not in the URL query or path), so it does not leak into
-image-server access logs, proxy logs, or the ISO's cloud-init/journal output. The
-token is stored only in a per-ICI Secret owned by the ICI (not in `status`, which
-is readable by anyone with `get` on the ICI), delivered inside the ignition
-overlay, compared in constant time on receipt, and invalidated once a terminal
-callback is accepted or the attempt times out. A fresh token is minted every boot
-attempt so one captured from an earlier attempt cannot drive a later one. Where
-supported, mutual TLS (a client certificate in the ignition overlay) is preferred
-over the bearer token. See [Challenge 3](#3-callback-authentication-and-security).
+The endpoint is authenticated with a **per-attempt** bearer token minted when the
+pre-provisioning phase starts, carried only in an `Authorization: Bearer` header
+and invalidated once a terminal callback is accepted or the attempt times out. The
+full token handling — header-not-URL, Secret-not-status, constant-time comparison,
+per-attempt expiry, and mTLS where available — is detailed in
+[Challenge 3](#3-callback-authentication-and-security).
 
 #### 3. BMH Image Configuration for ISO Boot
 
@@ -995,17 +1011,16 @@ preparation service within the ISO handles the actual disk installation.
 the exact artifact built and verified — a mutable HTTPS URL alone can be swapped
 for a stale or tampered ISO between build and boot. Because Ironic's `live-iso`
 path does **not** reliably enforce the BMH `Image.Checksum` the way the normal
-deploy path does, the operator does not rely solely on populating `Checksum`
-above: before setting `spec.image`, it **streams the ISO bytes from `ISOURL`**
-over HTTPS and computes the SHA-256 **over those bytes**, comparing to
-`ISODigest` and failing closed with `PreProvisioningConfigInvalid` on mismatch.
-A published `.sha256` **sidecar is explicitly not trusted**: comparing sidecar
-text to `ISODigest` only checks that two pieces of metadata agree, not that
-`ISOURL` returns those bytes — a stale or mispublished sidecar would pass while
-the URL serves an ISO that was never hashed. The bytes handed to the BMC are the
-bytes that must be hashed. This digest is the same value the seed-generation
-workflow records in `SeedGenerationStatus.ISODigest`, so the two proposals pin to
-one artifact end to end.
+deploy path does, the operator does not rely on populating `Checksum` above:
+before setting `spec.image`, it **streams the ISO bytes from `ISOURL`** and
+computes the SHA-256 **over those bytes**, comparing to `ISODigest` and failing
+closed with `PreProvisioningConfigInvalid` on mismatch. A published `.sha256`
+**sidecar is explicitly not trusted** — comparing sidecar text to `ISODigest`
+only checks that two pieces of metadata agree, not that `ISOURL` returns those
+bytes; the bytes handed to the BMC are the bytes that must be hashed. This digest
+is the same value the seed-generation workflow records in
+`SeedGenerationStatus.ISODigest`, pinning both proposals to one artifact end to
+end.
 
 **Restricting `ISOURL` before the operator fetches it.** Because `isoURL` is
 overridable through `hwMgmtParameters`, an untrusted caller could otherwise point
@@ -1016,46 +1031,46 @@ checks **before any byte of `ISOURL` is fetched**, failing closed with
 `PreProvisioningConfigInvalid`:
 
 - **Origin allowlist.** `ISOURL` must resolve to an operator-owned or
-  allowlisted ISO origin (the seed-generation upload origins plus any
-  operator-configured additions); a URL outside that set is rejected before the
-  fetch, so the operator never requests a caller-chosen host. The allowlist is
-  operator configuration, not template/`ProvisioningRequest` input, so a request
-  author cannot widen it.
+  allowlisted ISO origin (seed-generation upload origins plus operator-configured
+  additions); a URL outside that set is rejected before the fetch, so the
+  operator never requests a caller-chosen host. The allowlist is operator
+  configuration, not template/`ProvisioningRequest` input, so a request author
+  cannot widen it.
 - **Mandatory digest for automated boot.** `ISODigest` is **required** whenever
-  the operator drives an automated boot from a caller-influenceable `ISOURL`;
-  URL-only trust is not accepted. A missing digest is rejected up front, so the
-  bytes handed to the BMC are always pinned to a verified artifact.
+  the operator drives an automated boot; URL-only trust is not accepted. A
+  missing digest is rejected up front, so the bytes handed to the BMC are always
+  pinned to a verified artifact.
 
-**The operator's pre-fetch is necessary but not sufficient on its own — the
-`ISOURL` must also be immutable.** There is an unavoidable time-of-check /
-time-of-use gap: the operator verifies the bytes at `ISOURL` *before* setting
-`spec.image`, but the BMC (via Ironic) fetches them *later*, and BMO's
-`live-iso` path passes only `imageData.URL` as the Ironic `boot_iso` while
-clearing the checksum fields — so nothing in the boot path re-binds what the
-BMC actually pulls. If the content at `ISOURL` changes after the check, the BMC
+**The operator's pre-fetch is necessary but not sufficient — the `ISOURL` must
+also be immutable.** There is an unavoidable time-of-check/time-of-use gap: the
+operator verifies the bytes at `ISOURL` *before* setting `spec.image`, but the
+BMC fetches them *later*, and BMO's `live-iso` path passes only `imageData.URL`
+as the Ironic `boot_iso` while clearing the checksum fields — nothing in the boot
+path re-binds what the BMC pulls. If the content changes after the check, the BMC
 can boot different bytes than were verified. The design therefore **requires
 `ISOURL` to be an immutable, content-addressed reference** (a per-run URL whose
 bytes are never rewritten), not a mutable "latest" URL. The seed-generation
-workflow already satisfies this: it uploads to a **unique per-run path**
-(ProvisioningRequest name + seed image digest + filename), written once and
-never overwritten. Immutability is a **producer-side contract** (the seed
-workflow guarantees it; a generic webhook cannot prove a URL immutable), and the
-pre-fetch then confirms that artifact matches `ISODigest` — immutability closes
-the TOCTOU window, the pre-fetch confirms identity. Because `ISODigest` is
-mandatory for automated boot (above), identity is always verified at check time;
-what a non-immutable `ISOURL` costs is the guarantee that the BMC's *later* fetch
-pulls those same bytes. A deployment that cannot guarantee an immutable,
-allowlisted URL therefore cannot offer automated IBI pre-provisioning through
-this path — it is rejected up front, not silently downgraded to URL-only trust.
+workflow satisfies this, uploading to a **unique per-run path**
+(ProvisioningRequest name + seed image digest + filename), written once and never
+overwritten. Immutability is a **producer-side contract** (a generic webhook
+cannot prove a URL immutable) that closes the TOCTOU window, while the mandatory
+`ISODigest` pre-fetch confirms identity at check time. A deployment that cannot
+guarantee an immutable, allowlisted URL therefore cannot offer automated IBI
+pre-provisioning through this path — it is rejected up front, not silently
+downgraded to URL-only trust.
 
 The HTTPS client used for this fetch trusts the **same private CA as the boot**:
 when `ISOServerCACertRef` is set, the operator reads the `ca-bundle.crt` key from
 that ConfigMap (resolved in the ICI's namespace, requiring `get` on `configmaps`)
-and uses it as the root pool for the verification request; otherwise the system
-trust store. Without this, digest verification against a private-CA ISO server
-would fail the TLS handshake before the BMH boots. This is distinct from the
-BMC's own trust of the ISO server (a pre-installed prerequisite, out of scope) —
-`ISOServerCACertRef` configures the *operator's* client, not the BMC's.
+as the root pool for the verification request; otherwise the system trust store.
+Seed generation emits this bundle as a namespaced, keyed
+`SeedGenerationStatus.ISOServerCACertRef` in the O-Cloud Manager namespace under
+`ca-bundle.crt`; when rendering the ICI the O-Cloud Manager controller copies it
+into the ICI namespace under the same key so this name-only reference resolves.
+Without it, digest verification against a private-CA ISO server fails the TLS
+handshake before the BMH boots. This is distinct from the BMC's own trust of the
+ISO server (a pre-installed prerequisite, out of scope) — `ISOServerCACertRef`
+configures the *operator's* client, not the BMC's.
 
 #### 4. BMH State Transition After Pre-Provisioning
 
@@ -1108,13 +1123,12 @@ configured `Timeout` (default: 60m) on each reconciliation.
 
 **The timeout must be self-triggering.** A callback is the only external event
 that wakes the reconciler; if none arrives, nothing would re-enqueue the ICI and
-it would remain `PreProvisioningInProgress` forever. While an attempt is in
-flight, every reconcile therefore returns `RequeueAfter` set to the remaining
-time until `PreProvisioningBootTime + Timeout` (bounded to a minimum floor so
-clock skew cannot produce a zero/negative delay and a tight requeue loop),
-guaranteeing a reconcile fires at — or just after — the deadline even with no
-callback, no BMH change, and no other watched event. The no-callback path is
-covered by an envtest that advances the fake clock past the deadline and asserts
+it would stay `PreProvisioningInProgress` forever. While an attempt is in flight,
+every reconcile therefore returns `RequeueAfter` set to the time remaining until
+`PreProvisioningBootTime + Timeout` (bounded to a minimum floor so clock skew
+cannot produce a zero/negative delay and a tight requeue loop), guaranteeing a
+reconcile fires at the deadline even with no callback, BMH change, or other
+watched event. An envtest advances the fake clock past the deadline and asserts
 the transition to `PreProvisioningTimedOut`.
 
 **Timeout and callback compete for the same terminal state.** The timeout
@@ -1168,26 +1182,24 @@ The O-Cloud Manager changes are minimal:
    `hwMgmtDefaults` / `hwMgmtParameters` and populate the
    `ImageClusterInstall.spec.preProvisioning` fields. The **preferred** path is
    for SiteConfig to render `preProvisioning` into the ICI at creation time, so
-   the field is present before the IBI Operator reconciles the ICI. If instead it
-   must be patched onto an ICI SiteConfig already created, the patch introduces a
-   race: the IBI Operator could reconcile the ICI (and begin a normal,
-   non-pre-provisioning install) before the patch lands. The design therefore
-   requires that on the patch-after-create path, IBI reconciliation is **gated**
-   until `preProvisioning` is present — e.g. the ICI is created paused/annotated
-   and the O-Cloud Manager clears the gate only after the patch is applied — so
-   the operator never observes a pre-provisioning ICI without its spec.
+   the field is present before the IBI Operator reconciles it. Patching it onto an
+   already-created ICI instead races the IBI Operator, which could begin a normal,
+   non-pre-provisioning install before the patch lands; on that path IBI
+   reconciliation is therefore **gated** until `preProvisioning` is present (e.g.
+   the ICI is created paused/annotated and the O-Cloud Manager clears the gate
+   only after patching), so the operator never observes a pre-provisioning ICI
+   without its spec.
 2. **Validation**: Verify ConfigMaps referenced by `ibiPreProvisioning`
    exist and are valid during ClusterTemplate validation.
 3. **Status handoff (new controller logic)**: define how the ICI's
    pre-provisioning status maps onto `ProvisioningRequest` conditions and
-   `provisioningStatus`. This is a real gap: the ProvisioningRequest controller
-   today gates cluster-install progress on a fixed set of `ClusterInstance`
-   conditions (`ClusterInstanceValidated`, `RenderedTemplates`,
-   `RenderedTemplatesValidated`, `RenderedTemplatesApplied`) and does **not**
-   look at `ImageClusterInstall` status, so without an explicit handoff the
-   request could advance to (or report) cluster installation while
-   pre-provisioning is still pending or has failed. The controller must
-   therefore, **before** treating hardware as ready, block on the ICI
+   `provisioningStatus`. This is a real gap: the controller today gates
+   cluster-install progress on a fixed set of `ClusterInstance` conditions
+   (`ClusterInstanceValidated`, `RenderedTemplates`, `RenderedTemplatesValidated`,
+   `RenderedTemplatesApplied`) and does **not** look at `ImageClusterInstall`
+   status, so without an explicit handoff the request could advance to cluster
+   installation while pre-provisioning is still pending or has failed. Before
+   treating hardware as ready, the controller must block on the ICI
    pre-provisioning state and translate it:
 
    | ICI pre-provisioning reason | PR `HardwareProvisioned` condition | PR `provisioningStatus.provisioningPhase` |
@@ -1199,28 +1211,27 @@ The O-Cloud Manager changes are minimal:
    | `PreProvisioningTimedOut` | `False`, reason `TimedOut` | `failed` |
 
    Pre-provisioning is modelled as part of the hardware-provisioning gate: the
-   PR does not proceed to (or report) cluster installation until the ICI reports
+   PR does not proceed to cluster installation until the ICI reports
    `PreProvisioningSucceeded`. Crucially, `PreProvisioningRetrying` is
    **non-terminal** — the PR keeps `progressing` across a failed attempt's
    backoff, so the configured `MaxRetries`/`RetryBackoff` budget can be used
-   without the PR prematurely latching `failed`. Only
+   without prematurely latching `failed`. Only
    `PreProvisioningFailed`/`PreProvisioningTimedOut` (emitted after the budget is
-   exhausted) drive the PR to a terminal `failed` `provisioningStatus` with the
-   ICI message surfaced. `MaxRetries` and `RetryBackoff` are carried in
-   `ibiPreProvisioning` (same `hwMgmtDefaults`/`hwMgmtParameters` passthrough as
-   the other fields, present in the ClusterTemplate schema). This mapping is the
-   contract between the two controllers and must be covered by an integration
-   test, including the retry path.
+   exhausted) drive the PR to terminal `failed`, surfacing the ICI message.
+   `MaxRetries`/`RetryBackoff` ride the same
+   `hwMgmtDefaults`/`hwMgmtParameters` passthrough as the other fields. This
+   mapping is the contract between the two controllers and must be covered by an
+   integration test, including the retry path.
 4. **Watch `ImageClusterInstall` to enqueue the owning
    `ProvisioningRequest`.** The item-3 mapping only runs when the PR reconciles,
-   and pre-provisioning transitions (callback success/failure, timeout, retry)
+   but pre-provisioning transitions (callback success/failure, timeout, retry)
    update **`ImageClusterInstall` status and nothing else**. The
    `ProvisioningRequestReconciler` today watches `NodeAllocationRequest` and
    `ClusterInstance` but **not** `ImageClusterInstall`, so without a new watch a
-   callback- or timeout-driven ICI status change would not wake the PR, and the
-   request would sit stale — never advancing on success nor reporting failure —
-   until some unrelated event requeued it. The reconciler therefore adds a watch
-   on `ImageClusterInstall` with a mapper that enqueues the owning
+   callback- or timeout-driven ICI status change would leave the request stale —
+   never advancing on success nor reporting failure — until some unrelated event
+   requeued it. The reconciler therefore adds a watch on
+   `ImageClusterInstall` with a mapper that enqueues the owning
    `ProvisioningRequest` (resolved via the ICI→ClusterInstance→PR ownership
    chain, or a field index on the PR name). Consistent with **DD-002**, the
    enqueued `NamespacedName` omits the namespace because `ProvisioningRequest` is
@@ -1299,7 +1310,12 @@ spec:
                 required: [name]
               preProvisioningTimeout:
                 type: string
-            required: [isoURL]
+              maxRetries:
+                type: integer
+                minimum: 0
+              retryBackoff:
+                type: string
+            required: [isoURL, isoDigest]
         type: object
     type: object
 ```
@@ -1315,21 +1331,21 @@ disconnected environments, the server may be on a different network
 
 **Mitigation**: The IBI Operator's image server is already exposed via a Route
 or NodePort for serving config ISOs to BMHs; the same network path that lets
-BMH/Ironic fetch ISOs from the hub can carry the callback, using the same
+BMH/Ironic fetch ISOs from the hub can carry the callback over the same
 externally-reachable hostname. If the provisioning network is isolated, a Route
-or LoadBalancer service exposes the callback endpoint — the same requirement as
-DataImage ISO serving.
+or LoadBalancer exposes the callback endpoint — the same requirement as DataImage
+ISO serving.
 
 This reachability is an explicit **precondition**, not an assumption. BMH/Ironic
 fetches ISOs from the hub's *service* network via the BMC, whereas the callback
 originates from the *booted host* on the provisioning network — these can differ,
 so "Ironic can pull the ISO" does not prove "the host can reach the callback."
 Before booting, the IBI Operator validates that the resolved callback endpoint is
-DNS-resolvable, its hostname is routable from the target network, and its TLS
-certificate chains to a CA the host will trust (the same bundle injected via
+DNS-resolvable, its hostname routable from the target network, and its TLS
+certificate chains to a CA the host will trust (the bundle injected via
 `additionalTrustBundle`, see [Challenge 7](#7-hub-ca-trust-on-the-pre-provisioned-server)).
 If these fail, the ICI reports a configuration error up front rather than booting
-a server that can never call back. A `PreProvisioningTimedOut` is documented as
+a server that can never call back. `PreProvisioningTimedOut` is documented as
 ambiguous between "preparation never finished" and "callback could not be
 delivered," and the operator surfaces both possibilities.
 
@@ -1343,20 +1359,19 @@ temporarily unavailable. A missed callback would leave the ICI stuck in
 **Mitigation**: The `ibi-prep-callback` script retries curl against an
 **absolute wall-clock deadline derived from `CALLBACK_BUDGET_SECS`** (a loop with
 a per-attempt `--max-time`), so cumulative retry effort is bounded regardless of
-how many individual attempts fail — something `TimeoutStartSec` (per single
-start) and `Restart=on-failure` (unbounded relaunches) cannot guarantee alone.
+how many attempts fail — something `TimeoutStartSec` (per single start) and
+`Restart=on-failure` (unbounded relaunches) cannot guarantee alone.
 `CALLBACK_BUDGET_SECS` is the per-host budget delivered on the data carrier,
 derived from `PreProvisioningConfig.Timeout` (default 60m) anchored to
 `PreProvisioningBootTime`, so the host's retry window tracks the operator's
 timeout rather than a fixed value that could expire before it (a hard-coded 10m
-deadline would give up ~50m early on a default-timeout host and mark a prepared
-server as timed out). The script fails closed if `CALLBACK_BUDGET_SECS` is
-absent. `Restart=on-failure` plus `StartLimitIntervalSec`/`StartLimitBurst`
-remain only a bounded backstop for an outright script crash. This covers
-transient network issues during boot. Additionally, the operator's reconcile
-loop checks the timeout — if no callback arrives within it, the ICI transitions
-to `PreProvisioningTimedOut` — so the operator can distinguish "callback never
-arrived" (timeout) from "preparation failed" (failure callback).
+deadline would give up ~50m early on a default-timeout host). The script fails
+closed if `CALLBACK_BUDGET_SECS` is absent; `Restart=on-failure` plus
+`StartLimitIntervalSec`/`StartLimitBurst` remain only a bounded backstop for an
+outright script crash. Additionally, the operator's reconcile loop checks the
+timeout — if no callback arrives within it, the ICI transitions to
+`PreProvisioningTimedOut` — so it can distinguish "callback never arrived"
+(timeout) from "preparation failed" (failure callback).
 
 ### 3. Callback authentication and security
 
@@ -1404,44 +1419,39 @@ viable options remain:
   callback client (the `ibi-prep-callback` script and its
   `ibi-prep-callback.service` unit — identical for every server). The per-server
   data (`/etc/ibi-callback/env` and the root-only `/etc/ibi-callback/auth.cfg`)
-  is delivered at boot through a concrete carrier, not "a well-known location":
+  is delivered at boot through a concrete carrier:
 
   - **Carrier**: a per-ICI `DataImage` (a tiny ISO9660/FAT image the IBI
     Operator builds and attaches as an additional virtual-media device), used
-    **purely as a data device**, not as an ignition overlay. The `DataImage` is
-    **named and namespaced after the BareMetalHost** (BMO v0.13.2's
-    `DataImageReconciler` resolves the owning host by matching the request
-    name/namespace to a `BareMetalHost`, so a differently named carrier never
-    attaches); the attempt id is bound through the carrier content and an
-    `ibi.openshift.io/attempt` label, not the resource name. Its filesystem is
-    labelled `ibi-callback` so it is addressable by label regardless of device
-    enumeration order. An integration test verifies BMO attaches the image and
-    the guest sees the `ibi-callback` device label.
+    **purely as a data device**, not as an ignition overlay. It is **named and
+    namespaced after the BareMetalHost** (BMO v0.13.2's `DataImageReconciler`
+    resolves the owning host by matching request name/namespace to a
+    `BareMetalHost`, so a differently named carrier never attaches); the attempt
+    id is bound through the carrier content and an `ibi.openshift.io/attempt`
+    label, not the resource name. Its filesystem is labelled `ibi-callback` so it
+    is addressable regardless of device enumeration order. An integration test
+    verifies BMO attaches the image and the guest sees the `ibi-callback` label.
   - **Mount + materialize**: a baked-in `ibi-callback-data.service`
     (`Type=oneshot` **with `RemainAfterExit=yes`**) mounts
     `/dev/disk/by-label/ibi-callback` read-only, copies `env` to
     `/etc/ibi-callback/env` (0644) and `auth.cfg` to `/etc/ibi-callback/auth.cfg`
     (0600, root-only), then unmounts. Copying to a root-only path — rather than
-    reading the token off the shared virtual-media device — keeps the 0600
-    guarantee. `RemainAfterExit=yes` is load-bearing: without it a `Type=oneshot`
-    unit goes `inactive` the moment `ExecStart` returns, and since the reporter
-    declares `Requires=` on it, systemd would treat the dependency as inactive
-    and could stop the reporter before it runs. With it, the data unit stays
-    `active (exited)`, so the `Requires=`/`After=` pair holds for the whole boot.
-  - **Ordering and dependency (runtime, not `[Install]`)**: the dependency is a
-    **runtime** relationship in the reporter's `[Unit]` section —
-    `ibi-prep-callback.service` declares `Requires=ibi-callback-data.service` and
-    `After=ibi-callback-data.service`. Relying on `RequiredBy=`/`WantedBy=` in the
-    *data* unit's `[Install]` section is a mistake: `[Install]` directives take
-    effect only when the unit is `enable`d, so a missed enablement would let the
-    reporter run before (or without) its data files. Both units are also marked
-    `enabled: true` so they are active on first boot, but the correctness
-    guarantee comes from the runtime `Requires=`/`After=`, not enablement. With
-    `Requires=`, if the data mount fails (device absent) the reporter never starts,
-    surfacing as a timeout rather than a callback with an empty URL/token. A
-    systemd integration test must assert the data unit stays `active (exited)`
-    after materialization and the reporter then actually runs (not just that
-    ordering is declared).
+    reading the token off the shared device — keeps the 0600 guarantee.
+    `RemainAfterExit=yes` is load-bearing: without it a `Type=oneshot` unit goes
+    `inactive` when `ExecStart` returns, and the reporter's `Requires=` could then
+    be treated as inactive and stop the reporter before it runs; with it the data
+    unit stays `active (exited)` so the `Requires=`/`After=` pair holds for the
+    whole boot.
+  - **Ordering and dependency (runtime, not `[Install]`)**: the reporter's
+    `[Unit]` section declares `Requires=`/`After=ibi-callback-data.service`.
+    Relying on `RequiredBy=`/`WantedBy=` in the *data* unit's `[Install]` section
+    would be a mistake — `[Install]` takes effect only when the unit is `enable`d,
+    so a missed enablement would let the reporter run without its data files; the
+    correctness guarantee comes from the runtime `Requires=`/`After=`, not
+    enablement. With `Requires=`, a failed data mount (device absent) stops the
+    reporter from starting, surfacing as a timeout rather than a callback with an
+    empty URL/token. A systemd integration test asserts the data unit stays
+    `active (exited)` and the reporter then runs.
 
   This keeps the ISO reusable. It depends on version-specific `live-iso` +
   DataImage behavior in BMO/Ironic and therefore **must be backed by a
@@ -1499,47 +1509,40 @@ inconsistent state (partial RHCOS installation, incomplete seed image pull).
 **Mitigation**: IBI preparation is idempotent — rebooting from the ISO restarts
 the process. On failure callback (or timeout), the IBI Operator first tears the
 attempt down cleanly (clears `spec.image`, removes the per-attempt data carrier,
-powers the BMH off, invalidates the per-attempt token — leaving the host **not**
+powers the BMH off, invalidates the token — leaving the host **not**
 `externallyProvisioned`), records the retry-pending marker
 (`Status.RetryNotBefore`) while **clearing** the retired `PreProvisioningAttempt`
 so the invalidated token is never re-driven, then retries with a **fresh
-attempt**: new token and marker, and `Status.PreProvisioningBootTime` reset so
-the timeout is measured from the new boot.
+attempt**: new token and marker, and `Status.PreProvisioningBootTime` reset so the
+timeout is measured from the new boot.
 
-**Retry is explicitly bounded — there is no infinite retry and no retry
-after a terminal result.** `PreProvisioningConfig` carries the retry policy
-so the operator does not have to invent unbounded behavior:
+**Retry is explicitly bounded — no infinite retry, no retry after a terminal
+result.** `PreProvisioningConfig` carries the retry policy:
 
 - `MaxRetries` (default: `0`, a single attempt) caps additional attempts after
   the first; retries stop once this budget is exhausted.
 - `RetryBackoff` (default: `5m`) is the delay between a failed attempt's teardown
   and the next boot. It is persisted durably as `Status.RetryNotBefore` (=
-  failure time + `RetryBackoff`) in the same update that clears the retired
-  `PreProvisioningAttempt`, and also applied as a `RequeueAfter` so the retry is
-  self-triggering. The `RequeueAfter` is only a wake-up hint; `RetryNotBefore` is
-  the source of truth, so an operator restart that loses the in-memory timer
-  still waits out the remaining backoff and never re-drives the retired attempt.
+  failure time + `RetryBackoff`) and also applied as a `RequeueAfter` so the retry
+  is self-triggering. The `RequeueAfter` is only a wake-up hint; `RetryNotBefore`
+  is the source of truth, so an operator restart that loses the in-memory timer
+  still waits out the remaining backoff.
 - The per-attempt `Timeout` bounds each boot; the operator also enforces an
   overall ceiling of `(MaxRetries + 1) × Timeout + MaxRetries × RetryBackoff` so
   total retry effort is finite even in the worst case.
 
-**A failed attempt with budget remaining is a distinct, non-terminal state —
-`PreProvisioningFailed`/`PreProvisioningTimedOut` are *not* recorded until the
-budget is exhausted.** Those two reasons are terminal and map the
-`ProvisioningRequest` to `failed`; recording them on an attempt that still owes
-a retry would make the configured budget unusable (the PR would latch `failed`
-before the retry ran). Instead, a failed/timed-out attempt with
-`PreProvisioningRetryCount < MaxRetries` transitions to the non-terminal
-`PreProvisioningRetrying` reason, the PR keeps `progressing`, and the operator
-re-boots a fresh attempt after `RetryBackoff`. Only once the budget is exhausted
-does the operator write the terminal result — via the compare-and-swap above —
-and let the PR map to `failed`.
-
+**A failed attempt with budget remaining is non-terminal.**
+`PreProvisioningFailed`/`PreProvisioningTimedOut` are terminal (mapping the PR to
+`failed`) and are recorded **only** once the budget is exhausted — recording them
+while a retry is still owed would make the configured budget unusable. A
+failed/timed-out attempt with `PreProvisioningRetryCount < MaxRetries` instead
+transitions to the non-terminal `PreProvisioningRetrying` reason, the PR keeps
+`progressing`, and the operator re-boots a fresh attempt after `RetryBackoff`.
 `Status.PreProvisioningRetryCount` records attempts consumed so the budget
-survives operator restarts. A retry is scheduled **only** from the non-terminal
-`PreProvisioningRetrying` state (reached only after a clean teardown) and **only**
-while budget remains; once a terminal result has been written via the
-compare-and-swap above, no further attempt is booted.
+survives operator restarts; a retry is scheduled only from `PreProvisioningRetrying`
+(reached only after a clean teardown) and only while budget remains. Once a
+terminal result is written via the compare-and-swap above, no further attempt is
+booted.
 
 Each attempt is explicitly bound so a stale signal cannot be mistaken for the
 current one:
@@ -1686,7 +1689,8 @@ repository:
 
 - Validate `PreProvisioning` fields when set:
   - `ISOURL` must be a valid HTTPS URL
-  - `ISODigest`, when set, must match `^sha256:[a-f0-9]{64}$`
+  - `ISODigest` is required whenever `PreProvisioning` is set and must match
+    `^sha256:[a-f0-9]{64}$` (admission rejects a config that omits it)
   - `Timeout` must be a valid duration if provided
   - `MaxRetries` must be `>= 0`; `RetryBackoff`, when set, must be a valid
     non-negative duration

--- a/docs/proposals/ibi-server-pre-provisioning.md
+++ b/docs/proposals/ibi-server-pre-provisioning.md
@@ -117,17 +117,16 @@ Rather than SSH-based monitoring (which requires hub-to-server network
 access, SSH key management, and IP discovery), the IBI Operator uses an
 **HTTP callback** pattern:
 
-1. The IBI Operator generates a small ignition config override containing a
-   systemd unit that calls back to the hub after the IBI preparation service
-   completes (success or failure).
-2. This callback unit is injected into the ISO via the
-   `ignitionConfigOverride` field already supported by the
-   `ImageBasedInstallationConfig`.
-3. The IBI Operator's existing HTTP server exposes a callback endpoint
+1. The seed/ISO workflow bakes `ibi-prep-callback.service` and
+   `/usr/local/bin/ibi-prep-callback` into the reusable ISO via
+   `ignitionConfigOverride`; they read `/etc/ibi-callback/{env,auth.cfg}`.
+2. The IBI Operator creates a per-attempt `DataImage` with URL, attempt,
+   budget, and token; the client reads it after boot.
+3. The HTTP server exposes a callback endpoint
    (e.g., `/callbacks/<ici-namespace>/<ici-name>/status`).
-4. When the preparation service finishes, the callback unit `curl`s the
+4. When the preparation service finishes, the callback client `curl`s the
    hub endpoint with the result.
-5. The IBI Operator receives the callback, updates the ICI condition, and
+5. It receives the callback, updates the ICI condition, and
    proceeds with the BMH state transition.
 
 This approach:
@@ -171,7 +170,7 @@ This approach:
 ├─────────────────────────────────────────────────────────────────┤
 │ IBI Operator (upstream changes required)                        │
 │                                                                 │
-│  1. NEW: Generate callback ignition override                    │
+│  1. NEW: Create per-attempt DataImage; seed-baked client         │
 │  2. NEW: Boot BMH from live ISO via spec.image (live-iso)       │
 │  3. NEW: Receive HTTP callback on preparation completion        │
 │  4. NEW: Transition BMH to IBI-ready state                      │
@@ -1244,12 +1243,9 @@ The O-Cloud Manager changes are minimal:
    timeout-only ICI status change — with no NAR or ClusterInstance change — each
    wake the PR and drive the item-3 transition.
 
-No hub-side Jobs and no SSH infrastructure are introduced, but the status handoff
-above is new controller logic on the O-Cloud Manager side.
-
 ## Integration with Seed Generation Proposal
 
-When both proposals are implemented, the full automated pipeline is:
+Pipeline:
 
 ```text
 ProvisioningRequest (seed gen CT)     ProvisioningRequest (IBI CT)
@@ -1264,6 +1260,12 @@ ProvisioningRequest (seed gen CT)     ProvisioningRequest (IBI CT)
                                         │    └─ Cluster provisioned
                                         └─ Post-provisioning (policies)
 ```
+
+Phase 4 of the [seed-generation proposal](./automated-seed-image-generation.md#phase-4-live-iso-generation)
+bakes the generic client via `ignitionConfigOverride`; the IBI template
+references immutable ISO metadata without a status handoff. Deployments receive
+callback data in a `DataImage`; per-ICI ISO is the [Open Question 2](#open-questions)
+fallback.
 
 ## Sample: ClusterTemplate with IBI Pre-Provisioning
 

--- a/docs/proposals/ibi-server-pre-provisioning.md
+++ b/docs/proposals/ibi-server-pre-provisioning.md
@@ -472,6 +472,7 @@ hwMgmtParameters:
   properties:
     ibiPreProvisioning:
       type: object
+      additionalProperties: false
       properties:
         isoURL:
           type: string
@@ -489,6 +490,7 @@ hwMgmtParameters:
           pattern: '^sha256:[a-f0-9]{64}$'
         isoServerCACertRef:
           type: object
+          additionalProperties: false
           properties:
             name:
               type: string
@@ -510,20 +512,14 @@ hwMgmtParameters:
   type: object
 ```
 
-Validation mirrors the schema: `maxRetries` must be a non-negative integer and
-`retryBackoff` must parse as a non-negative Go `time.Duration`. Both the admission
-webhook and the ICI passthrough reject out-of-range values so a bad override is
-caught at write time rather than surfacing as a stuck attempt. When omitted, the
-controller applies the `PreProvisioningConfig` defaults (`maxRetries: 0`,
-`retryBackoff: 5m`).
+Validation mirrors the schema: `maxRetries` is non-negative and `retryBackoff`
+is a non-negative Go duration. Admission and ICI passthrough reject invalid
+values; omitted fields use `maxRetries: 0` and `retryBackoff: 5m`.
 
-Because `isoURL` and `isoDigest` are caller-overridable through
-`hwMgmtParameters`, validation enforces the two artifact-trust checks before the
-operator fetches the URL (see "Restricting `ISOURL`"): `isoURL` must resolve to an
-operator-owned or allowlisted origin, and `isoDigest` is required (schema, webhook
-and passthrough all re-check, rejecting a missing or off-allowlist value with
-`PreProvisioningConfigInvalid`). The allowlist is operator configuration and
-cannot be widened by a template or `ProvisioningRequest`.
+Because callers may override `isoURL` and `isoDigest`, schema, webhook, and
+passthrough all enforce the artifact checks before fetch: `isoURL` must be
+allowlisted and `isoDigest` is mandatory. The operator owns the allowlist; a
+template or `ProvisioningRequest` cannot widen it.
 
 ## IBI Operator Workflow Changes
 
@@ -616,6 +612,8 @@ ImageClusterInstall created (with spec.preProvisioning set)
       → callback payload: {"attempt": "<n>", "status": "success|failure", "message": "..."}
       → on success:
           → clear BMH spec.image
+          → remove the callback DataImage and wait for deletion before
+            creating the configuration DataImage
           → set BMH spec.externallyProvisioned = true
           → set BMH spec.online = false (power off)
           → set Status.PreProvisioningResult
@@ -1303,6 +1301,7 @@ spec:
         properties:
           ibiPreProvisioning:
             type: object
+            additionalProperties: false
             properties:
               isoURL:
                 type: string
@@ -1312,6 +1311,7 @@ spec:
                 pattern: '^sha256:[a-f0-9]{64}$'
               isoServerCACertRef:
                 type: object
+                additionalProperties: false
                 properties:
                   name:
                     type: string
@@ -1719,7 +1719,7 @@ repository:
 - Unit tests for the pre-provisioning state machine
 - Unit tests for the callback HTTP handler (with mock HTTP client)
 - Integration tests for the full pre-provisioning → cluster installation
-  flow
+  flow, covering carrier cleanup on success, retry, and deletion-in-progress
 
 ### Estimated Upstream Effort
 


### PR DESCRIPTION
## Summary

Adds two design proposals under `docs/proposals/` covering the two halves of a fully automated, API-driven Image-Based Install (IBI) workflow for O-Cloud Manager. Both are documentation only — no controller or API code changes.

- `docs/proposals/automated-seed-image-generation.md`
- `docs/proposals/ibi-server-pre-provisioning.md`

## 1. Automated Seed Image and Live ISO Generation

Turns the manual, SSH-driven LCA seed-generation procedure into a first-class operation driven by the existing `ProvisioningRequest` API.

- New `seedGeneration` key under `upgradeDefaults` / `upgradeParameters`, reusing the existing merge-and-validate infrastructure rather than adding a new CRD or controller.
- Automates seed image generation and live installation ISO build + upload, matching the correct `openshift-install` version automatically.
- Reports progress via a typed `SeedGenerationCompleted` condition and `SeedGenerationStatus` fields (no more SSH-and-tail).
- Treats the seed cluster as a disposable factory: removes ACM agent state (klusterlet + addons) so it never contaminates the seed; retains spoke access during generation via the hub-held admin kubeconfig; never auto-deletes the `ManagedCluster` or the `ProvisioningRequest`.
- Disconnected environments are the primary use case: mirror mappings and registry trust are auto-derived from the hub.
- Fails fast with `PreconditionChecksFailed` (push access, release reachability, TLS/CA trust, upload credentials) before the lengthy generation begins.
- Surfaces the ISO-server CA cert in status for downstream (IBI) consumption.

**Security posture:** credential and outbound-target fields
  (`seedAuthSecretRef`, `recertImage`, `liveISO.*`, `uploadSecretRef`, `urlBase`,
  `pullSecretRef`, `imageDigestSources`, `additionalTrustBundleConfigMapRef`) are
  template-owned. The PR-facing `templateParameterSchema` exposes only the
  overridable field(s) with `additionalProperties: false`, so any template-owned
  key in PR input is rejected structurally; a separate controller-internal
  effective-object schema validates the merged document post-merge.

  ## 2. Automated IBI Server Pre-Provisioning

  Automates booting bare-metal servers from the live ISO and confirming readiness,
  integrated into the IBI Operator (which already owns BMH lifecycle and runs an
  HTTP image server).

  - HTTP **callback** monitoring (server → hub) instead of SSH: a systemd unit
    injected via `ignitionConfigOverride` calls back to an IBI Operator endpoint
    when the preparation service finishes.
  - A pre-provisioning state machine with explicit condition reasons
    (`PreProvisioningPending` → `Booting` → `InProgress` →
    `Succeeded`/`Failed`/`TimedOut`, with `Retrying`).
  - Per-attempt bearer-token auth, a `DataImage` carrier bound to the BMH,
    wall-clock callback budget, durable retry-pending marker, and
    compare-and-swap on the terminal result to accept only the first terminal
    callback.
  - Stream-and-verify of ISO bytes against a mandatory digest before boot;
    origin allowlist.

  ## Testing

  - Docs-only change. `make markdownlint CONTAINER_TOOL=podman`: 0 errors.
  - Both proposals kept under 100 KB.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
