### PR TITLE
CNF-26878: Cap hardware-manager per-node goroutines

### DIFF
--- a/internal/hardwaremanager/controller/baremetalhost_manager.go
+++ b/internal/hardwaremanager/controller/baremetalhost_manager.go
@@ -880,36 +880,30 @@ func handleBMHCompletion(ctx context.Context,
 
 	logger.DebugContext(ctx, "Handling nodes for completion", slog.Int("count", len(nodes)))
 	var (
-		wg          sync.WaitGroup
 		mu          sync.Mutex
 		anyUpdating bool
 		errs        []error
 	)
 
-	// Process each node in parallel for better performance with large clusters (e.g. 3 masters + 50+ workers).
-	for _, node := range nodes {
-		wg.Add(1)
-		go func(node *hwmgmtv1alpha1.AllocatedNode) {
-			defer wg.Done()
+	// Process nodes in parallel (capped) for better performance with large
+	// clusters (e.g. 3 masters + 50+ workers).
+	forEachConcurrent(len(nodes), maxConcurrentNodeOps, func(i int) {
+		node := nodes[i]
+		nodeCtx := logging.AppendCtx(ctx, slog.String("node", node.Name))
+		updating, err := handleSingleNodeCompletion(nodeCtx, c, noncachedClient, logger, namespace, node)
 
-			nodeCtx := logging.AppendCtx(ctx, slog.String("node", node.Name))
-			updating, err := handleSingleNodeCompletion(nodeCtx, c, noncachedClient, logger, namespace, node)
+		mu.Lock()
+		defer mu.Unlock()
 
-			mu.Lock()
-			defer mu.Unlock()
-
-			if updating {
-				anyUpdating = true
-			}
-			if err != nil {
-				logger.ErrorContext(nodeCtx, "failed to handle single node completion",
-					slog.Any("error", err))
-				errs = append(errs, fmt.Errorf("node %s, error: %w", node.Name, err))
-			}
-		}(node)
-	}
-
-	wg.Wait()
+		if updating {
+			anyUpdating = true
+		}
+		if err != nil {
+			logger.ErrorContext(nodeCtx, "failed to handle single node completion",
+				slog.Any("error", err))
+			errs = append(errs, fmt.Errorf("node %s, error: %w", node.Name, err))
+		}
+	})
 
 	if len(errs) > 0 {
 		aggErr := fmt.Errorf("failed to handle BMH completion: %w", errors.Join(errs...))

--- a/internal/hardwaremanager/controller/helpers.go
+++ b/internal/hardwaremanager/controller/helpers.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,9 +36,51 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 )
 
-const ConfigAnnotation = "clcm.openshift.io/config-in-progress"
+const (
+	ConfigAnnotation       = "clcm.openshift.io/config-in-progress"
+	ScaleInNodesAnnotation = "clcm.openshift.io/scale-in-nodes"
 
-const ScaleInNodesAnnotation = "clcm.openshift.io/scale-in-nodes"
+	// UpdateAbandonedAnnotation marks an AllocatedNode whose in-progress hardware update
+	// was abandoned because the desired hardware profile changed mid-flight. The node is
+	// safe to re-process with the new profile on the next reconcile.
+	UpdateAbandonedAnnotation = "clcm.openshift.io/update-abandoned"
+
+	DoNotRequeue               = 0
+	RequeueAfterShortInterval  = 15
+	RequeueAfterMediumInterval = 30
+	RequeueAfterLongInterval   = 60
+
+	// maxConcurrentNodeOps is the operator-wide ceiling on in-flight per-node goroutines
+	// in a single reconcile (e.g., day-0 allocation, day-2 hardware-profile updates,etc.).
+	maxConcurrentNodeOps = 10
+)
+
+// forEachConcurrent calls fn(i) for i in [0, n) with at most limit goroutines
+// in flight, then waits for every call to finish. fn must be safe to run
+// concurrently. The helper does not collect or return errors, and a failed
+// call does not stop the rest. Callers must aggregate errors from inside fn
+// (for example appending to a shared slice under a mutex) and join them after
+// this function returns.
+func forEachConcurrent(n, limit int, fn func(i int)) {
+	if n == 0 {
+		return
+	}
+	if limit < 1 {
+		limit = 1
+	}
+
+	// Effective concurrency is min(limit, n).
+	g := new(errgroup.Group)
+	g.SetLimit(limit)
+	for i := 0; i < n; i++ {
+		g.Go(func() error {
+			fn(i)
+			return nil
+		})
+	}
+	// Wait for all goroutines to finish.
+	_ = g.Wait()
+}
 
 // syncSkipCleanupToAllocatedNodes propagates the SkipCleanup field from the NAR
 // to all child AllocatedNodes, so the AllocatedNode deletion handler can read it
@@ -205,18 +248,6 @@ func enableBMOManagementForIBINodes(
 
 	return nil
 }
-
-// UpdateAbandonedAnnotation marks an AllocatedNode whose in-progress hardware update
-// was abandoned because the desired hardware profile changed mid-flight. The node is
-// safe to re-process with the new profile on the next reconcile.
-const UpdateAbandonedAnnotation = "clcm.openshift.io/update-abandoned"
-
-const (
-	DoNotRequeue               = 0
-	RequeueAfterShortInterval  = 15
-	RequeueAfterMediumInterval = 30
-	RequeueAfterLongInterval   = 60
-)
 
 func setConfigAnnotation(object client.Object, reason string) {
 	annotations := object.GetAnnotations()
@@ -1169,71 +1200,64 @@ func executeNodeUpdates(
 	nodesToProcess []nodeAction,
 ) (ctrl.Result, error) {
 	var (
-		wg         sync.WaitGroup
 		mu         sync.Mutex
 		errs       []error
 		minRequeue time.Duration
 	)
 
-	for _, nodeToProcess := range nodesToProcess {
-		wg.Add(1)
-		go func(nodeToProcess nodeAction) {
-			defer wg.Done()
+	forEachConcurrent(len(nodesToProcess), maxConcurrentNodeOps, func(i int) {
+		nodeToProcess := nodesToProcess[i]
+		nodeCtx := logging.AppendCtx(ctx, slog.String("node", nodeToProcess.node.Name))
+		var res ctrl.Result
+		var err error
 
-			nodeCtx := logging.AppendCtx(ctx, slog.String("node", nodeToProcess.node.Name))
-			var res ctrl.Result
-			var err error
+		newHwProfile := getNewHwProfileForNode(nar, nodeToProcess.node)
 
-			newHwProfile := getNewHwProfileForNode(nar, nodeToProcess.node)
-
-			// For actionTransition and actionInProgressUpdate nodes, detect mid-flight profile changes:
-			// if the desired profile no longer matches the node's current spec, safely abandon the stale
-			// update so the node can be re-processed with the new profile.
-			switch nodeToProcess.actionType {
-			case actionInitiate:
-				res, err = initiateNodeUpdate(nodeCtx, c, noncachedClient, logger,
-					namespace, nodeToProcess.node, newHwProfile, nodeOps)
-			case actionTransition:
-				if nodeToProcess.node.Spec.HwProfile != newHwProfile {
-					res, err = abandonNodeUpdate(nodeCtx, c, noncachedClient, logger,
-						newHwProfile, nodeToProcess.node, nodeOps)
-				} else {
-					res, err = handleTransitionNode(nodeCtx, c, noncachedClient, logger,
-						namespace, nodeToProcess.node, true, nodeOps)
-				}
-			case actionInProgressUpdate:
-				if nodeToProcess.node.Spec.HwProfile != newHwProfile {
-					res, err = abandonNodeUpdate(nodeCtx, c, noncachedClient, logger,
-						newHwProfile, nodeToProcess.node, nodeOps)
-				} else {
-					res, err = handleNodeInProgressUpdate(nodeCtx, c, noncachedClient, logger,
-						namespace, nodeToProcess.node, nodeOps)
-				}
+		// For actionTransition and actionInProgressUpdate nodes, detect mid-flight profile changes:
+		// if the desired profile no longer matches the node's current spec, safely abandon the stale
+		// update so the node can be re-processed with the new profile.
+		switch nodeToProcess.actionType {
+		case actionInitiate:
+			res, err = initiateNodeUpdate(nodeCtx, c, noncachedClient, logger,
+				namespace, nodeToProcess.node, newHwProfile, nodeOps)
+		case actionTransition:
+			if nodeToProcess.node.Spec.HwProfile != newHwProfile {
+				res, err = abandonNodeUpdate(nodeCtx, c, noncachedClient, logger,
+					newHwProfile, nodeToProcess.node, nodeOps)
+			} else {
+				res, err = handleTransitionNode(nodeCtx, c, noncachedClient, logger,
+					namespace, nodeToProcess.node, true, nodeOps)
 			}
-
-			mu.Lock()
-			defer mu.Unlock()
-
-			if err != nil {
-				logger.ErrorContext(nodeCtx, "Node processing error",
-					slog.Any("error", err))
-				errs = append(errs, fmt.Errorf("node %s, error: %w", nodeToProcess.node.Name, err))
+		case actionInProgressUpdate:
+			if nodeToProcess.node.Spec.HwProfile != newHwProfile {
+				res, err = abandonNodeUpdate(nodeCtx, c, noncachedClient, logger,
+					newHwProfile, nodeToProcess.node, nodeOps)
+			} else {
+				res, err = handleNodeInProgressUpdate(nodeCtx, c, noncachedClient, logger,
+					namespace, nodeToProcess.node, nodeOps)
 			}
+		}
 
-			// Get the shortest requeue interval to requeue with.
-			if res.RequeueAfter > 0 || res.Requeue {
-				interval := res.RequeueAfter
-				if interval == 0 {
-					interval = time.Second
-				}
-				if minRequeue == 0 || interval < minRequeue {
-					minRequeue = interval
-				}
+		mu.Lock()
+		defer mu.Unlock()
+
+		if err != nil {
+			logger.ErrorContext(nodeCtx, "Node processing error",
+				slog.Any("error", err))
+			errs = append(errs, fmt.Errorf("node %s, error: %w", nodeToProcess.node.Name, err))
+		}
+
+		// Get the shortest requeue interval to requeue with.
+		if res.RequeueAfter > 0 || res.Requeue {
+			interval := res.RequeueAfter
+			if interval == 0 {
+				interval = time.Second
 			}
-		}(nodeToProcess)
-	}
-
-	wg.Wait()
+			if minRequeue == 0 || interval < minRequeue {
+				minRequeue = interval
+			}
+		}
+	})
 
 	if len(errs) > 0 {
 		aggErr := fmt.Errorf("failed to process nodes: %w", errors.Join(errs...))
@@ -1565,7 +1589,6 @@ func processNodeAllocationRequestAllocation(
 ) (ctrl.Result, error) {
 
 	var (
-		wg             sync.WaitGroup
 		mu             sync.Mutex
 		errs           []error
 		allocatedNames []string
@@ -1602,46 +1625,41 @@ func processNodeAllocationRequestAllocation(
 				nodeAllocationRequest.Spec.Site, nodeGroup.NodeGroupData.Name)
 		}
 
-		// Allocate up to 'pending' nodes concurrently
+		// Select up to 'pending' nodes to allocate
 		need := pending
+		var toAllocateBMHs []*metal3v1alpha1.BareMetalHost
 		for i := range unallocatedBMHs.Items {
-			mu.Lock()
 			if need <= 0 {
-				mu.Unlock()
 				break
 			}
 			need--
-			mu.Unlock()
-
-			bmh := &unallocatedBMHs.Items[i] // address of slice element (avoid range-var bug)
-
-			wg.Add(1)
-			go func(bmh *metal3v1alpha1.BareMetalHost) {
-				defer wg.Done()
-
-				bmhCtx := logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
-				nodeName, err := allocateBMHToNodeAllocationRequest(
-					bmhCtx, c, noncachedClient, logger, namespace,
-					bmh, nodeAllocationRequest, nodeGroup,
-				)
-
-				mu.Lock()
-				defer mu.Unlock()
-
-				if nodeName != "" {
-					allocatedNames = append(allocatedNames, nodeName)
-				}
-				if err != nil {
-					logger.ErrorContext(bmhCtx, "Failed to allocate BMH to NodeAllocationRequest",
-						slog.Any("error", err))
-					errs = append(errs, fmt.Errorf("bmh %s, error: %w", bmh.Name, err))
-				}
-			}(bmh)
+			toAllocateBMHs = append(toAllocateBMHs, &unallocatedBMHs.Items[i])
 		}
 
-		// Wait for all goroutines in this group to finish before processing the next group,
-		// so that fetchBMHList won't return BMHs still being allocated by in-flight goroutines.
-		wg.Wait()
+		// Allocate selected nodes concurrently, capped by maxConcurrentNodeOps.
+		forEachConcurrent(len(toAllocateBMHs), maxConcurrentNodeOps, func(i int) {
+			bmh := toAllocateBMHs[i]
+			bmhCtx := logging.AppendCtx(ctx, slog.String("bmh", bmh.Name))
+			nodeName, err := allocateBMHToNodeAllocationRequest(
+				bmhCtx, c, noncachedClient, logger, namespace,
+				bmh, nodeAllocationRequest, nodeGroup,
+			)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if nodeName != "" {
+				allocatedNames = append(allocatedNames, nodeName)
+			}
+			if err != nil {
+				logger.ErrorContext(bmhCtx, "Failed to allocate BMH to NodeAllocationRequest",
+					slog.Any("error", err))
+				errs = append(errs, fmt.Errorf("bmh %s, error: %w", bmh.Name, err))
+			}
+		})
+		// The next node group will not start until the current group is complete,
+		// ensuring that fetchBMHList will not return BMHs still being allocated
+		// by in-flight goroutines.
 	}
 
 	// Append all allocated node names and do a single NAR properties update

--- a/internal/hardwaremanager/controller/helpers_test.go
+++ b/internal/hardwaremanager/controller/helpers_test.go
@@ -84,6 +84,8 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -3723,5 +3725,85 @@ var _ = Describe("Helpers", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
+	})
+})
+
+var _ = Describe("forEachConcurrent", func() {
+	It("invokes fn for every index when n is greater than the limit", func() {
+		var (
+			mu   sync.Mutex
+			seen []int
+		)
+		forEachConcurrent(5, 2, func(i int) {
+			mu.Lock()
+			seen = append(seen, i)
+			mu.Unlock()
+		})
+		Expect(seen).To(ConsistOf(0, 1, 2, 3, 4))
+	})
+
+	It("invokes fn for every index when n is less than the limit", func() {
+		var (
+			mu   sync.Mutex
+			seen []int
+		)
+		forEachConcurrent(3, 10, func(i int) {
+			mu.Lock()
+			seen = append(seen, i)
+			mu.Unlock()
+		})
+		Expect(seen).To(ConsistOf(0, 1, 2))
+	})
+
+	It("does not skip later indices when one call is slow", func() {
+		var (
+			mu   sync.Mutex
+			seen []int
+		)
+		forEachConcurrent(4, 2, func(i int) {
+			if i == 0 {
+				time.Sleep(50 * time.Millisecond)
+			}
+			mu.Lock()
+			seen = append(seen, i)
+			mu.Unlock()
+		})
+		Expect(seen).To(ConsistOf(0, 1, 2, 3))
+	})
+
+	It("keeps at most limit goroutines in flight", func() {
+		var inFlight, maxInFlight atomic.Int32
+		started := make(chan struct{}, 8)
+		release := make(chan struct{})
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+			forEachConcurrent(6, 2, func(_ int) {
+				cur := inFlight.Add(1)
+				for {
+					old := maxInFlight.Load()
+					if cur <= old || maxInFlight.CompareAndSwap(old, cur) {
+						break
+					}
+				}
+				started <- struct{}{}
+				<-release
+				inFlight.Add(-1)
+			})
+		}()
+
+		Eventually(func() int { return len(started) }).
+			WithTimeout(2 * time.Second).
+			WithPolling(10 * time.Millisecond).
+			Should(Equal(2))
+		Consistently(inFlight.Load).
+			WithTimeout(80 * time.Millisecond).
+			WithPolling(10 * time.Millisecond).
+			Should(BeNumerically("<=", 2))
+		close(release)
+		Eventually(done).WithTimeout(2 * time.Second).Should(BeClosed())
+		Expect(maxInFlight.Load()).To(BeNumerically("<=", 2))
+		Expect(maxInFlight.Load()).To(BeNumerically(">=", 1))
 	})
 })


### PR DESCRIPTION
Replace unbounded per-node goroutines in a single NAR reconcile with forEachConcurrent. That helper starts at most maxConcurrentNodeOps workers at a time (errgroup.SetLimit). As before, it waits for every item to finish, and callers still collect and join errors themselves (a failed item does not cancel the rest).

Apply the cap to:
- day-0 BMH allocation (processNodeAllocationRequestAllocation)
- day-0 BMH completion checks (handleBMHCompletion)
- day-2 hardware-profile updates (executeNodeUpdates)

Start maxConcurrentNodeOps at 10. It only limits goroutine fan-out; MCP maxUnavailable still governs how many day-2 updates may be initiated per pool. We can raise or lower the cap after large-cluster testing.

Tested day0 MNO hardware provisioning and day2 hardware configuration updates.