### PR TITLE
CNF-26808: Drain scale-in nodes concurrently across worker MCPs

### DIFF
--- a/docs/dev/e2e-test-overview.md
+++ b/docs/dev/e2e-test-overview.md
@@ -27,8 +27,8 @@ feature, which parses test structure without executing tests.
   - [Handles day2 hardware configuration update with BMH error](#handles-day2-hardware-configuration-update-with-bmh-error)
   - [Handles mid-flight profile change by abandoning stale updates](#handles-mid-flight-profile-change-by-abandoning-stale-updates)
 - [MNO Scale-Out test [mno-scale-out]](#mno-scale-out-test-mno-scale-out)
-  - [Scale-out: add a worker node](#scale-out-add-a-worker-node)
-  - [Scale-in: remove a worker node](#scale-in-remove-a-worker-node)
+  - [Scale-out: add a worker to each custom pool](#scale-out-add-a-worker-to-each-custom-pool)
+  - [Scale-in: remove a worker from each custom pool](#scale-in-remove-a-worker-from-each-custom-pool)
 - [SNO End-to-end ProvisioningRequestReconcile with hardware manager [sno-provisioning]](#sno-end-to-end-provisioningrequestreconcile-with-hardware-manager-sno-provisioning)
 
 ## MNO Standard ClusterVersion Upgrade [mno-cv-upgrade]
@@ -148,13 +148,13 @@ File: `test/e2e/mno_scale_test.go`
 - Creating namespaces
 - Creating ConfigMaps
 - Creating ClusterTemplate and supporting resources
-- Creating 6 BMHs (3 masters + 3 workers: 2 initial + 1 extra for scale-out)
-- Waiting for all 6 BMHs to be visible
+- Creating 8 BMHs (3 masters + 2 r740 workers + 1 xr8620t worker + 1 extra xr8620t and 1 extra r740 for scale-out)
+- Waiting for all 8 BMHs to be visible
 - Waiting for ClusterTemplate reconciliation
-- Creating initial ProvisioningRequest with 3 masters + 2 workers
+- Creating initial ProvisioningRequest with 3 masters + 2 r740 workers + 1 xr8620t worker
 - Waiting for NAR creation
 - Verifying initial NAR NodeGroup sizes
-- Waiting for all 5 AllocatedNodes to be created
+- Waiting for all 6 AllocatedNodes to be created
 - Waiting for NAR Provisioned=True
 - Waiting for PR HardwareProvisioned=True
 - Capturing initial AllocatedNode names before scale-out
@@ -162,19 +162,19 @@ File: `test/e2e/mno_scale_test.go`
 - Simulating ClusterProvisioned=Completed on PR
 - Cleaning up scale test resources
 
-### Scale-out: add a worker node
+### Scale-out: add a worker to each custom pool
 
-1. should increase NAR worker NodeGroup Size after PR update
-   - Updating PR to append worker-3 under the worker nodeGroup
+1. should increase NAR Size for both worker groups
+   - Updating PR to append a host under worker-dell-r740 and worker-dell-xr8620t
    - Verifying NAR NodeGroup sizes after scale-out
-1. should create a new AllocatedNode for the added worker
-   - Waiting for 6 AllocatedNodes (3 masters + 3 workers)
-   - Verifying original nodes are preserved and new node is a worker
+1. should create a new AllocatedNode in each scaled worker group
+   - Waiting for 8 AllocatedNodes (3 masters + 3 r740 workers + 2 xr8620t workers)
+   - Verifying original nodes are preserved and each worker group gained one node
 
-### Scale-in: remove a worker node
+### Scale-in: remove a worker from each custom pool
 
-1. should decrease NAR worker NodeGroup Size after removing a worker
-   - Updating PR to remove worker-3 from the worker nodeGroup
+1. should decrease NAR Size for both worker groups
+   - Updating PR to remove the added host from worker-dell-r740 and worker-dell-xr8620t
    - Verifying NAR NodeGroup sizes after scale-in
 
 ## SNO End-to-end ProvisioningRequestReconcile with hardware manager [sno-provisioning]

--- a/docs/user-guide/cluster-configuration.md
+++ b/docs/user-guide/cluster-configuration.md
@@ -744,7 +744,7 @@ ProvisioningRequest.
   ClusterTemplate in use.
 * No upgrade operation is currently in progress.
 
-#### Adding a worker node (scale-out)
+#### Adding worker node(s) (scale-out)
 
 1. Ensure the ClusterTemplate / ClusterInstance defaults include the
    worker `nodeGroups` entry (see the following note).
@@ -753,8 +753,9 @@ ProvisioningRequest.
    > [!NOTE]
    > Scale-out adds hosts under a `nodeGroups` entry that already exists in
    > the ClusterInstance defaults. Typical STD templates already include
-   > both `master` and `worker`, so day-2 scale-in/out is only a
-   > ProvisioningRequest change.
+   > both `master` and `worker`, and templates with multiple worker
+   > MachineConfigPools already include those named worker groups, so
+   > day-2 scale-in/out is only a ProvisioningRequest change.
    >
    > If the cluster was provisioned from a 3-node template (no `worker`
    > group in defaults), create a new ClusterTemplate version whose
@@ -762,9 +763,10 @@ ProvisioningRequest.
    > worker group, then update the ProvisioningRequest to that version
    > and add the worker group with hosts under `nodeGroups[].nodes`.
 
-2. Update the ProvisioningRequest to append the new worker node under
-   `spec.templateParameters.clusterInstanceParameters.nodeGroups`
-   (worker group’s `nodes` list):
+2. Update the ProvisioningRequest to append the new worker node(s)
+   under the target `nodeGroup(s)`
+   (`spec.templateParameters.clusterInstanceParameters.nodeGroups[].nodes`).
+   A single update can append hosts under more than one worker group:
 
    ```yaml
    spec:
@@ -776,35 +778,44 @@ ProvisioningRequest.
                - hostName: master-1.cluster.example.com
                - hostName: master-2.cluster.example.com
                - hostName: master-3.cluster.example.com
-           - name: worker
+           - name: worker-dell-r740
              nodes:
-               - hostName: worker-1.cluster.example.com
+               - hostName: worker-r740-1.cluster.example.com
                  nodeNetwork:
                    interfaces:
                      - name: eno1
                        addresses:
                          ipv4: ["192.0.2.20/24"]
-               - hostName: worker-2.cluster.example.com
-                 nodeNetwork:
-                   interfaces:
-                     - name: eno1
-                       addresses:
-                         ipv4: ["192.0.2.21/24"]
-               - hostName: worker-3.cluster.example.com  # new worker
+               - hostName: worker-r740-2.cluster.example.com  # new worker
                  nodeNetwork:
                    interfaces:
                      - name: eno1
                        addresses:
                          ipv4: ["192.0.2.22/24"]
+           - name: worker-dell-xr8620t
+             nodes:
+               - hostName: worker-xr8620-1.cluster.example.com
+                 nodeNetwork:
+                   interfaces:
+                     - name: eno1
+                       addresses:
+                         ipv4: ["192.0.2.21/24"]
+               - hostName: worker-xr8620-2.cluster.example.com  # new worker
+                 nodeNetwork:
+                   interfaces:
+                     - name: eno1
+                       addresses:
+                         ipv4: ["192.0.2.23/24"]
    ```
 
-3. The controller detects the new node and:
-   * Increases the NodeAllocationRequest worker `NodeGroup.Size`.
+3. The controller detects the new node(s) and:
+   * Increases the NodeAllocationRequest `NodeGroup.Size` for each scaled
+     group.
    * The hardware manager allocates a new BareMetalHost and creates an
-     AllocatedNode CR.
-   * The new node's BMC address and MAC are mapped to the ClusterInstance.
+     AllocatedNode CR for each added host.
+   * Each new node's BMC address and MAC are mapped to the ClusterInstance.
    * The ClusterInstance is updated via Server-Side Apply and siteconfig
-     provisions the new node.
+     provisions the new node(s).
 
 4. Monitor progress:
 
@@ -813,11 +824,21 @@ ProvisioningRequest.
    ```
 
    The ProvisioningRequest transitions from `fulfilled` → `pending` →
-   `progressing` → `fulfilled` once the new node joins the cluster.
+   `progressing` → `fulfilled` once the new node(s) join the cluster.
 
-#### Removing a worker node (scale-in)
+##### Adding workers to a new MachineConfigPool at day-2
 
-To remove a worker node, remove its host entry from the worker group’s
+To add workers to a new MachineConfigPool after the cluster is
+fulfilled, first create the new MCP on spoke cluster through the
+PolicyGenerator, as described in [Adding a new manifest to an existing ACM PolicyGenerator](#adding-a-new-manifest-to-an-existing-acm-policygenerator).
+Then create a new ClusterTemplate version whose
+`hwMgmtDefaults.nodeGroupData` and ClusterInstance defaults include the
+new worker group. Update the ProvisioningRequest to that template version
+and add hosts under the new `nodeGroups[].nodes`.
+
+#### Removing worker node(s) (scale-in)
+
+To remove worker node(s), remove their host entries from the worker group’s
 `clusterInstanceParameters.nodeGroups[].nodes` list in the ProvisioningRequest.
 To remove the last worker (scale back to a 3-node cluster), either clear that
 `nodes` list or omit the entire worker group from the ProvisioningRequest.
@@ -825,9 +846,9 @@ To remove the last worker (scale back to a 3-node cluster), either clear that
 The controller automatically:
 
 1. Signals the hardware manager to drain and decommission the
-   removed node (via a NAR annotation)
-2. The hardware manager cordons and drains the node on the spoke,
-   deletes the Node object, deletes the AllocatedNode CR
+   removed node(s) (via a NAR annotation)
+2. The hardware manager cordons and drains the node(s) on the spoke,
+   deletes the Node object(s), deletes the AllocatedNode CR(s)
    (triggering BMH deallocation), and cleans up node tracking
 3. Applies an intermediate ClusterInstance with `pruneManifests` to
    instruct siteconfig to delete per-node resources (InfraEnv,
@@ -862,9 +883,9 @@ returns to normal operation.
 #### Replacing a worker node (swap)
 
 A swap operation replaces one or more worker nodes in a single
-ProvisioningRequest update. Remove the old node entries and add the new
-node entries in the worker group’s `clusterInstanceParameters.nodeGroups[].nodes`
-list at the same time.
+ProvisioningRequest update including hosts in different worker groups.
+Remove the old node entries and add the new node entries in the worker
+group’s `clusterInstanceParameters.nodeGroups[].nodes` list at the same time.
 
 The controller processes the swap sequentially:
 

--- a/internal/hardwaremanager/controller/helpers_test.go
+++ b/internal/hardwaremanager/controller/helpers_test.go
@@ -3706,17 +3706,19 @@ var _ = Describe("Helpers", func() {
 				Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
 					NodeGroup: []hwmgmtv1alpha1.NodeGroup{
 						{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "master", Role: "master"}, Size: 3},
-						{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker", Role: "worker"}, Size: 3},
+						{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker-dell-r740", Role: "worker"}, Size: 3},
+						{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker-dell-xr8620t", Role: "worker"}, Size: 1},
 					},
 				},
 			}
-			// 3 masters (satisfied) + 2 workers (needs 1 more)
+			// 3 masters (satisfied) + 2 r740 workers (needs 1 more) + 1 xr8620t (satisfied)
 			nodes := []client.Object{
 				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "master", NodeAllocationRequest: "test-nar"}},
 				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "m2", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "master", NodeAllocationRequest: "test-nar"}},
 				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "m3", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "master", NodeAllocationRequest: "test-nar"}},
-				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "w1", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker", NodeAllocationRequest: "test-nar"}},
-				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "w2", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker", NodeAllocationRequest: "test-nar"}},
+				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "r740-1", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker-dell-r740", NodeAllocationRequest: "test-nar"}},
+				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "r740-2", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker-dell-r740", NodeAllocationRequest: "test-nar"}},
+				&hwmgmtv1alpha1.AllocatedNode{ObjectMeta: metav1.ObjectMeta{Name: "xr-1", Namespace: "oran-o2ims", Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"}}, Spec: hwmgmtv1alpha1.AllocatedNodeSpec{GroupName: "worker-dell-xr8620t", NodeAllocationRequest: "test-nar"}},
 			}
 			testClient = fake.NewClientBuilder().WithScheme(testScheme).
 				WithObjects(nodes...).Build()

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller.go
@@ -8,14 +8,16 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -105,7 +107,7 @@ func (r *NodeAllocationRequestReconciler) Reconcile(ctx context.Context, req ctr
 	// Fetch the nodeAllocationRequest, using non-caching client
 	nodeAllocationRequest := &hwmgmtv1alpha1.NodeAllocationRequest{}
 	if err := hwmgrutils.GetNodeAllocationRequest(ctx, r.NoncachedClient, req.NamespacedName, nodeAllocationRequest); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// The NodeAllocationRequest object has likely been deleted
 			r.Logger.InfoContext(ctx, "NodeAllocationRequest not found, assuming deleted")
 			return hwmgrutils.DoNotRequeue(), nil
@@ -337,90 +339,56 @@ func (r *NodeAllocationRequestReconciler) handleScaleInNodesAnnotation(
 	}
 
 	var nodeOps NodeOps
+	var spokeClient client.Client
 	if ready {
-		nodeOps = NewNodeOps(spokeClients.Client, spokeClients.Clientset, r.Logger, false)
+		spokeClient = spokeClients.Client
+		nodeOps = NewNodeOps(spokeClient, spokeClients.Clientset, r.Logger, false)
 	}
 
-	var remainingNodeNames []string
-	for _, nn := range nar.Status.Properties.NodeNames {
-		remainingNodeNames = append(remainingNodeNames, nn)
-	}
+	remainingNodeNames := append([]string(nil), nar.Status.Properties.NodeNames...)
 
 	r.tryPopulateNodeHostnames(ctx, nar)
 
-	allProcessed := true
+	var names []string
 	for _, nodeName := range nodeNames {
 		nodeName = strings.TrimSpace(nodeName)
-		if nodeName == "" {
-			continue
+		if nodeName != "" {
+			names = append(names, nodeName)
 		}
-
-		an := &hwmgmtv1alpha1.AllocatedNode{}
-		if err := r.Client.Get(ctx, client.ObjectKey{
-			Name: nodeName, Namespace: r.Namespace,
-		}, an); err != nil {
-			if errors.IsNotFound(err) {
-				remainingNodeNames = removeFromSlice(remainingNodeNames, nodeName)
-				continue
-			}
-			return hwmgrutils.RequeueWithShortInterval(),
-				fmt.Errorf("failed to get AllocatedNode %s: %w", nodeName, err)
-		}
-
-		// Phase 1: Drain the node on the spoke
-		deprovCond := meta.FindStatusCondition(an.Status.Conditions, string(hwmgmtv1alpha1.Deprovisioned))
-		if deprovCond == nil || deprovCond.Reason == string(hwmgmtv1alpha1.InProgress) {
-			if nodeOps != nil && an.Status.Hostname == "" {
-				allProcessed = false
-				r.Logger.WarnContext(ctx, "Hostname not yet populated, deferring scale-in for node",
-					slog.String("allocatedNode", nodeName))
-				continue
-			}
-			if nodeOps != nil {
-				// Check if the node is reachable before attempting drain.
-				// If the node is NotReady or absent from the spoke, skip
-				// drain — it would retry indefinitely on a dead node.
-				if err := r.drainIfReady(ctx, nodeOps, an, nodeName); err != nil {
-					allProcessed = false
-					continue
-				}
-			}
-
-			hwmgrutils.SetStatusCondition(&an.Status.Conditions,
-				string(hwmgmtv1alpha1.Deprovisioned), string(hwmgmtv1alpha1.Completed),
-				metav1.ConditionTrue, "Node deprovisioned")
-			if err := r.Client.Status().Update(ctx, an); err != nil {
-				return hwmgrutils.RequeueWithShortInterval(),
-					fmt.Errorf("failed to update Deprovisioned condition on AllocatedNode %s: %w", nodeName, err)
-			}
-		}
-
-		// Phase 2: Delete Node from spoke and AllocatedNode CR
-		if spokeClients.Client != nil && an.Status.Hostname != "" {
-			spokeNode := &corev1.Node{}
-			spokeNode.Name = an.Status.Hostname
-			if err := spokeClients.Client.Delete(ctx, spokeNode); err != nil {
-				if !errors.IsNotFound(err) {
-					return hwmgrutils.RequeueWithShortInterval(),
-						fmt.Errorf("failed to delete node %s from spoke: %w", an.Status.Hostname, err)
-				}
-			}
-			r.Logger.InfoContext(ctx, "Deleted node from spoke cluster",
-				slog.String("hostname", an.Status.Hostname))
-		}
-
-		if err := r.Client.Delete(ctx, an); err != nil {
-			if !errors.IsNotFound(err) {
-				return hwmgrutils.RequeueWithShortInterval(),
-					fmt.Errorf("failed to delete AllocatedNode %s: %w", nodeName, err)
-			}
-		}
-		r.Logger.InfoContext(ctx, "Deleted AllocatedNode",
-			slog.String("allocatedNode", nodeName))
-
-		remainingNodeNames = removeFromSlice(remainingNodeNames, nodeName)
 	}
 
+	var (
+		mu           sync.Mutex
+		allProcessed = true
+		errs         []error
+	)
+
+	// Scale in nodes concurrently, capped by maxConcurrentNodeOps.
+	forEachConcurrent(len(names), maxConcurrentNodeOps, func(i int) {
+		nodeName := names[i]
+		nodeCtx := logging.AppendCtx(ctx, slog.String("node", nodeName))
+
+		processed, err := r.scaleInNode(nodeCtx, nodeName, nodeOps, spokeClient)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if err != nil {
+			r.Logger.ErrorContext(ctx, "Failed to scale in node", slog.String("nodeName", nodeName), slog.Any("error", err))
+			errs = append(errs, fmt.Errorf("node %s, error: %w", nodeName, err))
+			return
+		}
+
+		if processed {
+			remainingNodeNames = removeFromSlice(remainingNodeNames, nodeName)
+		} else {
+			allProcessed = false
+		}
+	})
+
+	if len(errs) > 0 {
+		return ctrl.Result{}, fmt.Errorf("failed to scale in nodes: %w", errors.Join(errs...))
+	}
 	if !allProcessed {
 		return hwmgrutils.RequeueWithMediumInterval(), nil
 	}
@@ -453,9 +421,75 @@ func (r *NodeAllocationRequestReconciler) handleScaleInNodesAnnotation(
 	return hwmgrutils.DoNotRequeue(), nil
 }
 
-// drainIfReady checks if a node is Ready and drains it. If the node is
-// NotReady or absent from the spoke, drain is skipped (returns nil).
-// Returns an error only if drain was attempted and failed (caller should retry).
+// scaleInNode drains a AllocatedNode and deletes it.
+// Returns:
+// true, nil when the node is fully processed (deleted or already gone).
+// false, nil when work is still in progress (hostname not yet populated, or drain not finished).
+// false, error when there is a transient error.
+func (r *NodeAllocationRequestReconciler) scaleInNode(
+	ctx context.Context,
+	nodeName string,
+	nodeOps NodeOps,
+	spokeClient client.Client,
+) (bool, error) {
+	an := &hwmgmtv1alpha1.AllocatedNode{}
+	if err := r.Client.Get(ctx, client.ObjectKey{
+		Name: nodeName, Namespace: r.Namespace,
+	}, an); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to get AllocatedNode %s: %w", nodeName, err)
+	}
+
+	// Phase 1: Drain the node on the spoke
+	deprovCond := meta.FindStatusCondition(an.Status.Conditions, string(hwmgmtv1alpha1.Deprovisioned))
+	if deprovCond == nil || deprovCond.Reason == string(hwmgmtv1alpha1.InProgress) {
+		if nodeOps != nil && an.Status.Hostname == "" {
+			r.Logger.WarnContext(ctx, "Hostname not yet populated, deferring scale-in for node",
+				slog.String("allocatedNode", nodeName))
+			return false, nil
+		}
+		if nodeOps != nil {
+			// Check if the node is reachable before attempting drain.
+			// If the node is NotReady or absent from the spoke, skip
+			// drain — it would retry indefinitely on a dead node.
+			if err := r.drainIfReady(ctx, nodeOps, an, nodeName); err != nil {
+				return false, nil
+			}
+		}
+
+		hwmgrutils.SetStatusCondition(&an.Status.Conditions,
+			string(hwmgmtv1alpha1.Deprovisioned), string(hwmgmtv1alpha1.Completed),
+			metav1.ConditionTrue, "Node deprovisioned")
+		if err := r.Client.Status().Update(ctx, an); err != nil {
+			return false, fmt.Errorf("failed to update Deprovisioned condition on AllocatedNode %s: %w", nodeName, err)
+		}
+	}
+
+	// Phase 2: Delete Node from spoke and AllocatedNode CR
+	if spokeClient != nil && an.Status.Hostname != "" {
+		spokeNode := &corev1.Node{}
+		spokeNode.Name = an.Status.Hostname
+		if err := spokeClient.Delete(ctx, spokeNode); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return false, fmt.Errorf("failed to delete node %s from spoke: %w", an.Status.Hostname, err)
+			}
+		}
+		r.Logger.InfoContext(ctx, "Deleted node from spoke cluster",
+			slog.String("hostname", an.Status.Hostname))
+	}
+
+	if err := r.Client.Delete(ctx, an); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to delete AllocatedNode %s: %w", nodeName, err)
+		}
+	}
+	r.Logger.InfoContext(ctx, "Deleted AllocatedNode",
+		slog.String("allocatedNode", nodeName))
+	return true, nil
+}
+
 // drainIfReady drains the node only if it is Ready on the spoke. NotReady or
 // absent nodes are skipped — a failed/unreachable node cannot be drained (the
 // kubelet is unresponsive), so attempting drain would retry indefinitely until
@@ -467,7 +501,7 @@ func (r *NodeAllocationRequestReconciler) drainIfReady(
 
 	ready, readyErr := nodeOps.IsNodeReady(ctx, an.Status.Hostname)
 	if readyErr != nil {
-		if errors.IsNotFound(readyErr) {
+		if k8serrors.IsNotFound(readyErr) {
 			r.Logger.InfoContext(ctx, "Node not found on spoke, skipping drain",
 				slog.String("hostname", an.Status.Hostname))
 			return nil
@@ -512,17 +546,23 @@ func removeFromSlice(s []string, val string) []string {
 }
 
 // removeAnnotation removes the specified annotation from the NAR.
-// Re-fetches the NAR to ensure the resourceVersion is current.
+// Callers may have just written NAR status (for example nodeNames after
+// scale-in). Get from the API, not the informer, to avoid a stale
+// resourceVersion after a status write in this reconcile.
 func (r *NodeAllocationRequestReconciler) removeAnnotation(
 	ctx context.Context, nar *hwmgmtv1alpha1.NodeAllocationRequest,
 	annotation string) error {
 
 	fresh := &hwmgmtv1alpha1.NodeAllocationRequest{}
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(nar), fresh); err != nil {
+	if err := r.NoncachedClient.Get(ctx, client.ObjectKeyFromObject(nar), fresh); err != nil {
 		return fmt.Errorf("failed to re-fetch NAR %s: %w", nar.Name, err)
 	}
-	patch := client.MergeFromWithOptions(fresh.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	annotations := fresh.GetAnnotations()
+	if _, ok := annotations[annotation]; !ok {
+		return nil
+	}
+
+	patch := client.MergeFromWithOptions(fresh.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	delete(annotations, annotation)
 	fresh.SetAnnotations(annotations)
 	if err := r.Client.Patch(ctx, fresh, patch); err != nil {

--- a/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
+++ b/internal/hardwaremanager/controller/nodeallocationrequest_controller_test.go
@@ -48,6 +48,48 @@ import (
 	"github.com/openshift-kni/oran-o2ims/internal/spokeclient"
 )
 
+// spokeAccessReadyObjects returns hub objects that make EnsureSpokeClient
+// report ready for the given MSA and ManifestWork names on test-cluster.
+func spokeAccessReadyObjects(msaName, mwName string) []client.Object {
+	tokenName := msaName + "-token"
+	return []client.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}},
+		&addonv1alpha1.ManagedClusterAddOn{
+			ObjectMeta: metav1.ObjectMeta{Name: "managed-serviceaccount", Namespace: "test-cluster"},
+		},
+		&msav1beta1.ManagedServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: msaName, Namespace: "test-cluster"},
+			Status: msav1beta1.ManagedServiceAccountStatus{
+				TokenSecretRef: &msav1beta1.SecretRef{Name: tokenName},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: tokenName, Namespace: "test-cluster", ResourceVersion: "100",
+			},
+			Data: map[string][]byte{"token": []byte("t"), "ca.crt": []byte("c")},
+		},
+		&workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{Name: mwName, Namespace: "test-cluster"},
+			Status: workv1.ManifestWorkStatus{
+				Conditions: []metav1.Condition{{
+					Type:               workv1.WorkAvailable,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+				}},
+			},
+		},
+		&clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+			Spec: clusterv1.ManagedClusterSpec{
+				ManagedClusterClientConfigs: []clusterv1.ClientConfig{
+					{URL: "https://api.test-cluster.example.com:6443"},
+				},
+			},
+		},
+	}
+}
+
 var _ = Describe("NodeAllocationRequest Controller Timeout Handling", func() {
 	var (
 		c          client.Client
@@ -411,7 +453,8 @@ var _ = Describe("handleScaleOut", func() {
 			},
 			Spec: hwmgmtv1alpha1.NodeAllocationRequestSpec{
 				NodeGroup: []hwmgmtv1alpha1.NodeGroup{
-					{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker", Role: "worker"}, Size: 3},
+					{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker-dell-r740", Role: "worker"}, Size: 3},
+					{NodeGroupData: hwmgmtv1alpha1.NodeGroupData{Name: "worker-dell-xr8620t", Role: "worker"}, Size: 1},
 				},
 			},
 		}
@@ -421,15 +464,20 @@ var _ = Describe("handleScaleOut", func() {
 			metav1.ConditionTrue, "Provisioned")
 		Expect(fakeClient.Status().Update(ctx, nar)).To(Succeed())
 
-		// Only 2 AllocatedNodes exist — Size is 3, so scale-out needed
-		for _, name := range []string{"w1", "w2"} {
+		// r740 is short of its desired size; xr8620t already matches.
+		nodes := []struct{ name, group string }{
+			{"r740-1", "worker-dell-r740"},
+			{"r740-2", "worker-dell-r740"},
+			{"xr-1", "worker-dell-xr8620t"},
+		}
+		for _, n := range nodes {
 			node := &hwmgmtv1alpha1.AllocatedNode{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name, Namespace: "oran-o2ims",
+					Name: n.name, Namespace: "oran-o2ims",
 					Labels: map[string]string{"clcm.openshift.io/nodeAllocationRequest": "test-nar"},
 				},
 				Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
-					GroupName:             "worker",
+					GroupName:             n.group,
 					NodeAllocationRequest: "test-nar",
 				},
 			}
@@ -525,9 +573,10 @@ var _ = Describe("handleScaleInAnnotations", func() {
 			Build()
 
 		reconciler = &NodeAllocationRequestReconciler{
-			Client:    fakeClient,
-			Logger:    logger,
-			Namespace: "test-ns",
+			Client:          fakeClient,
+			NoncachedClient: fakeClient,
+			Logger:          logger,
+			Namespace:       "test-ns",
 		}
 
 		// Create a ProvisioningRequest (looked up by ensureSpokeClients)
@@ -624,6 +673,50 @@ var _ = Describe("handleScaleInAnnotations", func() {
 		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 	})
 
+	It("should process every listed node and prune all of them from nodeNames", func() {
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-nar",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					ScaleInNodesAnnotation: "node-1, node-2",
+				},
+			},
+		}
+		Expect(fakeClient.Create(ctx, nar)).To(Succeed())
+		nar.Status.Properties.NodeNames = []string{"node-1", "node-2", "node-keep"}
+		Expect(fakeClient.Status().Update(ctx, nar)).To(Succeed())
+
+		for _, name := range []string{"node-1", "node-2"} {
+			node := &hwmgmtv1alpha1.AllocatedNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "test-ns",
+				},
+				Spec: hwmgmtv1alpha1.AllocatedNodeSpec{
+					NodeAllocationRequest: "test-nar",
+				},
+			}
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+			node.Status.Hostname = name + ".example.com"
+			Expect(fakeClient.Status().Update(ctx, node)).To(Succeed())
+		}
+
+		_, handled, err := reconciler.handleScaleInAnnotations(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeTrue())
+
+		updatedNAR := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nar), updatedNAR)).To(Succeed())
+		Expect(updatedNAR.GetAnnotations()).ToNot(HaveKey(ScaleInNodesAnnotation))
+		Expect(updatedNAR.Status.Properties.NodeNames).To(ConsistOf("node-keep"))
+
+		for _, name := range []string{"node-1", "node-2"} {
+			err := fakeClient.Get(ctx, client.ObjectKey{Name: name, Namespace: "test-ns"}, &hwmgmtv1alpha1.AllocatedNode{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		}
+	})
+
 	It("should skip AllocatedNodes that are not found and prune nodeNames", func() {
 		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
 			ObjectMeta: metav1.ObjectMeta{
@@ -649,6 +742,104 @@ var _ = Describe("handleScaleInAnnotations", func() {
 
 		// Verify nodeNames was pruned even for NotFound nodes
 		Expect(updatedNAR.Status.Properties.NodeNames).To(ConsistOf("other-node"))
+	})
+
+	It("should skip drain for NotReady nodes and still deallocate them", func() {
+		spokeclient.ClearCache()
+		DeferCleanup(spokeclient.ClearCache)
+
+		hostname := "worker1.example.com"
+		spokeScheme := runtime.NewScheme()
+		Expect(corev1.AddToScheme(spokeScheme)).To(Succeed())
+		spokeNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: hostname},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionFalse,
+				}},
+			},
+		}
+		spoke := fake.NewClientBuilder().WithScheme(spokeScheme).WithObjects(spokeNode).Build()
+		restore := spokeclient.SetTestSpokeClientCreator(
+			func(string, string, []byte, *runtime.Scheme) (client.Client, error) {
+				return spoke, nil
+			})
+		DeferCleanup(restore)
+		restoreCS := spokeclient.SetTestSpokeClientsetCreator(
+			func(string, string, []byte) (kubernetes.Interface, error) {
+				return kubefake.NewSimpleClientset(), nil
+			})
+		DeferCleanup(restoreCS)
+
+		nar := &hwmgmtv1alpha1.NodeAllocationRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-nar",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					ScaleInNodesAnnotation: "node-1",
+				},
+			},
+			Status: hwmgmtv1alpha1.NodeAllocationRequestStatus{
+				Properties: hwmgmtv1alpha1.Properties{
+					NodeNames: []string{"node-1", "node-keep"},
+				},
+			},
+		}
+		allocated := &hwmgmtv1alpha1.AllocatedNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-1", Namespace: "test-ns"},
+			Spec:       hwmgmtv1alpha1.AllocatedNodeSpec{NodeAllocationRequest: "test-nar"},
+			Status:     hwmgmtv1alpha1.AllocatedNodeStatus{Hostname: hostname},
+		}
+		pr := &provisioningv1alpha1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-nar"},
+			Spec: provisioningv1alpha1.ProvisioningRequestSpec{
+				Name: "test", TemplateName: "test-template", TemplateVersion: "v1",
+			},
+			Status: provisioningv1alpha1.ProvisioningRequestStatus{
+				Extensions: provisioningv1alpha1.Extensions{
+					ClusterDetails: &provisioningv1alpha1.ClusterDetails{Name: "test-cluster"},
+				},
+			},
+		}
+
+		objs := append([]client.Object{pr, nar, allocated},
+			spokeAccessReadyObjects("test-nar"+scaleInMSASuffix, "test-nar"+scaleInMWSuffix)...)
+		c := fake.NewClientBuilder().
+			WithScheme(fakeClient.Scheme()).
+			WithObjects(objs...).
+			WithStatusSubresource(
+				&hwmgmtv1alpha1.AllocatedNode{},
+				&hwmgmtv1alpha1.NodeAllocationRequest{},
+				&provisioningv1alpha1.ProvisioningRequest{},
+				&msav1beta1.ManagedServiceAccount{},
+				&workv1.ManifestWork{},
+			).
+			WithIndex(&hwmgmtv1alpha1.AllocatedNode{}, "spec.nodeAllocationRequest",
+				func(obj client.Object) []string {
+					return []string{obj.(*hwmgmtv1alpha1.AllocatedNode).Spec.NodeAllocationRequest}
+				}).
+			Build()
+		rec := &NodeAllocationRequestReconciler{
+			Client:          c,
+			NoncachedClient: c,
+			Logger:          logger,
+			Namespace:       "test-ns",
+		}
+
+		_, handled, err := rec.handleScaleInAnnotations(ctx, nar)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeTrue())
+
+		updatedNAR := &hwmgmtv1alpha1.NodeAllocationRequest{}
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(nar), updatedNAR)).To(Succeed())
+		Expect(updatedNAR.GetAnnotations()).ToNot(HaveKey(ScaleInNodesAnnotation))
+		Expect(updatedNAR.Status.Properties.NodeNames).To(ConsistOf("node-keep"))
+
+		err = c.Get(ctx, client.ObjectKeyFromObject(allocated), &hwmgmtv1alpha1.AllocatedNode{})
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		err = spoke.Get(ctx, client.ObjectKey{Name: hostname}, &corev1.Node{})
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 	})
 })
 
@@ -841,48 +1032,6 @@ var _ = Describe("handleHardwareProfileChanges", func() {
 		return scheme
 	}
 
-	spokeAccessReadyObjects := func() []client.Object {
-		msaName := narName + hwConfigMSASuffix
-		mwName := narName + hwConfigMWSuffix
-		tokenName := msaName + "-token"
-		return []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}},
-			&addonv1alpha1.ManagedClusterAddOn{
-				ObjectMeta: metav1.ObjectMeta{Name: "managed-serviceaccount", Namespace: "test-cluster"},
-			},
-			&msav1beta1.ManagedServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{Name: msaName, Namespace: "test-cluster"},
-				Status: msav1beta1.ManagedServiceAccountStatus{
-					TokenSecretRef: &msav1beta1.SecretRef{Name: tokenName},
-				},
-			},
-			&corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: tokenName, Namespace: "test-cluster", ResourceVersion: "100",
-				},
-				Data: map[string][]byte{"token": []byte("t"), "ca.crt": []byte("c")},
-			},
-			&workv1.ManifestWork{
-				ObjectMeta: metav1.ObjectMeta{Name: mwName, Namespace: "test-cluster"},
-				Status: workv1.ManifestWorkStatus{
-					Conditions: []metav1.Condition{{
-						Type:               workv1.WorkAvailable,
-						Status:             metav1.ConditionTrue,
-						LastTransitionTime: metav1.Now(),
-					}},
-				},
-			},
-			&clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
-				Spec: clusterv1.ManagedClusterSpec{
-					ManagedClusterClientConfigs: []clusterv1.ClientConfig{
-						{URL: "https://api.test-cluster.example.com:6443"},
-					},
-				},
-			},
-		}
-	}
-
 	stubSpokeCreators := func() {
 		restore := spokeclient.SetTestSpokeClientCreator(
 			func(string, string, []byte, *runtime.Scheme) (client.Client, error) {
@@ -1015,7 +1164,8 @@ var _ = Describe("handleHardwareProfileChanges", func() {
 			hwmgrutils.SetStatusCondition(&node.Status.Conditions,
 				string(hwmgmtv1alpha1.Configured), nodeReason, nodeStatus, nodeReason)
 
-			objs := append([]client.Object{nar, node, prWithCluster()}, spokeAccessReadyObjects()...)
+			objs := append([]client.Object{nar, node, prWithCluster()},
+				spokeAccessReadyObjects(narName+hwConfigMSASuffix, narName+hwConfigMWSuffix)...)
 			reconciler = newReconciler(hubScheme(), objs...)
 
 			_, err := reconciler.handleHardwareProfileChanges(ctx, nar)

--- a/test/e2e/mno_scale_test.go
+++ b/test/e2e/mno_scale_test.go
@@ -34,12 +34,14 @@ import (
 
 var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 	const (
-		timeout     = time.Minute * 2
-		interval    = time.Second * 3
-		master      = "master"
-		worker      = "worker"
-		masterCount = 3
-		workerCount = 2
+		timeout            = time.Minute * 2
+		interval           = time.Second * 3
+		master             = "master"
+		workerR740         = "worker-dell-r740"
+		workerXR8620t      = "worker-dell-xr8620t"
+		masterCount        = 3
+		r740WorkerCount    = 2
+		xr8620tWorkerCount = 1
 
 		scalePoolR740   = "scale-r740-pool"
 		scalePoolXR8620 = "scale-xr8620t-pool"
@@ -123,8 +125,8 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 			createdClusterImageSet = true
 		}
 
-		By("Creating 6 BMHs (3 masters + 3 workers: 2 initial + 1 extra for scale-out)")
-		bmhList := scaleBMHs(masterCount, workerCount+1)
+		By("Creating 8 BMHs (3 masters + 2 r740 workers + 1 xr8620t worker + 1 extra xr8620t and 1 extra r740 for scale-out)")
+		bmhList := scaleBMHs(masterCount, r740WorkerCount+1, xr8620tWorkerCount+1)
 		for _, bmhData := range bmhList {
 			bmh := testutils.CreateBareMetalHost(bmhData)
 			bmcSecret := testutils.CreateBMCSecret(bmhData.Name)
@@ -183,7 +185,7 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 		Expect(reqErr).ToNot(HaveOccurred())
 		poolSel = poolSel.Add(*req)
 
-		By("Waiting for all 6 BMHs to be visible")
+		By("Waiting for all 8 BMHs to be visible")
 		Eventually(func() int {
 			bmhListResult := &metal3v1alpha1.BareMetalHostList{}
 			Expect(K8SClient.List(testCtx, bmhListResult,
@@ -195,7 +197,7 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 				}
 			}
 			return available
-		}, timeout, interval).Should(Equal(masterCount + workerCount + 1))
+		}, timeout, interval).Should(Equal(masterCount + r740WorkerCount + 1 + xr8620tWorkerCount + 1))
 
 		By("Waiting for ClusterTemplate reconciliation")
 		Eventually(func() bool {
@@ -204,7 +206,7 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 			return newct.Status.Conditions != nil
 		}, timeout, interval).Should(BeTrue())
 
-		By("Creating initial ProvisioningRequest with 3 masters + 2 workers")
+		By("Creating initial ProvisioningRequest with 3 masters + 2 r740 workers + 1 xr8620t worker")
 		prFromYAML, err := testutils.LoadYAML[provisioningv1alpha1.ProvisioningRequest](resourceDir + "/pr-scale-initial.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		prName = prFromYAML.Name
@@ -218,12 +220,16 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 
 		By("Verifying initial NAR NodeGroup sizes")
 		Expect(K8SClient.Get(testCtx, client.ObjectKeyFromObject(nar), nar)).To(Succeed())
-		verifyNodeGroupSizes(nar, map[string]int{master: masterCount, worker: workerCount})
+		verifyNodeGroupSizes(nar, map[string]int{
+			master:        masterCount,
+			workerR740:    r740WorkerCount,
+			workerXR8620t: xr8620tWorkerCount,
+		})
 
-		By("Waiting for all 5 AllocatedNodes to be created")
+		By("Waiting for all 6 AllocatedNodes to be created")
 		Eventually(func() int {
 			return len(testNonCachingListAllocatedNodesForNAR(testCtx, prName).Items)
-		}, timeout, interval).Should(Equal(masterCount + workerCount))
+		}, timeout, interval).Should(Equal(masterCount + r740WorkerCount + xr8620tWorkerCount))
 
 		By("Waiting for NAR Provisioned=True")
 		Eventually(func() bool {
@@ -250,16 +256,21 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 		Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
 		nodeList := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
 		hostMap := make(map[string]string)
-		masterIdx, workerIdx := 1, 1
+		masterIdx, r740Idx, xr8620tIdx := 1, 1, 1
 		for _, node := range nodeList.Items {
 			hostname := ""
 			switch node.Spec.GroupName {
 			case master:
 				hostname = fmt.Sprintf("master-%d.%s.example.com", masterIdx, clusterName)
 				masterIdx++
-			case worker:
-				hostname = fmt.Sprintf("worker-%d.%s.example.com", workerIdx, clusterName)
-				workerIdx++
+			case workerR740:
+				hostname = fmt.Sprintf("worker-r740-%d.%s.example.com", r740Idx, clusterName)
+				r740Idx++
+			case workerXR8620t:
+				hostname = fmt.Sprintf("worker-xr8620-%d.%s.example.com", xr8620tIdx, clusterName)
+				xr8620tIdx++
+			default:
+				Fail(fmt.Sprintf("unexpected AllocatedNode group %q", node.Spec.GroupName))
 			}
 			hostMap[node.Name] = hostname
 		}
@@ -306,7 +317,7 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 		}
 
 		// Delete BMHs and associated resources
-		bmhList := scaleBMHs(masterCount, workerCount+1)
+		bmhList := scaleBMHs(masterCount, r740WorkerCount+1, xr8620tWorkerCount+1)
 		for _, bmhData := range bmhList {
 			for _, obj := range []client.Object{
 				&metal3v1alpha1.BareMetalHost{ObjectMeta: metav1.ObjectMeta{Name: bmhData.Name, Namespace: bmhData.Namespace}},
@@ -347,33 +358,21 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 		}
 	})
 
-	Describe("Scale-out: add a worker node", func() {
-		It("should increase NAR worker NodeGroup Size after PR update", func() {
-			By("Updating PR to append worker-3 under the worker nodeGroup")
+	Describe("Scale-out: add a worker to each custom pool", func() {
+		It("should increase NAR Size for both worker groups", func() {
+			By("Updating PR to append a host under worker-dell-r740 and worker-dell-xr8620t")
 			Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
 
 			var templateParams map[string]any
 			Expect(json.Unmarshal(pr.Spec.TemplateParameters.Raw, &templateParams)).To(Succeed())
 			ciParams := templateParams["clusterInstanceParameters"].(map[string]any)
 			nodeGroups := ciParams["nodeGroups"].([]any)
-			workerGroup := findNodeGroupByName(nodeGroups, worker)
-			Expect(workerGroup).ToNot(BeNil())
-			workerNodes := workerGroup["nodes"].([]any)
 
-			newWorkerNode := map[string]any{
-				"hostName": fmt.Sprintf("worker-3.%s.example.com", clusterName),
-				"nodeNetwork": map[string]any{
-					"interfaces": []any{
-						map[string]any{
-							"name": "eno1",
-							"addresses": map[string]any{
-								"ipv4": []any{"192.0.2.52/24"},
-							},
-						},
-					},
-				},
-			}
-			workerGroup["nodes"] = append(workerNodes, newWorkerNode)
+			appendWorkerHost(nodeGroups, workerR740,
+				fmt.Sprintf("worker-r740-3.%s.example.com", clusterName), "192.0.2.52/24")
+			appendWorkerHost(nodeGroups, workerXR8620t,
+				fmt.Sprintf("worker-xr8620-2.%s.example.com", clusterName), "192.0.2.57/24")
+
 			ciParams["nodeGroups"] = nodeGroups
 			templateParams["clusterInstanceParameters"] = ciParams
 
@@ -386,34 +385,37 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 			Eventually(func() bool {
 				Expect(K8SClient.Get(testCtx, client.ObjectKeyFromObject(nar), nar)).To(Succeed())
 				sizes := nodeGroupSizeMap(nar)
-				return sizes[worker] == workerCount+1 && sizes[master] == masterCount
+				return sizes[workerR740] == r740WorkerCount+1 &&
+					sizes[workerXR8620t] == xr8620tWorkerCount+1 &&
+					sizes[master] == masterCount
 			}, timeout, interval).Should(BeTrue(),
-				"Worker Size should be 3 and master Size should remain 3")
+				"both worker groups should grow by 1; master Size should remain %d", masterCount)
 		})
 
-		It("should create a new AllocatedNode for the added worker", func() {
-			By("Waiting for 6 AllocatedNodes (3 masters + 3 workers)")
+		It("should create a new AllocatedNode in each scaled worker group", func() {
+			By("Waiting for 8 AllocatedNodes (3 masters + 3 r740 workers + 2 xr8620t workers)")
 			Eventually(func() int {
 				return len(testNonCachingListAllocatedNodesForNAR(testCtx, prName).Items)
-			}, timeout, interval).Should(Equal(masterCount + workerCount + 1))
+			}, timeout, interval).Should(Equal(masterCount + r740WorkerCount + 1 + xr8620tWorkerCount + 1))
 
-			By("Verifying original nodes are preserved and new node is a worker")
+			By("Verifying original nodes are preserved and each worker group gained one node")
 			allNodes := testNonCachingListAllocatedNodesForNAR(testCtx, prName)
-			newWorkerCount := 0
+			newByGroup := map[string]int{}
 			for _, n := range allNodes.Items {
 				if !initialAllocatedNodeNames[n.Name] {
-					Expect(n.Spec.GroupName).To(Equal(worker),
-						"New AllocatedNode should be in the worker group")
-					newWorkerCount++
+					newByGroup[n.Spec.GroupName]++
 				}
 			}
-			Expect(newWorkerCount).To(Equal(1), "Exactly one new worker should be allocated")
+			Expect(newByGroup).To(Equal(map[string]int{
+				workerR740:    1,
+				workerXR8620t: 1,
+			}))
 		})
 	})
 
-	Describe("Scale-in: remove a worker node", func() {
-		It("should decrease NAR worker NodeGroup Size after removing a worker", func() {
-			By("Updating PR to remove worker-3 from the worker nodeGroup")
+	Describe("Scale-in: remove a worker from each custom pool", func() {
+		It("should decrease NAR Size for both worker groups", func() {
+			By("Updating PR to remove the added host from worker-dell-r740 and worker-dell-xr8620t")
 			Expect(K8SClient.Get(testCtx, types.NamespacedName{Name: prName}, pr)).To(Succeed())
 
 			var templateParams map[string]any
@@ -421,13 +423,9 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 			ciParams := templateParams["clusterInstanceParameters"].(map[string]any)
 			nodeGroups := ciParams["nodeGroups"].([]any)
 
-			workerGroup := findNodeGroupByName(nodeGroups, worker)
-			Expect(workerGroup).ToNot(BeNil())
-			workerNodes := workerGroup["nodes"].([]any)
+			truncateWorkerHosts(nodeGroups, workerR740, r740WorkerCount)
+			truncateWorkerHosts(nodeGroups, workerXR8620t, xr8620tWorkerCount)
 
-			Expect(len(workerNodes)).To(BeNumerically(">=", workerCount+1),
-				"Should have at least %d workers before scale-in", workerCount+1)
-			workerGroup["nodes"] = workerNodes[:workerCount]
 			ciParams["nodeGroups"] = nodeGroups
 			templateParams["clusterInstanceParameters"] = ciParams
 
@@ -440,9 +438,11 @@ var _ = Describe("MNO Scale-Out test", Ordered, Label("mno-scale-out"), func() {
 			Eventually(func() bool {
 				Expect(K8SClient.Get(testCtx, client.ObjectKeyFromObject(nar), nar)).To(Succeed())
 				sizes := nodeGroupSizeMap(nar)
-				return sizes[worker] == workerCount && sizes[master] == masterCount
+				return sizes[workerR740] == r740WorkerCount &&
+					sizes[workerXR8620t] == xr8620tWorkerCount &&
+					sizes[master] == masterCount
 			}, timeout, interval).Should(BeTrue(),
-				"Worker Size should be %d and master Size should remain %d", workerCount, masterCount)
+				"both worker groups should return to the initial size; master Size should remain %d", masterCount)
 		})
 
 		// NOTE: AllocatedNode deletion is gated on spoke node removal
@@ -467,7 +467,37 @@ func findNodeGroupByName(nodeGroups []any, name string) map[string]any {
 	return nil
 }
 
-func scaleBMHs(masterCount, workerCount int) []testutils.BMHData {
+func appendWorkerHost(nodeGroups []any, groupName, hostName, ipv4 string) {
+	group := findNodeGroupByName(nodeGroups, groupName)
+	Expect(group).ToNot(BeNil(), "nodeGroup %q should exist", groupName)
+	nodes, ok := group["nodes"].([]any)
+	Expect(ok).To(BeTrue(), "nodeGroup %q nodes should be a list", groupName)
+	group["nodes"] = append(nodes, map[string]any{
+		"hostName": hostName,
+		"nodeNetwork": map[string]any{
+			"interfaces": []any{
+				map[string]any{
+					"name": "eno1",
+					"addresses": map[string]any{
+						"ipv4": []any{ipv4},
+					},
+				},
+			},
+		},
+	})
+}
+
+func truncateWorkerHosts(nodeGroups []any, groupName string, keep int) {
+	group := findNodeGroupByName(nodeGroups, groupName)
+	Expect(group).ToNot(BeNil(), "nodeGroup %q should exist", groupName)
+	nodes, ok := group["nodes"].([]any)
+	Expect(ok).To(BeTrue(), "nodeGroup %q nodes should be a list", groupName)
+	Expect(len(nodes)).To(BeNumerically(">=", keep),
+		"nodeGroup %q should have at least %d hosts", groupName, keep)
+	group["nodes"] = nodes[:keep]
+}
+
+func scaleBMHs(masterCount, r740WorkerCount, xr8620tWorkerCount int) []testutils.BMHData {
 	var bmhs []testutils.BMHData
 	for i := 1; i <= masterCount; i++ {
 		bmhs = append(bmhs, testutils.BMHData{
@@ -480,12 +510,23 @@ func scaleBMHs(masterCount, workerCount int) []testutils.BMHData {
 			ResourcePoolId: "scale-r740-pool",
 		})
 	}
-	for i := 1; i <= workerCount; i++ {
+	for i := 1; i <= r740WorkerCount; i++ {
 		bmhs = append(bmhs, testutils.BMHData{
-			Name:           fmt.Sprintf("scale-worker%d", i),
-			Namespace:      "scale-xr8620t-pool",
+			Name:           fmt.Sprintf("scale-worker-r740-%d", i),
+			Namespace:      "scale-r740-pool",
 			MacAddress:     fmt.Sprintf("aa:bb:cc:44:00:%02x", i),
 			BmcAddress:     fmt.Sprintf("redfish://192.168.4.%d/redfish/v1/Systems/1", 100+i),
+			ServerType:     "R740",
+			Colour:         "blue",
+			ResourcePoolId: "scale-r740-pool",
+		})
+	}
+	for i := 1; i <= xr8620tWorkerCount; i++ {
+		bmhs = append(bmhs, testutils.BMHData{
+			Name:           fmt.Sprintf("scale-worker-xr8620t-%d", i),
+			Namespace:      "scale-xr8620t-pool",
+			MacAddress:     fmt.Sprintf("aa:bb:cc:55:00:%02x", i),
+			BmcAddress:     fmt.Sprintf("redfish://192.168.5.%d/redfish/v1/Systems/1", 100+i),
 			ServerType:     "XR8620t",
 			Colour:         "blue",
 			ResourcePoolId: "scale-xr8620t-pool",
@@ -497,16 +538,16 @@ func scaleBMHs(masterCount, workerCount int) []testutils.BMHData {
 func nodeGroupSizeMap(nar *hwmgmtv1alpha1.NodeAllocationRequest) map[string]int {
 	sizes := make(map[string]int)
 	for _, ng := range nar.Spec.NodeGroup {
-		sizes[ng.NodeGroupData.Role] = ng.Size
+		sizes[ng.NodeGroupData.Name] = ng.Size
 	}
 	return sizes
 }
 
 func verifyNodeGroupSizes(nar *hwmgmtv1alpha1.NodeAllocationRequest, expected map[string]int) {
 	sizes := nodeGroupSizeMap(nar)
-	for role, expectedSize := range expected {
-		Expect(sizes).To(HaveKey(role), "NodeGroup for role %q should exist", role)
-		Expect(sizes[role]).To(Equal(expectedSize),
-			"NodeGroup.Size for role %q should be %d", role, expectedSize)
+	for name, expectedSize := range expected {
+		Expect(sizes).To(HaveKey(name), "NodeGroup %q should exist", name)
+		Expect(sizes[name]).To(Equal(expectedSize),
+			"NodeGroup.Size for %q should be %d", name, expectedSize)
 	}
 }

--- a/test/resources/mno_scale/clusterinstance-defaults-v1.yaml
+++ b/test/resources/mno_scale/clusterinstance-defaults-v1.yaml
@@ -58,8 +58,38 @@ data:
         templateRefs:
           - name: ai-node-templates-v1
             namespace: open-cluster-management
-      - name: worker
+      - name: worker-dell-r740
         role: worker
+        nodeLabels:
+          node-role.kubernetes.io/worker-dell-r740: ""
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              label: boot-interface
+          config:
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-interface: eno1
+                  table-id: 254
+            interfaces:
+              - ipv6:
+                  enabled: false
+                ipv4:
+                  enabled: true
+                name: eno1
+                state: up
+                type: ethernet
+        templateRefs:
+          - name: ai-node-templates-v1
+            namespace: open-cluster-management
+      - name: worker-dell-xr8620t
+        role: worker
+        nodeLabels:
+          node-role.kubernetes.io/worker-dell-xr8620t: ""
         bootMode: UEFI
         rootDeviceHints:
           deviceName: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0

--- a/test/resources/mno_scale/ct-scale.yaml
+++ b/test/resources/mno_scale/ct-scale.yaml
@@ -17,7 +17,13 @@ spec:
           resourceSelector:
             "resourceselector.clcm.openshift.io/server-type": "R740"
             "resourceselector.clcm.openshift.io/server-colour": "green"
-        - name: worker
+        - name: worker-dell-r740
+          role: worker
+          resourcePoolId: scale-r740-pool
+          resourceSelector:
+            "resourceselector.clcm.openshift.io/server-type": "R740"
+            "resourceselector.clcm.openshift.io/server-colour": "blue"
+        - name: worker-dell-xr8620t
           role: worker
           resourcePoolId: scale-xr8620t-pool
           resourceSelector:

--- a/test/resources/mno_scale/pr-scale-initial.yaml
+++ b/test/resources/mno_scale/pr-scale-initial.yaml
@@ -12,7 +12,8 @@ spec:
     hwMgmtParameters:
       nodeGroupData:
         - name: master
-        - name: worker
+        - name: worker-dell-r740
+        - name: worker-dell-xr8620t
     policyTemplateParameters: {}
     clusterInstanceParameters:
       clusterName: scale-cluster
@@ -54,7 +55,7 @@ spec:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.18/24"]
-        - name: worker
+        - name: worker-dell-r740
           nodeNetwork:
             config:
               dns-resolver:
@@ -67,15 +68,34 @@ spec:
                 config:
                   - next-hop-address: 192.0.2.254
           nodes:
-            - hostName: worker-1.scale-cluster.example.com
+            - hostName: worker-r740-1.scale-cluster.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.123/24"]
-            - hostName: worker-2.scale-cluster.example.com
+            - hostName: worker-r740-2.scale-cluster.example.com
               nodeNetwork:
                 interfaces:
                   - name: eno1
                     addresses:
                       ipv4: ["192.0.2.51/24"]
+        - name: worker-dell-xr8620t
+          nodeNetwork:
+            config:
+              dns-resolver:
+                config:
+                  search:
+                    - example.com
+                  server:
+                    - 8.8.8.8
+              routes:
+                config:
+                  - next-hop-address: 192.0.2.254
+          nodes:
+            - hostName: worker-xr8620-1.scale-cluster.example.com
+              nodeNetwork:
+                interfaces:
+                  - name: eno1
+                    addresses:
+                      ipv4: ["192.0.2.56/24"]


### PR DESCRIPTION
Extract per-node scale-in into scaleInNode and drain listed Ready nodes in parallel.

Extend mno-scale-out e2e to two named worker pools and scale both in one PR. Docs cover appending hosts under the target nodeGroup(s) and adding workers to a new MCP at day-2.

Lab-tested on a fulfilled MNO: 3 masters and two worker pools (2 hosts and 3 hosts). Sequence:
- Scale-in: remove 1 host from each pool in one ProvisioningRequest.
- Scale-out: add 2 hosts back to each pool in one ProvisioningRequest.
- Scale-in: remove 1 host from the first pool and 2 from the second in one ProvisioningRequest.
- Swap: remove 1 host from each pool and add 1 host to each in the same ProvisioningRequest.
- Day-2 new MCP: add a new worker MachineConfigPool through PolicyGenerator and scale-out 1 host into it.

Verified that scale-in or scale-out across multiple worker pools is processed concurrently. Scale-in and scale-out across mulitple pools can also be performed in a single ProvisioningRequest, with scale-in completing first, followed by scale-out.
