### PR TITLE
CNF-26846: Seed catalog-template with released 4.22.0 and 4.22.1 bundles

### DIFF
--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -6,22 +6,28 @@ entries:
       mediatype: image/svg+xml
     name: o-cloud-manager
     schema: olm.package
-    # Channel entries for 'stable' channel
+    # Channel 'stable' — always points to the latest released z-stream
   - entries:
-      - name: o-cloud-manager.v5.0.0
-        skipRange: '>=4.21.0 <4.23.0'
+      - name: o-cloud-manager.v4.22.1
     name: stable
     package: o-cloud-manager
     schema: olm.channel
-    # Channel entries for '5.0' channel
+    # Channel '4.22.0' — pinned z-stream, no automatic upgrade
   - entries:
-      - name: o-cloud-manager.v5.0.0
-        skipRange: '>=4.21.0 <4.23.0'
-    name: "5.0"
+      - name: o-cloud-manager.v4.22.0
+    name: "4.22.0"
     package: o-cloud-manager
     schema: olm.channel
-  # v5.0.0 bundle
-  # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
-  - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
+    # Channel '4.22.1' — pinned z-stream, no automatic upgrade
+  - entries:
+      - name: o-cloud-manager.v4.22.1
+    name: "4.22.1"
+    package: o-cloud-manager
+    schema: olm.channel
+  # v4.22.0 bundle
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:fef1f183eb8cdc6330ed039fa6bb40432c0496dd4d2e146fd056c03310564da8
+    schema: olm.bundle
+  # v4.22.1 bundle
+  - image: registry.redhat.io/openshift4/o-cloud-manager-operator-bundle@sha256:50fe6d65b219314a92f2850d5ea6b57c9c25aefb59249516061fdfa699f96ca8
     schema: olm.bundle
 schema: olm.template.basic

--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -143,9 +143,9 @@ spec:
       value: $(params.image-expires-after)
     - name: SCRIPT_RUNNER_IMAGE
       value: quay.io/konflux-ci/yq@sha256:9b73d39c362692d0bc5787c2b5e955cd54713e6bb97195a0fb2e87a6557040ee
-        # update catalog template
+        # skip catalog template update; render catalog-template.in.yaml as-is
     - name: SCRIPT
-      value: ./telco5g-konflux/scripts/catalog/konflux-update-catalog-template.sh --set-catalog-template-input-file .konflux/catalog/catalog-template.in.yaml --set-bundle-builds-file .konflux/catalog/bundle.builds.in.yaml
+      value: "true"
     - name: HERMETIC
       value: $(params.hermetic)
     - name: SOURCE_ARTIFACT


### PR DESCRIPTION
## Summary
- Seed the 5.0 FBC catalog template with published O-Cloud Manager 4.22.0 and 4.22.1 entries from `upstream/release-4.22`
- Include the released `registry.redhat.io/openshift4/` bundle digests; omit the in-progress 4.22.2 placeholder and 5.0 channel/bundle entries
- Skip the FBC pipeline catalog-template update so those published entries are rendered as-is (needed for PLCC catalog availability of 4.X operators from the 5.0 branch)

## Test plan
- [ ] Confirm `catalog-template.in.yaml` lists `v4.22.0` and `v4.22.1` in `stable`, `4.22.0`, and `4.22.1` channels
- [ ] Confirm there is no placeholder image entry and no `5.0` channel
- [ ] Confirm FBC pipeline `run-opm-pre-actions` does not overwrite the last catalog bundle image
- [ ] Confirm FBC build succeeds (`opm serve --cache-only`)

## Jira

https://redhat.atlassian.net/browse/CNF-26846

Made with [Cursor](https://cursor.com)