### PR TITLE
CNF-26101: Use scoped spoke clients for hardware configuration and scale-in

### DIFF
--- a/.coverage-thresholds.yaml
+++ b/.coverage-thresholds.yaml
@@ -42,4 +42,4 @@ packages:
   internal/service/resources/db/repo: 89
   internal/service/resources/listener: 30
   internal/controllers/utils/cincinnati: 74
-  internal/controllers/utils/spokeclient: 75
+  internal/spokeclient: 75

--- a/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-o2ims.clusterserviceversion.yaml
@@ -2267,6 +2267,42 @@ spec:
           - list
           - watch
         - apiGroups:
+          - addon.open-cluster-management.io
+          resources:
+          - managedclusteraddons
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.open-cluster-management.io
+          resources:
+          - managedserviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclusters
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - work.open-cluster-management.io
+          resources:
+          - manifestworks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews

--- a/config/rbac/clusterrole_hardwaremanager_server.yaml
+++ b/config/rbac/clusterrole_hardwaremanager_server.yaml
@@ -142,3 +142,39 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - managedclusteraddons
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.open-cluster-management.io
+  resources:
+  - managedserviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
+  - manifestworks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch

--- a/docs/dev/e2e-test-overview.md
+++ b/docs/dev/e2e-test-overview.md
@@ -99,6 +99,7 @@ File: `test/e2e/mno_hw_configuration_test.go`
 - Waiting for day0 to complete (NAR Provisioned=True)
 - Waiting for PR HardwareProvisioned=True
 - Simulating AllocatedNodeHostMap on PR
+- Creating ManagedClusterAddOn for the cluster
 - Deleting created resources
 
 ### Performs day2 hardware configuration update successfully

--- a/docs/user-guide/prereqs.md
+++ b/docs/user-guide/prereqs.md
@@ -42,6 +42,19 @@ SPDX-License-Identifier: Apache-2.0
     oc patch multiclusterengines.multicluster.openshift.io multiclusterengine --type json --patch '[{"op": "add", "path":"/spec/overrides/components/-", "value": {"name":"image-based-install-operator","enabled": true}}]'
     ```
 
+  - Managed Service Account addon
+
+    The [ManagedServiceAccount](https://github.com/open-cluster-management-io/managed-serviceaccount)
+    addon is required for scoped access to managed clusters. The O-Cloud Manager
+    uses it for [MNO ClusterVersion upgrades](./upgrade.md#mno-clusterversion-upgrade),
+    [day-2 hardware configuration](./cluster-configuration.md#switching-to-a-new-hardware-profile),
+    and [worker node scale-in/out](./cluster-configuration.md#scaling-worker-nodes).
+    This addon is enabled by default in ACM/MCE. If it was disabled, enable it in the MultiClusterEngine:
+
+    ```console
+    oc patch multiclusterengines.multicluster.openshift.io multiclusterengine --type json --patch '[{"op": "add", "path":"/spec/overrides/components/-", "value": {"name":"managedserviceaccount","enabled": true}}]'
+    ```
+
 - Red Hat OpenShift GitOps Operator
 - Topology Aware Lifecycle Manager
 

--- a/docs/user-guide/upgrade.md
+++ b/docs/user-guide/upgrade.md
@@ -309,33 +309,8 @@ and worker nodes.
 
 ### MNO Prerequisites
 
-- The [ManagedServiceAccount](https://github.com/open-cluster-management-io/managed-serviceaccount)
-  addon is enabled on the hub cluster. This addon is enabled by default in
-  ACM/MCE. To verify, check the MultiClusterEngine CR:
-
-  ```console
-  oc get multiclusterengines.multicluster.openshift.io multiclusterengine \
-    -o jsonpath='{.spec.overrides.components[?(@.name=="managedserviceaccount")].enabled}'
-  ```
-
-  If it returns `false` or is not present, enable it using
-  `oc edit` to add or update the entry while preserving existing
-  component overrides:
-
-  ```console
-  oc edit multiclusterengines.multicluster.openshift.io multiclusterengine
-  ```
-
-  Ensure the `managedserviceaccount` component is listed and enabled:
-
-  ```yaml
-  spec:
-    overrides:
-      components:
-      - name: managedserviceaccount
-        enabled: true
-      # ... other existing components ...
-  ```
+- The ManagedServiceAccount addon is enabled on the hub cluster. See
+  [Hub Cluster Requirements](./prereqs.md#required-operators-and-addons-on-the-hub).
 
 - Administrator pre-upgrade tasks are completed before triggering the upgrade.
   These are the administrator's responsibility and must be done before updating

--- a/internal/controllers/provisioningrequest_clusterinstall.go
+++ b/internal/controllers/provisioningrequest_clusterinstall.go
@@ -33,9 +33,9 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils/spokeclient"
 	hwmgrcontroller "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/controller"
 	k8sclients "github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
+	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -1419,10 +1419,10 @@ func (t *provisioningRequestReconcilerTask) approveScaleOutCSRs(
 	msaName := t.object.Name + "-scaleout"
 	mwName := t.object.Name + "-scaleout-rbac"
 
-	spokeClient, ready, err := spokeclient.EnsureSpokeClient(
+	clients, ready, err := spokeclient.EnsureSpokeClient(
 		ctx, t.client, t.logger, clusterName,
 		msaName, mwName,
-		scaleOutCSRRBACRules, scaleOutSpokeScheme)
+		scaleOutCSRRBACRules, scaleOutSpokeScheme, spokeclient.RuntimeClientOnly)
 	if err != nil {
 		return fmt.Errorf("failed to setup spoke client for CSR approval: %w", err)
 	}
@@ -1430,6 +1430,7 @@ func (t *provisioningRequestReconcilerTask) approveScaleOutCSRs(
 		t.logger.InfoContext(ctx, "Spoke client for CSR approval not ready yet, will retry")
 		return nil
 	}
+	spokeClient := clients.Client
 
 	// Build set of valid hostnames from the rendered CI
 	validHostnames := getNodeRolesByHostname(clusterInstance)
@@ -1528,16 +1529,17 @@ func (t *provisioningRequestReconcilerTask) checkAllNodesJoined(
 	msaName := t.object.Name + "-scaleout"
 	mwName := t.object.Name + "-scaleout-rbac"
 
-	spokeClient, ready, err := spokeclient.EnsureSpokeClient(
+	clients, ready, err := spokeclient.EnsureSpokeClient(
 		ctx, t.client, t.logger, clusterName,
 		msaName, mwName,
-		scaleOutCSRRBACRules, scaleOutSpokeScheme)
+		scaleOutCSRRBACRules, scaleOutSpokeScheme, spokeclient.RuntimeClientOnly)
 	if err != nil {
 		return false, fmt.Errorf("failed to setup spoke client for node check: %w", err)
 	}
 	if !ready {
 		return false, nil
 	}
+	spokeClient := clients.Client
 
 	// List nodes on the spoke
 	nodeList := &corev1.NodeList{}

--- a/internal/controllers/provisioningrequest_upgrade.go
+++ b/internal/controllers/provisioningrequest_upgrade.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils/cincinnati"
-	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils/spokeclient"
+	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
 	upgradevalidation "github.com/openshift-kni/oran-o2ims/internal/validation"
 	configv1 "github.com/openshift/api/config/v1"
@@ -706,10 +706,10 @@ func (t *provisioningRequestReconcilerTask) handleClusterVersionUpgrade(
 	}
 
 	// Ensure spoke client is ready.
-	spokeClient, ready, err := spokeclient.EnsureSpokeClient(
+	clients, ready, err := spokeclient.EnsureSpokeClient(
 		ctx, t.client, t.logger, clusterName,
 		msaName, mwName,
-		upgradeRBACRules, upgradeSpokeScheme)
+		upgradeRBACRules, upgradeSpokeScheme, spokeclient.RuntimeClientOnly)
 	if err != nil {
 		if !typederrors.IsInputError(err) {
 			return ctrl.Result{}, false, fmt.Errorf("failed to setup spoke client: %w", err)
@@ -732,6 +732,7 @@ func (t *provisioningRequestReconcilerTask) handleClusterVersionUpgrade(
 		}
 		return requeueWithShortInterval(), false, nil
 	}
+	spokeClient := clients.Client
 
 	// Get ClusterVersion from spoke.
 	cv := &configv1.ClusterVersion{}

--- a/internal/controllers/provisioningrequest_upgrade_test.go
+++ b/internal/controllers/provisioningrequest_upgrade_test.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils/spokeclient"
+	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 	typederrors "github.com/openshift-kni/oran-o2ims/internal/typed-errors"
 	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"

--- a/internal/hardwaremanager/cmd/start_hardwaremanager.go
+++ b/internal/hardwaremanager/cmd/start_hardwaremanager.go
@@ -32,6 +32,10 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/exit"
 	hwmgrctrl "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/controller"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 )
 
 var (
@@ -44,6 +48,11 @@ func init() {
 	utilruntime.Must(bmhv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(provisioningv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(inventoryv1alpha1.AddToScheme(scheme))
+	// ACM types used by spokeclient to create/delete scoped hub access (MSA, ManifestWork).
+	utilruntime.Must(clusterv1.Install(scheme))
+	utilruntime.Must(msav1beta1.AddToScheme(scheme))
+	utilruntime.Must(workv1.Install(scheme))
+	utilruntime.Must(addonv1alpha1.Install(scheme))
 }
 
 // Start creates and returns the `hardwaremanager` command.

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -32,6 +32,7 @@ import (
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
 	"github.com/openshift-kni/oran-o2ims/internal/logging"
+	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 )
 
 const ConfigAnnotation = "clcm.openshift.io/config-in-progress"
@@ -997,17 +998,11 @@ const (
 // handleNodeAllocationRequestConfiguring orchestrates day2 hardware profile updates for all nodes
 // in a NodeAllocationRequest.
 //
-// Updates are processed by node group in priority order (masters first, then workers),
-// with each group completing before the next begins. When a hardware profile change is
+// The control-plane (master) group is updated first. While it still has work, no worker
+// pool is started. Once masters complete, worker pools roll out in parallel, each
+// independently bounded by its MCP maxUnavailable. When a hardware profile change is
 // detected for a node group, all nodes in that group are marked as ConfigUpdatePending
 // to ensure a clean starting state.
-//
-// Within a group, the number of nodes selected for processing is limited by the MCP
-// maxUnavailable value, and the selected nodes are processed in parallel.
-
-// This function also returns the nodeList for the caller to determine the NAR status.
-// Note that status conditions in the returned nodeList may be stale since nodes are updated
-// during processing, but the caller will refetch the latest version of each node.
 func handleNodeAllocationRequestConfiguring(
 	ctx context.Context,
 	c client.Client,
@@ -1015,50 +1010,33 @@ func handleNodeAllocationRequestConfiguring(
 	logger *slog.Logger,
 	namespace string,
 	nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest,
-) (ctrl.Result, *hwmgmtv1alpha1.AllocatedNodeList, error) {
+	nodelist *hwmgmtv1alpha1.AllocatedNodeList,
+	spokeClients spokeclient.Clients,
+) (ctrl.Result, error) {
 
 	logger.InfoContext(ctx, "Handling NodeAllocationRequest Configuring")
 
-	nodelist, err := hwmgrutils.GetChildNodes(ctx, logger, c, nodeAllocationRequest)
-	if err != nil {
-		return ctrl.Result{}, nil, fmt.Errorf("failed to get child nodes for NodeAllocationRequest %s: %w", nodeAllocationRequest.Name, err)
-	}
-	// Deterministic ordering of listed nodes by name across reconciles
-	sort.Slice(nodelist.Items, func(i, j int) bool {
-		return nodelist.Items[i].Name < nodelist.Items[j].Name
-	})
-
 	// Mark all nodes whose spec.HwProfile differs from the target profile as ConfigUpdatePending
 	if err := markPendingNodesForUpdate(ctx, c, noncachedClient, logger, nodelist, nodeAllocationRequest); err != nil {
-		return ctrl.Result{}, nodelist, fmt.Errorf("failed to mark pending nodes: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to mark pending nodes: %w", err)
 	}
 
 	// Ensure every node has Status.Hostname populated (reads PR once, patches nodes that are missing it)
 	if err := populateNodeHostnames(ctx, c, logger, nodelist, nodeAllocationRequest); err != nil {
-		return ctrl.Result{}, nodelist, fmt.Errorf("failed to populate node hostnames: %w", err)
-	}
-
-	spokeClient, spokeClientset, err := createSpokeClients(ctx, c, nodeAllocationRequest)
-	if err != nil {
-		return ctrl.Result{}, nodelist, fmt.Errorf("failed to create spoke clients: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to populate node hostnames: %w", err)
 	}
 
 	// Skip drain if there is only one node in the NAR
 	skipDrain := len(nodelist.Items) == 1
-	nodeOps := NewNodeOps(spokeClient, spokeClientset, logger, skipDrain)
+	nodeOps := NewNodeOps(spokeClients.Client, spokeClients.Clientset, logger, skipDrain)
 
 	nodesToProcess, err := selectNodesToProcess(ctx, logger, nodeOps, nodelist, nodeAllocationRequest)
 	if err != nil {
-		return ctrl.Result{}, nodelist, err
+		return ctrl.Result{}, err
 	}
 
-	result, err := executeNodeUpdates(ctx, c, noncachedClient, logger, namespace,
+	return executeNodeUpdates(ctx, c, noncachedClient, logger, namespace,
 		nodeAllocationRequest, nodeOps, nodesToProcess)
-	if err != nil {
-		return ctrl.Result{}, nodelist, err
-	}
-
-	return result, nodelist, nil
 }
 
 // selectNodesToProcess selects nodes that need to be processed for day2 hardware updates.

--- a/internal/hardwaremanager/controller/helpers_test.go
+++ b/internal/hardwaremanager/controller/helpers_test.go
@@ -83,6 +83,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -96,7 +97,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -105,6 +105,7 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 )
 
 // Helper functions
@@ -1405,14 +1406,13 @@ var _ = Describe("Helpers", func() {
 
 		Context("handleNodeInProgressUpdate", func() {
 			var (
-				testBMH            *metal3v1alpha1.BareMetalHost
-				testNode           *hwmgmtv1alpha1.AllocatedNode
-				testClient         client.Client
-				mockOps            *MockNodeOps
-				mockCtrl           *gomock.Controller
-				ctx                context.Context
-				logger             *slog.Logger
-				originalClientFunc func(context.Context, client.Client, string) (client.Client, error)
+				testBMH    *metal3v1alpha1.BareMetalHost
+				testNode   *hwmgmtv1alpha1.AllocatedNode
+				testClient client.Client
+				mockOps    *MockNodeOps
+				mockCtrl   *gomock.Controller
+				ctx        context.Context
+				logger     *slog.Logger
 			)
 
 			BeforeEach(func() {
@@ -1420,9 +1420,6 @@ var _ = Describe("Helpers", func() {
 				logger = slog.New(slog.NewTextHandler(GinkgoWriter, &slog.HandlerOptions{}))
 				mockCtrl = gomock.NewController(GinkgoT())
 				mockOps = NewMockNodeOps(mockCtrl)
-
-				// Save original function and restore in AfterEach
-				originalClientFunc = newClientForClusterFunc
 
 				// Create a test AllocatedNode with config-in-progress annotation and pre-populated hostname
 				testNode = &hwmgmtv1alpha1.AllocatedNode{
@@ -1484,7 +1481,6 @@ var _ = Describe("Helpers", func() {
 
 			AfterEach(func() {
 				mockCtrl.Finish()
-				newClientForClusterFunc = originalClientFunc
 			})
 
 			It("should clean up config annotation when BMH is in error state", func() {
@@ -1631,9 +1627,6 @@ var _ = Describe("Helpers", func() {
 				newHwProfileName     string = "profile-v2"
 				nar                  *hwmgmtv1alpha1.NodeAllocationRequest
 
-				savedClientForClusterFunc    func(ctx context.Context, hubClient client.Client, clusterName string) (client.Client, error)
-				savedClientsetForClusterFunc func(ctx context.Context, hubClient client.Client, clusterName string) (kubernetes.Interface, error)
-
 				spokeNodeNames []string // populated by each context's BeforeEach
 			)
 
@@ -1666,6 +1659,43 @@ var _ = Describe("Helpers", func() {
 				nar := createNodeAllocationRequest("test-nar", testNamespace)
 				nar.Spec.NodeGroup = nodeGroups
 				return nar
+			}
+
+			childNodes := func() *hwmgmtv1alpha1.AllocatedNodeList {
+				nodelist, err := hwmgrutils.GetChildNodes(ctx, logger, testClient, nar)
+				Expect(err).ToNot(HaveOccurred())
+				sort.Slice(nodelist.Items, func(i, j int) bool {
+					return nodelist.Items[i].Name < nodelist.Items[j].Name
+				})
+				return nodelist
+			}
+
+			readySpokeClients := func() spokeclient.Clients {
+				spokeScheme := runtime.NewScheme()
+				Expect(corev1.AddToScheme(spokeScheme)).To(Succeed())
+				Expect(machineconfigv1.Install(spokeScheme)).To(Succeed())
+				var objs []client.Object
+				var clientsetObjs []runtime.Object
+				for _, name := range spokeNodeNames {
+					objs = append(objs, &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: name},
+						Status: corev1.NodeStatus{
+							Conditions: []corev1.NodeCondition{
+								{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+							},
+						},
+					})
+					clientsetObjs = append(clientsetObjs, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}})
+				}
+				maxUnavailable := intstr.FromInt32(1)
+				objs = append(objs, &machineconfigv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Spec:       machineconfigv1.MachineConfigPoolSpec{MaxUnavailable: &maxUnavailable},
+				})
+				return spokeclient.Clients{
+					Client:    fake.NewClientBuilder().WithScheme(spokeScheme).WithObjects(objs...).Build(),
+					Clientset: kubefake.NewSimpleClientset(clientsetObjs...),
+				}
 			}
 
 			// createPRWithHostMap creates a ProvisioningRequest and sets up its status with the
@@ -1718,50 +1748,6 @@ var _ = Describe("Helpers", func() {
 						},
 					},
 				}
-
-				// Mock spoke client creation to return a fake spoke client with a default MCP.
-				// Tests needing custom spoke setup can override these after BeforeEach.
-				savedClientForClusterFunc = newClientForClusterFunc
-				savedClientsetForClusterFunc = newClientsetForClusterFunc
-
-				newClientForClusterFunc = func(_ context.Context, _ client.Client, _ string) (client.Client, error) {
-					spokeScheme := runtime.NewScheme()
-					Expect(corev1.AddToScheme(spokeScheme)).To(Succeed())
-					Expect(machineconfigv1.Install(spokeScheme)).To(Succeed())
-					var objs []client.Object
-					for _, name := range spokeNodeNames {
-						objs = append(objs, &corev1.Node{
-							ObjectMeta: metav1.ObjectMeta{Name: name},
-							Status: corev1.NodeStatus{
-								Conditions: []corev1.NodeCondition{
-									{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
-								},
-							},
-						})
-					}
-					// Explicitly set master MCP maxUnavailable to 1.
-					// For MNO clusters, the workers are updated sequentially if not setting the maxUnavailable.
-					maxUnavailable := intstr.FromInt32(1)
-					objs = append(objs,
-						&machineconfigv1.MachineConfigPool{
-							ObjectMeta: metav1.ObjectMeta{Name: "master"},
-							Spec:       machineconfigv1.MachineConfigPoolSpec{MaxUnavailable: &maxUnavailable},
-						},
-					)
-					return fake.NewClientBuilder().WithScheme(spokeScheme).WithObjects(objs...).Build(), nil
-				}
-				newClientsetForClusterFunc = func(_ context.Context, _ client.Client, _ string) (kubernetes.Interface, error) {
-					var objs []runtime.Object
-					for _, name := range spokeNodeNames {
-						objs = append(objs, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}})
-					}
-					return kubefake.NewSimpleClientset(objs...), nil
-				}
-			})
-
-			AfterEach(func() {
-				newClientForClusterFunc = savedClientForClusterFunc
-				newClientsetForClusterFunc = savedClientsetForClusterFunc
 			})
 
 			Context("SNO cluster", func() {
@@ -1789,21 +1775,19 @@ var _ = Describe("Helpers", func() {
 					testClient = buildClientWithIndex(scheme, upToDateNode, bmh, nar, newHwProfile)
 					createPRWithHostMap(testClient, map[string]string{"node1": "node1"})
 
-					result, nodelist, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar)
+					result, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar, childNodes(), readySpokeClients())
 
 					Expect(err).ToNot(HaveOccurred())
 					Expect(result.Requeue).To(BeFalse())
 					Expect(result.RequeueAfter).To(BeZero())
-					Expect(nodelist.Items).To(HaveLen(1))
 				})
 
 				It("should initiate update when node needs new profile", func() {
 					bmh := createBMH("node1", metal3v1alpha1.OperationalStatusOK)
 					Expect(testClient.Create(ctx, bmh)).To(Succeed())
 
-					result, nodelist, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar)
+					result, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar, childNodes(), readySpokeClients())
 					Expect(err).ToNot(HaveOccurred())
-					Expect(nodelist.Items).To(HaveLen(1))
 					Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
 
 					// Verify node spec was updated to new profile
@@ -1815,49 +1799,6 @@ var _ = Describe("Helpers", func() {
 					Expect(updatedNode.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
 					Expect(updatedNode.Status.Conditions[0].Reason).To(Equal(string(hwmgmtv1alpha1.ConfigUpdate)))
 					Expect(updatedNode.Status.Conditions[0].Message).To(Equal(string(hwmgmtv1alpha1.NodeUpdateRequested)))
-				})
-
-				It("should use cluster name from PR, not ClusterId from NAR, for spoke client", func() {
-					// Set NAR ClusterId to a value that differs from the PR's ClusterDetails.Name
-					nar.Spec.ClusterId = "node-cluster-name"
-
-					bmh := createBMH("node1", metal3v1alpha1.OperationalStatusOK)
-					testClient = buildClientWithIndex(scheme,
-						createNode("node1", "test-nar", "master", currentHwProfileName, currentHwProfileName, nil, nil),
-						bmh, nar, newHwProfile)
-					createPRWithHostMap(testClient, map[string]string{"node1": "node1"})
-
-					// Capture the cluster name passed to the spoke client constructors
-					var capturedClientClusterName, capturedClientsetClusterName string
-					newClientForClusterFunc = func(_ context.Context, _ client.Client, clusterName string) (client.Client, error) {
-						capturedClientClusterName = clusterName
-						spokeScheme := runtime.NewScheme()
-						Expect(corev1.AddToScheme(spokeScheme)).To(Succeed())
-						Expect(machineconfigv1.Install(spokeScheme)).To(Succeed())
-						return fake.NewClientBuilder().WithScheme(spokeScheme).WithObjects(
-							&corev1.Node{
-								ObjectMeta: metav1.ObjectMeta{Name: "node1"},
-								Status: corev1.NodeStatus{
-									Conditions: []corev1.NodeCondition{
-										{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
-									},
-								},
-							},
-						).Build(), nil
-					}
-					newClientsetForClusterFunc = func(_ context.Context, _ client.Client, clusterName string) (kubernetes.Interface, error) {
-						capturedClientsetClusterName = clusterName
-						return kubefake.NewSimpleClientset(
-							&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
-						), nil
-					}
-
-					_, _, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar)
-					Expect(err).ToNot(HaveOccurred())
-
-					// Must use the PR's ClusterDetails.Name ("test-cluster"), not the NAR's ClusterId ("node-cluster-name")
-					Expect(capturedClientClusterName).To(Equal("test-cluster"))
-					Expect(capturedClientsetClusterName).To(Equal("test-cluster"))
 				})
 			})
 
@@ -1890,9 +1831,8 @@ var _ = Describe("Helpers", func() {
 				})
 
 				It("should initiate update for first node only when all need update", func() {
-					result, nodelist, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar)
+					result, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar, childNodes(), readySpokeClients())
 					Expect(err).ToNot(HaveOccurred())
-					Expect(nodelist.Items).To(HaveLen(3))
 					Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
 
 					// Only node1 (first alphabetically) should have its spec updated
@@ -1935,9 +1875,8 @@ var _ = Describe("Helpers", func() {
 					bmh1.Status.OperationalStatus = metal3v1alpha1.OperationalStatusServicing
 					Expect(testClient.Status().Update(ctx, bmh1)).To(Succeed())
 
-					result, nodelist, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar)
+					result, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar, childNodes(), readySpokeClients())
 					Expect(err).ToNot(HaveOccurred())
-					Expect(nodelist.Items).To(HaveLen(3))
 					// Should requeue to continue monitoring the in-progress node
 					Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
 				})
@@ -1978,9 +1917,8 @@ var _ = Describe("Helpers", func() {
 					}
 					Expect(testClient.Create(ctx, hfs1)).To(Succeed())
 
-					result, nodelist, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar)
+					result, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar, childNodes(), readySpokeClients())
 					Expect(err).ToNot(HaveOccurred())
-					Expect(nodelist.Items).To(HaveLen(3))
 					// Should requeue to continue monitoring BMH operational status
 					Expect(result.RequeueAfter).To(Equal(15 * time.Second))
 
@@ -2000,9 +1938,8 @@ var _ = Describe("Helpers", func() {
 					}
 					Expect(testClient.Status().Update(ctx, node1)).To(Succeed())
 
-					result, nodelist, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar)
+					result, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar, childNodes(), readySpokeClients())
 					Expect(err).ToNot(HaveOccurred())
-					Expect(nodelist.Items).To(HaveLen(3))
 					Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
 
 					// node2 should be updated next
@@ -2059,9 +1996,8 @@ var _ = Describe("Helpers", func() {
 				})
 
 				It("should process master group before worker group", func() {
-					result, nodelist, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar)
+					result, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar, childNodes(), readySpokeClients())
 					Expect(err).ToNot(HaveOccurred())
-					Expect(nodelist.Items).To(HaveLen(5))
 					Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
 
 					// Master1 (first master alphabetically) should be updated first
@@ -2095,9 +2031,8 @@ var _ = Describe("Helpers", func() {
 					Expect(testClient.Status().Update(ctx, master1)).To(Succeed())
 					Expect(testClient.Status().Update(ctx, master2)).To(Succeed())
 
-					result, nodelist, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar)
+					result, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar, childNodes(), readySpokeClients())
 					Expect(err).ToNot(HaveOccurred())
-					Expect(nodelist.Items).To(HaveLen(5))
 					Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
 
 					// master3 should be updated next
@@ -2142,9 +2077,8 @@ var _ = Describe("Helpers", func() {
 					Expect(testClient.Status().Update(ctx, master2)).To(Succeed())
 					Expect(testClient.Status().Update(ctx, master3)).To(Succeed())
 
-					result, nodelist, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar)
+					result, err := handleNodeAllocationRequestConfiguring(ctx, testClient, testClient, logger, testNamespace, nar, childNodes(), readySpokeClients())
 					Expect(err).ToNot(HaveOccurred())
-					Expect(nodelist.Items).To(HaveLen(5))
 					Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
 
 					// Worker1 (first worker alphabetically) should be updated

--- a/internal/hardwaremanager/controller/node_operations.go
+++ b/internal/hardwaremanager/controller/node_operations.go
@@ -8,15 +8,17 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -27,12 +29,77 @@ import (
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
-	k8sclients "github.com/openshift-kni/oran-o2ims/internal/service/common/clients/k8s"
+	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 )
 
 const (
 	DefaultDrainTimeout   = 30 * time.Second
 	DefaultMaxUnavailable = 1
+
+	hwConfigMSASuffix = "-hwconfig"
+	hwConfigMWSuffix  = "-hwconfig-rbac"
+	scaleInMSASuffix  = "-scalein"
+	scaleInMWSuffix   = "-scalein-rbac"
+)
+
+// hwConfigRBACRules is the least-privilege spoke RBAC for day2 hardware
+// configuration (node readiness, cordon/drain/uncordon, MCP maxUnavailable).
+var hwConfigRBACRules = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{""},
+		Resources: []string{"nodes"},
+		Verbs:     []string{"get", "list", "update", "patch"},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"pods"},
+		Verbs:     []string{"get", "list", "delete"},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"pods/eviction"},
+		Verbs:     []string{"create"},
+	},
+	{
+		APIGroups: []string{"apps"},
+		Resources: []string{"daemonsets"},
+		Verbs:     []string{"get"},
+	},
+	{
+		APIGroups: []string{"machineconfiguration.openshift.io"},
+		Resources: []string{"machineconfigpools"},
+		Verbs:     []string{"get"},
+	},
+}
+
+// scaleInRBACRules is the least-privilege spoke RBAC for scale-in (drain plus
+// Node delete).
+var scaleInRBACRules = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{""},
+		Resources: []string{"nodes"},
+		Verbs:     []string{"get", "list", "update", "patch", "delete"},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"pods"},
+		Verbs:     []string{"get", "list", "delete"},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"pods/eviction"},
+		Verbs:     []string{"create"},
+	},
+	{
+		APIGroups: []string{"apps"},
+		Resources: []string{"daemonsets"},
+		Verbs:     []string{"get"},
+	},
+}
+
+var (
+	hwConfigSpokeScheme = spokeclient.NewSpokeScheme(corev1.AddToScheme, machineconfigv1.Install)
+	scaleInSpokeScheme  = spokeclient.NewSpokeScheme(corev1.AddToScheme)
 )
 
 // logWriter adapts an slog function into an io.Writer so that the kubectl drain
@@ -47,34 +114,6 @@ func (w logWriter) Write(p []byte) (int, error) {
 		w.logFunc(msg)
 	}
 	return len(p), nil
-}
-
-// Testability hooks for spoke client creation.
-var (
-	spokeClientCreatorsMu      sync.RWMutex
-	newClientForClusterFunc    = k8sclients.NewClientForCluster
-	newClientsetForClusterFunc = k8sclients.NewClientsetForCluster
-)
-
-// SetTestSpokeClientCreators overrides the spoke client creation functions for
-// e2e tests. It returns a restore function that resets the originals.
-func SetTestSpokeClientCreators(
-	clientFunc func(ctx context.Context, hubClient client.Client, clusterName string) (client.Client, error),
-	clientsetFunc func(ctx context.Context, hubClient client.Client, clusterName string) (kubernetes.Interface, error),
-) func() {
-	spokeClientCreatorsMu.Lock()
-	defer spokeClientCreatorsMu.Unlock()
-
-	origClient := newClientForClusterFunc
-	origClientset := newClientsetForClusterFunc
-	newClientForClusterFunc = clientFunc
-	newClientsetForClusterFunc = clientsetFunc
-	return func() {
-		spokeClientCreatorsMu.Lock()
-		defer spokeClientCreatorsMu.Unlock()
-		newClientForClusterFunc = origClient
-		newClientsetForClusterFunc = origClientset
-	}
 }
 
 // NodeOps abstracts node-level operations against a managed cluster
@@ -250,35 +289,62 @@ func isNodeStatusConditionTrue(conditions []corev1.NodeCondition, conditionType 
 	return false
 }
 
-// createSpokeClients creates both a controller-runtime client and a kubernetes clientset
-// for a managed cluster. The controller-runtime client is used for MCP and node status reads,
-// and the clientset is used for cordon/drain/uncordon operations.
-func createSpokeClients(
+// ensureSpokeClients returns scoped spoke clients for a managed cluster.
+// ready=false means the MSA token or ManifestWork is not available yet.
+func ensureSpokeClients(
 	ctx context.Context,
 	hubClient client.Client,
+	logger *slog.Logger,
 	nar *hwmgmtv1alpha1.NodeAllocationRequest,
-) (client.Client, kubernetes.Interface, error) {
+	msaName, mwName string,
+	rules []rbacv1.PolicyRule,
+	spokeScheme *runtime.Scheme,
+) (spokeclient.Clients, bool, error) {
 	clusterName, err := getClusterNameFromPR(ctx, hubClient, nar.Name)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to resolve cluster name for NAR %s: %w", nar.Name, err)
+		return spokeclient.Clients{}, false, fmt.Errorf("failed to resolve cluster name for NAR %s: %w", nar.Name, err)
 	}
 
-	spokeClient, err := newClientForClusterFunc(ctx, hubClient, clusterName)
+	clients, ready, err := spokeclient.EnsureSpokeClient(
+		ctx, hubClient, logger, clusterName, msaName, mwName, rules, spokeScheme, spokeclient.WithClientset)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create spoke client for cluster %s: %w", clusterName, err)
+		return spokeclient.Clients{}, false, fmt.Errorf("failed to ensure scoped spoke clients: %w", err)
 	}
-
-	clientset, err := newClientsetForClusterFunc(ctx, hubClient, clusterName)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create spoke clientset for cluster %s: %w", clusterName, err)
+	if !ready {
+		return spokeclient.Clients{}, false, nil
 	}
-
-	return spokeClient, clientset, nil
+	return clients, true, nil
 }
+
+func cleanupSpokeAccess(
+	ctx context.Context,
+	hubClient client.Client,
+	logger *slog.Logger,
+	nar *hwmgmtv1alpha1.NodeAllocationRequest,
+	msaName, mwName string,
+) error {
+	clusterName, err := getClusterNameFromPR(ctx, hubClient, nar.Name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) || errors.Is(err, errMissingClusterDetails) {
+			logger.InfoContext(ctx, "Skipping spoke access cleanup; cluster name could not be resolved",
+				slog.String("nar", nar.Name), slog.Any("error", err))
+			return nil
+		}
+		return fmt.Errorf("failed to get cluster name for NodeAllocationRequest %s: %w", nar.Name, err)
+	}
+	if err := spokeclient.CleanupSpokeAccess(ctx, hubClient, clusterName, msaName, mwName); err != nil {
+		return fmt.Errorf("failed to clean up spoke access %s: %w", msaName, err)
+	}
+	return nil
+}
+
+// errMissingClusterDetails is returned when the ProvisioningRequest exists but
+// has no cluster name in ClusterDetails.
+var errMissingClusterDetails = errors.New("provisioningRequest has no cluster name in ClusterDetails")
 
 // getClusterNameFromPR looks up the ProvisioningRequest (1:1 with the NAR by name)
 // and returns the actual cluster name from ClusterDetails. The cluster name is the
-// namespace where the kubeconfig secret is stored, which may differ from
+// namespace where hub MSA/ManifestWork objects live, which may differ from
 // nar.Spec.ClusterId.
 func getClusterNameFromPR(ctx context.Context, hubClient client.Client, narName string) (string, error) {
 	pr := &provisioningv1alpha1.ProvisioningRequest{}
@@ -287,11 +353,11 @@ func getClusterNameFromPR(ctx context.Context, hubClient client.Client, narName 
 	}
 
 	if pr.Status.Extensions.ClusterDetails == nil {
-		return "", fmt.Errorf("provisioningRequest %s has no ClusterDetails in status", narName)
+		return "", fmt.Errorf("%w: provisioningRequest %s has no ClusterDetails in status", errMissingClusterDetails, narName)
 	}
 
 	if pr.Status.Extensions.ClusterDetails.Name == "" {
-		return "", fmt.Errorf("provisioningRequest %s has no cluster name in ClusterDetails", narName)
+		return "", fmt.Errorf("%w: provisioningRequest %s has no cluster name in ClusterDetails", errMissingClusterDetails, narName)
 	}
 
 	return pr.Status.Extensions.ClusterDetails.Name, nil

--- a/internal/hardwaremanager/controller/node_operations_test.go
+++ b/internal/hardwaremanager/controller/node_operations_test.go
@@ -22,6 +22,9 @@ import (
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	workv1 "open-cluster-management.io/api/work/v1"
+	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 )
 
 var _ = Describe("Node Operations", func() {
@@ -301,5 +304,83 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(8))
 		})
+	})
+})
+
+var _ = Describe("cleanupSpokeAccess", func() {
+	const (
+		narName     = "test-nar"
+		clusterName = "std-test"
+		msaName     = narName + "-hwconfig"
+		mwName      = narName + "-hwconfig-rbac"
+	)
+
+	var (
+		ctx    context.Context
+		logger *slog.Logger
+		scheme *runtime.Scheme
+		nar    *hwmgmtv1alpha1.NodeAllocationRequest
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		logger = slog.Default()
+		scheme = runtime.NewScheme()
+		Expect(hwmgmtv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(provisioningv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(msav1beta1.AddToScheme(scheme)).To(Succeed())
+		Expect(workv1.Install(scheme)).To(Succeed())
+
+		nar = &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: narName, Namespace: "oran-o2ims"},
+		}
+	})
+
+	It("should no-op when the ProvisioningRequest is missing", func() {
+		hubClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		Expect(cleanupSpokeAccess(ctx, hubClient, logger, nar, msaName, mwName)).To(Succeed())
+	})
+
+	It("should no-op when ClusterDetails is nil", func() {
+		pr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: narName},
+		}
+		hubClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pr).Build()
+		Expect(cleanupSpokeAccess(ctx, hubClient, logger, nar, msaName, mwName)).To(Succeed())
+	})
+
+	It("should no-op when ClusterDetails.Name is empty", func() {
+		pr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: narName},
+			Status: provisioningv1alpha1.ProvisioningRequestStatus{
+				Extensions: provisioningv1alpha1.Extensions{
+					ClusterDetails: &provisioningv1alpha1.ClusterDetails{Name: ""},
+				},
+			},
+		}
+		hubClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pr).Build()
+		Expect(cleanupSpokeAccess(ctx, hubClient, logger, nar, msaName, mwName)).To(Succeed())
+	})
+
+	It("should delete MSA and ManifestWork when the cluster name is known", func() {
+		pr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: narName},
+			Status: provisioningv1alpha1.ProvisioningRequestStatus{
+				Extensions: provisioningv1alpha1.Extensions{
+					ClusterDetails: &provisioningv1alpha1.ClusterDetails{Name: clusterName},
+				},
+			},
+		}
+		msa := &msav1beta1.ManagedServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: msaName, Namespace: clusterName},
+		}
+		mw := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{Name: mwName, Namespace: clusterName},
+		}
+		hubClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pr, msa, mw).Build()
+
+		Expect(cleanupSpokeAccess(ctx, hubClient, logger, nar, msaName, mwName)).To(Succeed())
+		Expect(hubClient.Get(ctx, client.ObjectKeyFromObject(msa), msa)).To(HaveOccurred())
+		Expect(hubClient.Get(ctx, client.ObjectKeyFromObject(mw), mw)).To(HaveOccurred())
 	})
 })

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -232,15 +233,6 @@ func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 					nodeAllocationRequest.Name, updateErr)
 		}
 
-		// Update ObservedGeneration to mark this generation as processed
-		// This prevents FSM from treating this as a spec change on next reconciliation
-		if updateErr := hwmgrutils.UpdateNodeAllocationRequestObservedGeneration(ctx, r.Client, nodeAllocationRequest); updateErr != nil {
-			r.Logger.ErrorContext(ctx, "Failed to update ObservedGeneration after timeout",
-				slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-				slog.Any("error", updateErr))
-			// Don't return error, timeout condition is already set
-		}
-
 		if conditionType == hwmgmtv1alpha1.Configured {
 			if err := clearConfigAnnotationForAllocatedNodes(ctx, r.Client, r.NoncachedClient, r.Logger, nodeAllocationRequest); err != nil {
 				r.Logger.ErrorContext(ctx, "Failed to clear config in progress annotations after configuration timeout",
@@ -259,6 +251,11 @@ func (r *NodeAllocationRequestReconciler) HandleNodeAllocationRequest(
 				return hwmgrutils.RequeueWithMediumInterval(),
 					fmt.Errorf("failed to clear BMH update annotations after configuration timeout %s: %w",
 						nodeAllocationRequest.Name, err)
+			}
+			if err := cleanupSpokeAccess(ctx, r.Client, r.Logger, nodeAllocationRequest,
+				nodeAllocationRequest.Name+hwConfigMSASuffix, nodeAllocationRequest.Name+hwConfigMWSuffix); err != nil {
+				r.Logger.WarnContext(ctx, "Failed to clean up hw-config spoke access after timeout",
+					slog.Any("error", err))
 			}
 		}
 
@@ -327,16 +324,21 @@ func (r *NodeAllocationRequestReconciler) handleScaleInNodesAnnotation(
 	r.Logger.InfoContext(ctx, "Processing scale-in-nodes annotation",
 		slog.Any("nodes", nodeNames))
 
-	spokeClient, spokeClientset, err := createSpokeClients(ctx, r.Client, nar)
-	noSpokeKubeconfig := err != nil && strings.Contains(err.Error(), "no kubeconfig secret found")
-	if err != nil && !noSpokeKubeconfig {
+	spokeClients, ready, err := ensureSpokeClients(ctx, r.Client, r.Logger, nar,
+		nar.Name+scaleInMSASuffix, nar.Name+scaleInMWSuffix,
+		scaleInRBACRules, scaleInSpokeScheme)
+	if err != nil && !typederrors.IsInputError(err) {
 		return hwmgrutils.RequeueWithMediumInterval(),
 			fmt.Errorf("failed to create spoke clients for scale-in: %w", err)
 	}
+	if err == nil && !ready {
+		r.Logger.InfoContext(ctx, "Spoke client for scale-in not ready yet, will retry")
+		return hwmgrutils.RequeueWithShortInterval(), nil
+	}
 
 	var nodeOps NodeOps
-	if !noSpokeKubeconfig {
-		nodeOps = NewNodeOps(spokeClient, spokeClientset, r.Logger, false)
+	if ready {
+		nodeOps = NewNodeOps(spokeClients.Client, spokeClients.Clientset, r.Logger, false)
 	}
 
 	var remainingNodeNames []string
@@ -394,10 +396,10 @@ func (r *NodeAllocationRequestReconciler) handleScaleInNodesAnnotation(
 		}
 
 		// Phase 2: Delete Node from spoke and AllocatedNode CR
-		if spokeClient != nil && an.Status.Hostname != "" {
+		if spokeClients.Client != nil && an.Status.Hostname != "" {
 			spokeNode := &corev1.Node{}
 			spokeNode.Name = an.Status.Hostname
-			if err := spokeClient.Delete(ctx, spokeNode); err != nil {
+			if err := spokeClients.Client.Delete(ctx, spokeNode); err != nil {
 				if !errors.IsNotFound(err) {
 					return hwmgrutils.RequeueWithShortInterval(),
 						fmt.Errorf("failed to delete node %s from spoke: %w", an.Status.Hostname, err)
@@ -444,6 +446,10 @@ func (r *NodeAllocationRequestReconciler) handleScaleInNodesAnnotation(
 	}
 
 	r.Logger.InfoContext(ctx, "Scale-in processing complete")
+	if err := cleanupSpokeAccess(ctx, r.Client, r.Logger, nar, nar.Name+scaleInMSASuffix, nar.Name+scaleInMWSuffix); err != nil {
+		r.Logger.WarnContext(ctx, "Failed to clean up scale-in spoke access",
+			slog.Any("error", err))
+	}
 	return hwmgrutils.DoNotRequeue(), nil
 }
 
@@ -551,7 +557,7 @@ func (r *NodeAllocationRequestReconciler) handleNewNodeAllocationRequestCreate(
 		return hwmgrutils.RequeueWithMediumInterval(),
 			fmt.Errorf("failed to update status for NodeAllocationRequest %s: %w", nodeAllocationRequest.Name, err)
 	}
-	// Update the NodeAllocationRequest ObservedGeneration status
+	// Ack this generation on create. Special case to acknowledge generation on Provisioned=InProgress state.
 	if err := hwmgrutils.UpdateNodeAllocationRequestObservedGeneration(ctx, r.Client, nodeAllocationRequest); err != nil {
 		return hwmgrutils.RequeueWithShortInterval(), fmt.Errorf("failed to update ObservedGeneration status: %w", err)
 	}
@@ -630,15 +636,31 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestSpecChanged
 	if err != nil {
 		return hwmgrutils.RequeueWithShortInterval(), err
 	}
+
 	// If no HW profile actually changed and no configuration is in progress(e.g., only
-	// skipCleanup or clusterProvisioned was updated), acknowledge the spec change and skip.
+	// skipCleanup/clusterProvisioned was updated, or the user reverted a spec that failed
+	// before nodes were mutated), acknowledge the spec change and skip the hardware configuration
+	// handling.
 	if !hwProfileChanged && !configInProgress {
 		r.Logger.InfoContext(ctx, "No HW profile changes detected, acknowledging spec change")
-		if err := hwmgrutils.UpdateNodeAllocationRequestObservedStatus(ctx, r.Client, nodeAllocationRequest); err != nil {
-			return hwmgrutils.RequeueWithShortInterval(),
-				fmt.Errorf("failed to acknowledge spec change: %w", err)
+		if configuredCondition != nil {
+			// Re-derive Configured from existing AllocatedNodes and ack generation on terminal states.
+			// This is to cover the case where the spec was reverted after a failed config before nodes
+			// were mutated to the new profile.
+			nodelist, listErr := hwmgrutils.GetChildNodes(ctx, r.Logger, r.Client, nodeAllocationRequest)
+			if listErr != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to list AllocatedNodes: %w", listErr)
+			}
+			if _, _, updateErr := r.updateConfiguredFromNodes(ctx, nodeAllocationRequest, nodelist); updateErr != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to update status for NodeAllocationRequest %s: %w", nodeAllocationRequest.Name, updateErr)
+			}
+		} else {
+			if err := hwmgrutils.UpdateNodeAllocationRequestObservedStatus(ctx, r.Client, nodeAllocationRequest); err != nil {
+				return hwmgrutils.RequeueWithShortInterval(),
+					fmt.Errorf("failed to acknowledge spec change: %w", err)
+			}
 		}
-		return hwmgrutils.DoNotRequeue(), nil
+		return ctrl.Result{}, nil
 	}
 
 	// Set Configured=InProgress with message AwaitConfig when HW profile changed and not already in progress.
@@ -659,68 +681,81 @@ func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestSpecChanged
 	}
 
 	// Handle the hardware configuration changes.
-	result, nodelist, err := handleNodeAllocationRequestConfiguring(ctx, r.Client, r.NoncachedClient, r.Logger, r.Namespace, nodeAllocationRequest)
+	return r.handleHardwareProfileChanges(ctx, nodeAllocationRequest)
+}
 
-	if nodelist != nil {
-		// Check if NAR already has a terminal condition (Failed or TimedOut) - if so, skip aggregation
-		// to preserve the terminal status. These terminal states are detected at NAR level, not node level.
-		configuredCondition := meta.FindStatusCondition(nodeAllocationRequest.Status.Conditions, string(hwmgmtv1alpha1.Configured))
-		if configuredCondition != nil &&
-			(configuredCondition.Reason == string(hwmgmtv1alpha1.Failed) ||
-				configuredCondition.Reason == string(hwmgmtv1alpha1.TimedOut)) {
-			r.Logger.InfoContext(ctx, "Skipping status aggregation - NAR already has terminal condition",
-				slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-				slog.String("reason", configuredCondition.Reason))
-
-			// Update observedGeneration to acknowledge the spec change was processed
-			// This prevents the FSM from re-triggering spec change handling
-			if updateErr := hwmgrutils.UpdateNodeAllocationRequestObservedGeneration(ctx, r.Client, nodeAllocationRequest); updateErr != nil {
-				r.Logger.ErrorContext(ctx, "Failed to update ObservedGeneration status",
-					slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-					slog.Any("error", updateErr))
-				// Return error to trigger requeue
-				return hwmgrutils.RequeueWithShortInterval(),
-					fmt.Errorf("failed to update ObservedGeneration status: %w", updateErr)
-			}
-
-			return result, err
-		}
-
-		var status metav1.ConditionStatus
-		var reason, message string
-		if len(nodelist.Items) == 1 {
-			status, reason, message = deriveNARStatusFromSingleNode(ctx, r.NoncachedClient, r.Logger, &nodelist.Items[0])
-		} else {
-			status, reason, message = deriveNARStatusFromMultipleNodes(ctx, r.NoncachedClient, r.Logger, nodelist, nodeAllocationRequest)
-		}
-		// Update the NAR status
-		if updateErr := hwmgrutils.UpdateNodeAllocationRequestStatusCondition(ctx, r.Client, nodeAllocationRequest,
-			hwmgmtv1alpha1.Configured, hwmgmtv1alpha1.ConditionReason(reason), status, message); updateErr != nil {
-
-			r.Logger.ErrorContext(ctx, "Failed to update aggregated NodeAllocationRequest status",
-				slog.Any("error", updateErr))
-
-			if err == nil {
-				err = updateErr
-			}
-		}
-
-		// Update observedGeneration when configuration reaches a terminal state (success, failure, or timeout).
-		if status == metav1.ConditionTrue ||
-			reason == string(hwmgmtv1alpha1.Failed) ||
-			reason == string(hwmgmtv1alpha1.TimedOut) {
-			if updateErr := hwmgrutils.UpdateNodeAllocationRequestObservedGeneration(ctx, r.Client, nodeAllocationRequest); updateErr != nil {
-				r.Logger.ErrorContext(ctx, "Failed to update ObservedGeneration status",
-					slog.String("nodeAllocationRequest", nodeAllocationRequest.Name),
-					slog.Any("error", updateErr))
-				// Return error to trigger requeue
-				return hwmgrutils.RequeueWithShortInterval(),
-					fmt.Errorf("failed to update ObservedGeneration status: %w", updateErr)
-			}
-		}
+// handleHardwareProfileChanges prepares spoke access, applies day-2 hardware
+// profile updates, then sets Configured from AllocatedNodes.
+func (r *NodeAllocationRequestReconciler) handleHardwareProfileChanges(
+	ctx context.Context,
+	nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest,
+) (ctrl.Result, error) {
+	nodelist, err := hwmgrutils.GetChildNodes(ctx, r.Logger, r.Client, nodeAllocationRequest)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get child nodes for NodeAllocationRequest %s: %w", nodeAllocationRequest.Name, err)
 	}
 
+	// Deterministic ordering of listed nodes by name across reconciles
+	sort.Slice(nodelist.Items, func(i, j int) bool {
+		return nodelist.Items[i].Name < nodelist.Items[j].Name
+	})
+
+	spokeClients, ready, err := ensureSpokeClients(ctx, r.Client, r.Logger, nodeAllocationRequest,
+		nodeAllocationRequest.Name+hwConfigMSASuffix, nodeAllocationRequest.Name+hwConfigMWSuffix,
+		hwConfigRBACRules, hwConfigSpokeScheme)
+	if err != nil {
+		if !typederrors.IsInputError(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to create spoke clients: %w", err)
+		}
+		r.Logger.ErrorContext(ctx, "Hardware configuration failed", slog.Any("error", err))
+		if updateErr := hwmgrutils.UpdateNodeAllocationRequestStatusCondition(ctx, r.Client, nodeAllocationRequest,
+			hwmgmtv1alpha1.Configured, hwmgmtv1alpha1.Failed, metav1.ConditionFalse, err.Error()); updateErr != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update status for NodeAllocationRequest %s: %w", nodeAllocationRequest.Name, updateErr)
+		}
+		return ctrl.Result{}, nil
+	}
+	if !ready {
+		r.Logger.InfoContext(ctx, "Spoke client for hardware configuration not ready yet, will retry")
+		return hwmgrutils.RequeueWithShortInterval(), nil
+	}
+
+	result, err := handleNodeAllocationRequestConfiguring(ctx, r.Client, r.NoncachedClient, r.Logger, r.Namespace, nodeAllocationRequest, nodelist, spokeClients)
+
+	// Still aggregate even when configuring returns a transient error. The error is still returned so the reconcile requeues after aggregation.
+	status, reason, updateErr := r.updateConfiguredFromNodes(ctx, nodeAllocationRequest, nodelist)
+	if updateErr != nil {
+		return ctrl.Result{}, updateErr
+	}
+
+	if status == metav1.ConditionTrue || reason == string(hwmgmtv1alpha1.Failed) {
+		if cleanupErr := cleanupSpokeAccess(ctx, r.Client, r.Logger, nodeAllocationRequest,
+			nodeAllocationRequest.Name+hwConfigMSASuffix, nodeAllocationRequest.Name+hwConfigMWSuffix); cleanupErr != nil {
+			r.Logger.WarnContext(ctx, "Failed to clean up hw-config spoke access after terminal configuration",
+				slog.Any("error", cleanupErr))
+		}
+	}
 	return result, err
+}
+
+// updateConfiguredFromNodes aggregates AllocatedNode conditions onto the NAR Configured condition.
+func (r *NodeAllocationRequestReconciler) updateConfiguredFromNodes(
+	ctx context.Context,
+	nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest,
+	nodelist *hwmgmtv1alpha1.AllocatedNodeList,
+) (metav1.ConditionStatus, string, error) {
+	var status metav1.ConditionStatus
+	var reason, message string
+	if len(nodelist.Items) == 1 {
+		status, reason, message = deriveNARStatusFromSingleNode(ctx, r.NoncachedClient, r.Logger, &nodelist.Items[0])
+	} else {
+		status, reason, message = deriveNARStatusFromMultipleNodes(ctx, r.NoncachedClient, r.Logger, nodelist, nodeAllocationRequest)
+	}
+
+	if err := hwmgrutils.UpdateNodeAllocationRequestStatusCondition(ctx, r.Client, nodeAllocationRequest,
+		hwmgmtv1alpha1.Configured, hwmgmtv1alpha1.ConditionReason(reason), status, message); err != nil {
+		return "", "", fmt.Errorf("failed to update status for NodeAllocationRequest %s: %w", nodeAllocationRequest.Name, err)
+	}
+	return status, reason, nil
 }
 
 func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestProcessing(
@@ -903,6 +938,16 @@ func (r *NodeAllocationRequestReconciler) checkHardwareTimeout(
 func (r *NodeAllocationRequestReconciler) handleNodeAllocationRequestDeletion(ctx context.Context, nodeAllocationRequest *hwmgmtv1alpha1.NodeAllocationRequest) (bool, error) {
 
 	r.Logger.InfoContext(ctx, "Finalizing NodeAllocationRequest")
+
+	// Restrict cleanup of spoke access resources on NAR deletion.
+	if err := cleanupSpokeAccess(ctx, r.Client, r.Logger, nodeAllocationRequest,
+		nodeAllocationRequest.Name+hwConfigMSASuffix, nodeAllocationRequest.Name+hwConfigMWSuffix); err != nil {
+		return false, fmt.Errorf("failed to clean up hw-config spoke access: %w", err)
+	}
+	if err := cleanupSpokeAccess(ctx, r.Client, r.Logger, nodeAllocationRequest,
+		nodeAllocationRequest.Name+scaleInMSASuffix, nodeAllocationRequest.Name+scaleInMWSuffix); err != nil {
+		return false, fmt.Errorf("failed to clean up scale-in spoke access: %w", err)
+	}
 
 	return releaseNodeAllocationRequest(ctx, r.Client, r.Logger, nodeAllocationRequest)
 }

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
@@ -33,12 +33,19 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	hwmgrutils "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/utils"
+	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 )
 
 var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
@@ -498,6 +505,10 @@ var _ = Describe("handleScaleInAnnotations", func() {
 		Expect(hwmgmtv1alpha1.AddToScheme(scheme)).To(Succeed())
 		Expect(provisioningv1alpha1.AddToScheme(scheme)).To(Succeed())
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(addonv1alpha1.Install(scheme)).To(Succeed())
+		Expect(clusterv1.Install(scheme)).To(Succeed())
+		Expect(workv1.Install(scheme)).To(Succeed())
+		Expect(msav1beta1.AddToScheme(scheme)).To(Succeed())
 
 		fakeClient = fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -519,7 +530,7 @@ var _ = Describe("handleScaleInAnnotations", func() {
 			Namespace: "test-ns",
 		}
 
-		// Create a ProvisioningRequest (looked up by createSpokeClients)
+		// Create a ProvisioningRequest (looked up by ensureSpokeClients)
 		pr := &provisioningv1alpha1.ProvisioningRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-nar",
@@ -639,4 +650,390 @@ var _ = Describe("handleScaleInAnnotations", func() {
 		// Verify nodeNames was pruned even for NotFound nodes
 		Expect(updatedNAR.Status.Properties.NodeNames).To(ConsistOf("other-node"))
 	})
+})
+
+var _ = Describe("handleNodeAllocationRequestSpecChanged", func() {
+	var (
+		reconciler *NodeAllocationRequestReconciler
+		fakeClient client.Client
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		testLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		scheme := runtime.NewScheme()
+		Expect(hwmgmtv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(provisioningv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(&hwmgmtv1alpha1.NodeAllocationRequest{}, &hwmgmtv1alpha1.AllocatedNode{}).
+			WithIndex(&hwmgmtv1alpha1.AllocatedNode{}, "spec.nodeAllocationRequest", func(obj client.Object) []string {
+				return []string{obj.(*hwmgmtv1alpha1.AllocatedNode).Spec.NodeAllocationRequest}
+			}).
+			Build()
+
+		reconciler = &NodeAllocationRequestReconciler{
+			Client:          fakeClient,
+			NoncachedClient: fakeClient,
+			Logger:          testLogger,
+			Namespace:       "oran-o2ims",
+		}
+	})
+
+	createNAR := func(configuredReason string, configuredStatus metav1.ConditionStatus) *hwmgmtv1alpha1.NodeAllocationRequest {
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-nar",
+				Namespace:  "oran-o2ims",
+				Generation: 2,
+			},
+			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
+					{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+						Name: "master", Role: hwmgmtv1alpha1.NodeRoleMaster, HwProfile: "profile-v1",
+					}, Size: 2},
+				},
+			},
+		}
+		Expect(fakeClient.Create(ctx, nar)).To(Succeed())
+		hwmgrutils.SetStatusCondition(&nar.Status.Conditions,
+			string(hwmgmtv1alpha1.Provisioned), string(hwmgmtv1alpha1.Completed),
+			metav1.ConditionTrue, "Provisioned")
+		hwmgrutils.SetStatusCondition(&nar.Status.Conditions,
+			string(hwmgmtv1alpha1.Configured), configuredReason,
+			configuredStatus, "stale")
+		nar.Status.ObservedGeneration = 1
+		Expect(fakeClient.Status().Update(ctx, nar)).To(Succeed())
+		return nar
+	}
+
+	createNode := func(name, reason string, status metav1.ConditionStatus) {
+		node := &hwmgmtv1alpha1.AllocatedNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "oran-o2ims",
+			},
+			Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
+				GroupName:             "master",
+				HwProfile:             "profile-v1",
+				NodeAllocationRequest: "test-nar",
+			},
+		}
+		Expect(fakeClient.Create(ctx, node)).To(Succeed())
+		hwmgrutils.SetStatusCondition(&node.Status.Conditions,
+			string(hwmgmtv1alpha1.Configured), reason, status, reason)
+		Expect(fakeClient.Status().Update(ctx, node)).To(Succeed())
+	}
+
+	It("should keep Configured=Failed when a child node is Failed after a spec revert", func() {
+		nar := createNAR(string(hwmgmtv1alpha1.Failed), metav1.ConditionFalse)
+		createNode("n1", string(hwmgmtv1alpha1.Failed), metav1.ConditionFalse)
+		createNode("n2", string(hwmgmtv1alpha1.ConfigApplied), metav1.ConditionTrue)
+
+		result, err := reconciler.handleNodeAllocationRequestSpecChanged(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero())
+
+		updated := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nar), updated)).To(Succeed())
+		cond := meta.FindStatusCondition(updated.Status.Conditions, string(hwmgmtv1alpha1.Configured))
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.Reason).To(Equal(string(hwmgmtv1alpha1.Failed)))
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(updated.Status.ObservedGeneration).To(Equal(int64(2)))
+	})
+
+	It("should clear NAR-level Failed when all nodes are ConfigApplied after a spec revert", func() {
+		nar := createNAR(string(hwmgmtv1alpha1.Failed), metav1.ConditionFalse)
+		createNode("n1", string(hwmgmtv1alpha1.ConfigApplied), metav1.ConditionTrue)
+		createNode("n2", string(hwmgmtv1alpha1.ConfigApplied), metav1.ConditionTrue)
+
+		result, err := reconciler.handleNodeAllocationRequestSpecChanged(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero())
+
+		updated := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nar), updated)).To(Succeed())
+		cond := meta.FindStatusCondition(updated.Status.Conditions, string(hwmgmtv1alpha1.Configured))
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.Reason).To(Equal(string(hwmgmtv1alpha1.ConfigApplied)))
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(updated.Status.ObservedGeneration).To(Equal(int64(2)))
+	})
+
+	It("should ack a non-profile spec change without deriving from AllocatedNodes when Configured is not present", func() {
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-nar",
+				Namespace:  "oran-o2ims",
+				Generation: 2,
+			},
+			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+				ConfigTransactionId: 2,
+				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
+					{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+						Name: "master", Role: hwmgmtv1alpha1.NodeRoleMaster, HwProfile: "profile-v1",
+					}, Size: 1},
+				},
+			},
+		}
+		Expect(fakeClient.Create(ctx, nar)).To(Succeed())
+		hwmgrutils.SetStatusCondition(&nar.Status.Conditions,
+			string(hwmgmtv1alpha1.Provisioned), string(hwmgmtv1alpha1.Completed),
+			metav1.ConditionTrue, "Provisioned")
+		nar.Status.ObservedGeneration = 1
+		nar.Status.ObservedConfigTransactionId = 1
+		Expect(fakeClient.Status().Update(ctx, nar)).To(Succeed())
+
+		node := &hwmgmtv1alpha1.AllocatedNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "n1", Namespace: "oran-o2ims"},
+			Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
+				GroupName:             "master",
+				HwProfile:             "profile-v1",
+				NodeAllocationRequest: "test-nar",
+			},
+		}
+		Expect(fakeClient.Create(ctx, node)).To(Succeed())
+
+		result, err := reconciler.handleNodeAllocationRequestSpecChanged(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero())
+
+		updated := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nar), updated)).To(Succeed())
+		Expect(meta.FindStatusCondition(updated.Status.Conditions, string(hwmgmtv1alpha1.Configured))).To(BeNil())
+		Expect(updated.Status.ObservedGeneration).To(Equal(int64(2)))
+		Expect(updated.Status.ObservedConfigTransactionId).To(Equal(int64(2)))
+	})
+})
+
+var _ = Describe("handleHardwareProfileChanges", func() {
+	const (
+		narName   = "test-nar"
+		namespace = "oran-o2ims"
+	)
+
+	var (
+		ctx        context.Context
+		logger     *slog.Logger
+		reconciler *NodeAllocationRequestReconciler
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	})
+
+	AfterEach(func() {
+		spokeclient.ClearCache()
+	})
+
+	hubScheme := func() *runtime.Scheme {
+		scheme := runtime.NewScheme()
+		Expect(hwmgmtv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(provisioningv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(addonv1alpha1.Install(scheme)).To(Succeed())
+		Expect(clusterv1.Install(scheme)).To(Succeed())
+		Expect(workv1.Install(scheme)).To(Succeed())
+		Expect(msav1beta1.AddToScheme(scheme)).To(Succeed())
+		return scheme
+	}
+
+	spokeAccessReadyObjects := func() []client.Object {
+		msaName := narName + hwConfigMSASuffix
+		mwName := narName + hwConfigMWSuffix
+		tokenName := msaName + "-token"
+		return []client.Object{
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}},
+			&addonv1alpha1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{Name: "managed-serviceaccount", Namespace: "test-cluster"},
+			},
+			&msav1beta1.ManagedServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: msaName, Namespace: "test-cluster"},
+				Status: msav1beta1.ManagedServiceAccountStatus{
+					TokenSecretRef: &msav1beta1.SecretRef{Name: tokenName},
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tokenName, Namespace: "test-cluster", ResourceVersion: "100",
+				},
+				Data: map[string][]byte{"token": []byte("t"), "ca.crt": []byte("c")},
+			},
+			&workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{Name: mwName, Namespace: "test-cluster"},
+				Status: workv1.ManifestWorkStatus{
+					Conditions: []metav1.Condition{{
+						Type:               workv1.WorkAvailable,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.Now(),
+					}},
+				},
+			},
+			&clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Spec: clusterv1.ManagedClusterSpec{
+					ManagedClusterClientConfigs: []clusterv1.ClientConfig{
+						{URL: "https://api.test-cluster.example.com:6443"},
+					},
+				},
+			},
+		}
+	}
+
+	stubSpokeCreators := func() {
+		restore := spokeclient.SetTestSpokeClientCreator(
+			func(string, string, []byte, *runtime.Scheme) (client.Client, error) {
+				return fake.NewClientBuilder().Build(), nil
+			})
+		DeferCleanup(restore)
+		restoreCS := spokeclient.SetTestSpokeClientsetCreator(
+			func(string, string, []byte) (kubernetes.Interface, error) {
+				return kubefake.NewSimpleClientset(), nil
+			})
+		DeferCleanup(restoreCS)
+	}
+
+	newReconciler := func(scheme *runtime.Scheme, objs ...client.Object) *NodeAllocationRequestReconciler {
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(objs...).
+			WithStatusSubresource(
+				&hwmgmtv1alpha1.NodeAllocationRequest{},
+				&hwmgmtv1alpha1.AllocatedNode{},
+				&provisioningv1alpha1.ProvisioningRequest{},
+			).
+			WithIndex(&hwmgmtv1alpha1.AllocatedNode{}, "spec.nodeAllocationRequest",
+				func(obj client.Object) []string {
+					return []string{obj.(*hwmgmtv1alpha1.AllocatedNode).Spec.NodeAllocationRequest}
+				}).
+			Build()
+		return &NodeAllocationRequestReconciler{
+			Client:          c,
+			NoncachedClient: c,
+			Logger:          logger,
+			Namespace:       namespace,
+		}
+	}
+
+	narAndNode := func(configuredReason string, configuredStatus metav1.ConditionStatus) (*hwmgmtv1alpha1.NodeAllocationRequest, *hwmgmtv1alpha1.AllocatedNode) {
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: narName, Namespace: namespace, Generation: 2},
+			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+				ClusterId: "test-cluster",
+				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
+					{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{
+						Name: "master", Role: hwmgmtv1alpha1.NodeRoleMaster, HwProfile: "profile-v2",
+					}, Size: 1},
+				},
+			},
+		}
+		hwmgrutils.SetStatusCondition(&nar.Status.Conditions,
+			string(hwmgmtv1alpha1.Configured), configuredReason, configuredStatus, "in progress")
+		node := &hwmgmtv1alpha1.AllocatedNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-1", Namespace: namespace},
+			Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
+				GroupName:             "master",
+				HwProfile:             "profile-v1",
+				NodeAllocationRequest: narName,
+			},
+		}
+		hwmgrutils.SetStatusCondition(&node.Status.Conditions,
+			string(hwmgmtv1alpha1.Configured), string(hwmgmtv1alpha1.ConfigApplied),
+			metav1.ConditionTrue, "applied")
+		return nar, node
+	}
+
+	prWithCluster := func() *provisioningv1alpha1.ProvisioningRequest {
+		return &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: narName},
+			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
+				Name: "test", TemplateName: "test-template", TemplateVersion: "v1",
+			},
+			Status: provisioningv1alpha1.ProvisioningRequestStatus{
+				Extensions: provisioningv1alpha1.Extensions{
+					ClusterDetails: &provisioningv1alpha1.ClusterDetails{Name: "test-cluster"},
+				},
+			},
+		}
+	}
+
+	It("should fail NAR when managed-serviceaccount addon is not available", func() {
+		nar, node := narAndNode(string(hwmgmtv1alpha1.InProgress), metav1.ConditionFalse)
+		reconciler = newReconciler(hubScheme(), nar, node, prWithCluster())
+
+		_, err := reconciler.handleHardwareProfileChanges(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(nar), updated)).To(Succeed())
+		cond := meta.FindStatusCondition(updated.Status.Conditions, string(hwmgmtv1alpha1.Configured))
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.Reason).To(Equal(string(hwmgmtv1alpha1.Failed)))
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Message).To(ContainSubstring("managed-serviceaccount addon is not available"))
+
+		updatedNode := &hwmgmtv1alpha1.AllocatedNode{}
+		Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(node), updatedNode)).To(Succeed())
+		Expect(updatedNode.Spec.HwProfile).To(Equal("profile-v1"))
+	})
+
+	It("should not aggregate while spoke clients are not ready", func() {
+		nar, node := narAndNode(string(hwmgmtv1alpha1.InProgress), metav1.ConditionFalse)
+		reconciler = newReconciler(hubScheme(), nar, node, prWithCluster(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}},
+			&addonv1alpha1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{Name: "managed-serviceaccount", Namespace: "test-cluster"},
+			},
+		)
+
+		result, err := reconciler.handleHardwareProfileChanges(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+
+		updated := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(nar), updated)).To(Succeed())
+		cond := meta.FindStatusCondition(updated.Status.Conditions, string(hwmgmtv1alpha1.Configured))
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.Reason).To(Equal(string(hwmgmtv1alpha1.InProgress)))
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+
+		msa := &msav1beta1.ManagedServiceAccount{}
+		Expect(reconciler.Get(ctx, client.ObjectKey{
+			Name: narName + hwConfigMSASuffix, Namespace: "test-cluster",
+		}, msa)).To(Succeed())
+	})
+
+	DescribeTable("should clean up hw-config spoke access after terminal configuration",
+		func(nodeReason string, nodeStatus metav1.ConditionStatus) {
+			stubSpokeCreators()
+
+			nar, node := narAndNode(string(hwmgmtv1alpha1.InProgress), metav1.ConditionFalse)
+			node.Spec.HwProfile = "profile-v2"
+			node.Status.Hostname = "node-1"
+			hwmgrutils.SetStatusCondition(&node.Status.Conditions,
+				string(hwmgmtv1alpha1.Configured), nodeReason, nodeStatus, nodeReason)
+
+			objs := append([]client.Object{nar, node, prWithCluster()}, spokeAccessReadyObjects()...)
+			reconciler = newReconciler(hubScheme(), objs...)
+
+			_, err := reconciler.handleHardwareProfileChanges(ctx, nar)
+			Expect(err).ToNot(HaveOccurred())
+
+			msa := &msav1beta1.ManagedServiceAccount{}
+			err = reconciler.Get(ctx, client.ObjectKey{
+				Name: narName + hwConfigMSASuffix, Namespace: "test-cluster",
+			}, msa)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+			mw := &workv1.ManifestWork{}
+			err = reconciler.Get(ctx, client.ObjectKey{
+				Name: narName + hwConfigMWSuffix, Namespace: "test-cluster",
+			}, mw)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		},
+		Entry("when configuration completed", string(hwmgmtv1alpha1.ConfigApplied), metav1.ConditionTrue),
+		Entry("when configuration failed", string(hwmgmtv1alpha1.Failed), metav1.ConditionFalse),
+	)
 })

--- a/internal/hardwaremanager/utils/node_allocation_request.go
+++ b/internal/hardwaremanager/utils/node_allocation_request.go
@@ -166,6 +166,11 @@ func UpdateNodeAllocationRequestStatusCondition(
 				conditionReason == hwmgmtv1alpha1.TimedOut {
 				// Clear start time when provisioning operation completes, fails, or times out
 				newNodeAllocationRequest.Status.HardwareOperationStartTime = nil
+				// Acknowledge generation only on Failed/TimedOut states.
+				if conditionReason == hwmgmtv1alpha1.Failed ||
+					conditionReason == hwmgmtv1alpha1.TimedOut {
+					newNodeAllocationRequest.Status.ObservedGeneration = newNodeAllocationRequest.ObjectMeta.Generation
+				}
 			}
 
 		case hwmgmtv1alpha1.Configured:
@@ -195,6 +200,8 @@ func UpdateNodeAllocationRequestStatusCondition(
 				conditionReason == hwmgmtv1alpha1.TimedOut {
 				// Clear start time when configuration operation completes, fails, or times out
 				newNodeAllocationRequest.Status.HardwareOperationStartTime = nil
+				// Acknowledge generation on terminal states.
+				newNodeAllocationRequest.Status.ObservedGeneration = newNodeAllocationRequest.ObjectMeta.Generation
 			}
 		}
 

--- a/internal/hardwaremanager/utils/node_allocation_request_test.go
+++ b/internal/hardwaremanager/utils/node_allocation_request_test.go
@@ -63,3 +63,73 @@ var _ = Describe("UpdateNodeAllocationRequestObservedStatus", func() {
 		Expect(updated.Status.ObservedConfigTransactionId).To(Equal(int64(4)))
 	})
 })
+
+var _ = Describe("UpdateNodeAllocationRequestStatusCondition", func() {
+	var (
+		ctx context.Context
+		c   client.Client
+		nar *hwmgmtv1alpha1.NodeAllocationRequest
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme := runtime.NewScheme()
+		Expect(hwmgmtv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		nar = &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-nar",
+				Namespace:  "default",
+				Generation: 5,
+			},
+			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
+				ConfigTransactionId: 4,
+			},
+			Status: hwmgmtv1alpha1.NodeAllocationRequestStatus{
+				ObservedGeneration:          3,
+				ObservedConfigTransactionId: 2,
+			},
+		}
+
+		c = fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(nar).
+			WithStatusSubresource(nar).
+			Build()
+	})
+
+	DescribeTable("conditionally acks ObservedGeneration",
+		func(conditionType hwmgmtv1alpha1.ConditionType,
+			reason hwmgmtv1alpha1.ConditionReason,
+			status metav1.ConditionStatus,
+			expectAck bool) {
+
+			err := UpdateNodeAllocationRequestStatusCondition(ctx, c, nar, conditionType, reason, status, "test")
+			Expect(err).ToNot(HaveOccurred())
+
+			updated := &hwmgmtv1alpha1.NodeAllocationRequest{}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(nar), updated)).To(Succeed())
+			if expectAck {
+				Expect(updated.Status.ObservedGeneration).To(Equal(int64(5)))
+			} else {
+				Expect(updated.Status.ObservedGeneration).To(Equal(int64(3)))
+			}
+		},
+		Entry("Configured InProgress does not ack",
+			hwmgmtv1alpha1.Configured, hwmgmtv1alpha1.InProgress, metav1.ConditionFalse, false),
+		Entry("Configured Failed acks",
+			hwmgmtv1alpha1.Configured, hwmgmtv1alpha1.Failed, metav1.ConditionFalse, true),
+		Entry("Configured TimedOut acks",
+			hwmgmtv1alpha1.Configured, hwmgmtv1alpha1.TimedOut, metav1.ConditionFalse, true),
+		Entry("Configured ConfigApplied acks",
+			hwmgmtv1alpha1.Configured, hwmgmtv1alpha1.ConfigApplied, metav1.ConditionTrue, true),
+		Entry("Provisioned InProgress does not ack",
+			hwmgmtv1alpha1.Provisioned, hwmgmtv1alpha1.InProgress, metav1.ConditionFalse, false),
+		Entry("Provisioned Completed does not ack",
+			hwmgmtv1alpha1.Provisioned, hwmgmtv1alpha1.Completed, metav1.ConditionTrue, false),
+		Entry("Provisioned Failed acks",
+			hwmgmtv1alpha1.Provisioned, hwmgmtv1alpha1.Failed, metav1.ConditionFalse, true),
+		Entry("Provisioned TimedOut acks",
+			hwmgmtv1alpha1.Provisioned, hwmgmtv1alpha1.TimedOut, metav1.ConditionFalse, true),
+	)
+})

--- a/internal/spokeclient/spokeclient.go
+++ b/internal/spokeclient/spokeclient.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -36,8 +37,21 @@ const (
 	defaultAddonInstallNamespace   = "open-cluster-management-agent-addon"
 )
 
+// Clients holds the spoke clients built from a scoped MSA token.
+type Clients struct {
+	Client    client.Client
+	Clientset kubernetes.Interface
+}
+
+const (
+	// RuntimeClientOnly skips building a kubernetes.Interface.
+	RuntimeClientOnly = false
+	// WithClientset also builds a kubernetes.Interface from the scoped token.
+	WithClientset = true
+)
+
 type spokeClientEntry struct {
-	client               client.Client
+	clients              Clients
 	tokenResourceVersion string
 }
 
@@ -46,13 +60,27 @@ var (
 	spokeClients   = make(map[string]*spokeClientEntry)
 )
 
-// newSpokeClientFunc builds a spoke client from connection details.
+// newSpokeClientFunc builds a controller-runtime spoke client from connection details.
 // Extracted as a package-level variable so tests can override it.
 var newSpokeClientFunc = buildSpokeClient
 
+// newSpokeClientsetFunc builds a kubernetes clientset from the same connection details.
+var newSpokeClientsetFunc = buildSpokeClientset
+
 // SetTestSpokeClientCreator overrides the spoke client builder for tests.
-func SetTestSpokeClientCreator(fn func(apiServerURL, token string, caCert []byte, spokeScheme *runtime.Scheme) (client.Client, error)) {
+// It returns a restore function that resets the original builder.
+func SetTestSpokeClientCreator(fn func(apiServerURL, token string, caCert []byte, spokeScheme *runtime.Scheme) (client.Client, error)) func() {
+	orig := newSpokeClientFunc
 	newSpokeClientFunc = fn
+	return func() { newSpokeClientFunc = orig }
+}
+
+// SetTestSpokeClientsetCreator overrides the spoke clientset builder for tests.
+// It returns a restore function that resets the original builder.
+func SetTestSpokeClientsetCreator(fn func(apiServerURL, token string, caCert []byte) (kubernetes.Interface, error)) func() {
+	orig := newSpokeClientsetFunc
+	newSpokeClientsetFunc = fn
+	return func() { newSpokeClientsetFunc = orig }
 }
 
 // NewSpokeScheme creates a scheme from the provided installer functions.
@@ -64,23 +92,38 @@ func NewSpokeScheme(installers ...func(*runtime.Scheme) error) *runtime.Scheme {
 	return s
 }
 
-// buildSpokeClient creates a controller-runtime client for a spoke cluster
-// using bearer token authentication and the provided scheme.
-func buildSpokeClient(apiServerURL, token string, caCert []byte, spokeScheme *runtime.Scheme) (client.Client, error) {
+func spokeRESTConfig(apiServerURL, token string, caCert []byte) *rest.Config {
 	tlsConfig := rest.TLSClientConfig{}
 	if len(caCert) > 0 {
 		tlsConfig.CAData = caCert
 	}
-	cfg := &rest.Config{
+	return &rest.Config{
 		Host:            apiServerURL,
 		BearerToken:     token,
 		TLSClientConfig: tlsConfig,
 	}
-	c, err := client.New(cfg, client.Options{Scheme: spokeScheme})
+}
+
+// buildSpokeClient creates a controller-runtime client for a spoke cluster
+// using bearer token authentication and the provided scheme.
+func buildSpokeClient(apiServerURL, token string, caCert []byte, spokeScheme *runtime.Scheme) (client.Client, error) {
+	config := spokeRESTConfig(apiServerURL, token, caCert)
+	c, err := client.New(config, client.Options{Scheme: spokeScheme})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create spoke client: %w", err)
 	}
 	return c, nil
+}
+
+// buildSpokeClientset creates a kubernetes clientset for a spoke cluster
+// using bearer token authentication.
+func buildSpokeClientset(apiServerURL, token string, caCert []byte) (kubernetes.Interface, error) {
+	config := spokeRESTConfig(apiServerURL, token, caCert)
+	cs, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create spoke clientset: %w", err)
+	}
+	return cs, nil
 }
 
 // EnsureSpokeClient returns a scoped spoke client or creates one through the
@@ -88,15 +131,16 @@ func buildSpokeClient(apiServerURL, token string, caCert []byte, spokeScheme *ru
 // on cache miss it runs the full setup.
 //
 // Returns:
-//   - (client, true, nil): spoke client is ready to use
-//   - (nil, false, nil): spoke client is not ready yet — caller should requeue
-//   - (nil, false, err): real failure (API error or InputError) — caller should handle
+//   - (clients, true, nil): spoke client is ready to use
+//   - (zero, false, nil): spoke client is not ready yet — caller should requeue
+//   - (zero, false, err): real failure (API error or InputError) — caller should handle
 //
 // Parameters:
 //   - msaName: name for the ManagedServiceAccount CR (e.g. "<pr-name>-upgrade")
 //   - mwName: name for the RBAC ManifestWork (e.g. "<pr-name>-upgrade-rbac")
 //   - rules: RBAC PolicyRules to deliver to the spoke via ManifestWork
 //   - spokeScheme: scheme for the spoke client (determines which types it can work with)
+//   - needClientset: whether to build a kubernetes.Interface from the same token
 func EnsureSpokeClient(
 	ctx context.Context,
 	hubClient client.Client,
@@ -104,19 +148,20 @@ func EnsureSpokeClient(
 	clusterName, msaName, mwName string,
 	rules []rbacv1.PolicyRule,
 	spokeScheme *runtime.Scheme,
-) (client.Client, bool, error) {
+	buildClientset bool,
+) (Clients, bool, error) {
 	spokeClientsMu.RLock()
 	entry, cached := spokeClients[msaName]
 	spokeClientsMu.RUnlock()
 
 	if cached {
-		spokeClient, needsFullSetup, err := refreshCachedSpokeClient(
-			ctx, hubClient, logger, clusterName, msaName, entry, spokeScheme)
+		clients, needsFullSetup, err := refreshCachedSpokeClient(
+			ctx, hubClient, logger, clusterName, msaName, entry, spokeScheme, buildClientset)
 		if err != nil {
-			return nil, false, err
+			return Clients{}, false, err
 		}
 		if !needsFullSetup {
-			return spokeClient, true, nil
+			return clients, true, nil
 		}
 	}
 
@@ -127,10 +172,10 @@ func EnsureSpokeClient(
 		Name: managedServiceAccountAddonName, Namespace: clusterName,
 	}, addon); err != nil {
 		if errors.IsNotFound(err) {
-			return nil, false, typederrors.NewInputError(
+			return Clients{}, false, typederrors.NewInputError(
 				"the managed-serviceaccount addon is not available on cluster %s", clusterName)
 		}
-		return nil, false, fmt.Errorf("failed to check managed-serviceaccount addon: %w", err)
+		return Clients{}, false, fmt.Errorf("failed to check managed-serviceaccount addon: %w", err)
 	}
 
 	// 2. Create ManagedServiceAccount if not present.
@@ -139,7 +184,7 @@ func EnsureSpokeClient(
 		Name: msaName, Namespace: clusterName,
 	}, msa); err != nil {
 		if !errors.IsNotFound(err) {
-			return nil, false, fmt.Errorf("failed to get ManagedServiceAccount: %w", err)
+			return Clients{}, false, fmt.Errorf("failed to get ManagedServiceAccount: %w", err)
 		}
 		msa = &msav1beta1.ManagedServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
@@ -154,7 +199,7 @@ func EnsureSpokeClient(
 			},
 		}
 		if err := hubClient.Create(ctx, msa); err != nil {
-			return nil, false, fmt.Errorf("failed to create ManagedServiceAccount: %w", err)
+			return Clients{}, false, fmt.Errorf("failed to create ManagedServiceAccount: %w", err)
 		}
 	}
 
@@ -162,7 +207,7 @@ func EnsureSpokeClient(
 	if msa.Status.TokenSecretRef == nil || msa.Status.TokenSecretRef.Name == "" {
 		logger.InfoContext(ctx, "Waiting for ManagedServiceAccount token to be synced",
 			slog.String("clusterName", clusterName), slog.String("msaName", msaName))
-		return nil, false, nil
+		return Clients{}, false, nil
 	}
 
 	// 4. Read token Secret.
@@ -170,7 +215,7 @@ func EnsureSpokeClient(
 	if err := hubClient.Get(ctx, types.NamespacedName{
 		Name: msa.Status.TokenSecretRef.Name, Namespace: clusterName,
 	}, tokenSecret); err != nil {
-		return nil, false, fmt.Errorf("failed to read token secret: %w", err)
+		return Clients{}, false, fmt.Errorf("failed to read token secret: %w", err)
 	}
 
 	// 5. Create RBAC ManifestWork if not present.
@@ -183,14 +228,14 @@ func EnsureSpokeClient(
 		Name: mwName, Namespace: clusterName,
 	}, mw); err != nil {
 		if !errors.IsNotFound(err) {
-			return nil, false, fmt.Errorf("failed to get RBAC ManifestWork: %w", err)
+			return Clients{}, false, fmt.Errorf("failed to get RBAC ManifestWork: %w", err)
 		}
 		mw, err = BuildRBACManifestWork(mwName, clusterName, msaName, saNamespace, rules)
 		if err != nil {
-			return nil, false, fmt.Errorf("failed to build RBAC ManifestWork: %w", err)
+			return Clients{}, false, fmt.Errorf("failed to build RBAC ManifestWork: %w", err)
 		}
 		if err := hubClient.Create(ctx, mw); err != nil {
-			return nil, false, fmt.Errorf("failed to create RBAC ManifestWork: %w", err)
+			return Clients{}, false, fmt.Errorf("failed to create RBAC ManifestWork: %w", err)
 		}
 	}
 
@@ -199,39 +244,47 @@ func EnsureSpokeClient(
 	if availableCondition == nil || availableCondition.Status != metav1.ConditionTrue {
 		logger.InfoContext(ctx, "Waiting for RBAC ManifestWork resources to be available on spoke",
 			slog.String("clusterName", clusterName), slog.String("mwName", mwName))
-		return nil, false, nil
+		return Clients{}, false, nil
 	}
 
-	// 7. Build spoke client.
+	// 7. Build spoke clients from the scoped token.
 	token, caCert, err := extractTokenData(tokenSecret, clusterName)
 	if err != nil {
-		return nil, false, err
+		return Clients{}, false, err
 	}
 	apiServerURL, err := getAPIServerURL(ctx, hubClient, clusterName)
 	if err != nil {
-		return nil, false, err
+		return Clients{}, false, err
 	}
-	spokeClient, err := newSpokeClientFunc(apiServerURL, string(token), caCert, spokeScheme)
+	c, err := newSpokeClientFunc(apiServerURL, string(token), caCert, spokeScheme)
 	if err != nil {
-		return nil, false, err
+		return Clients{}, false, err
+	}
+	clients := Clients{Client: c}
+	if buildClientset {
+		cs, err := newSpokeClientsetFunc(apiServerURL, string(token), caCert)
+		if err != nil {
+			return Clients{}, false, err
+		}
+		clients.Clientset = cs
 	}
 
-	// 8. Cache the client.
+	// 8. Cache the clients.
 	spokeClientsMu.Lock()
 	spokeClients[msaName] = &spokeClientEntry{
-		client:               spokeClient,
+		clients:              clients,
 		tokenResourceVersion: tokenSecret.ResourceVersion,
 	}
 	spokeClientsMu.Unlock()
 
-	return spokeClient, true, nil
+	return clients, true, nil
 }
 
 // refreshCachedSpokeClient checks whether a cached spoke client is still valid.
 // Returns:
-//   - (client, false, nil): cached client is still valid or was rebuilt from rotated token
-//   - (nil, true, nil): cache invalidated (token secret gone) — caller should fall through to full setup
-//   - (nil, false, err): transient API error — caller should requeue without re-running full setup
+//   - (clients, false, nil): cached clients are still valid or were rebuilt from rotated token
+//   - (zero, true, nil): cache invalidated (token secret gone) — caller should fall through to full setup
+//   - (zero, false, err): transient API error — caller should requeue without re-running full setup
 func refreshCachedSpokeClient(
 	ctx context.Context,
 	hubClient client.Client,
@@ -239,7 +292,8 @@ func refreshCachedSpokeClient(
 	clusterName, msaName string,
 	entry *spokeClientEntry,
 	spokeScheme *runtime.Scheme,
-) (client.Client, bool, error) {
+	needClientset bool,
+) (Clients, bool, error) {
 	tokenSecret, err := getTokenSecret(ctx, hubClient, msaName, clusterName)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -248,37 +302,44 @@ func refreshCachedSpokeClient(
 			spokeClientsMu.Unlock()
 			logger.InfoContext(ctx, "Spoke client token secret missing, re-creating spoke access",
 				slog.String("clusterName", clusterName))
-			return nil, true, nil
+			return Clients{}, true, nil
 		}
-		return nil, false, fmt.Errorf("failed to refresh spoke client token: %w", err)
+		return Clients{}, false, fmt.Errorf("failed to refresh spoke client token: %w", err)
 	}
 
 	if tokenSecret.ResourceVersion == entry.tokenResourceVersion {
-		return entry.client, false, nil
+		return entry.clients, false, nil
 	}
 
 	logger.InfoContext(ctx, "Spoke client token rotated, rebuilding client",
 		slog.String("clusterName", clusterName))
 	token, caCert, err := extractTokenData(tokenSecret, clusterName)
 	if err != nil {
-		return nil, false, err
+		return Clients{}, false, err
 	}
 	apiServerURL, err := getAPIServerURL(ctx, hubClient, clusterName)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to get API server URL during token rotation: %w", err)
+		return Clients{}, false, fmt.Errorf("failed to get API server URL during token rotation: %w", err)
 	}
-	spokeClient, err := newSpokeClientFunc(
-		apiServerURL, string(token), caCert, spokeScheme)
+	c, err := newSpokeClientFunc(apiServerURL, string(token), caCert, spokeScheme)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to rebuild spoke client after token rotation: %w", err)
+		return Clients{}, false, fmt.Errorf("failed to rebuild spoke client after token rotation: %w", err)
+	}
+	clients := Clients{Client: c}
+	if needClientset {
+		cs, err := newSpokeClientsetFunc(apiServerURL, string(token), caCert)
+		if err != nil {
+			return Clients{}, false, fmt.Errorf("failed to rebuild spoke client after token rotation: %w", err)
+		}
+		clients.Clientset = cs
 	}
 	spokeClientsMu.Lock()
 	spokeClients[msaName] = &spokeClientEntry{
-		client:               spokeClient,
+		clients:              clients,
 		tokenResourceVersion: tokenSecret.ResourceVersion,
 	}
 	spokeClientsMu.Unlock()
-	return spokeClient, false, nil
+	return clients, false, nil
 }
 
 // CleanupSpokeAccess deletes the ManagedServiceAccount and RBAC ManifestWork,

--- a/internal/spokeclient/spokeclient_test.go
+++ b/internal/spokeclient/spokeclient_test.go
@@ -22,6 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
@@ -110,17 +112,21 @@ var _ = Describe("EnsureSpokeClient", func() {
 		SetTestSpokeClientCreator(func(apiServerURL, token string, caCert []byte, spokeScheme *runtime.Scheme) (client.Client, error) {
 			return fake.NewClientBuilder().WithScheme(testScheme).Build(), nil
 		})
+		SetTestSpokeClientsetCreator(func(apiServerURL, token string, caCert []byte) (kubernetes.Interface, error) {
+			return kubefake.NewSimpleClientset(), nil
+		})
 	})
 
 	AfterEach(func() {
 		newSpokeClientFunc = buildSpokeClient
+		newSpokeClientsetFunc = buildSpokeClientset
 	})
 
 	It("should return InputError when managed-serviceaccount addon is not found", func() {
 		c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(ns).Build()
 
 		_, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), RuntimeClientOnly)
 		Expect(err).To(HaveOccurred())
 		Expect(ready).To(BeFalse())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
@@ -131,7 +137,7 @@ var _ = Describe("EnsureSpokeClient", func() {
 		c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(ns, addon).Build()
 
 		_, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), RuntimeClientOnly)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ready).To(BeFalse())
 	})
@@ -143,7 +149,7 @@ var _ = Describe("EnsureSpokeClient", func() {
 			WithObjects(ns, addon, tokenSecret, mc, msa, mw).Build()
 
 		_, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), RuntimeClientOnly)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ready).To(BeFalse())
 	})
@@ -161,7 +167,7 @@ var _ = Describe("EnsureSpokeClient", func() {
 		Expect(c.Status().Update(ctx, msa)).To(Succeed())
 
 		_, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), RuntimeClientOnly)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ready).To(BeFalse())
 
@@ -187,7 +193,7 @@ var _ = Describe("EnsureSpokeClient", func() {
 
 		// First call: MW created but not yet Available → not ready.
 		_, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), WithClientset)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ready).To(BeFalse())
 
@@ -207,18 +213,37 @@ var _ = Describe("EnsureSpokeClient", func() {
 		Expect(c.Status().Update(ctx, mw)).To(Succeed())
 
 		// Second call: MW Available → ready.
-		spokeClient, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+		clients, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), WithClientset)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ready).To(BeTrue())
-		Expect(spokeClient).ToNot(BeNil())
+		Expect(clients.Client).ToNot(BeNil())
+		Expect(clients.Clientset).ToNot(BeNil())
 
-		// Verify client is cached.
+		// Verify both clients are cached.
 		spokeClientsMu.RLock()
 		entry, ok := spokeClients["test-pr-upgrade"]
 		spokeClientsMu.RUnlock()
 		Expect(ok).To(BeTrue())
 		Expect(entry.tokenResourceVersion).To(Equal("100"))
+		Expect(entry.clients.Clientset).ToNot(BeNil())
+	})
+
+	It("should not build a clientset when called with RuntimeClientOnly", func() {
+		c := fake.NewClientBuilder().WithScheme(testScheme).
+			WithObjects(ns, addon, tokenSecret, mc, msa, mw).Build()
+
+		clients, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), RuntimeClientOnly)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ready).To(BeTrue())
+		Expect(clients.Client).ToNot(BeNil())
+		Expect(clients.Clientset).To(BeNil())
+
+		spokeClientsMu.RLock()
+		entry := spokeClients["test-pr-upgrade"]
+		spokeClientsMu.RUnlock()
+		Expect(entry.clients.Clientset).To(BeNil())
 	})
 
 	It("should return InputError when token secret is missing the 'token' key", func() {
@@ -228,7 +253,7 @@ var _ = Describe("EnsureSpokeClient", func() {
 			WithObjects(ns, addon, tokenSecret, mc, msa, mw).Build()
 
 		_, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), RuntimeClientOnly)
 		Expect(err).To(HaveOccurred())
 		Expect(ready).To(BeFalse())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
@@ -242,7 +267,7 @@ var _ = Describe("EnsureSpokeClient", func() {
 			WithObjects(ns, addon, tokenSecret, mc, msa, mw).Build()
 
 		_, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), RuntimeClientOnly)
 		Expect(err).To(HaveOccurred())
 		Expect(ready).To(BeFalse())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
@@ -256,7 +281,7 @@ var _ = Describe("EnsureSpokeClient", func() {
 			WithObjects(ns, addon, tokenSecret, mc, msa, mw).Build()
 
 		_, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), RuntimeClientOnly)
 		Expect(err).To(HaveOccurred())
 		Expect(ready).To(BeFalse())
 		Expect(typederrors.IsInputError(err)).To(BeTrue())
@@ -265,9 +290,10 @@ var _ = Describe("EnsureSpokeClient", func() {
 
 	It("should return cached client when token resourceVersion is unchanged", func() {
 		fakeSpokeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+		fakeSpokeClientset := kubefake.NewSimpleClientset()
 		spokeClientsMu.Lock()
 		spokeClients["test-pr-upgrade"] = &spokeClientEntry{
-			client:               fakeSpokeClient,
+			clients:              Clients{Client: fakeSpokeClient, Clientset: fakeSpokeClientset},
 			tokenResourceVersion: "100",
 		}
 		spokeClientsMu.Unlock()
@@ -276,17 +302,19 @@ var _ = Describe("EnsureSpokeClient", func() {
 			WithObjects(ns, msa, tokenSecret).Build()
 
 		result, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), WithClientset)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ready).To(BeTrue())
-		Expect(result).To(Equal(fakeSpokeClient))
+		Expect(result.Client).To(Equal(fakeSpokeClient))
+		Expect(result.Clientset).To(Equal(fakeSpokeClientset))
 	})
 
 	It("should rebuild client when token resourceVersion changes", func() {
 		oldClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+		oldClientset := kubefake.NewSimpleClientset()
 		spokeClientsMu.Lock()
 		spokeClients["test-pr-upgrade"] = &spokeClientEntry{
-			client:               oldClient,
+			clients:              Clients{Client: oldClient, Clientset: oldClientset},
 			tokenResourceVersion: "99",
 		}
 		spokeClientsMu.Unlock()
@@ -295,21 +323,24 @@ var _ = Describe("EnsureSpokeClient", func() {
 			WithObjects(ns, msa, tokenSecret, mc).Build()
 
 		result, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), WithClientset)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ready).To(BeTrue())
-		Expect(result).ToNot(Equal(oldClient))
+		Expect(result.Client).ToNot(Equal(oldClient))
+		Expect(result.Clientset).ToNot(BeNil())
+		Expect(result.Clientset).ToNot(Equal(oldClientset))
 
 		spokeClientsMu.RLock()
 		entry := spokeClients["test-pr-upgrade"]
 		spokeClientsMu.RUnlock()
 		Expect(entry.tokenResourceVersion).To(Equal("100"))
+		Expect(entry.clients.Clientset).ToNot(Equal(oldClientset))
 	})
 
 	It("should clear cache and re-setup when token secret is missing", func() {
 		spokeClientsMu.Lock()
 		spokeClients["test-pr-upgrade"] = &spokeClientEntry{
-			client:               fake.NewClientBuilder().WithScheme(testScheme).Build(),
+			clients:              Clients{Client: fake.NewClientBuilder().WithScheme(testScheme).Build()},
 			tokenResourceVersion: "99",
 		}
 		spokeClientsMu.Unlock()
@@ -317,7 +348,7 @@ var _ = Describe("EnsureSpokeClient", func() {
 		c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(ns).Build()
 
 		_, ready, err := EnsureSpokeClient(ctx, c, testLogger, clusterName,
-			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme())
+			"test-pr-upgrade", "test-pr-upgrade-rbac", testRules, NewSpokeScheme(), RuntimeClientOnly)
 		Expect(err).To(HaveOccurred())
 		Expect(ready).To(BeFalse())
 
@@ -348,7 +379,7 @@ var _ = Describe("CleanupSpokeAccess", func() {
 
 		spokeClientsMu.Lock()
 		spokeClients["test-pr-upgrade"] = &spokeClientEntry{
-			client:               fake.NewClientBuilder().WithScheme(testScheme).Build(),
+			clients:              Clients{Client: fake.NewClientBuilder().WithScheme(testScheme).Build()},
 			tokenResourceVersion: "100",
 		}
 		spokeClientsMu.Unlock()

--- a/test/e2e/mno_cv_upgrade_test.go
+++ b/test/e2e/mno_cv_upgrade_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	provisioningcontrollers "github.com/openshift-kni/oran-o2ims/internal/controllers"
 	ctlrutils "github.com/openshift-kni/oran-o2ims/internal/controllers/utils"
-	"github.com/openshift-kni/oran-o2ims/internal/controllers/utils/spokeclient"
+	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
 	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
@@ -42,8 +42,6 @@ import (
 	siteconfig "github.com/stolostron/siteconfig/api/v1alpha1"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
-	workv1 "open-cluster-management.io/api/work/v1"
-	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 )
 
 const (
@@ -51,6 +49,8 @@ const (
 	cvUpgradeInterval = time.Second * 3
 	prName            = "88744070-717a-4305-8461-796244098339"
 	clusterName       = "std-du-cluster"
+	upgradeMSAName    = prName + "-upgrade"
+	upgradeMWName     = prName + "-upgrade-rbac"
 )
 
 // --- Test suite ---
@@ -345,7 +345,7 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 				},
 			})
 
-			simulateSpokeAccessReady(testCtx, K8SClient)
+			testutils.SimulateSpokeAccessReady(testCtx, K8SClient, clusterName, upgradeMSAName, upgradeMWName, timeout, interval)
 			waitForPRUpgradeCondition(testCtx, K8SClient,
 				string(provisioningv1alpha1.CRconditionReasons.PreconditionChecksFailed),
 				"does not match the ClusterTemplate spec.release",
@@ -451,7 +451,7 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 			)
 
 			// Verify spoke access resources are cleaned up
-			assertSpokeAccessCleaned(testCtx, K8SClient)
+			testutils.AssertSpokeAccessCleaned(testCtx, K8SClient, clusterName, upgradeMSAName, upgradeMWName, timeout, interval)
 
 			// Simulate the ACM controller behavior after upgrade - update the ManagedCluster label to the new version
 			mc := &clusterv1.ManagedCluster{}
@@ -476,7 +476,7 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 				},
 			})
 
-			simulateSpokeAccessReady(testCtx, K8SClient)
+			testutils.SimulateSpokeAccessReady(testCtx, K8SClient, clusterName, upgradeMSAName, upgradeMWName, timeout, interval)
 
 			updateSpokeCV(testCtx, spokeClient, func(cv *configv1.ClusterVersion) {
 				cv.Status.History = []configv1.UpdateHistory{
@@ -517,7 +517,7 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 				provisioningv1alpha1.StateFailed,
 			)
 
-			assertSpokeAccessCleaned(testCtx, K8SClient)
+			testutils.AssertSpokeAccessCleaned(testCtx, K8SClient, clusterName, upgradeMSAName, upgradeMWName, timeout, interval)
 		})
 	})
 
@@ -570,7 +570,7 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 				},
 			})
 
-			simulateSpokeAccessReady(testCtx, K8SClient)
+			testutils.SimulateSpokeAccessReady(testCtx, K8SClient, clusterName, upgradeMSAName, upgradeMWName, timeout, interval)
 
 			waitForPRUpgradeCondition(testCtx, K8SClient,
 				string(provisioningv1alpha1.CRconditionReasons.Pending),
@@ -618,7 +618,7 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 			Expect(spokeClient.Get(testCtx, types.NamespacedName{Name: "worker"}, mcp)).To(Succeed())
 			Expect(mcp.Spec.Paused).To(BeTrue(), "Worker MCP should still be paused after timeout")
 
-			assertSpokeAccessCleaned(testCtx, K8SClient)
+			testutils.AssertSpokeAccessCleaned(testCtx, K8SClient, clusterName, upgradeMSAName, upgradeMWName, timeout, interval)
 		})
 	})
 
@@ -671,7 +671,7 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 				},
 			})
 
-			simulateSpokeAccessReady(testCtx, K8SClient)
+			testutils.SimulateSpokeAccessReady(testCtx, K8SClient, clusterName, upgradeMSAName, upgradeMWName, timeout, interval)
 
 			waitForPRUpgradeCondition(testCtx, K8SClient,
 				string(provisioningv1alpha1.CRconditionReasons.PreconditionChecksFailed),
@@ -809,7 +809,7 @@ var _ = Describe("MNO Standard ClusterVersion Upgrade", Ordered, Label("mno-cv-u
 				provisioningv1alpha1.StateFulfilled,
 			)
 
-			assertSpokeAccessCleaned(testCtx, K8SClient)
+			testutils.AssertSpokeAccessCleaned(testCtx, K8SClient, clusterName, upgradeMSAName, upgradeMWName, timeout, interval)
 
 			mc := &clusterv1.ManagedCluster{}
 			Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: clusterName}, mc)).To(Succeed())
@@ -866,66 +866,6 @@ func setCVCondition(
 		Type: condType, Status: status, Message: message,
 		LastTransitionTime: metav1.Now(),
 	})
-}
-
-// simulateSpokeAccessReady waits for the controller to create the MSA and MW,
-// then simulates the addon controller by creating the token secret and setting
-// the MSA tokenSecretRef and MW Available status.
-func simulateSpokeAccessReady(ctx context.Context, k8sClient client.Client) {
-	msaName := prName + "-upgrade"
-	mwName := prName + "-upgrade-rbac"
-	tokenSecretName := msaName + "-token"
-
-	Eventually(func() error {
-		return k8sClient.Get(ctx, types.NamespacedName{Name: msaName, Namespace: clusterName},
-			&msav1beta1.ManagedServiceAccount{})
-	}, cvUpgradeTimeout, cvUpgradeInterval).Should(Succeed(), "MSA should be created by the controller")
-
-	tokenSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: tokenSecretName, Namespace: clusterName},
-		Data:       map[string][]byte{"token": []byte("test-token"), "ca.crt": []byte("test-ca")},
-	}
-	err := k8sClient.Create(ctx, tokenSecret)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	msa := &msav1beta1.ManagedServiceAccount{}
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: msaName, Namespace: clusterName}, msa)).To(Succeed())
-	msa.Status.TokenSecretRef = &msav1beta1.SecretRef{
-		Name:                 tokenSecretName,
-		LastRefreshTimestamp: metav1.Now(),
-	}
-	Expect(k8sClient.Status().Update(ctx, msa)).To(Succeed())
-
-	Eventually(func() error {
-		return k8sClient.Get(ctx, types.NamespacedName{Name: mwName, Namespace: clusterName},
-			&workv1.ManifestWork{})
-	}, cvUpgradeTimeout, cvUpgradeInterval).Should(Succeed(), "ManifestWork should be created by the controller")
-
-	mw := &workv1.ManifestWork{}
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mwName, Namespace: clusterName}, mw)).To(Succeed())
-	mw.Status.Conditions = []metav1.Condition{
-		{Type: workv1.WorkAvailable, Status: metav1.ConditionTrue, Reason: "Applied", LastTransitionTime: metav1.Now()},
-	}
-	Expect(k8sClient.Status().Update(ctx, mw)).To(Succeed())
-}
-
-func assertSpokeAccessCleaned(ctx context.Context, k8sClient client.Client) {
-	msaName := prName + "-upgrade"
-	mwName := prName + "-upgrade-rbac"
-
-	Eventually(func() bool {
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: msaName, Namespace: clusterName},
-			&msav1beta1.ManagedServiceAccount{})
-		return errors.IsNotFound(err)
-	}, cvUpgradeTimeout, cvUpgradeInterval).Should(BeTrue(), "MSA should be deleted")
-
-	Eventually(func() bool {
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: mwName, Namespace: clusterName},
-			&workv1.ManifestWork{})
-		return errors.IsNotFound(err)
-	}, cvUpgradeTimeout, cvUpgradeInterval).Should(BeTrue(), "ManifestWork should be deleted")
 }
 
 func waitForPRUpgradeCondition(ctx context.Context, k8SClient client.Client,

--- a/test/e2e/mno_hw_configuration_test.go
+++ b/test/e2e/mno_hw_configuration_test.go
@@ -33,10 +33,13 @@ import (
 	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/openshift-kni/oran-o2ims/internal/constants"
 	hwmgrcontrollers "github.com/openshift-kni/oran-o2ims/internal/hardwaremanager/controller"
+	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 	testutils "github.com/openshift-kni/oran-o2ims/test/utils"
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"k8s.io/client-go/kubernetes"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
 const (
@@ -61,13 +64,16 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		// Resource pool label values on MNO BMHs (see testutils.MnoBMHsTwoWorkerPools).
 		mnoBMHResourcePoolDellR740   = "dell-r740-pool"
 		mnoBMHResourcePoolDellXR8620 = "dell-xr8620t-pool"
+
+		prName          = "88744070-717a-4305-8461-796244098338"
+		hwConfigMSAName = prName + "-hwconfig"
+		hwConfigMWName  = prName + "-hwconfig-rbac"
 	)
 
 	var (
 		testCtx      context.Context
 		clusterName  = "std-test"
 		ctNamespace  = "std-4-20-15"
-		prName       string // populated from PR YAML metadata.name
 		spokeRestore func()
 
 		pr  *provisioningv1alpha1.ProvisioningRequest
@@ -193,6 +199,14 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		}
 		resources := []client.Object{
 			pullSecret, extraManifests, clusterImageSet,
+			&clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+				Spec: clusterv1.ManagedClusterSpec{
+					ManagedClusterClientConfigs: []clusterv1.ClientConfig{
+						{URL: "https://api." + clusterName + ".example.com:6443"},
+					},
+				},
+			},
 		}
 		for _, r := range resources {
 			Expect(K8SClient.Create(testCtx, r)).To(Succeed())
@@ -306,7 +320,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		By("Creating ProvisioningRequest with v1 hwProfiles (basic BIOS settings)")
 		prFromYAML, err := testutils.LoadYAML[provisioningv1alpha1.ProvisioningRequest]("../resources/mno_hw_configuration/pr-std.yaml")
 		Expect(err).ToNot(HaveOccurred())
-		prName = prFromYAML.Name
+		Expect(prFromYAML.Name).To(Equal(prName))
 		Expect(K8SClient.Create(testCtx, prFromYAML)).To(Succeed())
 
 		By("Waiting for NAR creation")
@@ -360,6 +374,10 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			hostnames = append(hostnames, hostname)
 		}
 		pr.Status.Extensions.AllocatedNodeHostMap = hostMap
+		if pr.Status.Extensions.ClusterDetails == nil {
+			pr.Status.Extensions.ClusterDetails = &provisioningv1alpha1.ClusterDetails{}
+		}
+		pr.Status.Extensions.ClusterDetails.Name = clusterName
 		Expect(K8SClient.Status().Update(testCtx, pr)).To(Succeed())
 		Eventually(func() bool {
 			Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
@@ -367,7 +385,12 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 		}, timeout, interval).Should(BeTrue(), "AllocatedNodeHostMap should be populated")
 
 		// Set up spoke client mock for day2 operations
-		spokeRestore = setupSpokeClientMock(testCtx, hostnames)
+		spokeRestore = setupSpokeClientMock(hostnames)
+
+		By("Creating ManagedClusterAddOn for the cluster")
+		Expect(client.IgnoreAlreadyExists(K8SClient.Create(testCtx, &addonv1alpha1.ManagedClusterAddOn{
+			ObjectMeta: metav1.ObjectMeta{Name: "managed-serviceaccount", Namespace: clusterName},
+		}))).To(Succeed())
 	})
 
 	AfterAll(func() {
@@ -446,6 +469,10 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			_ = K8SClient.Delete(testCtx, cis)
 		}
 
+		Expect(client.IgnoreNotFound(K8SClient.Delete(testCtx, &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+		}))).To(Succeed())
+
 		// Delete remaining resources in test namespaces.
 		for _, obj := range []client.Object{
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "pull-secret", Namespace: ctNamespace}},
@@ -466,6 +493,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			Expect(err).ToNot(HaveOccurred())
 			pr.Spec.TemplateParameters = newPrFromYAML.Spec.TemplateParameters
 			Expect(K8SClient.Update(testCtx, pr)).To(Succeed())
+			testutils.SimulateSpokeAccessReady(testCtx, K8SClient, clusterName, hwConfigMSAName, hwConfigMWName, timeout, interval)
 		})
 
 		It("Should detect HW configuration changes and begin update process (NAR InProgress=True)", func() {
@@ -646,6 +674,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			Expect(err).ToNot(HaveOccurred())
 			pr.Spec.TemplateParameters = newPrFromYAML.Spec.TemplateParameters
 			Expect(K8SClient.Update(testCtx, pr)).To(Succeed())
+			testutils.SimulateSpokeAccessReady(testCtx, K8SClient, clusterName, hwConfigMSAName, hwConfigMWName, timeout, interval)
 		})
 
 		It("Should detect worker configuration changes and begin update (NAR InProgress)", func() {
@@ -767,6 +796,7 @@ var _ = Describe("MNO Day2 Hardware Configuration test", Ordered, Label("mno-day
 			Expect(err).ToNot(HaveOccurred())
 			pr.Spec.TemplateParameters = runtime.RawExtension{Raw: raw}
 			Expect(K8SClient.Update(testCtx, pr)).To(Succeed())
+			testutils.SimulateSpokeAccessReady(testCtx, K8SClient, clusterName, hwConfigMSAName, hwConfigMWName, timeout, interval)
 		})
 
 		It("Should have 3 workers in ConfigUpdate and advance one BMH to Servicing", func() {
@@ -930,8 +960,7 @@ func testNonCachingListAllocatedNodesForNAR(ctx context.Context, narName string)
 	return filtered
 }
 
-func setupSpokeClientMock(ctx context.Context, hostnames []string) func() {
-	_ = ctx
+func setupSpokeClientMock(hostnames []string) func() {
 	spokeScheme := runtime.NewScheme()
 	Expect(corev1.AddToScheme(spokeScheme)).To(Succeed())
 	Expect(machineconfigv1.Install(spokeScheme)).To(Succeed())
@@ -979,14 +1008,21 @@ func setupSpokeClientMock(ctx context.Context, hostnames []string) func() {
 		Build()
 	spokeClientset := kubefake.NewSimpleClientset(k8sNodes...)
 
-	return hwmgrcontrollers.SetTestSpokeClientCreators(
-		func(_ context.Context, _ client.Client, _ string) (client.Client, error) {
+	restoreClient := spokeclient.SetTestSpokeClientCreator(
+		func(_ string, _ string, _ []byte, _ *runtime.Scheme) (client.Client, error) {
 			return spokeClient, nil
 		},
-		func(_ context.Context, _ client.Client, _ string) (kubernetes.Interface, error) {
+	)
+	restoreClientset := spokeclient.SetTestSpokeClientsetCreator(
+		func(_ string, _ string, _ []byte) (kubernetes.Interface, error) {
 			return spokeClientset, nil
 		},
 	)
+	return func() {
+		restoreClient()
+		restoreClientset()
+		spokeclient.ClearCache()
+	}
 }
 
 // failBMHDay2 simulates a BMH entering an error state during a day2 hardware configuration update.

--- a/test/utils/spoke_access.go
+++ b/test/utils/spoke_access.go
@@ -1,0 +1,83 @@
+/*
+SPDX-FileCopyrightText: Red Hat
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package teste2eutils
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	workv1 "open-cluster-management.io/api/work/v1"
+	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SimulateSpokeAccessReady waits for the controller to create the MSA and ManifestWork,
+// then simulates the addon controller by creating the token secret and setting
+// the MSA tokenSecretRef and MW Available status.
+func SimulateSpokeAccessReady(
+	ctx context.Context,
+	k8sClient client.Client,
+	clusterName, msaName, mwName string,
+	timeout, interval time.Duration,
+) {
+	tokenSecretName := msaName + "-token"
+
+	Eventually(func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Name: msaName, Namespace: clusterName},
+			&msav1beta1.ManagedServiceAccount{})
+	}, timeout, interval).Should(Succeed(), "MSA should be created by the controller")
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: tokenSecretName, Namespace: clusterName},
+		Data:       map[string][]byte{"token": []byte("test-token"), "ca.crt": []byte("test-ca")},
+	}
+	Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, tokenSecret))).To(Succeed())
+
+	msa := &msav1beta1.ManagedServiceAccount{}
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: msaName, Namespace: clusterName}, msa)).To(Succeed())
+	msa.Status.TokenSecretRef = &msav1beta1.SecretRef{
+		Name:                 tokenSecretName,
+		LastRefreshTimestamp: metav1.Now(),
+	}
+	Expect(k8sClient.Status().Update(ctx, msa)).To(Succeed())
+
+	Eventually(func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Name: mwName, Namespace: clusterName},
+			&workv1.ManifestWork{})
+	}, timeout, interval).Should(Succeed(), "ManifestWork should be created by the controller")
+
+	mw := &workv1.ManifestWork{}
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mwName, Namespace: clusterName}, mw)).To(Succeed())
+	mw.Status.Conditions = []metav1.Condition{
+		{Type: workv1.WorkAvailable, Status: metav1.ConditionTrue, Reason: "Applied", LastTransitionTime: metav1.Now()},
+	}
+	Expect(k8sClient.Status().Update(ctx, mw)).To(Succeed())
+}
+
+func AssertSpokeAccessCleaned(
+	ctx context.Context,
+	k8sClient client.Client,
+	clusterName, msaName, mwName string,
+	timeout, interval time.Duration,
+) {
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: msaName, Namespace: clusterName},
+			&msav1beta1.ManagedServiceAccount{})
+		return errors.IsNotFound(err)
+	}, timeout, interval).Should(BeTrue(), "MSA should be deleted")
+
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: mwName, Namespace: clusterName},
+			&workv1.ManifestWork{})
+		return errors.IsNotFound(err)
+	}, timeout, interval).Should(BeTrue(), "ManifestWork should be deleted")
+}


### PR DESCRIPTION
## Summary

Replace hub-admin kubeconfig access with ManagedServiceAccount-scoped spoke
clients for day-2 hardware profile updates and worker scale-in. The hardware
manager now uses the same least-privilege spoke-access pattern already used
for ClusterVersion upgrades and scale-out.

**Jira**: [CNF-26101](https://issues.redhat.com/browse/CNF-26101) — Use scoped spoke clients for hardware configuration and scale-in

## Changes

- Move `spokeclient` out of `internal/controllers/utils` so the hardware manager can share it. `EnsureSpokeClient` returns a `Clients` struct and a `WithClientset` flag (hw-config and scale-in need drain; upgrades and scale-out use `RuntimeClientOnly`).
- Register ACM types on the hardware-manager scheme and grant the hardware-manager ClusterRole create/get/list/watch/delete on ManagedCluster, ManagedServiceAccount, ManifestWork, and ManagedClusterAddOn.
- Own MSA/ManifestWork lifecycle with per-operation suffixes (`-hwconfig`, `-scalein`). Missing managed-serviceaccount addon is an `InputError` and fails NAR `Configured` as a terminal condition.
- Clean up spoke access on terminal states (best-effort) and restrict cleanup to NAR deletion.
- Refactor hardware-profile change handling: the caller prepares spoke access and aggregates status; `handleNodeAllocationRequestConfiguring` no longer lists or returns stale AllocatedNodes.
- Set `ObservedGeneration` in the same status update as terminal `Configured` / `Provisioned` conditions to avoid a race with a follow-up generation patch.
- On SpecChanged with no hardware-profile change, re-derive `Configured` from AllocatedNodes when it is already present; when it is absent, ack generation and config transaction id without starting hardware configuration.
- Document the ManagedServiceAccount addon as a hub prerequisite for upgrades, day-2 hardware configuration, and worker scale-in/out.

## Test Plan

- [x] Unit tests
- [x] E2E test
- [x] In-cluster: day-2 hardware profile updates, worker scale-in